### PR TITLE
basic iot network rewards emission framework 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,6 +2381,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "poc-iot-rewards"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "db-store",
+ "dotenv",
+ "file-store",
+ "futures",
+ "futures-util",
+ "helium-crypto",
+ "helium-proto",
+ "http",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "once_cell",
+ "poc-metrics",
+ "prost",
+ "rand",
+ "rust_decimal",
+ "rust_decimal_macros",
+ "serde",
+ "serde_json",
+ "sha2 0.9.9",
+ "sqlx",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+ "triggered",
+]
+
+[[package]]
 name = "poc-iot-verifier"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "db_store",
     "file_store",
     "mobile_rewards",
+    "poc_iot_rewards",
     "poc_mobile_verifier",
     "entropy",
     "poc_iot_verifier",

--- a/poc_iot_rewards/Cargo.toml
+++ b/poc_iot_rewards/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "poc-iot-rewards"
+version = "0.1.0"
+description = "Reward Server for the Helium IoT Network"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[dependencies]
+dotenv = {workspace = true}
+thiserror = {workspace = true}
+serde = {workspace = true}
+serde_json = {workspace = true}
+sqlx = {workspace = true}
+tokio = {workspace = true}
+tracing = {workspace = true}
+tracing-subscriber = {workspace = true}
+base64 = {workspace = true}
+sha2 = {workspace = true}
+chrono = {workspace = true}
+triggered = {workspace = true}
+futures = {workspace = true}
+futures-util = {workspace = true}
+prost = {workspace = true}
+once_cell = {workspace = true}
+db-store = {path = "../db_store"}
+file-store = {path = "../file_store"}
+poc-metrics = {path = "../metrics"}
+helium-proto = {workspace = true}
+helium-crypto = {workspace = true}
+rust_decimal = {workspace = true}
+rust_decimal_macros = {workspace = true}
+tonic = {workspace = true}
+http = {workspace = true}
+metrics = {workspace = true}
+metrics-exporter-prometheus = {workspace = true}
+rand = "*"
+async-trait = "*"
+
+[package.metadata.deb]
+depends = "$auto"
+assets = [
+  ["target/release/poc-iot-rewards", "/opt/poc-iot-rewards/bin/", "755"],
+  ["pkg/deb/env-template", "/usr/share/poc-iot-rewards/env-template", "644"]
+]
+maintainer-scripts = "pkg/deb/"
+systemd-utils = {}

--- a/poc_iot_rewards/migrations/1_setup.sql
+++ b/poc_iot_rewards/migrations/1_setup.sql
@@ -1,0 +1,27 @@
+-- This extension gives us `uuid_generate_v1mc()` which generates UUIDs that cluster better than `gen_random_uuid()`
+-- while still being difficult to predict and enumerate.
+-- Also, while unlikely, `gen_random_uuid()` can in theory produce collisions which can trigger spurious errors on
+-- insertion, whereas it's much less likely with `uuid_generate_v1mc()`.
+create extension if not exists "uuid-ossp";
+
+create or replace function set_updated_at()
+    returns trigger as
+$$
+begin
+    NEW.updated_at = now();
+    return NEW;
+end;
+$$ language plpgsql;
+
+create or replace function trigger_updated_at(tablename regclass)
+    returns void as
+$$
+begin
+    execute format('CREATE TRIGGER set_updated_at
+        BEFORE UPDATE
+        ON %s
+        FOR EACH ROW
+        WHEN (OLD is distinct from NEW)
+    EXECUTE FUNCTION set_updated_at();', tablename);
+end;
+$$ language plpgsql;

--- a/poc_iot_rewards/migrations/2_meta_store.sql
+++ b/poc_iot_rewards/migrations/2_meta_store.sql
@@ -1,0 +1,4 @@
+create table meta_store (
+    key text primary key not null,
+    value text
+);

--- a/poc_iot_rewards/migrations/3_pending_txn.sql
+++ b/poc_iot_rewards/migrations/3_pending_txn.sql
@@ -1,0 +1,23 @@
+-- migrations/3_pending_txns.sql
+
+create type status AS enum (
+    'created',
+    'pending',
+    'cleared',
+    'failed'
+);
+
+create table pending_txn (
+    hash text primary key not null,
+    txn_bin bytea not null,
+    status status default 'created' not null,
+
+    submitted_at timestamptz,
+    completed_at timestamptz,
+
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create index pending_txn_created_idx on pending_txn (created_at);
+select trigger_updated_at('pending_txn');

--- a/poc_iot_rewards/pkg/deb/env-template
+++ b/poc_iot_rewards/pkg/deb/env-template
@@ -1,0 +1,7 @@
+RUST_LOG=info
+VERIFIER_BUCKET=examplenet-poc-verifier
+REWARDS_BUCKET=examplenet-poc-rewards
+DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/poc_iot_rewards_db
+METRICS_SCRAPE_ENDPOINT=127.0.0.1:19000
+FOLLOWER_URI=http://localhost:8080
+FOLLOWER_START_BLOCK=100

--- a/poc_iot_rewards/pkg/deb/poc-iot-rewards.service
+++ b/poc_iot_rewards/pkg/deb/poc-iot-rewards.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=poc-iot-rewards
+After=network.target
+StartLimitInterval=60
+StartLimitBurst=3
+
+[Service]
+Type=simple
+ExecStart=/opt/poc-iot-rewards/bin/poc-iot-rewards
+User=helium
+PIDFile=/var/run/poc-iot-rewards
+Restart=always
+RestartSec=15
+
+[Install]
+WantedBy=multi-user.target

--- a/poc_iot_rewards/pkg/deb/postinst
+++ b/poc_iot_rewards/pkg/deb/postinst
@@ -1,0 +1,4 @@
+# add to /usr/local/bin it appears in path
+ln -s /opt/poc-iot-rewards/bin/poc-iot-rewards /usr/local/bin/poc-iot-rewards || true
+
+#DEBHELPER#

--- a/poc_iot_rewards/pkg/deb/postrm
+++ b/poc_iot_rewards/pkg/deb/postrm
@@ -1,0 +1,3 @@
+rm -f /usr/local/bin/poc-iot-rewards
+
+#DEBHELPER#

--- a/poc_iot_rewards/pkg/deb/preinst
+++ b/poc_iot_rewards/pkg/deb/preinst
@@ -1,0 +1,4 @@
+# add system user for file ownership and systemd user, if not exists
+useradd --system --home-dir /opt/helium --create-home helium || true
+
+#DEBHELPER#

--- a/poc_iot_rewards/src/error.rs
+++ b/poc_iot_rewards/src/error.rs
@@ -1,0 +1,91 @@
+use thiserror::Error;
+
+pub type Result<T = ()> = std::result::Result<T, Error>;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("environment error")]
+    DotEnv(#[from] dotenv::Error),
+    #[error("sql error")]
+    Sql(#[from] sqlx::Error),
+    #[error("io error")]
+    Io(#[from] std::io::Error),
+    #[error("encode error")]
+    Encode(#[from] EncodeError),
+    #[error("decode error")]
+    Decode(#[from] DecodeError),
+    #[error("migration error")]
+    Migrate(#[from] sqlx::migrate::MigrateError),
+    #[error("service error")]
+    Service(#[from] helium_proto::services::Error),
+    #[error("grpc {}", .0.message())]
+    Grpc(#[from] tonic::Status),
+    #[error("crypto error")]
+    Crypto(#[from] helium_crypto::Error),
+    #[error("store error")]
+    Store(#[from] file_store::Error),
+    #[error("not found")]
+    NotFound(String),
+    #[error("env error")]
+    Env(#[from] std::env::VarError),
+    #[error("transaction error")]
+    TransactionError(String),
+    #[error("meta error")]
+    MetaError(#[from] db_store::MetaError),
+}
+
+#[derive(Debug, Error)]
+pub enum DecodeError {
+    #[error("prost error")]
+    Prost(#[from] helium_proto::DecodeError),
+    #[error("uri error")]
+    Uri(#[from] http::uri::InvalidUri),
+    #[error("parse int error")]
+    ParseInt(#[from] std::num::ParseIntError),
+    #[error("datetime error")]
+    Chrono(#[from] chrono::ParseError),
+    #[error("invalid decimals in {0}, only 8 allowed")]
+    Decimals(String),
+    #[error("base64 decode error")]
+    Base64(#[from] base64::DecodeError),
+}
+
+#[derive(Debug, Error)]
+pub enum EncodeError {
+    #[error("prost error")]
+    Prost(#[from] helium_proto::EncodeError),
+    #[error("json error")]
+    Json(#[from] serde_json::Error),
+}
+
+impl Error {
+    pub fn not_found<E: ToString>(msg: E) -> Self {
+        Self::NotFound(msg.to_string())
+    }
+}
+
+impl DecodeError {
+    pub fn decimals(value: &str) -> Self {
+        Self::Decimals(value.to_string())
+    }
+}
+
+macro_rules! from_err {
+    ($to_type:ty, $from_type:ty) => {
+        impl From<$from_type> for Error {
+            fn from(v: $from_type) -> Self {
+                Self::from(<$to_type>::from(v))
+            }
+        }
+    };
+}
+
+// Encode Errors
+from_err!(EncodeError, prost::EncodeError);
+from_err!(EncodeError, serde_json::Error);
+
+// Decode Errors
+from_err!(DecodeError, http::uri::InvalidUri);
+from_err!(DecodeError, prost::DecodeError);
+from_err!(DecodeError, chrono::ParseError);
+from_err!(DecodeError, base64::DecodeError);

--- a/poc_iot_rewards/src/iot.rs
+++ b/poc_iot_rewards/src/iot.rs
@@ -1,0 +1,112 @@
+use crate::{error::DecodeError, Error, Result};
+use core::fmt;
+use rust_decimal::prelude::*;
+use serde::{de::Deserializer, Deserialize, Serialize};
+use std::str::FromStr;
+
+macro_rules! decimal_scalar {
+    ($stype:ident, $scalar:literal, $scale:literal) => {
+        #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+        pub struct $stype(Decimal);
+
+        impl FromStr for $stype {
+            type Err = Error;
+
+            fn from_str(s: &str) -> Result<Self> {
+                match Decimal::from_str(s).or_else(|_| Decimal::from_scientific(s)) {
+                    Ok(data) if data.scale() > 8 => Err(DecodeError::decimals(s).into()),
+                    Ok(data) => Ok(Self(data)),
+                    Err(_) => Err(DecodeError::decimals(s).into()),
+                }
+            }
+        }
+
+        impl fmt::Display for $stype {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+
+        impl $stype {
+            pub fn new(d: Decimal) -> Self {
+                Self(d)
+            }
+
+            pub fn into_inner(self) -> Decimal {
+                self.0
+            }
+
+            pub fn deserialize<'de, D>(d: D) -> std::result::Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let val = u64::deserialize(d)?;
+                Ok(Self::from(val))
+            }
+
+            pub fn deserialize_option<'de, D>(d: D) -> std::result::Result<Option<Self>, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let v: Option<u64> = Option::deserialize(d)?;
+                if let Some(val) = v {
+                    Ok(Some(Self::from(val)))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+
+        impl From<u64> for $stype {
+            fn from(v: u64) -> Self {
+                if let Some(mut data) = Decimal::from_u64(v) {
+                    data.set_scale($scale).unwrap();
+                    return Self(data);
+                }
+                panic!("u64 could not be converted into Decimal")
+            }
+        }
+
+        impl From<Decimal> for $stype {
+            fn from(mut v: Decimal) -> Self {
+                // rescale the decimal back to 8 digits of precision
+                v.rescale(8);
+                Self(v)
+            }
+        }
+
+        impl From<$stype> for u64 {
+            fn from(v: $stype) -> Self {
+                if let Some(scaled_dec) = v.0.checked_mul($scalar.into()) {
+                    if let Some(num) = scaled_dec.to_u64() {
+                        return num;
+                    }
+                }
+                panic!("Invalid scaled decimal construction")
+            }
+        }
+
+        impl From<i32> for $stype {
+            fn from(v: i32) -> Self {
+                if let Some(mut data) = Decimal::from_i32(v) {
+                    data.set_scale($scale).unwrap();
+                    return Self(data);
+                }
+                panic!("i32 could not be converted info Decimal")
+            }
+        }
+
+        impl From<$stype> for i32 {
+            fn from(v: $stype) -> Self {
+                if let Some(scaled_dec) = v.0.checked_mul($scalar.into()) {
+                    if let Some(num) = scaled_dec.to_i32() {
+                        return num;
+                    }
+                }
+                panic!("Invalid scaled decimal construction")
+            }
+        }
+    };
+}
+
+decimal_scalar!(Iot, 100_000_000, 8);

--- a/poc_iot_rewards/src/keypair.rs
+++ b/poc_iot_rewards/src/keypair.rs
@@ -1,0 +1,17 @@
+use crate::Result;
+use std::{convert::TryFrom, fs, io, path};
+
+pub use helium_crypto::Keypair;
+
+pub fn load_from_file(path: &str) -> Result<Keypair> {
+    let data = fs::read(path)?;
+    Ok(helium_crypto::Keypair::try_from(&data[..])?)
+}
+
+pub fn save_to_file(keypair: &Keypair, path: &str) -> io::Result<()> {
+    if let Some(parent) = path::PathBuf::from(path).parent() {
+        fs::create_dir_all(parent)?;
+    };
+    fs::write(path, &keypair.to_vec())?;
+    Ok(())
+}

--- a/poc_iot_rewards/src/lib.rs
+++ b/poc_iot_rewards/src/lib.rs
@@ -1,0 +1,44 @@
+mod error;
+mod iot;
+mod pending_txn;
+mod token_type;
+mod traits;
+mod transaction;
+mod txn_status;
+
+pub mod keypair;
+pub mod server;
+
+pub use error::{Error, Result};
+pub use keypair::Keypair;
+pub use server::Server;
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+use sqlx::{postgres::PgPoolOptions, Pool, Postgres};
+use std::{env, path::Path};
+
+pub fn datetime_from_epoch(secs: i64) -> DateTime<Utc> {
+    DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(secs, 0), Utc)
+}
+
+pub fn write_json<T: ?Sized + serde::Serialize>(
+    fname_prefix: &str,
+    start_ts: u64,
+    end_ts: u64,
+    data: &T,
+) -> Result {
+    let tmp_output_dir = env::var("TMP_OUTPUT_DIR").unwrap_or_else(|_| "/tmp".to_string());
+    let fname = format!("{}-{}-{}.json", fname_prefix, start_ts, end_ts);
+    let fpath = Path::new(&tmp_output_dir).join(&fname);
+    std::fs::write(Path::new(&fpath), serde_json::to_string_pretty(data)?)?;
+    Ok(())
+}
+
+pub async fn mk_db_pool(size: u32) -> Result<Pool<Postgres>> {
+    let db_connection_str = std::env::var("DATABASE_URL")?;
+    let pool = PgPoolOptions::new()
+        .max_connections(size)
+        .connect(&db_connection_str)
+        .await?;
+    Ok(pool)
+}

--- a/poc_iot_rewards/src/pending_txn.rs
+++ b/poc_iot_rewards/src/pending_txn.rs
@@ -1,0 +1,188 @@
+use crate::{Error, Result};
+use chrono::{DateTime, Utc};
+use futures::TryFutureExt;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, sqlx::Type)]
+#[sqlx(type_name = "status", rename_all = "lowercase")]
+pub enum Status {
+    Created,
+    Pending,
+    Cleared,
+    Failed,
+}
+
+impl Status {
+    fn update_query(&self) -> &'static str {
+        match self {
+            Self::Created => {
+                r#"
+                update pending_txn set
+                status = $1
+                where hash = $2;
+                "#
+            }
+            Self::Pending => {
+                r#"
+                update pending_txn set
+                status = $1,
+                submitted_at = $3
+                where hash = $2;
+                "#
+            }
+            Self::Cleared | Self::Failed => {
+                r#"
+                update pending_txn set
+                status = $1,
+                completed_at = $3
+                where hash = $2;
+                "#
+            }
+        }
+    }
+
+    fn update_all_query(&self) -> &'static str {
+        match self {
+            Self::Created => {
+                r#"update pending_txn set
+                status = $1
+                where hash = any($2);"#
+            }
+            Self::Pending => {
+                r#"
+                update pending_txn set
+                status = $1,
+                submitted_at = $3
+                where hash = any($2);
+                "#
+            }
+            Self::Cleared | Self::Failed => {
+                r#"
+                update pending_txn set
+                status = $1,
+                completed_at = $3
+                where hash = any($2);
+                "#
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, sqlx::FromRow)]
+#[sqlx(type_name = "pending_txn")]
+pub struct PendingTxn {
+    pub hash: String,
+    pub txn_bin: Vec<u8>,
+    pub status: Status,
+
+    pub submitted_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+impl PendingTxn {
+    pub fn pending_key(&self) -> Result<Vec<u8>> {
+        self.created_at
+            .map(|ts| ts.timestamp_millis().to_be_bytes().to_vec())
+            .ok_or_else(|| Error::not_found("no created_at in pending txn for key"))
+    }
+
+    pub fn submitted_at(&self) -> Result<DateTime<Utc>> {
+        self.submitted_at
+            .ok_or_else(|| Error::not_found("no pending submitted_at present"))
+    }
+
+    pub fn created_at(&self) -> Result<DateTime<Utc>> {
+        self.created_at
+            .ok_or_else(|| Error::not_found("no pending created_at present"))
+    }
+
+    pub async fn insert_new<'c, E>(executor: E, hash: &str, txn_bin: Vec<u8>) -> Result<Self>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
+        let pt = PendingTxn {
+            hash: hash.to_string(),
+            txn_bin,
+            status: Status::Created,
+
+            created_at: None,
+            updated_at: None,
+
+            submitted_at: None,
+            completed_at: None,
+        };
+        pt.insert_into(executor).await
+    }
+
+    pub async fn insert_into<'c, E>(&self, executor: E) -> Result<Self>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
+        sqlx::query_as::<_, Self>(
+            r#"
+            insert into pending_txn (hash, txn_bin)
+            values ($1, $2)
+            on conflict (hash) do nothing
+            returning *;
+            "#,
+        )
+        .bind(&self.hash)
+        .bind(&self.txn_bin)
+        .fetch_one(executor)
+        .map_err(Error::from)
+        .await
+    }
+
+    pub async fn update<'c, E, T>(executor: E, hash: &str, status: Status, timestamp: T) -> Result
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+        T: Into<DateTime<Utc>>,
+    {
+        sqlx::query(status.update_query())
+            .bind(status)
+            .bind(hash)
+            .bind(timestamp.into())
+            .execute(executor)
+            .map_ok(|_| ())
+            .map_err(Error::from)
+            .await
+    }
+
+    pub async fn update_all<'c, E, T>(
+        executor: E,
+        hashes: Vec<String>,
+        status: Status,
+        timestamp: T,
+    ) -> Result
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+        T: Into<DateTime<Utc>>,
+    {
+        sqlx::query(status.update_all_query())
+            .bind(status)
+            .bind(hashes)
+            .bind(timestamp.into())
+            .execute(executor)
+            .map_ok(|_| ())
+            .map_err(Error::from)
+            .await
+    }
+
+    pub async fn list<'c, E>(executor: E, status: Status) -> Result<Vec<Self>>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
+        sqlx::query_as::<_, PendingTxn>(
+            r#"
+            select * from pending_txn where status = $1;
+            "#,
+        )
+        .bind(status)
+        .fetch_all(executor)
+        .map_err(Error::from)
+        .await
+    }
+}

--- a/poc_iot_rewards/src/server.rs
+++ b/poc_iot_rewards/src/server.rs
@@ -1,0 +1,452 @@
+use crate::{
+    datetime_from_epoch,
+    error::DecodeError,
+    keypair::Keypair,
+    pending_txn::{PendingTxn, Status},
+    traits::{TxnHash, TxnSign, B64},
+    transaction::TransactionService,
+    txn_status::TxnStatus,
+    Error, Result,
+};
+use chrono::{DateTime, Duration, Utc};
+use db_store::MetaValue;
+use file_store::FileStore;
+use helium_proto::{
+    blockchain_txn::Txn,
+    services::{
+        follower::{
+            self, FollowerSubnetworkLastRewardHeightReqV1, FollowerTxnStreamReqV1,
+            FollowerTxnStreamRespV1,
+        },
+        transaction::{TxnQueryRespV1, TxnStatus as TxnStatusProto},
+        Channel, Endpoint,
+    },
+    BlockchainTokenTypeV1, BlockchainTxn, BlockchainTxnSubnetworkRewardsV1, Message,
+    SubnetworkReward,
+};
+use http::Uri;
+use poc_metrics::record_duration;
+use sqlx::{Pool, Postgres};
+use std::{env, ops::Range, time::Duration as StdDuration};
+use tokio::time;
+use tonic::Streaming;
+
+const DEFAULT_START_REWARD_BLOCK: i64 = 1_500_000;
+const DEFAULT_REWARD_INTERVAL_SECS: i64 = 1800; // 30 min
+const RECONNECT_WAIT_SECS: i64 = 5;
+const DEFAULT_TRIGGER_INTERVAL_SECS: i64 = 900; // 15 min
+const STALE_PENDING_TIMEOUT_SECS: i64 = 1800; // 30 min
+const DEFAULT_LOOKUP_DELAY_SECS: i64 = 1800; // 30 min
+const CONNECT_TIMEOUT: StdDuration = StdDuration::from_secs(5);
+const RPC_TIMEOUT: StdDuration = StdDuration::from_secs(5);
+const DEFAULT_URI: &str = "http://0.0.0.0:8080";
+
+const TXN_TYPES: &[&str] = &["blockchain_txn_subnetwork_rewards_v1"];
+
+pub struct Server {
+    keypair: Keypair,
+    follower_client: follower::Client<Channel>,
+    pool: Pool<Postgres>,
+    reward_interval: Duration,
+    start_reward_block: i64,
+    trigger_interval: Duration,
+    txn_service: TransactionService,
+    verifier_store: FileStore,
+}
+
+impl Server {
+    pub async fn new(pool: Pool<Postgres>, keypair: Keypair) -> Result<Self> {
+        let result = Self {
+            pool,
+            keypair,
+            follower_client: new_follower_from_env()?,
+            reward_interval: Duration::seconds(
+                env::var("REWARD_INTERVAL")
+                    .unwrap_or_else(|_| DEFAULT_REWARD_INTERVAL_SECS.to_string())
+                    .parse()
+                    .map_err(DecodeError::from)?,
+            ),
+            start_reward_block: env::var("FOLLOWER_START_BLOCK")
+                .unwrap_or_else(|_| DEFAULT_START_REWARD_BLOCK.to_string())
+                .parse()
+                .map_err(DecodeError::from)?,
+            trigger_interval: Duration::seconds(
+                env::var("TRIGGER_INTERVAL")
+                    .unwrap_or_else(|_| DEFAULT_TRIGGER_INTERVAL_SECS.to_string())
+                    .parse()
+                    .map_err(DecodeError::from)?,
+            ),
+            txn_service: TransactionService::from_env()?,
+            verifier_store: FileStore::from_env().await?,
+        };
+        Ok(result)
+    }
+
+    pub async fn run(&mut self, shutdown: triggered::Listener) -> Result {
+        tracing::info!("starting iot-reward server");
+
+        // Handle any rewards created but not submitted on a previous run
+        self.process_prior_created_txns().await?;
+
+        loop {
+            if shutdown.is_triggered() {
+                tracing::info!("stopping iot-reward server");
+                return Ok(());
+            }
+
+            let follow_start =
+                *MetaValue::<i64>::fetch_or_insert_with(&self.pool, "last_follower_height", || {
+                    self.start_reward_block
+                })
+                .await?
+                .value() as u64;
+
+            tracing::info!("connecting to blockchain txn stream at height {follow_start}");
+            tokio::select! {
+                _ = shutdown.clone() => (),
+                stream_result = txn_stream(&mut self.follower_client, follow_start, &[], TXN_TYPES) => match stream_result {
+                    Ok(txn_stream) => {
+                        tracing::info!("connected to txn stream");
+                        self.run_with_txn_stream(txn_stream, shutdown.clone()).await?
+                    }
+                    Err(err) => {
+                        tracing::warn!("failed to connect to txn stream: {err}");
+                        self.reconnect_wait(shutdown.clone()).await
+                    }
+                }
+            }
+        }
+    }
+
+    async fn reconnect_wait(&mut self, shutdown: triggered::Listener) {
+        let timer = time::sleep(
+            Duration::seconds(RECONNECT_WAIT_SECS)
+                .to_std()
+                .expect("valid interval in seconds"),
+        );
+        tokio::select! {
+            _ = timer => (),
+            _ = shutdown => (),
+        }
+    }
+
+    async fn run_with_txn_stream(
+        &mut self,
+        mut txn_stream: Streaming<FollowerTxnStreamRespV1>,
+        shutdown: triggered::Listener,
+    ) -> Result {
+        let mut trigger_timer = time::interval(
+            self.trigger_interval
+                .to_std()
+                .expect("valid interval in seconds"),
+        );
+
+        loop {
+            tokio::select! {
+                msg = txn_stream.message() => match msg {
+                    Ok(Some(txn)) => {
+                        tracing::info!("txn received from stream");
+                        self.process_txn_entry(txn).await?
+                    }
+                    Ok(None) => {
+                        tracing::warn!("txn stream disconnected");
+                        return Ok(());
+                    }
+                    Err(err) => {
+                        metrics::increment_counter!("reward_server_txn_stream_error_count");
+                        tracing::warn!("txn stream error {err:?}");
+                        return Ok(());
+                    }
+                },
+                _ = trigger_timer.tick() => {
+                    self.process_clock_tick().await?
+                },
+                _ = shutdown.clone() => return Ok(())
+            }
+        }
+    }
+
+    async fn process_txn_entry(&mut self, entry: FollowerTxnStreamRespV1) -> Result {
+        let txn = match entry.txn {
+            Some(BlockchainTxn { txn: Some(ref txn) }) => txn,
+            _ => {
+                tracing::warn!("ignoring missing txn in stream");
+                return Ok(());
+            }
+        };
+        match txn {
+            Txn::SubnetworkRewards(txn) => self.process_subnet_rewards(&entry, txn).await,
+            _ => Ok(()),
+        }
+    }
+
+    async fn process_subnet_rewards(
+        &mut self,
+        envelope: &FollowerTxnStreamRespV1,
+        txn: &BlockchainTxnSubnetworkRewardsV1,
+    ) -> Result {
+        if txn.token_type() != BlockchainTokenTypeV1::Iot {
+            return Ok(());
+        }
+
+        let txn_hash = &envelope.txn_hash.to_b64_url()?;
+        let txn_ts = envelope.timestamp;
+        PendingTxn::update(
+            &self.pool,
+            txn_hash,
+            Status::Cleared,
+            datetime_from_epoch(txn_ts as i64),
+        )
+        .await
+    }
+
+    async fn process_clock_tick(&mut self) -> Result {
+        let now = Utc::now();
+        let reward_period = reward_period(&mut self.follower_client).await?;
+        let current_height = reward_period.end;
+        tracing::info!(
+            "processing clock tick at height {} with time {}",
+            current_height,
+            now.to_string()
+        );
+
+        update_last_follower_height(&self.pool, current_height).await?;
+
+        // Early exit if we found failed pending txns
+        match self.check_pending().await {
+            Ok(_) => {
+                tracing::info!("no failed pending transactions");
+            }
+            Err(err) => {
+                tracing::error!("pending transactions check failed with error: {err:?}");
+                return Err(err);
+            }
+        }
+
+        let last_reward_time =
+            MetaValue::<i64>::fetch_or_insert_with(&self.pool, "last_reward_end_time", || {
+                let starting_ts = now.timestamp();
+                tracing::info!(
+                    "no last_reward_end_time found, inserting current timestamp {starting_ts}"
+                );
+                starting_ts
+            })
+            .await?;
+
+        tracing::info!(
+            "found last_reward_end_time: {:#?}",
+            *last_reward_time.value()
+        );
+
+        let (start_utc, end_utc) = get_time_range(*last_reward_time.value());
+        if end_utc - start_utc > self.reward_interval {
+            // Handle rewards if we've passed our duration
+            record_duration!(
+                "reward_server_emission_duration",
+                self.handle_rewards(reward_period, last_reward_time, start_utc..end_utc)
+                    .await?
+            )
+        }
+        Ok(())
+    }
+
+    async fn check_pending(&mut self) -> Result {
+        let pending_txns = PendingTxn::list(&self.pool, Status::Pending).await?;
+        let mut failed_hashes: Vec<String> = Vec::new();
+        for txn in pending_txns {
+            let submitted_at = txn.submitted_at()?;
+            let created_at = txn.created_at()?;
+            let txn_key = txn.pending_key()?;
+            match self.txn_service.query(&txn_key).await {
+                Ok(TxnQueryRespV1 { status, .. }) => {
+                    if TxnStatus::try_from(status)? == TxnStatus::from(TxnStatusProto::NotFound)
+                        && (Utc::now() - submitted_at)
+                            > Duration::seconds(STALE_PENDING_TIMEOUT_SECS)
+                    {
+                        failed_hashes.push(txn.hash)
+                    }
+                }
+                Err(_) => {
+                    tracing::error!("failed to retrieve txn {created_at} status")
+                }
+            }
+        }
+        if !failed_hashes.is_empty() {
+            PendingTxn::update_all(&self.pool, failed_hashes, Status::Failed, Utc::now()).await?
+        }
+        let failed_pending_txns = PendingTxn::list(&self.pool, Status::Failed).await?;
+        if !failed_pending_txns.is_empty() {
+            tracing::error!("found failed_pending_txns {:#?}", failed_pending_txns);
+            return Err(Error::TransactionError(
+                "failed txns in pending".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn handle_rewards(
+        &mut self,
+        reward_period: Range<u64>,
+        mut last_reward_end_time: MetaValue<i64>,
+        time_range: Range<DateTime<Utc>>,
+    ) -> Result {
+        tracing::info!("triggering rewards emission");
+
+        // Grab the appropriate files from the verifier store for iot
+
+        let rewards = vec![];
+
+        // Iterate over the results coming from the store and construct txn based on the rewardable shares computed per owner
+
+        if !rewards.is_empty() {
+            let pool = self.pool.clone();
+
+            // Submit the rewards txn
+            self.issue_rewards(rewards, reward_period).await?;
+
+            // Update the meta record for a successful submission
+            last_reward_end_time
+                .update(&pool, time_range.end.timestamp())
+                .await?;
+        } else {
+            tracing::error!("cannot continue; unable to determine reward period!");
+            return Err(Error::NotFound("invalid reward period".to_string()));
+        }
+        Ok(())
+    }
+
+    async fn issue_rewards(
+        &mut self,
+        rewards: Vec<SubnetworkReward>,
+        reward_period: Range<u64>,
+    ) -> Result {
+        if rewards.is_empty() {
+            tracing::info!("nothing to reward");
+            return Ok(());
+        }
+
+        let (txn, txn_hash_str) = construct_txn(&self.keypair, rewards, reward_period)?;
+
+        // binary encode txn for storage
+        let txn_encoded = txn.encode_to_vec();
+
+        // insert in the pending_txn tbl (status: created)
+        let pt = PendingTxn::insert_new(&self.pool, &txn_hash_str, txn_encoded).await?;
+        tracing::info!("inserted pending_txn with hash: {txn_hash_str}");
+
+        // submit the txn
+        if let Ok(_resp) = self
+            .txn_service
+            .submit(
+                BlockchainTxn {
+                    txn: Some(Txn::SubnetworkRewards(txn)),
+                },
+                &pt.pending_key()?,
+            )
+            .await
+        {
+            metrics::increment_counter!("reward_server_emission");
+            PendingTxn::update(&self.pool, &txn_hash_str, Status::Pending, Utc::now()).await?;
+        }
+        Ok(())
+    }
+
+    async fn process_prior_created_txns(&mut self) -> Result {
+        tracing::info!("processing any unsubmitted reward txns from previous run");
+
+        let created_txns = PendingTxn::list(&self.pool, Status::Created).await?;
+        if !created_txns.is_empty() {
+            for pending_txn in created_txns {
+                let txn = Message::decode(pending_txn.txn_bin.as_ref())?;
+                if let Ok(_resp) = self
+                    .txn_service
+                    .submit(
+                        BlockchainTxn {
+                            txn: Some(Txn::SubnetworkRewards(txn)),
+                        },
+                        &pending_txn.pending_key()?,
+                    )
+                    .await
+                {
+                    PendingTxn::update(&self.pool, &pending_txn.hash, Status::Pending, Utc::now())
+                        .await?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn update_last_follower_height(pool: &Pool<Postgres>, last_height: u64) -> Result {
+    metrics::gauge!("reward_server_last_reward_height", last_height as f64);
+    MetaValue::new("last_follower_height", last_height)
+        .insert(pool)
+        .await?;
+    Ok(())
+}
+
+fn new_follower_from_env() -> Result<follower::Client<Channel>> {
+    let uri: Uri = env::var("FOLLOWER_URI")
+        .unwrap_or_else(|_| DEFAULT_URI.to_string())
+        .parse()?;
+    let channel = Endpoint::from(uri)
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(RPC_TIMEOUT)
+        .connect_lazy();
+    Ok(follower::Client::new(channel))
+}
+
+async fn txn_stream<T>(
+    client: &mut follower::Client<Channel>,
+    height: u64,
+    txn_hash: &[u8],
+    txn_types: &[T],
+) -> Result<Streaming<FollowerTxnStreamRespV1>>
+where
+    T: ToString,
+{
+    let req = FollowerTxnStreamReqV1 {
+        height,
+        txn_hash: txn_hash.to_vec(),
+        txn_types: txn_types.iter().map(|e| e.to_string()).collect(),
+    };
+    let res = client.txn_stream(req).await?.into_inner();
+    Ok(res)
+}
+
+async fn reward_period(client: &mut follower::Client<Channel>) -> Result<Range<u64>> {
+    let req = FollowerSubnetworkLastRewardHeightReqV1 {
+        token_type: BlockchainTokenTypeV1::Iot.into(),
+    };
+    let res = client
+        .subnetwork_last_reward_height(req)
+        .await?
+        .into_inner();
+
+    Ok(res.reward_height + 1..res.height)
+}
+
+fn get_time_range(last_reward_end_time: i64) -> (DateTime<Utc>, DateTime<Utc>) {
+    let after_utc = datetime_from_epoch(last_reward_end_time);
+    let now = Utc::now();
+    let stop_utc = now - Duration::seconds(DEFAULT_LOOKUP_DELAY_SECS);
+    let start_utc = after_utc.min(stop_utc);
+    (start_utc, stop_utc)
+}
+
+fn construct_txn(
+    keypair: &Keypair,
+    rewards: Vec<SubnetworkReward>,
+    period: Range<u64>,
+) -> Result<(BlockchainTxnSubnetworkRewardsV1, String)> {
+    let mut txn = BlockchainTxnSubnetworkRewardsV1 {
+        rewards,
+        token_type: BlockchainTokenTypeV1::Iot.into(),
+        start_epoch: period.start,
+        end_epoch: period.end,
+        reward_server_signature: vec![],
+    };
+    txn.reward_server_signature = txn.sign(keypair)?;
+    let hash_str = txn.hash().and_then(|hash| hash.to_b64_url())?;
+    Ok((txn, hash_str))
+}

--- a/poc_iot_rewards/src/token_type.rs
+++ b/poc_iot_rewards/src/token_type.rs
@@ -1,0 +1,34 @@
+use crate::{Error, Result};
+use helium_proto::BlockchainTokenTypeV1 as TokenTypeProto;
+use std::fmt::Display;
+
+#[derive(Clone, Debug)]
+pub struct BlockchainTokenTypeV1(pub TokenTypeProto);
+
+impl From<TokenTypeProto> for BlockchainTokenTypeV1 {
+    fn from(tt: TokenTypeProto) -> Self {
+        Self(tt)
+    }
+}
+
+impl Display for BlockchainTokenTypeV1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0.as_str_name())
+    }
+}
+
+impl TryFrom<i32> for BlockchainTokenTypeV1 {
+    type Error = Error;
+    fn try_from(value: i32) -> Result<Self> {
+        match TokenTypeProto::from_i32(value) {
+            Some(v) => Ok(Self::from(v)),
+            None => Err(Error::NotFound(format!("unknown value {value}"))),
+        }
+    }
+}
+
+impl From<BlockchainTokenTypeV1> for i32 {
+    fn from(tt: BlockchainTokenTypeV1) -> i32 {
+        tt.0 as i32
+    }
+}

--- a/poc_iot_rewards/src/traits/b64.rs
+++ b/poc_iot_rewards/src/traits/b64.rs
@@ -1,0 +1,54 @@
+use crate::Result;
+
+pub trait B64 {
+    fn to_b64(&self) -> Result<String> {
+        self.to_b64_config(base64::STANDARD)
+    }
+
+    fn to_b64_url(&self) -> Result<String> {
+        self.to_b64_config(base64::URL_SAFE_NO_PAD)
+    }
+
+    fn from_b64(str: &str) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Self::from_b64_config(str, base64::STANDARD)
+    }
+
+    fn from_b64_url(str: &str) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Self::from_b64_config(str, base64::URL_SAFE_NO_PAD)
+    }
+
+    fn to_b64_config(&self, config: base64::Config) -> Result<String>;
+    fn from_b64_config(str: &str, config: base64::Config) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+}
+
+impl B64 for Vec<u8> {
+    fn to_b64_config(&self, config: base64::Config) -> Result<String> {
+        Ok(base64::encode_config(self, config))
+    }
+
+    fn from_b64_config(b64: &str, config: base64::Config) -> Result<Self> {
+        let decoded = base64::decode_config(b64, config)?;
+        Ok(decoded)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let known_b64_enc: &str = "QslzojktHlbSuMF3FEpAW0nuIhgxhm_PUjE4QXo_x9A";
+        let raw = Vec::from_b64_url(known_b64_enc).expect("decoded raw string");
+        let b64 = raw.to_b64_url().expect("re-encoded b64");
+        assert_eq!(b64, known_b64_enc);
+    }
+}

--- a/poc_iot_rewards/src/traits/mod.rs
+++ b/poc_iot_rewards/src/traits/mod.rs
@@ -1,0 +1,7 @@
+pub mod b64;
+pub mod txn_hash;
+pub mod txn_sign;
+
+pub use b64::B64;
+pub use txn_hash::TxnHash;
+pub use txn_sign::TxnSign;

--- a/poc_iot_rewards/src/traits/txn_hash.rs
+++ b/poc_iot_rewards/src/traits/txn_hash.rs
@@ -1,0 +1,23 @@
+use crate::Result;
+use helium_proto::{BlockchainTxnSubnetworkRewardsV1, Message};
+use sha2::{Digest, Sha256};
+
+pub trait TxnHash: Message + std::clone::Clone {
+    fn hash(&self) -> Result<Vec<u8>>
+    where
+        Self: std::marker::Sized;
+}
+
+macro_rules! impl_hash {
+    ($txn_type:ty, $( $sig: ident ),+ ) => {
+        impl TxnHash for $txn_type {
+            fn hash(&self) -> Result<Vec<u8>> {
+                let mut txn = self.clone();
+                $(txn.$sig = vec![];)+
+                Ok(Sha256::digest(&txn.encode_to_vec()).to_vec())
+            }
+        }
+    }
+}
+
+impl_hash!(BlockchainTxnSubnetworkRewardsV1, reward_server_signature);

--- a/poc_iot_rewards/src/traits/txn_sign.rs
+++ b/poc_iot_rewards/src/traits/txn_sign.rs
@@ -1,0 +1,30 @@
+use crate::{Error, Keypair, Result};
+use helium_crypto::{PublicKey, Sign, Verify};
+use helium_proto::{BlockchainTxnSubnetworkRewardsV1, Message};
+
+pub trait TxnSign: Message + std::clone::Clone {
+    fn sign(&self, keypair: &Keypair) -> Result<Vec<u8>>
+    where
+        Self: std::marker::Sized;
+    fn verify(&self, pubkey: &PublicKey, signature: &[u8]) -> Result;
+}
+
+macro_rules! impl_sign {
+    ($txn_type:ty, $( $sig: ident ),+ ) => {
+        impl TxnSign for $txn_type {
+            fn sign(&self, keypair: &Keypair) -> Result<Vec<u8>> {
+                let mut txn = self.clone();
+                $(txn.$sig = vec![];)+
+                keypair.sign(&txn.encode_to_vec()).map_err(Error::from)
+            }
+
+            fn verify(&self, pubkey: &PublicKey, signature: &[u8]) -> Result {
+                let mut txn = self.clone();
+                $(txn.$sig = vec![];)+
+                pubkey.verify(&txn.encode_to_vec(), &signature).map_err(|err| err.into())
+            }
+        }
+    }
+}
+
+impl_sign!(BlockchainTxnSubnetworkRewardsV1, reward_server_signature);

--- a/poc_iot_rewards/src/transaction.rs
+++ b/poc_iot_rewards/src/transaction.rs
@@ -1,0 +1,55 @@
+use crate::Result;
+use helium_proto::{
+    services::{
+        transaction::{self, TxnQueryReqV1, TxnQueryRespV1, TxnSubmitReqV1, TxnSubmitRespV1},
+        Channel, Endpoint,
+    },
+    BlockchainTxn,
+};
+use http::Uri;
+use std::{env, time::Duration};
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const RPC_TIMEOUT: Duration = Duration::from_secs(5);
+pub const DEFAULT_URI: &str = "http://0.0.0.0:8080";
+
+type TransactionClient = transaction::Client<Channel>;
+
+#[derive(Clone, Debug)]
+pub struct TransactionService {
+    client: TransactionClient,
+}
+
+impl TransactionService {
+    pub fn from_env() -> Result<Self> {
+        let uri: Uri = env::var("TRANSACTION_URI")
+            .unwrap_or_else(|_| DEFAULT_URI.to_string())
+            .parse()?;
+        Self::new(uri)
+    }
+
+    pub fn new(uri: Uri) -> Result<Self> {
+        let channel = Endpoint::from(uri)
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(RPC_TIMEOUT)
+            .connect_lazy();
+        Ok(Self {
+            client: TransactionClient::new(channel),
+        })
+    }
+
+    pub async fn submit(&mut self, txn: BlockchainTxn, key: &[u8]) -> Result<TxnSubmitRespV1> {
+        let req = TxnSubmitReqV1 {
+            txn: Some(txn),
+            key: key.to_vec(),
+        };
+        let res = self.client.submit(req).await?.into_inner();
+        Ok(res)
+    }
+
+    pub async fn query(&mut self, key: &[u8]) -> Result<TxnQueryRespV1> {
+        let req = TxnQueryReqV1 { key: key.to_vec() };
+        let res = self.client.query(req).await?.into_inner();
+        Ok(res)
+    }
+}

--- a/poc_iot_rewards/src/txn_status.rs
+++ b/poc_iot_rewards/src/txn_status.rs
@@ -1,0 +1,34 @@
+use crate::{Error, Result};
+use helium_proto::services::transaction::TxnStatus as TxnStatusProto;
+use std::fmt::Display;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TxnStatus(pub TxnStatusProto);
+
+impl From<TxnStatusProto> for TxnStatus {
+    fn from(status: TxnStatusProto) -> Self {
+        Self(status)
+    }
+}
+
+impl Display for TxnStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0.as_str_name())
+    }
+}
+
+impl TryFrom<i32> for TxnStatus {
+    type Error = Error;
+    fn try_from(value: i32) -> Result<Self> {
+        match TxnStatusProto::from_i32(value) {
+            Some(v) => Ok(Self::from(v)),
+            None => Err(Error::NotFound(format!("unknown value {value}"))),
+        }
+    }
+}
+
+impl From<TxnStatus> for i32 {
+    fn from(status: TxnStatus) -> i32 {
+        status.0 as i32
+    }
+}


### PR DESCRIPTION
Implements the basic framework for a rewards emission server for helium iot network. 

The server.rs module needs only to have the logic of handling reward shares reports from the iot verifier to prepare rewards transactions to submit to the destination chain. 