### PR TITLE
high power outdoor radio fcc_id correction

### DIFF
--- a/src/cell_type.rs
+++ b/src/cell_type.rs
@@ -13,7 +13,7 @@ pub enum CellType {
 impl CellType {
     pub fn fcc_id(&self) -> &'static str {
         match self {
-            Self::Nova436H => "2AG32PBS3101S",
+            Self::Nova436H => "2AG32MBS3100196N",
             Self::Nova430I => "2AG32PBS3101S",
             Self::Neutrino430 => "2AG32PBS31010",
             Self::SercommIndoor => "P27-SCE4255W",


### PR DESCRIPTION
fccID for the high power outdoor radios (Nova436H) is `2AG32MBS3100196N` 

was previously set to match the lower power outdoor cells