### PR TITLE
pin rand to a recent version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,7 +946,7 @@ source = "git+https://github.com/helium/ed25519-dalek?branch=madninja/bump_rand#
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2 0.9.9",
  "zeroize",
@@ -1031,12 +1031,6 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -1781,7 +1775,7 @@ dependencies = [
  "poc-metrics",
  "poc-store",
  "prost",
- "rand 0.8.5",
+ "rand",
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
@@ -2098,7 +2092,6 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "tempdir",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2339,19 +2332,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -2370,21 +2350,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2411,15 +2376,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aa2540135b6a94f74c7bc90ad4b794f822026a894f3d7bcd185c100d13d4ad6"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2898,7 +2854,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "rust_decimal",
  "rustls 0.20.6",
  "rustls-pemfile",
@@ -3019,16 +2975,6 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]
@@ -3268,7 +3214,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",

--- a/mobile_rewards/Cargo.toml
+++ b/mobile_rewards/Cargo.toml
@@ -36,7 +36,7 @@ tonic = "0"
 http = "*"
 metrics = "0.20"
 metrics-exporter-prometheus = "0.11.0"
-rand = "*"
+rand = "0.8"
 async-trait = "*"
 
 [package.metadata.deb]

--- a/mobile_rewards/Cargo.toml
+++ b/mobile_rewards/Cargo.toml
@@ -36,7 +36,7 @@ tonic = "0"
 http = "*"
 metrics = "0.20"
 metrics-exporter-prometheus = "0.11.0"
-rand = "0.8"
+rand = "*"
 async-trait = "*"
 
 [package.metadata.deb]

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -37,5 +37,4 @@ strum_macros = "0"
 
 [dev-dependencies]
 base64 = "0"
-tempdir = "0"
 tempfile = "3"

--- a/store/src/file_sink.rs
+++ b/store/src/file_sink.rs
@@ -302,11 +302,12 @@ mod tests {
     use crate::{file_source, FileInfo};
     use futures::stream::StreamExt;
     use std::str::FromStr;
+    use tempfile::TempDir;
     use tokio::fs::DirEntry;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn writes_a_framed_gzip_encoded_file() {
-        let tmp_dir = tempdir::TempDir::new("entropy_tests").expect("Unable to create temp dir");
+        let tmp_dir = TempDir::new().expect("Unable to create temp dir");
         let (shutdown_trigger, shutdown_listener) = triggered::trigger();
         let (sender, receiver) = message_channel(10);
 
@@ -344,7 +345,7 @@ mod tests {
             .expect("invalid data in file")
     }
 
-    async fn get_entropy_file(tmp_dir: &tempdir::TempDir) -> DirEntry {
+    async fn get_entropy_file(tmp_dir: &TempDir) -> DirEntry {
         let mut entries = fs::read_dir(tmp_dir.path())
             .await
             .expect("failed to read tmp dir");


### PR DESCRIPTION
The mobile rewards being too lenient with it's version of the rand crate is causing build problems with other dependencies that specify much older versions of the crate