### PR TITLE
Test cached CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,12 +34,6 @@ jobs:
         with:
           key: ${{ runner.os }}-build
 
-      - name: Run tests
-        run: cargo test
-      - uses: Swatinem/rust-cache@v1
-        with:
-          key: ${{ runner.os }}-test
-
       - name: Check formatting
         run: cargo fmt  -- --check
       - uses: Swatinem/rust-cache@v1
@@ -54,6 +48,12 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           key: ${{ runner.os }}-clippy
+
+      - name: Run tests
+        run: cargo test
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ runner.os }}-test
 
       - name: PackageIngestorServer
         id: build_ingestor

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,26 +19,41 @@ jobs:
           default: true
           override: true
           components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ runner.os }}-checkout
 
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.5.0
         with:
           access_token: ${{ github.token }}
 
+      - name: Build
+        run: cargo build --all --release
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ runner.os }}-build
+
       - name: Run tests
         run: cargo test
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ runner.os }}-test
 
       - name: Check formatting
         run: cargo fmt  -- --check
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ runner.os }}-fmt
 
       - name: Clippy
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: -- -Dclippy::all
-
-      - name: Build
-        run: cargo build --all --release
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ runner.os }}-clippy
 
       - name: PackageIngestorServer
         id: build_ingestor
@@ -77,7 +92,7 @@ jobs:
         if: contains(github.ref, 'refs/tags/')
         uses: novalabsxyz/cargo-deb-amd64-ubuntu@v2.7
         with:
-          toml_path: mobile_verifier 
+          toml_path: mobile_verifier
           cmd: cargo deb -p mobile-verifier
 
       - name: PackagecloudUpload


### PR DESCRIPTION
# Summary
- Change order of `build` and `clippy` steps, do `build` first
- Add rust-cache CI step

Fix https://github.com/helium/oracles/issues/86