### PR TITLE
Instrument IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,6 +931,8 @@ dependencies = [
 name = "db-store"
 version = "0.1.0"
 dependencies = [
+ "metrics",
+ "poc-metrics",
  "sqlx",
  "thiserror",
 ]
@@ -1137,11 +1139,13 @@ dependencies = [
  "hex-literal",
  "http",
  "lazy_static",
+ "metrics",
+ "poc-metrics",
  "prost",
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "strum",
  "strum_macros",
  "tempfile",
@@ -2405,7 +2409,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "sqlx",
  "thiserror",
  "tokio",
@@ -2454,7 +2458,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "sqlx",
  "thiserror",
  "tokio",

--- a/db_store/Cargo.toml
+++ b/db_store/Cargo.toml
@@ -7,5 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+metrics = {workspace = true }
+poc-metrics = { path = "../metrics" }
 thiserror = {workspace = true}
 sqlx = {workspace = true}

--- a/entropy/src/entropy_generator.rs
+++ b/entropy/src/entropy_generator.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Result};
 use chrono::Utc;
-use file_store::file_sink;
+use file_store::{file_sink, file_sink_write};
 use futures::TryFutureExt;
 use helium_proto::EntropyReportV1;
 use jsonrpsee::{
@@ -152,7 +152,12 @@ impl EntropyGenerator {
             entropy.to_string(),
             entropy.timestamp
         );
-        file_sink::write(file_sink, EntropyReportV1::from(entropy)).await?;
+        file_sink_write!(
+            "report_submission",
+            file_sink,
+            EntropyReportV1::from(entropy)
+        )
+        .await?;
         Ok(())
     }
 

--- a/entropy/src/server.rs
+++ b/entropy/src/server.rs
@@ -33,6 +33,7 @@ impl ApiServer {
             .route("/health", get(empty_handler))
             // entropy
             .route("/entropy", get(get_entropy))
+            .layer(poc_metrics::request_layer!("entropy_request"))
             .layer(TraceLayer::new_for_http())
             .layer(Extension(entropy_watch));
 

--- a/file_store/Cargo.toml
+++ b/file_store/Cargo.toml
@@ -34,6 +34,8 @@ aws-sdk-s3 = "0"
 strum = {version = "0", features = ["derive"]}
 strum_macros = "0"
 sha2 = {workspace = true}
+metrics = {workspace = true }
+poc-metrics = { path = "../metrics" }
 
 [dev-dependencies]
 base64 = "0"

--- a/file_store/src/file_store.rs
+++ b/file_store/src/file_store.rs
@@ -124,26 +124,32 @@ impl FileStore {
         let byte_stream = ByteStream::from_path(&file)
             .await
             .map_err(|_| Error::not_found(format!("could not open {}", file.display())))?;
-        self.client
-            .put_object()
-            .bucket(&self.bucket)
-            .key(file.file_name().map(|name| name.to_string_lossy()).unwrap())
-            .body(byte_stream)
-            .send()
-            .map_ok(|_| ())
-            .map_err(Error::s3_error)
-            .await
+        poc_metrics::record_duration!(
+            "file_store_put_duration",
+            self.client
+                .put_object()
+                .bucket(&self.bucket)
+                .key(file.file_name().map(|name| name.to_string_lossy()).unwrap())
+                .body(byte_stream)
+                .send()
+                .map_ok(|_| ())
+                .map_err(Error::s3_error)
+                .await
+        )
     }
 
     pub async fn remove(&self, key: &str) -> Result {
-        self.client
-            .delete_object()
-            .bucket(&self.bucket)
-            .key(key)
-            .send()
-            .map_ok(|_| ())
-            .map_err(Error::s3_error)
-            .await
+        poc_metrics::record_duration!(
+            "file_store_remove_duration",
+            self.client
+                .delete_object()
+                .bucket(&self.bucket)
+                .key(key)
+                .send()
+                .map_ok(|_| ())
+                .map_err(Error::s3_error)
+                .await
+        )
     }
 
     pub async fn get<K>(&self, key: K) -> Result<ByteStream>

--- a/poc_iot_verifier/src/purger.rs
+++ b/poc_iot_verifier/src/purger.rs
@@ -1,8 +1,9 @@
 use crate::{entropy::Entropy, mk_db_pool, poc_report::Report, Result};
 use file_store::{
-    file_sink, file_sink::MessageSender, file_upload, lora_beacon_report::LoraBeaconIngestReport,
-    lora_invalid_poc::LoraInvalidBeaconReport, lora_invalid_poc::LoraInvalidWitnessReport,
-    lora_witness_report::LoraWitnessIngestReport, FileType,
+    file_sink, file_sink::MessageSender, file_sink_write, file_upload,
+    lora_beacon_report::LoraBeaconIngestReport, lora_invalid_poc::LoraInvalidBeaconReport,
+    lora_invalid_poc::LoraInvalidWitnessReport, lora_witness_report::LoraWitnessIngestReport,
+    FileType,
 };
 use helium_proto::services::poc_lora::{
     InvalidParticipantSide, InvalidReason, LoraBeaconIngestReportV1, LoraInvalidBeaconReportV1,
@@ -162,7 +163,12 @@ impl Purger {
             report: beacon.clone(),
         }
         .into();
-        file_sink::write(lora_invalid_beacon_tx, invalid_beacon_proto).await?;
+        file_sink_write!(
+            "invalid_beacon",
+            lora_invalid_beacon_tx,
+            invalid_beacon_proto
+        )
+        .await?;
         // delete the report from the DB
         let public_key = beacon_report.report.pub_key.to_vec();
         self.delete_db_report(public_key, packet_data.clone()).await;
@@ -187,7 +193,12 @@ impl Purger {
             participant_side: InvalidParticipantSide::Witness,
         }
         .into();
-        file_sink::write(lora_invalid_witness_tx, invalid_witness_report_proto).await?;
+        file_sink_write!(
+            "invalid_witness_report",
+            lora_invalid_witness_tx,
+            invalid_witness_report_proto
+        )
+        .await?;
 
         // delete the report from the DB
         self.delete_db_report(public_key, packet_data.clone()).await;

--- a/poc_mobile_verifier/src/heartbeats.rs
+++ b/poc_mobile_verifier/src/heartbeats.rs
@@ -3,7 +3,7 @@
 use crate::{cell_type::CellType, Error, Result};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use file_store::{
-    file_sink,
+    file_sink, file_sink_write,
     heartbeat::{CellHeartbeat, CellHeartbeatIngestReport},
     traits::MsgDecode,
     FileStore, FileType,
@@ -169,7 +169,8 @@ impl Heartbeat {
 
     pub async fn write(&self, heartbeats_tx: &file_sink::MessageSender) -> file_store::Result {
         let cell_type = CellType::from_cbsd_id(&self.cbsd_id).unwrap_or(CellType::Nova436H) as i32;
-        file_sink::write(
+        file_sink_write!(
+            "heartbeat",
             heartbeats_tx,
             proto::Heartbeat {
                 cbsd_id: self.cbsd_id.clone(),
@@ -178,7 +179,7 @@ impl Heartbeat {
                 cell_type,
                 validity: self.validity as i32,
                 timestamp: self.timestamp.timestamp() as u64,
-            },
+            }
         )
         .await?;
         Ok(())

--- a/poc_mobile_verifier/src/speedtests.rs
+++ b/poc_mobile_verifier/src/speedtests.rs
@@ -1,7 +1,7 @@
 use crate::{Error, Result};
 use chrono::{DateTime, Duration, NaiveDateTime, Utc};
 use file_store::{
-    file_sink,
+    file_sink, file_sink_write,
     speedtest::{CellSpeedtest, CellSpeedtestIngestReport},
     traits::{MsgDecode, TimestampEncode},
     FileStore, FileType,
@@ -100,7 +100,8 @@ impl SpeedtestRollingAverage {
             latency_avg_ms,
             ..
         } = average;
-        file_sink::write(
+        file_sink_write!(
+            "speedtest_average",
             averages_tx,
             proto::SpeedtestAvg {
                 pub_key: self.id.to_vec(),
@@ -120,7 +121,7 @@ impl SpeedtestRollingAverage {
                     .collect(),
                 validity,
                 reward_multiplier,
-            },
+            }
         )
         .await?;
 

--- a/poc_mobile_verifier/src/subnetwork_rewards.rs
+++ b/poc_mobile_verifier/src/subnetwork_rewards.rs
@@ -5,7 +5,7 @@ use crate::{
     speedtests::SpeedtestAverages,
 };
 use chrono::{DateTime, Utc};
-use file_store::file_sink;
+use file_store::{file_sink, file_sink_write};
 use helium_crypto::PublicKey;
 use rust_decimal::Decimal;
 use std::collections::HashMap;
@@ -69,13 +69,14 @@ impl SubnetworkRewards {
         self,
         subnet_rewards_tx: &file_sink::MessageSender,
     ) -> file_store::Result<oneshot::Receiver<file_store::Result>> {
-        file_sink::write(
+        file_sink_write!(
+            "subnet_rewards",
             subnet_rewards_tx,
             proto::SubnetworkRewards {
                 start_epoch: self.epoch.start.timestamp() as u64,
                 end_epoch: self.epoch.end.timestamp() as u64,
                 rewards: self.rewards,
-            },
+            }
         )
         .await
     }


### PR DESCRIPTION
Summary:
1. instruments:
- `file_store::file_store::{put, remove}` to:
  - __time__ writes to AWS (reads timing is less clear, since it returns a stream)
- `file_store::file_sink::write` to:
  - __count__ all successes and failures
- `db_store::{insert, fetch_or_insert_with, update}` to:
  - __count__ all successes and failures
  - __time__ execution durations
2. updates all affected call sites with the newly-required static tag
3. extends `poc_metrics::ActiveRequests` layer to also __time__ request handling durations (renaming it to simply `poc_metrics::Requests`) in addition to __counting__ currently active connections that it was already doing
4. updates the metrics layer usage in:
  - `ingest::server_5g`
5. adds the metrics layer to:
  - `ingest::server_lora`
  - `entropy::server`