### PR TITLE
Skip gathering shares if operation-mode is false

### DIFF
--- a/rewards/src/reward_share.rs
+++ b/rewards/src/reward_share.rs
@@ -163,10 +163,11 @@ pub async fn gather_shares(
             pub_key,
             cbsd_id,
             timestamp,
+            operation_mode,
             ..
         } = CellHeartbeatReqV1::decode(msg)?;
 
-        if timestamp < after_utc || timestamp >= before_utc {
+        if !operation_mode || timestamp < after_utc || timestamp >= before_utc {
             continue;
         }
 


### PR DESCRIPTION
Fix https://github.com/novalabsxyz/poc5g-server/issues/44

TODO:
- [x] Cross check whether hotspot_shares is consistent with operation_mode