### PR TITLE
denylist verification for witness and receipt reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +581,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +704,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
@@ -696,9 +729,9 @@ dependencies = [
  "clap_lex",
  "indexmap",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
- "textwrap",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
@@ -707,7 +740,7 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1015,6 +1048,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "denylist"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "bincode",
+ "bytes",
+ "cmake",
+ "config",
+ "helium-crypto",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2 0.10.6",
+ "structopt",
+ "thiserror",
+ "tracing",
+ "twox-hash",
+ "xorf",
+]
+
+[[package]]
 name = "der"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,6 +1194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,7 +1237,7 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
- "clap",
+ "clap 3.2.23",
  "config",
  "csv",
  "density-scaler",
@@ -1589,6 +1652,15 @@ dependencies = [
  "rustc_version 0.4.0",
  "spin 0.9.4",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2142,7 +2214,7 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
- "clap",
+ "clap 3.2.23",
  "config",
  "db-store",
  "file-store",
@@ -2179,7 +2251,7 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
- "clap",
+ "clap 3.2.23",
  "config",
  "db-store",
  "file-store",
@@ -2470,7 +2542,7 @@ dependencies = [
  "base64",
  "bs58",
  "chrono",
- "clap",
+ "clap 3.2.23",
  "config",
  "file-store",
  "futures",
@@ -2501,7 +2573,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "chrono",
- "clap",
+ "clap 3.2.23",
  "config",
  "file-store",
  "futures",
@@ -2530,7 +2602,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "chrono",
- "clap",
+ "clap 3.2.23",
  "config",
  "db-store",
  "density-scaler",
@@ -2567,11 +2639,12 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
- "clap",
+ "clap 3.2.23",
  "cmake",
  "config",
  "db-store",
  "density-scaler",
+ "denylist",
  "file-store",
  "futures",
  "futures-util",
@@ -2621,7 +2694,7 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
- "clap",
+ "clap 3.2.23",
  "config",
  "db-store",
  "file-store",
@@ -2725,7 +2798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8b442418ea0822409d9e7d047cbf1e7e9e1760b172bf9982cf29d517c93511"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.0",
  "itertools",
  "lazy_static",
  "log",
@@ -2939,6 +3012,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+dependencies = [
+ "async-compression",
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
 ]
 
 [[package]]
@@ -3422,7 +3536,7 @@ checksum = "b850fa514dc11f2ee85be9d055c512aa866746adfacd1cb42d867d68e6a5b0d9"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.4.0",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -3451,6 +3565,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3462,9 +3582,39 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap 2.34.0",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "strum"
@@ -3481,7 +3631,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3544,6 +3694,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -3900,6 +4059,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "rand",
+ "static_assertions",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3992,6 +4162,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4069,6 +4245,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4283,6 +4471,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "xmlparser"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4296,6 +4493,7 @@ checksum = "7afb3a52aef0211e557044386369919b033004fdcf4c56c5017710f97fa9aa3c"
 dependencies = [
  "libm",
  "rand",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,7 +1110,6 @@ dependencies = [
  "base64",
  "bincode",
  "bytes",
- "cmake",
  "config",
  "helium-crypto",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +614,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2b_simd"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake3"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +837,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +857,15 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cortex-m"
@@ -1682,6 +1738,7 @@ dependencies = [
  "ed25519-dalek",
  "k256",
  "lazy_static",
+ "multihash",
  "p256",
  "rand_core 0.6.4",
  "serde",
@@ -2023,6 +2080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,6 +2343,37 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "triggered",
+]
+
+[[package]]
+name = "multihash"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
+dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "blake3",
+ "core2",
+ "digest 0.10.5",
+ "multihash-derive",
+ "sha2 0.10.6",
+ "sha3",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -2746,6 +2840,16 @@ checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+dependencies = [
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -3374,6 +3478,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.5",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+dependencies = [
+ "digest 0.10.5",
+ "keccak",
 ]
 
 [[package]]
@@ -4119,6 +4233,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "poc_iot_injector",
     "node_follower",
     "density_scaler",
+    "denylist",
     "mobile_index",
     "metrics",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ sqlx = {version = "0", features = [
   "macros",
   "runtime-tokio-rustls"
 ]}
-helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.5.0", features=["sqlx-postgres"]}
+helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.5.0", features=["sqlx-postgres", "multisig"]}
 helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
 humantime = "2"
 metrics = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ members = [
     "poc_iot_injector",
     "node_follower",
     "density_scaler",
-    "denylist",
     "mobile_index",
     "metrics",
+    "denylist",
 ]
 
 [workspace.package]
@@ -47,6 +47,7 @@ sqlx = {version = "0", features = [
 ]}
 helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.5.0", features=["sqlx-postgres", "multisig"]}
 helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
 humantime = "2"
 metrics = "0"
 metrics-exporter-prometheus = "0"
@@ -66,3 +67,11 @@ once_cell = "1"
 lazy_static = "1"
 config = {version="0", default-features=false, features=["toml"]}
 h3ron = "*"
+xorf = {version = "0", features = ["serde"] }
+bytes = "*"
+structopt = "0"
+bincode = "1"
+twox-hash = "1"
+async-trait = "*"
+geo-types = "*"
+geo = "*"

--- a/denylist/Cargo.toml
+++ b/denylist/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "denylist"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 description = "Maintains latest denylist"
-authors = ["Andrew McKenzie <andrewm@nova.xyz>"]
-license = "Apache-2.0"
+authors.workspace = true
+license.workspace = true
 
 
 [dependencies]

--- a/denylist/Cargo.toml
+++ b/denylist/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "denylist"
+version = "0.1.0"
+edition = "2021"
+description = "Maintains latest denylist"
+authors = ["Andrew McKenzie <andrewm@nova.xyz>"]
+license = "Apache-2.0"
+
+[build-dependencies]
+cmake = "0.1"
+
+[dependencies]
+thiserror = {workspace = true}
+tracing = {workspace = true}
+reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
+helium-crypto = {workspace = true}
+base64 = {workspace = true}
+sha2 = {workspace = true}
+bytes = "*"
+structopt = "0"
+bincode = "1"
+twox-hash = "1"
+xorf = {version = "0", features = ["serde"] }
+serde = {workspace = true}
+serde_json = {workspace = true}
+config = {workspace = true}

--- a/denylist/Cargo.toml
+++ b/denylist/Cargo.toml
@@ -6,21 +6,19 @@ description = "Maintains latest denylist"
 authors = ["Andrew McKenzie <andrewm@nova.xyz>"]
 license = "Apache-2.0"
 
-[build-dependencies]
-cmake = "0.1"
 
 [dependencies]
 thiserror = {workspace = true}
 tracing = {workspace = true}
-reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
+reqwest = {workspace = true}
 helium-crypto = {workspace = true}
 base64 = {workspace = true}
 sha2 = {workspace = true}
-bytes = "*"
-structopt = "0"
-bincode = "1"
-twox-hash = "1"
-xorf = {version = "0", features = ["serde"] }
+bytes = {workspace = true}
+structopt = {workspace = true}
+bincode = {workspace = true}
+twox-hash = {workspace = true}
+xorf = {workspace = true}
 serde = {workspace = true}
 serde_json = {workspace = true}
 config = {workspace = true}

--- a/denylist/src/client.rs
+++ b/denylist/src/client.rs
@@ -2,7 +2,7 @@ use crate::{error::Error, models::metadata::DenyListMetaData, Result};
 use std::{str, time::Duration};
 
 /// The default client useragent for denylist http requests
-static USERAGENT: &str = "https://github.com/helium/miner";
+static USERAGENT: &str = "oracle/poc_iot_verifier/1.0";
 /// The default timeout for http requests
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 

--- a/denylist/src/client.rs
+++ b/denylist/src/client.rs
@@ -1,0 +1,47 @@
+use crate::{error::Error, models::metadata::DenyListMetaData, Result};
+use std::{str, time::Duration};
+
+/// The default client useragent for denylist http requests
+static USERAGENT: &str = "https://github.com/helium/miner";
+/// The default timeout for http requests
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Debug)]
+pub struct DenyListClient {
+    pub client: reqwest::Client,
+}
+
+// TODO: basic non production client. productionise....
+impl DenyListClient {
+    pub fn new() -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .gzip(true)
+            .user_agent(USERAGENT)
+            .timeout(DEFAULT_TIMEOUT)
+            .build()
+            .map_err(Error::from)?;
+        Ok(Self { client })
+    }
+
+    pub async fn get_metadata(&mut self, url: &String) -> Result<DenyListMetaData> {
+        let response = self.client.get(url).send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => {
+                let json = response.json::<DenyListMetaData>().await?;
+                Ok(json)
+            }
+            other => Err(Error::UnexpectedStatus(other.to_string())),
+        }
+    }
+
+    pub async fn get_bin(&mut self, url: &String) -> Result<Vec<u8>> {
+        let response = self.client.get(url).send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => {
+                let bytes = response.bytes().await?;
+                Ok(bytes.to_vec())
+            }
+            other => Err(Error::UnexpectedStatus(other.to_string())),
+        }
+    }
+}

--- a/denylist/src/denylist.rs
+++ b/denylist/src/denylist.rs
@@ -13,6 +13,7 @@ pub const SERIAL_SIZE: usize = 32;
 const PUB_KEY_B58: &str = "1SbEYKju337P6aYsRd9DT2k4qgK5ZK62kXbSvnJgqeaxK3hqQrYURZjL";
 /// a copy of the last saved filter bin downloaded from github
 /// if present will be used to initialise the denylist upon verifier startup
+// TODO: look at using the tempfile crate to handle this
 const FILTER_BIN_PATH: &str = "./tmp/last_saved_filter.bin";
 
 #[derive(Serialize)]
@@ -91,7 +92,7 @@ impl DenyList {
     pub async fn check_key(&self, pub_key: &PublicKey) -> bool {
         if self.filter.len() == 0 {
             tracing::warn!("empty denylist filter, rejecting key");
-            return false;
+            return true;
         }
         self.filter.contains(&public_key_hash(pub_key))
     }

--- a/denylist/src/denylist.rs
+++ b/denylist/src/denylist.rs
@@ -1,0 +1,134 @@
+use crate::denylist::client::DenyListClient;
+use crate::Result;
+use crate::{models::metadata::Asset, *};
+use bytes::Buf;
+use helium_crypto::{PublicKey, Verify};
+use serde::Serialize;
+use std::{fs, hash::Hasher, path, str::FromStr};
+use twox_hash::XxHash64;
+use xorf::{Filter as XorFilter, Xor32};
+
+pub const SERIAL_SIZE: usize = 32;
+
+/// the pubkey used to verify the signature of denylist updates
+// TODO: is there a better home for this key ?
+const PUB_KEY_B58: &str = "1SbEYKju337P6aYsRd9DT2k4qgK5ZK62kXbSvnJgqeaxK3hqQrYURZjL";
+/// a copy of the last saved filter bin downloaded from github
+/// if present will be used to initialise the denylist upon verifier startup
+const FILTER_BIN_PATH: &str = "./tmp/last_saved_filter.bin";
+
+#[derive(Serialize)]
+pub struct DenyList {
+    pub tag_name: u64,
+    #[serde(skip_serializing)]
+    pub filter: Xor32,
+}
+
+impl Default for DenyList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DenyList {
+    pub fn new() -> Self {
+        tracing::debug!("initializing new denylist");
+        // if exists default to the local saved filter bin,
+        // otherwise default to empty filter
+        // a local filter should always be present
+        // after the verifier has been run at least once
+        // in the current dir and has previously successfully downloaded
+        // a filter from github
+        let bin: Vec<u8> = fs::read(FILTER_BIN_PATH).unwrap_or_else(|_| {
+            tracing::warn!(
+                "failed to initialise with a denylist filter, filter is currently empty"
+            );
+            Vec::new()
+        });
+        let filter = filter_from_bin(&bin).unwrap_or_else(|_| Xor32::from(Vec::new()));
+        Self {
+            // default tag to 0, proper tag name will be set on first
+            // call to update_to_latest
+            tag_name: 0,
+            filter,
+        }
+    }
+
+    pub async fn update_to_latest(&mut self, metadata_url: &String) -> Result {
+        tracing::info!("checking for updated denylist");
+        let mut dl_client = DenyListClient::new()?;
+        let metadata = dl_client.get_metadata(metadata_url).await?;
+        let new_tag_name = metadata.tag_name.parse::<u64>()?;
+        if new_tag_name > self.tag_name {
+            tracing::info!("updated denylist tag: {:?}", new_tag_name);
+            // get the asset
+            // filter out any assets which do not have a name == "filter.bin"
+            let assets: Vec<Asset> = metadata
+                .assets
+                .into_iter()
+                .filter(|a| a.name == "filter.bin")
+                .collect();
+            // we should be left with a single asset
+            // at least this is the assumption the erlang implementation followed
+            if let Some(asset) = assets.first() {
+                tracing::debug!("found asset for tag");
+                let asset_url = &asset.browser_download_url;
+                let bin = dl_client.get_bin(asset_url).await?;
+                if let Ok(filter) = filter_from_bin(&bin) {
+                    self.filter = filter;
+                    self.tag_name = new_tag_name;
+                    save_local_filter_bin(&bin, FILTER_BIN_PATH)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn check_key(&self, pub_key: &PublicKey) -> bool {
+        self.filter.contains(&public_key_hash(pub_key))
+    }
+}
+
+/// deconstruct bytes into the filter component parts
+pub fn filter_from_bin(bin: &Vec<u8>) -> Result<Xor32> {
+    if bin.is_empty() {
+        return Err(Error::InvalidBinary("invalid filter bin".to_string()));
+    }
+    let mut buf: &[u8] = bin;
+    // whilst we dont use version, we do need to advance the cursor
+    let _version = buf.get_u8();
+    let signature_len = buf.get_u16_le() as usize;
+    let signature = buf.copy_to_bytes(signature_len).to_vec();
+    let pubkey = PublicKey::from_str(PUB_KEY_B58)?;
+    match pubkey.verify(buf, &signature) {
+        Ok(_) => {
+            tracing::info!("updating filter to latest");
+            let _serial = buf.get_u32_le();
+            let xor = bincode::deserialize::<Xor32>(buf)?;
+            Ok(xor)
+        }
+        Err(_) => {
+            tracing::warn!("filter signature verification failed");
+            Err(Error::InvalidBinary(
+                "filter signature verification failed".to_string(),
+            ))
+        }
+    }
+}
+
+fn public_key_hash(public_key: &PublicKey) -> u64 {
+    let mut hasher = XxHash64::default();
+    hasher.write(&public_key.to_vec());
+    hasher.finish()
+}
+
+/// save a copy of the xor file locally
+// the local copy will be used should during init
+// github be unreachable
+pub fn save_local_filter_bin(bin: &Vec<u8>, path: &str) -> Result {
+    if let Some(parent) = path::PathBuf::from(path).parent() {
+        fs::create_dir_all(parent)?;
+        fs::write(path, &bin)?;
+    }
+    Ok(())
+}

--- a/denylist/src/denylist.rs
+++ b/denylist/src/denylist.rs
@@ -85,6 +85,10 @@ impl DenyList {
     }
 
     pub async fn check_key(&self, pub_key: &PublicKey) -> bool {
+        if self.filter.len() == 0 {
+            tracing::warn!("empty denylist filter, rejecting key");
+            return false;
+        }
         self.filter.contains(&public_key_hash(pub_key))
     }
 }

--- a/denylist/src/error.rs
+++ b/denylist/src/error.rs
@@ -1,0 +1,46 @@
+use thiserror::Error;
+pub type Result<T = ()> = std::result::Result<T, Error>;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("request error")]
+    Request(#[from] reqwest::Error),
+    #[error("unexpected binary")]
+    InvalidBinary(String),
+    #[error("unexpected value")]
+    Value(serde_json::Value),
+    #[error("invalid decimals in {0}, only 8 allowed")]
+    Decimals(String),
+    #[error("unexpected or invalid number {0}")]
+    Number(String),
+    #[error("crypto error")]
+    Crypto(#[from] helium_crypto::Error),
+    #[error("bincode error")]
+    BinCode(#[from] bincode::Error),
+    #[error("unexpected status {0}")]
+    UnexpectedStatus(String),
+    #[error("unable to parse metadata")]
+    ParseInt(#[from] std::num::ParseIntError),
+    #[error("io error")]
+    Io(#[from] std::io::Error),
+    #[error("config error")]
+    Config(#[from] config::ConfigError),
+}
+
+impl Error {
+    pub fn invalid_binary<E: ToString>(msg: E) -> Self {
+        Self::InvalidBinary(msg.to_string())
+    }
+
+    pub fn value(value: serde_json::Value) -> Self {
+        Self::Value(value)
+    }
+
+    pub fn decimals(value: &str) -> Self {
+        Self::Decimals(value.to_string())
+    }
+
+    pub fn number(value: &str) -> Self {
+        Self::Number(value.to_string())
+    }
+}

--- a/denylist/src/lib.rs
+++ b/denylist/src/lib.rs
@@ -1,0 +1,9 @@
+mod error;
+pub use error::{Error, Result};
+pub mod client;
+pub mod denylist;
+pub mod models;
+pub mod settings;
+
+pub use crate::denylist::DenyList;
+pub use crate::settings::Settings;

--- a/denylist/src/models/metadata.rs
+++ b/denylist/src/models/metadata.rs
@@ -11,7 +11,7 @@ pub struct DenyListMetaData {
     html_url: String,
     id: i64,
     author: Item,
-    pnode_id: String,
+    node_id: String,
     pub tag_name: String,
     target_commitish: String,
     name: String,
@@ -43,7 +43,7 @@ pub struct Asset {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct Item {
+struct Item {
     login: String,
     id: i64,
     node_id: String,

--- a/denylist/src/models/metadata.rs
+++ b/denylist/src/models/metadata.rs
@@ -1,0 +1,66 @@
+// model representing the JSON payload returned from:
+// https://api.github.com/repos/helium/denylist/releases/latest
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct DenyListMetaData {
+    url: String,
+    assets_url: String,
+    upload_url: String,
+    html_url: String,
+    id: i64,
+    author: Item,
+    pnode_id: String,
+    pub tag_name: String,
+    target_commitish: String,
+    name: String,
+    draft: bool,
+    prerelease: bool,
+    created_at: String,
+    published_at: String,
+    pub assets: Vec<Asset>,
+    tarball_url: String,
+    zipball_url: String,
+    body: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct Asset {
+    url: String,
+    id: i64,
+    node_id: String,
+    pub name: String,
+    label: String,
+    uploader: Item,
+    content_type: String,
+    state: String,
+    size: i64,
+    download_count: i64,
+    created_at: String,
+    updated_at: String,
+    pub browser_download_url: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct Item {
+    login: String,
+    id: i64,
+    node_id: String,
+    avatar_url: String,
+    gravatar_id: String,
+    url: String,
+    html_url: String,
+    followers_url: String,
+    following_url: String,
+    gists_url: String,
+    starred_url: String,
+    subscriptions_url: String,
+    organizations_url: String,
+    repos_url: String,
+    events_url: String,
+    received_events_url: String,
+    #[serde(rename = "type")]
+    r#type: String,
+    site_admin: bool,
+}

--- a/denylist/src/models/mod.rs
+++ b/denylist/src/models/mod.rs
@@ -1,0 +1,1 @@
+pub mod metadata;

--- a/denylist/src/settings.rs
+++ b/denylist/src/settings.rs
@@ -1,0 +1,59 @@
+use crate::{Error, Result};
+use config::{Config, Environment, File};
+use serde::Deserialize;
+use std::{path::Path, time::Duration};
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Settings {
+    /// RUST_LOG compatible settings string. Default to
+    /// "denylist=debug"
+    #[serde(default = "default_log")]
+    pub log: String,
+    /// Listen address for http requests for entropy. Default "0.0.0.0:8080"
+    #[serde(default = "default_denylist_url")]
+    pub denylist_url: String,
+    /// Cadence at which we poll for an updated denylist (secs)
+    #[serde(default = "default_trigger_interval")]
+    pub trigger: u64,
+}
+
+pub fn default_log() -> String {
+    "poc_entropy=debug,poc_store=info".to_string()
+}
+
+pub fn default_denylist_url() -> String {
+    "https://api.github.com/repos/helium/denylist/releases/latest".to_string()
+}
+
+fn default_trigger_interval() -> u64 {
+    180
+}
+
+impl Settings {
+    /// Load Settings from a given path. Settings are loaded from a given
+    /// optional path and can be overriden with environment variables.
+    ///
+    /// Environemnt overrides have the same name as the entries in the settings
+    /// file in uppercase and prefixed with "DENYLIST_". For example
+    /// "DENYLIST_LOG" will override the log setting.
+    pub fn new<P: AsRef<Path>>(path: Option<P>) -> Result<Self> {
+        let mut builder = Config::builder();
+
+        if let Some(file) = path {
+            // Add optional settings file
+            builder = builder
+                .add_source(File::with_name(&file.as_ref().to_string_lossy()).required(false));
+        }
+        // Add in settings from the environment (with a prefix of APP)
+        // Eg.. `DENYLIST_DEBUG=1 ./target/app` would set the `debug` key
+        builder
+            .add_source(Environment::with_prefix("DENYLIST").separator("_"))
+            .build()
+            .and_then(|config| config.try_deserialize())
+            .map_err(Error::from)
+    }
+
+    pub fn trigger_interval(&self) -> Duration {
+        Duration::from_secs(self.trigger)
+    }
+}

--- a/denylist/src/settings.rs
+++ b/denylist/src/settings.rs
@@ -18,7 +18,7 @@ pub struct Settings {
 }
 
 pub fn default_log() -> String {
-    "poc_entropy=debug,poc_store=info".to_string()
+    "denylist=debug".to_string()
 }
 
 pub fn default_denylist_url() -> String {

--- a/file_store/src/error.rs
+++ b/file_store/src/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
     #[error("not found")]
     NotFound(String),
     #[error("crypto error")]
-    Crypto(#[from] helium_crypto::Error),
+    Crypto(Box<helium_crypto::Error>),
     #[error("csv error")]
     Csv(#[from] csv::Error),
     #[error("aws error")]
@@ -85,5 +85,11 @@ impl Error {
 impl DecodeError {
     pub fn file_info<E: ToString>(msg: E) -> Error {
         Error::Decode(Self::FileInfo(msg.to_string()))
+    }
+}
+
+impl From<helium_crypto::Error> for Error {
+    fn from(err: helium_crypto::Error) -> Self {
+        Self::Crypto(Box::new(err))
     }
 }

--- a/poc_iot_verifier/Cargo.toml
+++ b/poc_iot_verifier/Cargo.toml
@@ -44,7 +44,5 @@ poc-metrics = { path = "../metrics" }
 db-store = {path = "../db_store"}
 density-scaler = {path = "../density_scaler/"}
 denylist = {path = "../denylist"}
-lazy_static = {workspace = true}
-once_cell = {workspace = true}
 rust_decimal = {workspace = true}
 rust_decimal_macros = {workspace = true}

--- a/poc_iot_verifier/Cargo.toml
+++ b/poc_iot_verifier/Cargo.toml
@@ -36,6 +36,7 @@ node-follower = { path = "../node_follower" }
 poc-metrics = { path = "../metrics" }
 db-store = {path = "../db_store"}
 density-scaler = {path = "../density_scaler/"}
+denylist = {path = "../denylist"}
 async-trait = "*"
 h3ron = {workspace = true}
 geo-types = "*"

--- a/poc_iot_verifier/Cargo.toml
+++ b/poc_iot_verifier/Cargo.toml
@@ -30,6 +30,13 @@ prost = {workspace = true}
 chrono = { workspace = true }
 helium-proto = { workspace = true }
 helium-crypto = {workspace = true }
+async-trait = {workspace = true}
+h3ron = {workspace = true}
+geo-types = {workspace = true}
+geo = {workspace = true}
+xorf = {workspace = true}
+lazy_static = {workspace = true}
+once_cell = {workspace = true}
 file-store = { path = "../file_store" }
 metrics = {workspace = true}
 node-follower = { path = "../node_follower" }
@@ -37,11 +44,6 @@ poc-metrics = { path = "../metrics" }
 db-store = {path = "../db_store"}
 density-scaler = {path = "../density_scaler/"}
 denylist = {path = "../denylist"}
-async-trait = "*"
-h3ron = {workspace = true}
-geo-types = "*"
-geo = "*"
-xorf = "*"
 lazy_static = {workspace = true}
 once_cell = {workspace = true}
 rust_decimal = {workspace = true}

--- a/poc_iot_verifier/Cargo.toml
+++ b/poc_iot_verifier/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = {workspace = true}
 prost = {workspace = true}
 chrono = { workspace = true }
 helium-proto = { workspace = true }
-helium-crypto = {workspace = true, features = [ "multisig" ] }
+helium-crypto = {workspace = true }
 file-store = { path = "../file_store" }
 metrics = {workspace = true}
 node-follower = { path = "../node_follower" }

--- a/poc_iot_verifier/Cargo.toml
+++ b/poc_iot_verifier/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = {workspace = true}
 prost = {workspace = true}
 chrono = { workspace = true }
 helium-proto = { workspace = true }
-helium-crypto = {workspace = true }
+helium-crypto = {workspace = true, features = [ "multisig" ] }
 file-store = { path = "../file_store" }
 metrics = {workspace = true}
 node-follower = { path = "../node_follower" }

--- a/poc_iot_verifier/pkg/deb/settings-template.toml
+++ b/poc_iot_verifier/pkg/deb/settings-template.toml
@@ -7,6 +7,10 @@
 #
 cache = "/var/data/iot-verified"
 
+# Denylist url
+#
+# denylist_url = "https://api.github.com/repos/helium/denylist/releases/latest"
+
 
 [database]
 

--- a/poc_iot_verifier/src/error.rs
+++ b/poc_iot_verifier/src/error.rs
@@ -42,6 +42,8 @@ pub enum Error {
     Geo(#[from] geo::vincenty_distance::FailedToConvergeError),
     #[error("density scaler error")]
     DensityScaler(#[from] density_scaler::Error),
+    #[error("denylist error")]
+    DenyList(#[from] denylist::Error),
 }
 
 #[derive(Error, Debug)]

--- a/poc_iot_verifier/src/poc.rs
+++ b/poc_iot_verifier/src/poc.rs
@@ -1,4 +1,5 @@
 use crate::{last_beacon::LastBeacon, Error, Result};
+use ::denylist::denylist::DenyList;
 use chrono::{DateTime, Duration, Utc};
 use density_scaler::QuerySender;
 use file_store::{
@@ -87,12 +88,25 @@ impl Poc {
     pub async fn verify_beacon(
         &mut self,
         density_queries: QuerySender,
+        deny_list: &DenyList,
     ) -> Result<VerifyBeaconResult> {
         let beacon = &self.beacon_report.report;
         // use pub key to get GW info from our follower
         let beaconer_pub_key = beacon.pub_key.clone();
         let beacon_received_ts = self.beacon_report.received_timestamp;
 
+        // check if beaconer is on the deny list
+        if deny_list.check_key(&beaconer_pub_key).await {
+            let resp = VerifyBeaconResult {
+                result: VerificationStatus::Invalid,
+                invalid_reason: Some(InvalidReason::Denied),
+                gateway_info: None,
+                hex_scale: None,
+            };
+            return Ok(resp);
+        }
+
+        // pull the beaconer info from our follower
         let beaconer_info = match self
             .follower_service
             .resolve_gateway_info(&beaconer_pub_key)
@@ -213,13 +227,16 @@ impl Poc {
         &mut self,
         beacon_info: &GatewayInfo,
         density_queries: QuerySender,
+        deny_list: &DenyList,
     ) -> Result<VerifyWitnessesResult> {
         let mut valid_witnesses: Vec<LoraValidWitnessReport> = Vec::new();
         let mut invalid_witnesses: Vec<LoraInvalidWitnessReport> = Vec::new();
         let mut failed_witnesses: Vec<LoraInvalidWitnessReport> = Vec::new();
         let witnesses = self.witness_reports.clone();
         for witness_report in witnesses {
-            let witness_result = self.verify_witness(&witness_report, beacon_info).await?;
+            let witness_result = self
+                .verify_witness(&witness_report, beacon_info, deny_list)
+                .await?;
             match witness_result.result {
                 VerificationStatus::Valid => {
                     let gw_info: GatewayInfo = witness_result.gateway_info.ok_or_else(|| {
@@ -277,11 +294,23 @@ impl Poc {
         &mut self,
         witness_report: &LoraWitnessIngestReport,
         beaconer_info: &GatewayInfo,
+        deny_list: &DenyList,
     ) -> Result<VerifyWitnessResult> {
-        // use pub key to get GW info from our follower and verify the witness
         let witness = &witness_report.report;
         let beacon = &self.beacon_report.report;
         let witness_pub_key = witness.pub_key.clone();
+
+        // check if witness is on the deny list
+        if deny_list.check_key(&witness_pub_key).await {
+            let resp = VerifyWitnessResult {
+                result: VerificationStatus::Failed,
+                invalid_reason: Some(InvalidReason::Denied),
+                gateway_info: None,
+            };
+            return Ok(resp);
+        }
+
+        // use pub key to get GW info from our follower and verify the witness
         let witness_info = match self
             .follower_service
             .resolve_gateway_info(&witness_pub_key)

--- a/poc_iot_verifier/src/runner.rs
+++ b/poc_iot_verifier/src/runner.rs
@@ -232,7 +232,9 @@ impl Runner {
                 None => return Err(Error::custom("missing density scaler query sender")),
             };
             // verify POC beacon
-            let beacon_verify_result = poc.verify_beacon(density_queries.clone(), &self.deny_list).await?;
+            let beacon_verify_result = poc
+                .verify_beacon(density_queries.clone(), &self.deny_list)
+                .await?;
             match beacon_verify_result.result {
                 VerificationStatus::Valid => {
                     tracing::info!(
@@ -242,8 +244,9 @@ impl Runner {
                     );
                     // beacon is valid, verify the POC witnesses
                     if let Some(beacon_info) = beacon_verify_result.gateway_info {
-                        let verified_witnesses_result =
-                            poc.verify_witnesses(&beacon_info, density_queries, &self.deny_list).await?;
+                        let verified_witnesses_result = poc
+                            .verify_witnesses(&beacon_info, density_queries, &self.deny_list)
+                            .await?;
                         // check if there are any failed witnesses
                         // if so update the DB attempts count
                         // and halt here, let things be reprocessed next tick

--- a/poc_iot_verifier/src/runner.rs
+++ b/poc_iot_verifier/src/runner.rs
@@ -49,7 +49,7 @@ impl Runner {
     pub async fn from_settings(settings: &Settings) -> Result<Self> {
         let pool = settings.database.connect(LOADER_DB_POOL_SIZE).await?;
         let follower_service = FollowerService::from_settings(&settings.follower)?;
-        let deny_list = DenyList::new();
+        let deny_list = DenyList::new()?;
         Ok(Self {
             pool,
             deny_list_latest_url: settings.denylist.denylist_url.clone(),
@@ -158,12 +158,14 @@ impl Runner {
         // sink any errors whilst updating the denylist
         // the verifier should not stop just because github
         // could not be reached for example
-        match self.deny_list
+        match self
+            .deny_list
             .update_to_latest(&self.deny_list_latest_url)
-            .await {
-                Ok(())=> (),
-                Err(e) => tracing::warn!("failed to update denylist: {e}")
-            }
+            .await
+        {
+            Ok(()) => (),
+            Err(e) => tracing::warn!("failed to update denylist: {e}"),
+        }
         Ok(())
     }
 

--- a/poc_iot_verifier/src/runner.rs
+++ b/poc_iot_verifier/src/runner.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use chrono::Utc;
 use density_scaler::QuerySender;
+use denylist::DenyList;
 use file_store::{
     file_sink,
     file_sink::MessageSender,
@@ -26,17 +27,19 @@ use helium_proto::{
 };
 use node_follower::follower_service::FollowerService;
 use sqlx::PgPool;
-use std::path::Path;
+use std::{path::Path, time::Duration};
 use tokio::time;
 
 /// the cadence in seconds at which the DB is polled for ready POCs
 const DB_POLL_TIME: time::Duration = time::Duration::from_secs(30);
-
 const LOADER_WORKERS: usize = 10;
 const LOADER_DB_POOL_SIZE: usize = 2 * LOADER_WORKERS;
 
 pub struct Runner {
     pool: PgPool,
+    deny_list_latest_url: String,
+    deny_list_trigger_interval: Duration,
+    deny_list: DenyList,
     settings: Settings,
     follower_service: FollowerService,
     density_queries: Option<QuerySender>,
@@ -46,8 +49,12 @@ impl Runner {
     pub async fn from_settings(settings: &Settings) -> Result<Self> {
         let pool = settings.database.connect(LOADER_DB_POOL_SIZE).await?;
         let follower_service = FollowerService::from_settings(&settings.follower)?;
+        let deny_list = DenyList::new();
         Ok(Self {
             pool,
+            deny_list_latest_url: settings.denylist.denylist_url.clone(),
+            deny_list_trigger_interval: settings.denylist.trigger_interval(),
+            deny_list,
             settings: settings.clone(),
             follower_service,
             density_queries: None,
@@ -65,6 +72,9 @@ impl Runner {
 
         let mut db_timer = time::interval(DB_POLL_TIME);
         db_timer.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+
+        let mut denylist_timer = time::interval(self.deny_list_trigger_interval);
+        denylist_timer.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
 
         let store_base_path = Path::new(&self.settings.cache);
         let (lora_invalid_beacon_tx, lora_invalid_beacon_rx) = file_sink::message_channel(50);
@@ -129,10 +139,31 @@ impl Runner {
                         tracing::error!("fatal db runner error: {err:?}");
                         return Err(err)
                     }
+                },
+                _ = denylist_timer.tick() =>
+                    match self.handle_denylist_tick().await {
+                    Ok(()) => (),
+                    Err(err) => {
+                        tracing::error!("fatal db runner error: {err:?}");
+                        return Err(err)
+                    }
                 }
             }
         }
         tracing::info!("stopping runner");
+        Ok(())
+    }
+
+    async fn handle_denylist_tick(&mut self) -> Result {
+        // sink any errors whilst updating the denylist
+        // the verifier should not stop just because github
+        // could not be reached for example
+        match self.deny_list
+            .update_to_latest(&self.deny_list_latest_url)
+            .await {
+                Ok(())=> (),
+                Err(e) => tracing::warn!("failed to update denylist: {e}")
+            }
         Ok(())
     }
 
@@ -199,7 +230,7 @@ impl Runner {
                 None => return Err(Error::custom("missing density scaler query sender")),
             };
             // verify POC beacon
-            let beacon_verify_result = poc.verify_beacon(density_queries.clone()).await?;
+            let beacon_verify_result = poc.verify_beacon(density_queries.clone(), &self.deny_list).await?;
             match beacon_verify_result.result {
                 VerificationStatus::Valid => {
                     tracing::info!(
@@ -210,7 +241,7 @@ impl Runner {
                     // beacon is valid, verify the POC witnesses
                     if let Some(beacon_info) = beacon_verify_result.gateway_info {
                         let verified_witnesses_result =
-                            poc.verify_witnesses(&beacon_info, density_queries).await?;
+                            poc.verify_witnesses(&beacon_info, density_queries, &self.deny_list).await?;
                         // check if there are any failed witnesses
                         // if so update the DB attempts count
                         // and halt here, let things be reprocessed next tick

--- a/poc_iot_verifier/src/settings.rs
+++ b/poc_iot_verifier/src/settings.rs
@@ -5,12 +5,13 @@ use std::path::Path;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Settings {
-    /// RUST_LOG compatible settings string. Defsault to
-    /// "mobile_verifier=debug,poc_store=info"
+    /// RUST_LOG compatible settings string. Default to
+    /// "poc_iot_verifier=debug,poc_store=info"
     #[serde(default = "default_log")]
     pub log: String,
     /// Cache location for generated verified reports
     pub cache: String,
+
     pub database: db_store::Settings,
     pub follower: node_follower::Settings,
     pub ingest: file_store::Settings,
@@ -18,6 +19,7 @@ pub struct Settings {
     pub output: file_store::Settings,
     pub metrics: poc_metrics::Settings,
     pub density_scaler: density_scaler::Settings,
+    pub denylist: denylist::Settings,
 }
 
 pub fn default_log() -> String {

--- a/poc_iot_verifier/src/settings.rs
+++ b/poc_iot_verifier/src/settings.rs
@@ -11,7 +11,6 @@ pub struct Settings {
     pub log: String,
     /// Cache location for generated verified reports
     pub cache: String,
-
     pub database: db_store::Settings,
     pub follower: node_follower::Settings,
     pub ingest: file_store::Settings,


### PR DESCRIPTION
Adds support for denylist verification for beacon and witness reports.  
The denylist is fetched from github on startup and then periodically checked for updates.   

Once a denylist has been fetched from github, the filter will be saved locally.  Next time the verifier is restarted, this locally saved filter will be used as the initial filter during init and replaced with any newer version from github.
This enables a default filter to always be in use should github be unreachable for whatever reason.


