### PR TITLE
purge db of stale data

### DIFF
--- a/poc_iot_verifier/migrations/3_poc_report.sql
+++ b/poc_iot_verifier/migrations/3_poc_report.sql
@@ -11,6 +11,8 @@ create type reporttype  AS enum (
 
 create table poc_report (
     id bytea primary key not null,
+    -- remote_entropy: allow nulls as only beacon reports will populate this
+    remote_entropy bytea,
     packet_data bytea not null,
     report_data bytea not null,
     report_type reporttype,

--- a/poc_iot_verifier/src/entropy.rs
+++ b/poc_iot_verifier/src/entropy.rs
@@ -74,7 +74,7 @@ impl Entropy {
         .map_err(Error::from)
     }
 
-    pub async fn purge<'c, 'q, E>(executor: E, stale_period: &i32) -> Result
+    pub async fn purge<'c, 'q, E>(executor: E, stale_period: i32) -> Result
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres> + Clone,
     {

--- a/poc_iot_verifier/src/entropy.rs
+++ b/poc_iot_verifier/src/entropy.rs
@@ -2,6 +2,13 @@ use crate::{Error, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// measurement in seconds of a piece of entropy
+/// its lifespan will be valid from entropy.timestamp to entropy.timestamp + ENTROPY_LIFESPAN
+/// any beacon or witness report received after this period and before the ENTROPY_STALE_PERIOD
+/// defined below will be rejected due to being outside of the entropy lifespan
+/// TODO: determine a sane value here
+pub const ENTROPY_LIFESPAN: i32 = 90;
+
 #[derive(sqlx::Type, Serialize, Deserialize, Debug)]
 #[sqlx(type_name = "report_type", rename_all = "lowercase")]
 pub enum ReportType {
@@ -67,17 +74,17 @@ impl Entropy {
         .map_err(Error::from)
     }
 
-    pub async fn purge<'c, 'q, E>(executor: E, timestamp: &'q DateTime<Utc>) -> Result
+    pub async fn purge<'c, 'q, E>(executor: E, stale_period: &i32) -> Result
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres> + Clone,
     {
         sqlx::query(
             r#"
             delete from entropy
-            where timestamp > $1
+            where timestamp < (NOW() - INTERVAL '$1 MINUTES')
             "#,
         )
-        .bind(timestamp)
+        .bind(stale_period)
         .execute(executor.clone())
         .await
         .map(|_| ())

--- a/poc_iot_verifier/src/lib.rs
+++ b/poc_iot_verifier/src/lib.rs
@@ -6,6 +6,7 @@ pub mod loader;
 pub mod meta;
 pub mod poc;
 pub mod poc_report;
+pub mod purger;
 pub mod runner;
 pub mod traits;
 

--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -162,6 +162,7 @@ impl Loader {
                 Report::insert_into(
                     &self.pool,
                     beacon.ingest_id(),
+                    beacon.report.remote_entropy,
                     packet_data,
                     buf.to_vec(),
                     &beacon.received_timestamp,
@@ -178,6 +179,7 @@ impl Loader {
                 Report::insert_into(
                     &self.pool,
                     witness.ingest_id(),
+                    Vec::<u8>::with_capacity(0),
                     packet_data,
                     buf.to_vec(),
                     &witness.received_timestamp,

--- a/poc_iot_verifier/src/main.rs
+++ b/poc_iot_verifier/src/main.rs
@@ -1,4 +1,4 @@
-use poc_iot_verifier::{loader, mk_db_pool, runner, Result};
+use poc_iot_verifier::{loader, mk_db_pool, purger, runner, Result};
 use tokio::signal;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -28,5 +28,11 @@ async fn main() -> Result {
 
     let loader = loader::Loader::from_env().await?;
     let runner = runner::Runner::from_env().await?;
-    tokio::try_join!(runner.run(&shutdown), loader.run(&shutdown)).map(|_| ())
+    let purger = purger::Purger::from_env().await?;
+    tokio::try_join!(
+        runner.run(&shutdown),
+        loader.run(&shutdown),
+        purger.run(&shutdown)
+    )
+    .map(|_| ())
 }

--- a/poc_iot_verifier/src/poc.rs
+++ b/poc_iot_verifier/src/poc.rs
@@ -365,6 +365,8 @@ impl Poc {
             witness.signal,
             min_rcv_signal
         );
+        // signal is submitted as DBM * 10
+        // min_rcv_signal is plain old DBM
         if witness.signal / 10 < min_rcv_signal as i32 {
             tracing::debug!(
                 "witness verification failed, reason: {:?}",

--- a/poc_iot_verifier/src/poc.rs
+++ b/poc_iot_verifier/src/poc.rs
@@ -367,7 +367,7 @@ impl Poc {
         );
         // signal is submitted as DBM * 10
         // min_rcv_signal is plain old DBM
-        if witness.signal / 10 < min_rcv_signal as i32 {
+        if (witness.signal / 10) < min_rcv_signal as i32 {
             tracing::debug!(
                 "witness verification failed, reason: {:?}",
                 InvalidReason::BadRssi

--- a/poc_iot_verifier/src/poc_report.rs
+++ b/poc_iot_verifier/src/poc_report.rs
@@ -244,7 +244,10 @@ impl Report {
         .map_err(Error::from)
     }
 
-    pub async fn get_stale_pending_beacons<'c, E>(executor: E) -> Result<Vec<Self>>
+    pub async fn get_stale_pending_beacons<'c, E>(
+        executor: E,
+        base_stale_period: i32,
+    ) -> Result<Vec<Self>>
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
@@ -264,13 +267,16 @@ impl Report {
             order by created_at asc
             "#,
         )
-        .bind(REPORT_STALE_PERIOD)
+        .bind(base_stale_period + REPORT_STALE_PERIOD)
         .fetch_all(executor)
         .await
         .map_err(Error::from)
     }
 
-    pub async fn get_stale_pending_witnesses<'c, E>(executor: E) -> Result<Vec<Self>>
+    pub async fn get_stale_pending_witnesses<'c, E>(
+        executor: E,
+        base_stale_period: i32,
+    ) -> Result<Vec<Self>>
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
@@ -289,7 +295,7 @@ impl Report {
             order by created_at asc
             "#,
         )
-        .bind(REPORT_STALE_PERIOD)
+        .bind(base_stale_period + REPORT_STALE_PERIOD)
         .fetch_all(executor)
         .await
         .map_err(Error::from)

--- a/poc_iot_verifier/src/poc_report.rs
+++ b/poc_iot_verifier/src/poc_report.rs
@@ -119,16 +119,16 @@ impl Report {
     {
         sqlx::query_as::<_, Self>(
             r#"
-            select  poc_report.id,
-                    poc_report.remote_entropy,
-                    poc_report.packet_data,
-                    poc_report.report_data,
-                    poc_report.report_type,
-                    poc_report.status,
-                    poc_report.attempts,
-                    poc_report.report_timestamp,
-                    poc_report.last_processed,
-                    poc_report.created_at
+            select  id,
+                    remote_entropy,
+                    packet_data,
+                    report_data,
+                    report_type,
+                    status,
+                    attempts,
+                    report_timestamp,
+                    last_processed,
+                    created_at
             from poc_report
             left join entropy on poc_report.remote_entropy=entropy.data
             where poc_report.report_type = 'beacon' and status = 'pending'

--- a/poc_iot_verifier/src/poc_report.rs
+++ b/poc_iot_verifier/src/poc_report.rs
@@ -1,10 +1,16 @@
-use crate::{Error, Result};
+use crate::{entropy::ENTROPY_LIFESPAN, Error, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-const POC_LIFESPAN: i16 = 5; //minutes TODO: determine a sane value here
-const BEACON_MAX_RETRY_ATTEMPTS: i16 = 15; //TODO: determine a sane value here
-const WITNESS_MAX_RETRY_ATTEMPTS: i16 = 15; //TODO: determine a sane value here
+/// the period in seconds after when a beacon or witness report in the DB will be deemed stale
+/// this period needs to be sufficiently long that we can be sure the beacon has
+/// zero change of validating
+/// NOTE: this period should permit the verifier to be down for an extended period
+const REPORT_STALE_PERIOD: i32 = 60 * 60 * 8; // 8 hours in seconds;
+/// the max number of attempts a failed beacon report will be retried
+const BEACON_MAX_RETRY_ATTEMPTS: i16 = 5; //TODO: determine a sane value here
+/// the max number of attempts a failed witness report will be retried
+const WITNESS_MAX_RETRY_ATTEMPTS: i16 = 5; //TODO: determine a sane value here
 
 #[derive(sqlx::Type, Serialize, Deserialize, Debug)]
 #[sqlx(type_name = "reporttype", rename_all = "lowercase")]
@@ -25,6 +31,7 @@ pub enum LoraStatus {
 #[sqlx(type_name = "poc_report")]
 pub struct Report {
     pub id: Vec<u8>,
+    pub remote_entropy: Vec<u8>,
     pub packet_data: Vec<u8>,
     pub report_data: Vec<u8>,
     pub report_type: ReportType,
@@ -39,6 +46,7 @@ impl Report {
     pub async fn insert_into<'c, E>(
         executor: E,
         id: Vec<u8>,
+        remote_entropy: Vec<u8>,
         packet_data: Vec<u8>,
         report_data: Vec<u8>,
         report_timestamp: &DateTime<Utc>,
@@ -51,14 +59,16 @@ impl Report {
             r#"
         insert into poc_report (
             id,
+            remote_entropy,
             packet_data,
             report_data,
             report_timestamp,
             report_type
-        ) values ($1, $2, $3, $4, $5)
+        ) values ($1, $2, $3, $4, $5, $6)
             "#,
         )
         .bind(id)
+        .bind(remote_entropy)
         .bind(packet_data)
         .bind(report_data)
         .bind(report_timestamp)
@@ -86,21 +96,49 @@ impl Report {
         .map_err(Error::from)
     }
 
+    pub async fn delete_report<'c, 'q, E>(executor: E, id: &'q Vec<u8>) -> Result
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres> + Clone,
+    {
+        sqlx::query(
+            r#"
+            delete from poc_report
+            where id = $1
+            "#,
+        )
+        .bind(id)
+        .execute(executor.clone())
+        .await
+        .map(|_| ())
+        .map_err(Error::from)
+    }
+
     pub async fn get_next_beacons<'c, E>(executor: E) -> Result<Vec<Self>>
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
         sqlx::query_as::<_, Self>(
             r#"
-            select * from poc_report
-            where report_type = 'beacon' and status = 'pending'
-            and report_timestamp < (NOW() - INTERVAL '$1 MINUTES')
+            select  poc_report.id,
+                    poc_report.remote_entropy,
+                    poc_report.packet_data,
+                    poc_report.report_data,
+                    poc_report.report_type,
+                    poc_report.status,
+                    poc_report.attempts,
+                    poc_report.report_timestamp,
+                    poc_report.last_processed,
+                    poc_report.created_at
+            from poc_report
+            left join entropy on poc_report.remote_entropy=entropy.data
+            where poc_report.report_type = 'beacon' and status = 'pending'
+            and entropy.timestamp < (NOW() - INTERVAL '$1 SECONDS')
             and attempts < $2
             order by report_timestamp asc
             limit 500
             "#,
         )
-        .bind(POC_LIFESPAN)
+        .bind(ENTROPY_LIFESPAN)
         .bind(BEACON_MAX_RETRY_ATTEMPTS)
         .fetch_all(executor)
         .await
@@ -203,6 +241,57 @@ impl Report {
         .execute(executor)
         .await
         .map(|_| ())
+        .map_err(Error::from)
+    }
+
+    pub async fn get_stale_pending_beacons<'c, E>(executor: E) -> Result<Vec<Self>>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
+        // NOTE: the query for stale beacons cannot rely on poc_report.attempts
+        // as beacons could be deteached from any entropy report
+        // ie we may receive a beacon report but never see an assocaited entropy report
+        // in such cases, the beacon report will never be processed
+        // as when pulling beacon reports, the verifier performs a join to entropy table
+        // if the entropy is not there the beacon will never be processed
+        // Such beacons will eventually be handled by the purger and failed there
+        // stale beacon reports, for this reason, are determined solely based on time
+        sqlx::query_as::<_, Self>(
+            r#"
+            select * from poc_report
+            where poc_report.report_type = 'beacon' and status = 'pending'
+            and created_at < (NOW() - INTERVAL '$1 SECONDS')
+            order by created_at asc
+            "#,
+        )
+        .bind(REPORT_STALE_PERIOD)
+        .fetch_all(executor)
+        .await
+        .map_err(Error::from)
+    }
+
+    pub async fn get_stale_pending_witnesses<'c, E>(executor: E) -> Result<Vec<Self>>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
+        // NOTE: the query for stale witnesses cannot rely on poc_report.attempts
+        // as witnesses could be deteached from any beacon report
+        // ie we may receive witnesses but not receive the associated beacon report
+        // in such cases, the witness report will never be verified
+        // as the verifier processes beacon reports and then pulls witness reports
+        // linked to current beacon being processed
+        // stale witness reports, for this reason, are determined solely based on time
+        sqlx::query_as::<_, Self>(
+            r#"
+            select * from poc_report
+            where report_type = 'witness' and status = 'pending'
+            and created_at < (NOW() - INTERVAL '$1 SECONDS')
+            order by created_at asc
+            "#,
+        )
+        .bind(REPORT_STALE_PERIOD)
+        .fetch_all(executor)
+        .await
         .map_err(Error::from)
     }
 }

--- a/poc_iot_verifier/src/poc_report.rs
+++ b/poc_iot_verifier/src/poc_report.rs
@@ -107,7 +107,7 @@ impl Report {
             "#,
         )
         .bind(id)
-        .execute(executor.clone())
+        .execute(executor)
         .await
         .map(|_| ())
         .map_err(Error::from)

--- a/poc_iot_verifier/src/purger.rs
+++ b/poc_iot_verifier/src/purger.rs
@@ -139,9 +139,8 @@ impl Purger {
     ) -> Result {
         let packet_data = &db_beacon.packet_data;
         let beacon_buf: &[u8] = &db_beacon.report_data;
-        let beacon_report = LoraBeaconIngestReport::try_from(
-            LoraBeaconIngestReportV1::decode(beacon_buf).unwrap(),
-        )?;
+        let beacon_report: LoraBeaconIngestReport =
+            LoraBeaconIngestReportV1::decode(beacon_buf)?.try_into()?;
         let beacon = &beacon_report.report;
         let invalid_beacon_proto: LoraInvalidBeaconReportV1 = LoraInvalidBeaconReport {
             received_timestamp: beacon_report.received_timestamp,
@@ -163,9 +162,8 @@ impl Purger {
     ) -> Result {
         let packet_data = &db_witness.packet_data;
         let witness_buf: &[u8] = &db_witness.report_data;
-        let witness_report = LoraWitnessIngestReport::try_from(
-            LoraWitnessIngestReportV1::decode(witness_buf).unwrap(),
-        )?;
+        let witness_report: LoraWitnessIngestReport =
+            LoraWitnessIngestReportV1::decode(witness_buf)?.try_into()?;
         let witness = &witness_report.report;
         let public_key = witness.pub_key.to_vec().clone();
         let invalid_witness_report_proto: LoraInvalidWitnessReportV1 = LoraInvalidWitnessReport {

--- a/poc_iot_verifier/src/purger.rs
+++ b/poc_iot_verifier/src/purger.rs
@@ -81,7 +81,6 @@ impl Purger {
         .await?;
 
         // spawn off the file sinks
-        // TODO: how to avoid all da cloning?
         let shutdown2 = shutdown.clone();
         let shutdown3 = shutdown.clone();
         let shutdown4 = shutdown.clone();

--- a/poc_iot_verifier/src/purger.rs
+++ b/poc_iot_verifier/src/purger.rs
@@ -1,0 +1,194 @@
+use crate::{entropy::Entropy, mk_db_pool, poc_report::Report, Result};
+use file_store::{
+    file_sink, file_sink::MessageSender, file_upload, lora_beacon_report::LoraBeaconIngestReport,
+    lora_invalid_poc::LoraInvalidBeaconReport, lora_invalid_poc::LoraInvalidWitnessReport,
+    lora_witness_report::LoraWitnessIngestReport, FileType,
+};
+use helium_proto::services::poc_lora::{
+    InvalidParticipantSide, InvalidReason, LoraBeaconIngestReportV1, LoraInvalidBeaconReportV1,
+    LoraInvalidWitnessReportV1, LoraWitnessIngestReportV1,
+};
+use std::path::Path;
+
+use helium_proto::Message;
+use sha2::{Digest, Sha256};
+use sqlx::PgPool;
+use tokio::time;
+
+const DB_POLL_TIME: time::Duration = time::Duration::from_secs(300);
+const LOADER_WORKERS: u32 = 10;
+const LOADER_DB_POOL_SIZE: u32 = 2 * LOADER_WORKERS;
+/// the fallback value to define the period in seconds after when a piece of entropy
+/// in the DB will be deemed stale and purged from the DB
+/// any beacon or witness using this entropy & received after this period will fail
+/// due to being stale
+/// the report itself will never be verified but instead handled by the stale purger
+/// NOTE: the verifier being down needs to be considered here
+const ENTROPY_STALE_PERIOD: i32 = 60 * 60 * 8; // 8 hours in seconds
+
+pub struct Purger {
+    pool: PgPool,
+    store_path: String,
+    entropy_stale_period: i32,
+}
+
+impl Purger {
+    pub async fn from_env() -> Result<Self> {
+        let pool = mk_db_pool(LOADER_DB_POOL_SIZE).await?;
+        let store_path =
+            std::env::var("VERIFIER_STORE").unwrap_or_else(|_| String::from("/var/data/verifier"));
+        let entropy_stale_period: i32 = std::env::var("ENTROPY_STALE_PERIOD").map_or_else(
+            |_| ENTROPY_STALE_PERIOD,
+            |v: String| v.parse::<i32>().unwrap_or(ENTROPY_STALE_PERIOD),
+        );
+        Ok(Self {
+            pool,
+            store_path,
+            entropy_stale_period,
+        })
+    }
+
+    pub async fn run(&self, shutdown: &triggered::Listener) -> Result {
+        tracing::info!("starting purger");
+
+        let mut db_timer = time::interval(DB_POLL_TIME);
+        db_timer.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+
+        let store_base_path = Path::new(&self.store_path);
+        let (lora_invalid_beacon_tx, lora_invalid_beacon_rx) = file_sink::message_channel(50);
+        let (lora_invalid_witness_tx, lora_invalid_witness_rx) = file_sink::message_channel(50);
+
+        let (file_upload_tx, file_upload_rx) = file_upload::message_channel();
+        let file_upload =
+            file_upload::FileUpload::from_env_with_prefix("VERIFIER", file_upload_rx).await?;
+
+        let mut lora_invalid_beacon_sink = file_sink::FileSinkBuilder::new(
+            FileType::LoraInvalidBeaconReport,
+            store_base_path,
+            lora_invalid_beacon_rx,
+        )
+        .deposits(Some(file_upload_tx.clone()))
+        .create()
+        .await?;
+
+        let mut lora_invalid_witness_sink = file_sink::FileSinkBuilder::new(
+            FileType::LoraInvalidWitnessReport,
+            store_base_path,
+            lora_invalid_witness_rx,
+        )
+        .deposits(Some(file_upload_tx.clone()))
+        .create()
+        .await?;
+
+        // spawn off the file sinks
+        // TODO: how to avoid all da cloning?
+        let shutdown2 = shutdown.clone();
+        let shutdown3 = shutdown.clone();
+        let shutdown4 = shutdown.clone();
+        tokio::spawn(async move { lora_invalid_beacon_sink.run(&shutdown2).await });
+        tokio::spawn(async move { lora_invalid_witness_sink.run(&shutdown3).await });
+        tokio::spawn(async move { file_upload.run(&shutdown4).await });
+
+        loop {
+            if shutdown.is_triggered() {
+                break;
+            }
+            tokio::select! {
+                _ = shutdown.clone() => break,
+                _ = db_timer.tick() =>
+                    match self.handle_db_tick(lora_invalid_beacon_tx.clone(),lora_invalid_witness_tx.clone()).await {
+                    Ok(()) => (),
+                    Err(err) => {
+                        tracing::error!("fatal purger error: {err:?}");
+                        return Err(err)
+                    }
+                }
+            }
+        }
+        tracing::info!("stopping purger");
+        Ok(())
+    }
+
+    async fn handle_db_tick(
+        &self,
+        lora_invalid_beacon_tx: MessageSender,
+        lora_invalid_witness_tx: MessageSender,
+    ) -> Result {
+        // pull stale beacons and witnesses which are in a pending state
+        // for each we have to write out an invalid report to S3
+        // as these wont have previously resulted in a file going to s3
+        // once the report is safely on s3 we can then proceed to purge from the db
+        _ = Report::get_stale_pending_beacons(&self.pool)
+            .await?
+            .iter()
+            .map(|report| self.handle_purged_beacon(report, &lora_invalid_beacon_tx));
+
+        _ = Report::get_stale_pending_witnesses(&self.pool)
+            .await?
+            .iter()
+            .map(|report| self.handle_purged_witness(report, &lora_invalid_witness_tx));
+
+        // purge any stale entropy, no need to output anything to s3 here
+        _ = Entropy::purge(&self.pool, &self.entropy_stale_period).await;
+        Ok(())
+    }
+
+    async fn handle_purged_beacon(
+        &self,
+        db_beacon: &Report,
+        lora_invalid_beacon_tx: &MessageSender,
+    ) -> Result {
+        let packet_data = &db_beacon.packet_data;
+        let beacon_buf: &[u8] = &db_beacon.report_data;
+        let beacon_report = LoraBeaconIngestReport::try_from(
+            LoraBeaconIngestReportV1::decode(beacon_buf).unwrap(),
+        )?;
+        let beacon = &beacon_report.report;
+        let invalid_beacon_proto: LoraInvalidBeaconReportV1 = LoraInvalidBeaconReport {
+            received_timestamp: beacon_report.received_timestamp,
+            reason: InvalidReason::Stale,
+            report: beacon.clone(),
+        }
+        .into();
+        file_sink::write(lora_invalid_beacon_tx, invalid_beacon_proto).await?;
+        // delete the report from the DB
+        let public_key = beacon_report.report.pub_key.to_vec();
+        self.delete_db_report(public_key, packet_data.clone()).await;
+        Ok(())
+    }
+
+    async fn handle_purged_witness(
+        &self,
+        db_witness: &Report,
+        lora_invalid_witness_tx: &MessageSender,
+    ) -> Result {
+        let packet_data = &db_witness.packet_data;
+        let witness_buf: &[u8] = &db_witness.report_data;
+        let witness_report = LoraWitnessIngestReport::try_from(
+            LoraWitnessIngestReportV1::decode(witness_buf).unwrap(),
+        )?;
+        let witness = &witness_report.report;
+        let public_key = witness.pub_key.to_vec().clone();
+        let invalid_witness_report_proto: LoraInvalidWitnessReportV1 = LoraInvalidWitnessReport {
+            received_timestamp: witness_report.received_timestamp,
+            report: witness_report.report,
+            reason: InvalidReason::Stale,
+            participant_side: InvalidParticipantSide::Witness,
+        }
+        .into();
+        file_sink::write(lora_invalid_witness_tx, invalid_witness_report_proto).await?;
+
+        // delete the report from the DB
+        self.delete_db_report(public_key, packet_data.clone()).await;
+        Ok(())
+    }
+
+    /// delete the report from the DB using ID
+    async fn delete_db_report(&self, mut pub_key_bytes: Vec<u8>, packet_data: Vec<u8>) {
+        // delete the report from the DB using ID
+        let mut id: Vec<u8> = packet_data;
+        id.append(&mut pub_key_bytes);
+        let id_hash = Sha256::digest(&id).to_vec();
+        _ = Report::delete_report(&self.pool, &id_hash).await;
+    }
+}

--- a/poc_iot_verifier/src/runner.rs
+++ b/poc_iot_verifier/src/runner.rs
@@ -31,6 +31,7 @@ use tokio::time;
 const DB_POLL_TIME: time::Duration = time::Duration::from_secs(30);
 const LOADER_WORKERS: usize = 10;
 const LOADER_DB_POOL_SIZE: usize = 2 * LOADER_WORKERS;
+/// the cadence in seconds at which hotspots are permitted to beacon
 const BEACON_INTERVAL: i64 = 10 * 60; // 10 mins
 
 pub struct Runner {
@@ -235,6 +236,9 @@ impl Runner {
                     // check if there are any failed witnesses
                     // if so update the DB attempts count
                     // and halt here, let things be reprocessed next tick
+                    // if a witness continues to fail it will eventually
+                    // be discarded from the list returned for the beacon
+                    // thus one of more failing witnesses will not block the overall POC
                     if !verified_witnesses_result.failed_witnesses.is_empty() {
                         for failed_witness_report in verified_witnesses_result.failed_witnesses {
                             // something went wrong whilst verifying witnesses


### PR DESCRIPTION
linked Proto PR: [andymck/add-stale-invalid-reason](https://github.com/helium/proto/pull/195)

Adds purging of stale data from the verifier postgres DB to prevent data growing unbounded

Cover 3 main scenarios:


1. Verified beacon and witness reports ( valid or invalid ), these are deleted from the DB immediately after verification and after the associated report is outputted to S3

2. Stale beacon and witness reports, these are reports which are not verifiable.  It could be a witness report which has no associated beacon report or a beacon report which has no associated entropy report.  These are purged after a defined period of time.

3. Entropy reports, these are deleted after a defined period of time 

I may still add a subsequent PR to better cater for the verifier being down for an extended period of time.  We likely want to avoid the potential of all reports added to the DB just before the verifier went down being rejected due to associated data being purged as it is considered stale when the verifier next comes up
