### PR TITLE
add local s3 api service for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ flamegraph.*
 *.json
 .envrc
 .env
+
+!/minio/bucket-policy.json

--- a/minio/bucket-policy.json
+++ b/minio/bucket-policy.json
@@ -1,0 +1,17 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ListObjectsInBucket",
+            "Effect": "Allow",
+            "Action": ["s3:ListBucket"],
+            "Resource": ["arn:aws:s3:::*"]
+        },
+        {
+            "Sid": "AllObjectActions",
+            "Effect": "Allow",
+            "Action": "s3:*Object",
+            "Resource": ["arn:aws:s3:::*"]
+        }
+    ]
+}

--- a/minio/docker-compose.yml
+++ b/minio/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "2.4"
+services:
+  minio:
+    image: minio/minio:latest
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    ports:
+      - "9000:9000"
+      - "9090:9090"
+    volumes:
+      - bucket-data:/data
+    command: server /data --console-address ":9090"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  config:
+    image: minio/mc:latest
+    depends_on:
+      - minio
+    volumes:
+      - ${PWD}/bucket-policy.json:/tmp/bucket-policy.json
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc alias set localminio http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD};
+
+      if ! /usr/bin/mc ls localminio/${MINIO_BUCKET} > /dev/null 2>&1 ; then
+          /usr/bin/mc mb localminio/${MINIO_BUCKET};
+      fi;
+
+      /usr/bin/mc admin policy add localminio fullaccess /tmp/bucket-policy.json;
+
+      /usr/bin/mc admin user add localminio ${AWS_ACCESS_KEY_ID} ${AWS_SECRET_ACCESS_KEY};
+      /usr/bin/mc admin policy set localminio fullaccess user=${AWS_ACCESS_KEY_ID}
+      "
+
+volumes:
+  bucket-data:

--- a/minio/minio.sh
+++ b/minio/minio.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+minio-start() {
+    if [[ -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]];
+       then echo "required creds unset"; return 1
+    else
+        MINIO_ROOT_USER=${MINIO_ROOT_USER:-novaadmin} \
+            MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-novaadmin} \
+            MINIO_BUCKET=${MINIO_BUCKET:-heartbeats} \
+            docker-compose up -d
+    fi
+}
+
+minio-stop() {
+    docker-compose down
+    if [[ ${1} == "drop" ]];
+        then
+            volume=$(docker volume ls | grep bucket-data | awk '{print $2}')
+            docker volume rm $volume
+    fi
+}


### PR DESCRIPTION
This change adds a local s3 compatible service to the environment for testing, allowing for rapid development locally without needing to manage buckets, users or bucket policies from within the Amazon S3 API or console. This also allows us to develop the reader/writer data ingestion API against a generic s3-compatible API for future diversification across cloud providers.

By sourcing the `minio.sh` file the user gains access to the `minio-start` and `minio-stop` shell functions for starting and stopping a fully configured instance of a local minio s3 object storage service running in docker.

The start script configures the API endpoint on port 9000 and the web console for the service on 9090 of the development host. It also sets the administrative user and password via environment variable, defaulting both to `novaadmin`. The sidecar configuration container further adds a development user ACCESS_KEY_ID and SECRET_ACCESS_KEY, drawing the credentials from the environment the same way standard s3 tools and API integrations do, with the intention for these credentials to be the ones injected into the running Rust ingestion service under test. It further configures an "full access" bucket policy for the user, and creates a bucket.

The `minio-stop` function will stop the docker-compose containers and optionally remove/drop the persistent docker volume storing the s3 bucket(s) created by adding the `drop` argument (i.e. `minio-stop drop`)