### PR TITLE
allow multiple minio buckets on setup

### DIFF
--- a/minio/config-entrypoint.sh
+++ b/minio/config-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+sleep 3
+
+/usr/bin/mc alias set localminio http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}
+
+for bucket in ${MINIO_BUCKETS}; do
+    if ! /usr/bin/mc ls localminio/${bucket} > /dev/null 2>&1 ; then
+        /usr/bin/mc mb localminio/${bucket}
+    fi
+done
+
+/usr/bin/mc admin policy add localminio fullaccess /bucket-policy.json
+
+/usr/bin/mc admin user add localminio ${TEST_USER_ID} ${TEST_USER_KEY}
+/usr/bin/mc admin policy set localminio fullaccess user=${TEST_USER_ID}

--- a/minio/docker-compose.yml
+++ b/minio/docker-compose.yml
@@ -21,21 +21,17 @@ services:
     image: minio/mc:latest
     depends_on:
       - minio
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      MINIO_BUCKETS: ${MINIO_BUCKETS}
+      TEST_USER_ID: ${AWS_ACCESS_KEY_ID}
+      TEST_USER_KEY: ${AWS_SECRET_ACCESS_KEY}
     volumes:
-      - ${PWD}/bucket-policy.json:/tmp/bucket-policy.json
-    entrypoint: >
-      /bin/sh -c "
-      /usr/bin/mc alias set localminio http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD};
-
-      if ! /usr/bin/mc ls localminio/${MINIO_BUCKET} > /dev/null 2>&1 ; then
-          /usr/bin/mc mb localminio/${MINIO_BUCKET};
-      fi;
-
-      /usr/bin/mc admin policy add localminio fullaccess /tmp/bucket-policy.json;
-
-      /usr/bin/mc admin user add localminio ${AWS_ACCESS_KEY_ID} ${AWS_SECRET_ACCESS_KEY};
-      /usr/bin/mc admin policy set localminio fullaccess user=${AWS_ACCESS_KEY_ID}
-      "
+      - ${PWD}/bucket-policy.json:/bucket-policy.json
+      - ${PWD}/config-entrypoint.sh:/config-entrypoint.sh
+    entrypoint:
+      - /config-entrypoint.sh
 
 volumes:
   bucket-data:

--- a/minio/minio.sh
+++ b/minio/minio.sh
@@ -6,7 +6,7 @@ minio-start() {
     else
         MINIO_ROOT_USER=${MINIO_ROOT_USER:-novaadmin} \
             MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-novaadmin} \
-            MINIO_BUCKET=${MINIO_BUCKET:-heartbeats} \
+            MINIO_BUCKETS=${MINIO_BUCKETS:-"poc5g-ingest poc5g-rewards"} \
             docker-compose up -d
     fi
 }


### PR DESCRIPTION
Configure two buckets by default: one for rewards and one for data ingest. Allows overriding the names of the buckets (and the number of buckets) by setting the `MINIO_BUCKETS` environment variable in your shell before running the start function to a string of space-separated bucket names.