### PR TITLE
density scaler crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "density-scaler"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "h3ron",
+ "helium-proto",
+ "http",
+ "itertools",
+ "lazy_static",
+ "prost",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+ "triggered",
+]
+
+[[package]]
 name = "der"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,8 @@ dependencies = [
  "itertools",
  "node-follower",
  "prost",
+ "rust_decimal",
+ "rust_decimal_macros",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,11 +940,12 @@ name = "density-scaler"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "futures",
  "h3ron",
  "helium-proto",
  "http",
  "itertools",
- "lazy_static",
+ "node-follower",
  "prost",
  "serde",
  "serde_json",
@@ -2075,6 +2076,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "dotenv",
+ "futures",
  "helium-crypto",
  "helium-proto",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,17 @@
 [workspace]
-members = [ "ingest", "db_store", "file_store", "mobile_rewards", "poc_mobile_verifier", "entropy",
-"poc_iot_verifier", "poc_iot_injector", "node_follower"]
+members = [
+    "ingest",
+    "db_store",
+    "file_store",
+    "mobile_rewards",
+    "poc_mobile_verifier",
+    "entropy",
+    "poc_iot_verifier",
+    "poc_iot_injector",
+    "node_follower",
+    "density_scaler",
+    "metrics",
+]
 
 [workspace.package]
 authors = ["Nova Labs <info@nova-labs.com>"]
@@ -51,4 +62,3 @@ futures-util = "*"
 prost = "*"
 once_cell = "1"
 lazy_static = "1"
-

--- a/density_scaler/Cargo.toml
+++ b/density_scaler/Cargo.toml
@@ -7,17 +7,18 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+futures = {workspace = true}
 thiserror = {workspace = true}
 serde = {workspace = true}
 serde_json = {workspace = true}
 tokio = {workspace = true}
 tracing = {workspace = true}
-lazy_static = {workspace = true}
 chrono = {workspace = true}
 triggered = {workspace = true}
 prost = {workspace = true}
 helium-proto = {workspace = true}
 tonic = {workspace = true}
 http = {workspace = true}
+node-follower = { path = "../node_follower" }
 h3ron = {version = "0.15"}
 itertools = "*"

--- a/density_scaler/Cargo.toml
+++ b/density_scaler/Cargo.toml
@@ -22,3 +22,5 @@ http = {workspace = true}
 node-follower = { path = "../node_follower" }
 h3ron = {version = "0.15"}
 itertools = "*"
+rust_decimal = {workspace = true}
+rust_decimal_macros = {workspace = true}

--- a/density_scaler/Cargo.toml
+++ b/density_scaler/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "density-scaler"
+version = "0.1.0"
+description = "Calculates hex density scaling factor based on relative neighbor population"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+thiserror = {workspace = true}
+serde = {workspace = true}
+serde_json = {workspace = true}
+tokio = {workspace = true}
+tracing = {workspace = true}
+lazy_static = {workspace = true}
+chrono = {workspace = true}
+triggered = {workspace = true}
+prost = {workspace = true}
+helium-proto = {workspace = true}
+tonic = {workspace = true}
+http = {workspace = true}
+h3ron = {version = "0.15"}
+itertools = "*"

--- a/density_scaler/README.md
+++ b/density_scaler/README.md
@@ -1,0 +1,41 @@
+# Density Scaler
+
+This crate is designed to run a separate threaded tokio process within other applications
+in the Helium Network Oracle infrastructure and provide h3dex density scaling factors on
+request to the managing service for calculating coverage rewards relative to the population
+density of a gateway's hex and neighboring hexes per the algorithms adopted in HIPs 15 and 17.
+
+## API
+
+The density scaler provides an API for communicating between the scaler server and the managing
+application based on the tokio flavor of mpsc and oneshot channels. Before starting the scaler,
+generate the two ends of the connection between your process and the scaler server with
+`density_scaler::query_channel()`, which returns the two ends of the connection as structs. Pass the
+receiving end to the scaler when the process is started and send messages to it through the sending
+end via the `density_scaler::QuerySender.query(hex: String)` method. Await the result in the form
+of a `Result<Option<f64>>` the success case float indicating the value by which rewards for the
+requested hex should be multiplied.
+
+## Server
+
+The density scaler server runs as a separate tokio threaded process within other Helium Oracles,
+such as the PoC Verifier for the IoT network. When starting the managing application (likely within
+the main function) you must first generate the message channel for making queries and store the
+sending half (QuerySender) in your own server. Pass the receiving half of the channel (QueryReceiver)
+to the density scaler's `Server::run` method alongside the shutdown trigger of your application.
+The scaler server runs in a configurable loop, periodically querying the on-chain source of asserted
+gateway location data and rebuilding the density scaling map globally each time. With each new version
+of the scaling factor lookup table, the density scaler will continue to server responses to individual
+hex scaling queries as well as write the contents of the scaling factor lookup table as an output
+report alongside other oracles' reports.
+
+## Configuration
+
+Density scaler behavior is adjustable through the following environment variables:
+
+- `FOLLOWER_URI`: The fully-qualified protocol, URL or IP and port of the gateway grpc location stream.
+                  Defaults to `"http://127.0.0.1:8080"` when not defined in the environment.
+- `TRIGGER_INTERVAL_SECS`: The duration in seconds between runs of the server loop to regenerate the scaling
+                  factor map. Defaults to 1800 (30 min) when not defined in the environment.
+- `GW_STREAM_BATCH_SIZE`: The size of batches of gateway location info to request from the source of on-chain
+                  location data in the grpc response stream. Defaults to 1000 when not defined in the environment.

--- a/density_scaler/README.md
+++ b/density_scaler/README.md
@@ -35,7 +35,7 @@ Density scaler behavior is adjustable through the following environment variable
 
 - `FOLLOWER_URI`: The fully-qualified protocol, URL or IP and port of the gateway grpc location stream.
                   Defaults to `"http://127.0.0.1:8080"` when not defined in the environment.
-- `TRIGGER_INTERVAL_SECS`: The duration in seconds between runs of the server loop to regenerate the scaling
+- `DENSITY_TRIGGER_INTERVAL_SECS`: The duration in seconds between runs of the server loop to regenerate the scaling
                   factor map. Defaults to 1800 (30 min) when not defined in the environment.
-- `GW_STREAM_BATCH_SIZE`: The size of batches of gateway location info to request from the source of on-chain
+- `DENSITY_GW_STREAM_BATCH_SIZE`: The size of batches of gateway location info to request from the source of on-chain
                   location data in the grpc response stream. Defaults to 1000 when not defined in the environment.

--- a/density_scaler/src/error.rs
+++ b/density_scaler/src/error.rs
@@ -14,20 +14,16 @@ pub enum Error {
     Decode(#[from] DecodeError),
     #[error("query channel error")]
     QueryChannel,
-    #[error("service error")]
-    Service(#[from] helium_proto::services::Error),
-    #[error("grpc {}", .0.message())]
-    Grpc(#[from] tonic::Status),
     #[error("not found")]
     NotFound(String),
+    #[error("follower error")]
+    Follower(#[from] node_follower::Error),
 }
 
 #[derive(Debug, Error)]
 pub enum DecodeError {
     #[error("prost error")]
     Prost(#[from] helium_proto::DecodeError),
-    #[error("uri error")]
-    Uri(#[from] http::uri::InvalidUri),
     #[error("parse int error")]
     ParseInt(#[from] std::num::ParseIntError),
 }
@@ -65,5 +61,4 @@ from_err!(EncodeError, prost::EncodeError);
 from_err!(EncodeError, serde_json::Error);
 
 // Decode Errors
-from_err!(DecodeError, http::uri::InvalidUri);
 from_err!(DecodeError, prost::DecodeError);

--- a/density_scaler/src/error.rs
+++ b/density_scaler/src/error.rs
@@ -1,0 +1,69 @@
+use thiserror::Error;
+
+pub type Result<T = ()> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("env error")]
+    Env(#[from] std::env::VarError),
+    #[error("io error")]
+    Io(#[from] std::io::Error),
+    #[error("encode error")]
+    Encode(#[from] EncodeError),
+    #[error("decode error")]
+    Decode(#[from] DecodeError),
+    #[error("query channel error")]
+    QueryChannel,
+    #[error("service error")]
+    Service(#[from] helium_proto::services::Error),
+    #[error("grpc {}", .0.message())]
+    Grpc(#[from] tonic::Status),
+    #[error("not found")]
+    NotFound(String),
+}
+
+#[derive(Debug, Error)]
+pub enum DecodeError {
+    #[error("prost error")]
+    Prost(#[from] helium_proto::DecodeError),
+    #[error("uri error")]
+    Uri(#[from] http::uri::InvalidUri),
+    #[error("parse int error")]
+    ParseInt(#[from] std::num::ParseIntError),
+}
+
+#[derive(Debug, Error)]
+pub enum EncodeError {
+    #[error("prost error")]
+    Prost(#[from] helium_proto::EncodeError),
+    #[error("json error")]
+    Json(#[from] serde_json::Error),
+}
+
+impl Error {
+    pub fn not_found<E: ToString>(msg: E) -> Self {
+        Self::NotFound(msg.to_string())
+    }
+
+    pub fn channel() -> Self {
+        Self::QueryChannel
+    }
+}
+
+macro_rules! from_err {
+    ($to_type:ty, $from_type:ty) => {
+        impl From<$from_type> for Error {
+            fn from(v: $from_type) -> Self {
+                Self::from(<$to_type>::from(v))
+            }
+        }
+    };
+}
+
+// Encode Errors
+from_err!(EncodeError, prost::EncodeError);
+from_err!(EncodeError, serde_json::Error);
+
+// Decode Errors
+from_err!(DecodeError, http::uri::InvalidUri);
+from_err!(DecodeError, prost::DecodeError);

--- a/density_scaler/src/hex.rs
+++ b/density_scaler/src/hex.rs
@@ -1,0 +1,229 @@
+use h3ron::{FromH3Index, H3Cell, Index};
+use itertools::Itertools;
+use lazy_static::lazy_static;
+use serde::Serialize;
+use std::{cmp, collections::HashMap, ops::Range};
+
+pub struct HexResConfig {
+    pub neighbors: u64,
+    pub target: u64,
+    pub max: u64,
+}
+
+impl HexResConfig {
+    pub fn new(neighbors: u64, target: u64, max: u64) -> Self {
+        Self {
+            neighbors,
+            target,
+            max,
+        }
+    }
+}
+
+type HexMap = HashMap<H3Cell, u64>;
+
+const MAX_RES: u8 = 11;
+const DENSITY_TGT_RES: u8 = 4;
+const USED_RES: Range<u8> = DENSITY_TGT_RES..MAX_RES;
+
+lazy_static! {
+    static ref HIP17_RES_CONFIG: HashMap<u8, HexResConfig> = {
+        let mut conf_map = HashMap::new();
+        // Hex resolutions 0 - 3 and 11 and 12 are currently ignored by the
+        // global hex population constructor, filtered by their target value.
+        // For completeness sake their on-chain settings are N=2, TGT=100_000, MAX=100_000
+        conf_map.insert(4, HexResConfig::new(1, 250, 800));
+        conf_map.insert(5, HexResConfig::new(1, 100, 400));
+        conf_map.insert(6, HexResConfig::new(1, 25, 100));
+        conf_map.insert(7, HexResConfig::new(2, 5, 20));
+        conf_map.insert(8, HexResConfig::new(2, 1, 4));
+        conf_map.insert(9, HexResConfig::new(2, 1, 2));
+        conf_map.insert(10, HexResConfig::new(2, 1, 1));
+        conf_map
+    };
+}
+
+#[derive(Debug, Serialize)]
+pub struct ScalingMap(HashMap<String, f64>);
+
+impl ScalingMap {
+    pub fn new() -> ScalingMap {
+        let map: HashMap<String, f64> = HashMap::new();
+        ScalingMap(map)
+    }
+
+    pub fn insert(&mut self, hex: &str, scale_factor: f64) -> Option<f64> {
+        self.0.insert(hex.to_string(), scale_factor)
+    }
+
+    pub fn get(&self, hex: &str) -> Option<&f64> {
+        self.0.get(hex)
+    }
+}
+
+#[derive(Debug)]
+pub struct GlobalHexMap {
+    clipped_hexes: HexMap,
+    unclipped_hexes: HexMap,
+    asserted_hexes: Vec<H3Cell>,
+}
+
+impl GlobalHexMap {
+    pub fn new() -> Self {
+        Self {
+            clipped_hexes: HashMap::new(),
+            unclipped_hexes: HashMap::new(),
+            asserted_hexes: Vec::new(),
+        }
+    }
+
+    pub fn increment_unclipped(&mut self, index: u64) {
+        let cell = H3Cell::from_h3index(index);
+        if let Ok(parent) = cell.get_parent(MAX_RES) {
+            self.unclipped_hexes
+                .entry(parent)
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
+            self.clipped_hexes
+                .entry(parent)
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
+            self.asserted_hexes.push(cell);
+        }
+    }
+
+    pub fn reduce_global(&mut self) {
+        let starting_hexes: Vec<H3Cell> = self.unclipped_hexes.clone().into_keys().collect();
+        reduce_hex_res(
+            &mut self.unclipped_hexes,
+            &mut self.clipped_hexes,
+            starting_hexes,
+        )
+    }
+}
+
+fn rollup_child_count(
+    unclipped_map: &mut HexMap,
+    clipped_map: &mut HexMap,
+    cell: H3Cell,
+    parent: H3Cell,
+) {
+    let cell_count = clipped_map.get(&cell).map_or(0, |count| *count);
+
+    unclipped_map
+        .entry(parent)
+        .and_modify(|parent_count| *parent_count += cell_count)
+        .or_insert(cell_count);
+
+    // This block is marked in the original code as "not sure if required" but removing it
+    // results in dynamically unpredictable result scaling maps.
+    clipped_map
+        .entry(parent)
+        .and_modify(|parent_count| *parent_count += cell_count)
+        .or_insert(cell_count);
+}
+
+fn reduce_hex_res(unclipped: &mut HexMap, clipped: &mut HexMap, hex_list: Vec<H3Cell>) {
+    let mut hexes_at_res: Vec<H3Cell> = hex_list;
+    for res in USED_RES.rev() {
+        std::mem::take(&mut hexes_at_res)
+            .into_iter()
+            .unique()
+            .for_each(|cell| {
+                if let Ok(parent) = cell.get_parent(res) {
+                    rollup_child_count(unclipped, clipped, cell, parent);
+                    hexes_at_res.push(parent);
+                }
+            });
+        let density_tgt = get_res_tgt(res);
+        for parent_hex in &hexes_at_res {
+            let occupied_count = occupied_count(clipped, parent_hex, density_tgt);
+            let limit = limit(res, occupied_count);
+            if let Some(count) = unclipped.get(parent_hex) {
+                let actual = cmp::min(limit, *count);
+                clipped.insert(*parent_hex, actual);
+            }
+        }
+    }
+}
+
+fn occupied_count(cell_map: &HexMap, hex: &H3Cell, density_tgt: u64) -> u64 {
+    match hex.grid_disk(1) {
+        Ok(k_ring) => {
+            let mut count = 0;
+            for cell in k_ring.into_iter() {
+                if let Some(population) = cell_map.get(&cell) {
+                    if *population >= density_tgt {
+                        count += 1
+                    }
+                }
+            }
+            count
+        }
+        Err(_) => 0,
+    }
+}
+
+fn limit(res: u8, occupied_count: u64) -> u64 {
+    match HIP17_RES_CONFIG.get(&res) {
+        Some(res_config) => {
+            let occupied_neighbor_diff = occupied_count.saturating_sub(res_config.neighbors);
+            let max = cmp::max((occupied_neighbor_diff) + 1, 1);
+            cmp::min(res_config.max, res_config.target * max)
+        }
+        None => 1,
+    }
+}
+
+pub fn compute_scaling_map(global_map: &GlobalHexMap, scaling_map: &mut ScalingMap) {
+    for hex in &global_map.asserted_hexes {
+        let mut scale: f64 = 1.0;
+        for res in USED_RES.rev() {
+            if let Ok(parent) = hex.get_parent(res) {
+                if let Some(unclipped) = global_map.unclipped_hexes.get(&parent) {
+                    if let Some(clipped) = global_map.clipped_hexes.get(&parent) {
+                        scale *= *clipped as f64 / *unclipped as f64;
+                    }
+                }
+            }
+        }
+        scaling_map.insert(&hex.h3index().to_string(), scale);
+    }
+}
+
+fn get_res_tgt(res: u8) -> u64 {
+    HIP17_RES_CONFIG
+        .get(&res)
+        .map(|config| config.target)
+        .unwrap_or(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_scale_check() {
+        let indexes: Vec<u64> = vec![
+            631210990515645439,
+            631210990515609087,
+            631210990516667903,
+            631210990528935935,
+            631210990528385535,
+            631210990528546815,
+            631210990529462783,
+            631210990529337343,
+            631210990524024831,
+            631210990524753919,
+            631210990525267455,
+        ];
+        let mut gw_map = GlobalHexMap::new();
+        for index in indexes {
+            gw_map.increment_unclipped(index);
+        }
+        gw_map.reduce_global();
+        let mut scale_map = ScalingMap::new();
+        compute_scaling_map(&gw_map, &mut scale_map);
+        println!("Result {scale_map:?}");
+    }
+}

--- a/density_scaler/src/lib.rs
+++ b/density_scaler/src/lib.rs
@@ -1,0 +1,8 @@
+mod error;
+mod hex;
+pub mod query;
+pub mod server;
+
+pub use error::{Error, Result};
+pub use query::{query_channel, QueryReceiver, QuerySender};
+pub use server::Server;

--- a/density_scaler/src/query.rs
+++ b/density_scaler/src/query.rs
@@ -1,0 +1,55 @@
+use crate::{Error, Result};
+use tokio::sync::{mpsc, oneshot};
+
+#[derive(Debug)]
+pub struct QueryMsg {
+    pub hex: String,
+    pub response: ResultSender,
+}
+
+#[derive(Debug)]
+pub struct QuerySender(mpsc::Sender<QueryMsg>);
+pub struct QueryReceiver(mpsc::Receiver<QueryMsg>);
+
+pub fn query_channel(size: usize) -> (QuerySender, QueryReceiver) {
+    let (tx, rx) = mpsc::channel(size);
+    (QuerySender(tx), QueryReceiver(rx))
+}
+
+impl QuerySender {
+    pub async fn query(&self, hex: String) -> Result<Option<f64>> {
+        let (tx, rx) = result_channel();
+        let _ = self.0.send(QueryMsg { hex, response: tx }).await;
+        rx.recv().await
+    }
+}
+
+impl QueryReceiver {
+    pub async fn recv(&mut self) -> Option<QueryMsg> {
+        self.0.recv().await
+    }
+}
+
+#[derive(Debug)]
+pub struct ResultSender(oneshot::Sender<Option<f64>>);
+pub struct ResultReceiver(oneshot::Receiver<Option<f64>>);
+
+pub fn result_channel() -> (ResultSender, ResultReceiver) {
+    let (tx, rx) = oneshot::channel();
+    (ResultSender(tx), ResultReceiver(rx))
+}
+
+impl ResultSender {
+    pub fn send(self, msg: Option<f64>) {
+        match self.0.send(msg) {
+            Ok(()) => (),
+            Err(err) => tracing::warn!("failed to return result for reason : {err:?}"),
+        }
+    }
+}
+
+impl ResultReceiver {
+    pub async fn recv(self) -> Result<Option<f64>> {
+        self.0.await.map_err(|_| Error::channel())
+    }
+}

--- a/density_scaler/src/server.rs
+++ b/density_scaler/src/server.rs
@@ -1,0 +1,125 @@
+use crate::{
+    error::DecodeError,
+    hex::{compute_scaling_map, GlobalHexMap, ScalingMap},
+    query::{QueryMsg, QueryReceiver},
+    Result,
+};
+use chrono::Duration;
+use helium_proto::services::{
+    follower::{
+        self, FollowerGatewayRespV1, FollowerGatewayStreamReqV1, FollowerGatewayStreamRespV1,
+    },
+    Channel, Endpoint,
+};
+use http::Uri;
+use std::{env, time::Duration as StdDuration};
+use tokio::time;
+use tonic::Streaming;
+
+const DEFAULT_TRIGGER_INTERVAL_SECS: i64 = 1800; // 30 min
+const CONNECT_TIMEOUT: StdDuration = StdDuration::from_secs(5);
+const RPC_TIMEOUT: StdDuration = StdDuration::from_secs(5);
+const DEFAULT_URI: &str = "http://127.0.0.1:8080";
+const DEFAULT_STREAM_BATCH_SIZE: u32 = 1000;
+
+pub struct Server {
+    scaling_map: ScalingMap,
+    follower_client: follower::Client<Channel>,
+    trigger_interval: Duration,
+}
+
+impl Server {
+    pub fn new() -> Result<Self> {
+        let result = Self {
+            scaling_map: ScalingMap::new(),
+            follower_client: new_follower_from_env()?,
+            trigger_interval: Duration::seconds(
+                env::var("TRIGGER_INTERVAL_SECS")
+                    .unwrap_or_else(|_| DEFAULT_TRIGGER_INTERVAL_SECS.to_string())
+                    .parse()
+                    .map_err(DecodeError::from)?,
+            ),
+        };
+        Ok(result)
+    }
+
+    pub async fn run(
+        &mut self,
+        mut queries: QueryReceiver,
+        shutdown: triggered::Listener,
+    ) -> Result {
+        tracing::info!("starting density scaler process");
+
+        let mut trigger_timer = time::interval(
+            self.trigger_interval
+                .to_std()
+                .expect("valid interval in seconds"),
+        );
+
+        loop {
+            if shutdown.is_triggered() {
+                tracing::info!("stopping density scaler");
+                return Ok(());
+            }
+
+            tokio::select! {
+                query = queries.recv() => match query {
+                    Some(QueryMsg{hex, response: tx}) => {
+                        let resp = self
+                                   .scaling_map
+                                   .get(&hex)
+                                   .map(|scale| scale.to_owned());
+                        tx.send(resp)
+                    },
+                    None => {
+                        tracing::warn!("query channel closed");
+                        return Ok(())
+                    }
+                },
+                _ = trigger_timer.tick() => self.refresh_scaling_map().await?,
+                _ = shutdown.clone() => return Ok(()),
+            }
+        }
+    }
+
+    pub async fn refresh_scaling_map(&mut self) -> Result {
+        let mut global_map = GlobalHexMap::new();
+        let mut gw_stream = active_gateways(&mut self.follower_client).await?;
+        while let Some(FollowerGatewayStreamRespV1 { gateways }) = gw_stream.message().await? {
+            for FollowerGatewayRespV1 { location, .. } in gateways {
+                if let Ok(h3index) = location.parse::<u64>() {
+                    global_map.increment_unclipped(h3index)
+                }
+            }
+        }
+        global_map.reduce_global();
+        let mut scaling_map = ScalingMap::new();
+        compute_scaling_map(&global_map, &mut scaling_map);
+        self.scaling_map = scaling_map;
+        Ok(())
+    }
+}
+
+fn new_follower_from_env() -> Result<follower::Client<Channel>> {
+    let uri: Uri = env::var("FOLLOWER_URI")
+        .unwrap_or_else(|_| DEFAULT_URI.to_string())
+        .parse()?;
+    let channel = Endpoint::from(uri)
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(RPC_TIMEOUT)
+        .connect_lazy();
+    Ok(follower::Client::new(channel))
+}
+
+async fn active_gateways(
+    client: &mut follower::Client<Channel>,
+) -> Result<Streaming<FollowerGatewayStreamRespV1>> {
+    let req = FollowerGatewayStreamReqV1 {
+        batch_size: env::var("GW_STREAM_BATCH_SIZE")
+            .unwrap_or_else(|_| DEFAULT_STREAM_BATCH_SIZE.to_string())
+            .parse()
+            .map_err(DecodeError::from)?,
+    };
+    let res = client.active_gateways(req).await?.into_inner();
+    Ok(res)
+}

--- a/node_follower/Cargo.toml
+++ b/node_follower/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+futures = {workspace = true}
 thiserror = {workspace = true}
 helium-proto = { workspace = true }
 helium-crypto = { workspace = true }

--- a/node_follower/src/error.rs
+++ b/node_follower/src/error.rs
@@ -4,6 +4,8 @@ pub type Result<T = ()> = std::result::Result<T, Error>;
 
 #[derive(Error, Debug)]
 pub enum Error {
+    #[error("parse batch size error")]
+    ParseInt(#[from] std::num::ParseIntError),
     #[error("uri error")]
     Uri(#[from] http::uri::InvalidUri),
     #[error("grpc {}", .0.message())]

--- a/node_follower/src/lib.rs
+++ b/node_follower/src/lib.rs
@@ -1,3 +1,4 @@
+use futures::stream::BoxStream;
 use std::time::Duration;
 
 pub mod error;
@@ -8,4 +9,9 @@ pub use error::{Error, Result};
 
 pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 pub(crate) const RPC_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const DEFAULT_STREAM_BATCH_SIZE: u32 = 1000;
 pub(crate) const DEFAULT_URI: &str = "http://127.0.0.1:8080";
+
+pub type Stream<T> = BoxStream<'static, T>;
+
+pub type GatewayInfoStream = Stream<gateway_resp::GatewayInfo>;


### PR DESCRIPTION
implement a density scaling crate; the density_scaler runs as a separate tokio process within a service. it schedules a recurring process at a regular interval that queries a blockchain-node, retrieves the h3dex index location of all active gateways over a grpc stream and computes the scaling factor for all res 11 hexes, storing them in a wrapped hashmap. the scaler process also provides a query api wrapped around message channels for communicating between the calling service and the scaler.
- [x] test this with a collection of hexes