### PR TITLE
realign follower proto response with new structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#97d063d2eeec0e950e90f50f050e8048a5031a48"
+source = "git+https://github.com/helium/proto?branch=master#0896e488d62c86a2978b8546b268d5aa4608388d"
 dependencies = [
  "bytes",
  "prost",

--- a/node_follower/src/error.rs
+++ b/node_follower/src/error.rs
@@ -12,4 +12,6 @@ pub enum Error {
     StakingMode(String),
     #[error("unsupported region {0}")]
     Region(String),
+    #[error("hotspot not found {0}")]
+    GatewayNotFound(String),
 }

--- a/node_follower/src/lib.rs
+++ b/node_follower/src/lib.rs
@@ -1,5 +1,11 @@
+use std::time::Duration;
+
 pub mod error;
 pub mod follower_service;
 pub mod gateway_resp;
 pub mod txn_service;
 pub use error::{Error, Result};
+
+pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const RPC_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const DEFAULT_URI: &str = "http://127.0.0.1:8080";

--- a/node_follower/src/txn_service.rs
+++ b/node_follower/src/txn_service.rs
@@ -1,4 +1,4 @@
-use crate::Result;
+use crate::{Result, CONNECT_TIMEOUT, DEFAULT_URI, RPC_TIMEOUT};
 use helium_proto::{
     services::{
         transaction::{self, TxnQueryReqV1, TxnQueryRespV1, TxnSubmitReqV1, TxnSubmitRespV1},
@@ -7,11 +7,7 @@ use helium_proto::{
     BlockchainTxn,
 };
 use http::Uri;
-use std::{env, str::FromStr, time::Duration};
-
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-const RPC_TIMEOUT: Duration = Duration::from_secs(5);
-pub const DEFAULT_URI: &str = "http://127.0.0.1:8080";
+use std::{env, str::FromStr};
 
 type TransactionClient = transaction::Client<Channel>;
 

--- a/poc_iot_verifier/src/poc.rs
+++ b/poc_iot_verifier/src/poc.rs
@@ -12,7 +12,7 @@ use helium_proto::{
 };
 use node_follower::{
     follower_service::FollowerService,
-    gateway_resp::{FollowerGatewayResp, GatewayInfoResolver},
+    gateway_resp::{GatewayInfo, GatewayInfoResolver},
 };
 use std::f64::consts::PI;
 /// C is the speed of light in air in meters per second
@@ -42,14 +42,14 @@ pub struct Poc {
 pub struct VerifyBeaconResult {
     pub result: VerificationStatus,
     pub invalid_reason: Option<InvalidReason>,
-    pub gateway_info: Option<FollowerGatewayResp>,
+    pub gateway_info: Option<GatewayInfo>,
     pub hex_scale: Option<f32>,
 }
 
 pub struct VerifyWitnessResult {
     result: VerificationStatus,
     invalid_reason: Option<InvalidReason>,
-    pub gateway_info: Option<FollowerGatewayResp>,
+    pub gateway_info: Option<GatewayInfo>,
 }
 
 pub struct VerifyWitnessesResult {
@@ -180,7 +180,7 @@ impl Poc {
 
     pub async fn verify_witnesses(
         &mut self,
-        beacon_info: &FollowerGatewayResp,
+        beacon_info: &GatewayInfo,
     ) -> Result<VerifyWitnessesResult> {
         let mut valid_witnesses: Vec<LoraValidWitnessReport> = Vec::new();
         let mut invalid_witnesses: Vec<LoraInvalidWitnessReport> = Vec::new();
@@ -234,7 +234,7 @@ impl Poc {
     async fn verify_witness(
         &mut self,
         witness_report: &LoraWitnessIngestReport,
-        beaconer_info: &FollowerGatewayResp,
+        beaconer_info: &GatewayInfo,
     ) -> Result<VerifyWitnessResult> {
         // use pub key to get GW info from our follower and verify the witness
         let witness = &witness_report.report;

--- a/poc_iot_verifier/src/runner.rs
+++ b/poc_iot_verifier/src/runner.rs
@@ -23,7 +23,7 @@ use helium_proto::services::poc_lora::{
     LoraInvalidWitnessReportV1, LoraValidPocV1, LoraWitnessIngestReportV1,
 };
 use helium_proto::Message;
-use node_follower::gateway_resp::FollowerGatewayResp;
+use node_follower::gateway_resp::GatewayInfo;
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use std::path::Path;
@@ -233,8 +233,7 @@ impl Runner {
             match beacon_verify_result.result {
                 VerificationStatus::Valid => {
                     // beacon is valid, verify the witnesses
-                    let beacon_info: FollowerGatewayResp =
-                        beacon_verify_result.gateway_info.unwrap();
+                    let beacon_info: GatewayInfo = beacon_verify_result.gateway_info.unwrap();
                     let verified_witnesses_result = poc.verify_witnesses(&beacon_info).await?;
                     // check if there are any failed witnesses
                     // if so update the DB attempts count

--- a/poc_mobile_verifier/src/reward_share.rs
+++ b/poc_mobile_verifier/src/reward_share.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use helium_proto::services::{
-    follower::{self, FollowerGatewayReqV1},
+    follower::{self, follower_gateway_resp_v1::Result as GatewayResult, FollowerGatewayReqV1},
     Channel,
 };
 use lazy_static::lazy_static;
@@ -103,8 +103,10 @@ impl OwnerResolver for follower::Client<Channel> {
         };
         let res = self.find_gateway(req).await?.into_inner();
 
-        if let Ok(pub_key) = PublicKey::try_from(res.owner) {
-            return Ok(Some(pub_key));
+        if let Some(GatewayResult::Info(gateway_info)) = res.result {
+            if let Ok(pub_key) = PublicKey::try_from(gateway_info.owner) {
+                return Ok(Some(pub_key));
+            }
         }
 
         Ok(None)


### PR DESCRIPTION
The addition of a "GatewayNotFound" response to the follower node GRPC API requires a restructuring of the response struct received by clients of the service querying the `find_gateway` RPC; this change adapts to the new proto structure to handle the possibility the gateway is not found and converts it to an appropriate error in that situation.