### PR TITLE
Write poc receipt txns to s3 bucket

### DIFF
--- a/file_store/src/file_info.rs
+++ b/file_store/src/file_info.rs
@@ -103,6 +103,7 @@ pub const LORA_INVALID_BEACON_REPORT: &str = "lora_invalid_beacon";
 pub const LORA_INVALID_WITNESS_REPORT: &str = "lora_invalid_witness";
 pub const SPEEDTEST_AVG: &str = "speedtest_avg";
 pub const VALIDATED_HEARTBEAT: &str = "validated_heartbeat";
+pub const SIGNED_POC_RECEIPT_TXN: &str = "signed_poc_receipt_txn";
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Copy, strum::EnumCount)]
 #[serde(rename_all = "snake_case")]
@@ -121,6 +122,7 @@ pub enum FileType {
     LoraInvalidWitnessReport,
     SpeedtestAvg,
     ValidatedHeartbeat,
+    SignedPocReceiptTxn,
 }
 
 impl fmt::Display for FileType {
@@ -140,6 +142,7 @@ impl fmt::Display for FileType {
             Self::LoraInvalidWitnessReport => LORA_INVALID_WITNESS_REPORT,
             Self::SpeedtestAvg => SPEEDTEST_AVG,
             Self::ValidatedHeartbeat => VALIDATED_HEARTBEAT,
+            Self::SignedPocReceiptTxn => SIGNED_POC_RECEIPT_TXN,
         };
         f.write_str(s)
     }
@@ -162,6 +165,7 @@ impl FileType {
             Self::LoraInvalidWitnessReport => LORA_INVALID_WITNESS_REPORT,
             Self::SpeedtestAvg => SPEEDTEST_AVG,
             Self::ValidatedHeartbeat => VALIDATED_HEARTBEAT,
+            Self::SignedPocReceiptTxn => SIGNED_POC_RECEIPT_TXN,
         }
     }
 }
@@ -184,6 +188,7 @@ impl FromStr for FileType {
             LORA_INVALID_WITNESS_REPORT => Self::LoraInvalidWitnessReport,
             SPEEDTEST_AVG => Self::SpeedtestAvg,
             VALIDATED_HEARTBEAT => Self::ValidatedHeartbeat,
+            SIGNED_POC_RECEIPT_TXN => Self::SignedPocReceiptTxn,
             _ => return Err(Error::from(io::Error::from(io::ErrorKind::InvalidInput))),
         };
         Ok(result)

--- a/poc_iot_injector/pkg/deb/env-template
+++ b/poc_iot_injector/pkg/deb/env-template
@@ -1,8 +1,9 @@
-RUST_LOG=info
+RUST_LOG=poc_iot_injector=info
+FOLLOWER_URI=http://127.0.0.1:8080
 METRICS_SCRAPE_ENDPOINT=127.0.0.1:19000
 DATABASE_URL=db_url
-FOLLOWER_URI=http://127.0.0.1:8080
-BUCKET=examplenet-pociot-verified
-POC_IOT_ORACLE_KEY=/tmp/poc_oracle_key
-POC_IOT_REWARDS_STORE=examplenet-pociot-rewards
+INPUT_BUCKET=examplenet-pociot-verified
+OUTPUT_BUCKET=examplenet-pociot-rewards
+POC_IOT_ORACLE_KEY=/path/to/poc_oracle_key
+POC_IOT_REWARDS_STORE=/path/to/poc_iot_rewards_store
 LAST_POC_SUBMISSION_TS=0000000000

--- a/poc_iot_injector/pkg/deb/env-template
+++ b/poc_iot_injector/pkg/deb/env-template
@@ -3,5 +3,6 @@ METRICS_SCRAPE_ENDPOINT=127.0.0.1:19000
 DATABASE_URL=db_url
 FOLLOWER_URI=http://127.0.0.1:8080
 BUCKET=examplenet-pociot-verified
-POC_ORACLE_KEY=/tmp/poc_oracle_key
+POC_IOT_ORACLE_KEY=/tmp/poc_oracle_key
+POC_IOT_REWARDS_STORE=examplenet-pociot-rewards
 LAST_POC_SUBMISSION_TS=0000000000

--- a/poc_iot_injector/src/cli/generate.rs
+++ b/poc_iot_injector/src/cli/generate.rs
@@ -1,11 +1,12 @@
 use crate::{
     keypair::{load_from_file, Keypair},
     receipt_txn::handle_report_msg,
-    Result, LOADER_WORKERS, STORE_WORKERS,
+    Error, Result, LOADER_WORKERS, STORE_WORKERS,
 };
 use chrono::{NaiveDateTime, TimeZone, Utc};
-use file_store::{FileStore, FileType};
+use file_store::{file_sink, file_sink_write, file_upload, FileStore, FileType};
 use futures::stream::{self, StreamExt};
+use futures_util::TryFutureExt;
 use helium_proto::{blockchain_txn::Txn, BlockchainTxn, Message};
 use std::sync::Arc;
 
@@ -18,12 +19,60 @@ pub struct Cmd {
     /// Required before time to look for (inclusive)
     #[clap(long)]
     before: NaiveDateTime,
+    /// Optional flag to save txns to S3 bucket
+    #[clap(long)]
+    save: bool,
 }
 
 impl Cmd {
     pub async fn run(&self) -> Result {
-        let store = FileStore::from_env().await?;
+        let mut store = FileStore::from_env_with_prefix("INPUT").await?;
 
+        let poc_injector_kp_path = std::env::var("POC_IOT_ORACLE_KEY")
+            .unwrap_or_else(|_| String::from("/tmp/poc_iot_oracle_key"));
+        let poc_oracle_key = load_from_file(&poc_injector_kp_path)?;
+        let shared_key = Arc::new(poc_oracle_key);
+
+        let (file_upload_tx, file_upload_rx) = file_upload::message_channel();
+        let file_upload =
+            file_upload::FileUpload::from_env_with_prefix("OUTPUT", file_upload_rx).await?;
+
+        let poc_iot_rewards_store = std::env::var("POC_IOT_REWARDS_STORE")
+            .unwrap_or_else(|_| String::from("/tmp/poc_iot_rewards_store"));
+        let store_base_path = std::path::Path::new(&poc_iot_rewards_store);
+
+        // file sink for poc receipts
+        let (sender, receiver) = file_sink::message_channel(50);
+        let mut sink = file_sink::FileSinkBuilder::new(
+            FileType::SignedPocReceiptTxn,
+            store_base_path,
+            receiver,
+        )
+        .deposits(Some(file_upload_tx.clone()))
+        .create()
+        .await?;
+
+        let (shutdown_trigger, shutdown_listener) = triggered::trigger();
+        tokio::spawn(async move {
+            let _ = tokio::signal::ctrl_c().await;
+            shutdown_trigger.trigger()
+        });
+
+        tokio::try_join!(
+            sink.run(&shutdown_listener).map_err(Error::from),
+            file_upload.run(&shutdown_listener).map_err(Error::from),
+            self.handle_stream(&mut store, shared_key, sender)
+        )?;
+
+        Ok(())
+    }
+
+    async fn handle_stream(
+        &self,
+        store: &mut FileStore,
+        shared_key: Arc<Keypair>,
+        sender: file_sink::MessageSender,
+    ) -> Result<()> {
         let after_utc = Utc.from_utc_datetime(&self.after);
         let before_utc = Utc.from_utc_datetime(&self.before);
 
@@ -33,29 +82,44 @@ impl Cmd {
 
         let before_ts = before_utc.timestamp_millis();
 
-        let poc_injector_kp_path = std::env::var("POC_IOT_ORACLE_KEY")
-            .unwrap_or_else(|_| String::from("/tmp/poc_iot_oracle_key"));
-        let poc_oracle_key = load_from_file(&poc_injector_kp_path)?;
-        let shared_key = Arc::new(poc_oracle_key);
-
         store
             .source_unordered(LOADER_WORKERS, stream::iter(file_list).map(Ok).boxed())
             .for_each_concurrent(STORE_WORKERS, |msg| {
                 let shared_key_clone = shared_key.clone();
+                let shared_sender = sender.clone();
                 async move {
                     match msg {
-                        Ok(m) => process_msg(m, shared_key_clone, before_ts).await,
+                        Ok(m) => {
+                            if let Some(txn) = process_msg(m, shared_key_clone, before_ts).await {
+                                if self.save {
+                                    tracing::debug!("writing txn to s3");
+                                    // write txn to s3 bucket
+                                    let _ = file_sink_write!(
+                                        "signed_poc_receipt_txn",
+                                        &shared_sender,
+                                        txn
+                                    )
+                                    .await
+                                    .unwrap()
+                                    .await;
+                                }
+                            }
+                        }
                         Err(e) => tracing::error!("unable to process msg due to: {:?}", e),
                     }
                 }
             })
             .await;
-
+        tracing::info!("completed processing stream");
         Ok(())
     }
 }
 
-async fn process_msg(msg: prost::bytes::BytesMut, shared_key_clone: Arc<Keypair>, before_ts: i64) {
+async fn process_msg(
+    msg: prost::bytes::BytesMut,
+    shared_key_clone: Arc<Keypair>,
+    before_ts: i64,
+) -> Option<BlockchainTxn> {
     if let Ok(Some((txn, _hash, _hash_b64_url))) =
         handle_report_msg(msg.clone(), shared_key_clone, before_ts)
     {
@@ -64,7 +128,9 @@ async fn process_msg(msg: prost::bytes::BytesMut, shared_key_clone: Arc<Keypair>
         };
 
         tracing::debug!("txn_bin: {:?}", tx.encode_to_vec());
+        return Some(tx);
     } else {
         tracing::error!("unable to construct txn for msg {:?}", msg)
     }
+    None
 }

--- a/poc_iot_injector/src/cli/generate.rs
+++ b/poc_iot_injector/src/cli/generate.rs
@@ -33,8 +33,8 @@ impl Cmd {
 
         let before_ts = before_utc.timestamp_millis();
 
-        let poc_injector_kp_path =
-            std::env::var("POC_ORACLE_KEY").unwrap_or_else(|_| String::from("/tmp/poc_oracle_key"));
+        let poc_injector_kp_path = std::env::var("POC_IOT_ORACLE_KEY")
+            .unwrap_or_else(|_| String::from("/tmp/poc_iot_oracle_key"));
         let poc_oracle_key = load_from_file(&poc_injector_kp_path)?;
         let shared_key = Arc::new(poc_oracle_key);
 

--- a/poc_iot_injector/src/cli/server.rs
+++ b/poc_iot_injector/src/cli/server.rs
@@ -26,7 +26,7 @@ impl Cmd {
 
         // Configure poc iot rewards store
         let store_path = std::env::var("POC_IOT_REWARDS_STORE")
-            .unwrap_or_else(|_| String::from("/var/data/poc_iot_rewards"));
+            .unwrap_or_else(|_| String::from("/var/data/poc_iot_rewards_store"));
         let store_base_path = path::Path::new(&store_path);
 
         // Configure file_upload

--- a/poc_iot_injector/src/cli/server.rs
+++ b/poc_iot_injector/src/cli/server.rs
@@ -1,4 +1,7 @@
-use crate::{keypair::load_from_file, mk_db_pool, server::Server, Result};
+use crate::{keypair::load_from_file, mk_db_pool, server::Server, Error, Result};
+use file_store::{file_sink, file_upload, FileType};
+use futures_util::TryFutureExt;
+use std::path;
 use tokio::signal;
 
 /// Start rewards server
@@ -15,23 +18,50 @@ impl Cmd {
         sqlx::migrate!().run(&pool).await?;
 
         // Configure shutdown trigger
-        let (shutdown_trigger, shutdown_listener) = triggered::trigger();
+        let (shutdown_trigger, shutdown) = triggered::trigger();
         tokio::spawn(async move {
             let _ = signal::ctrl_c().await;
             shutdown_trigger.trigger()
         });
 
+        // Configure poc iot rewards store
+        let store_path = std::env::var("POC_IOT_REWARDS_STORE")
+            .unwrap_or_else(|_| String::from("/var/data/poc_iot_rewards"));
+        let store_base_path = path::Path::new(&store_path);
+
+        // Configure file_upload
+        let (file_upload_tx, file_upload_rx) = file_upload::message_channel();
+        let file_upload =
+            file_upload::FileUpload::from_env_with_prefix("OUTPUT", file_upload_rx).await?;
+
+        // Poc receipt txns
+        let (poc_receipt_txn_tx, poc_receipt_txn_rx) = file_sink::message_channel(50);
+        let mut poc_receipts = file_sink::FileSinkBuilder::new(
+            FileType::SignedPocReceiptTxn,
+            store_base_path,
+            poc_receipt_txn_rx,
+        )
+        .deposits(Some(file_upload_tx.clone()))
+        .create()
+        .await?;
+
         // injector server keypair from env
-        let poc_injector_kp_path =
-            std::env::var("POC_ORACLE_KEY").unwrap_or_else(|_| String::from("/tmp/poc_oracle_key"));
+        let poc_injector_kp_path = std::env::var("POC_IOT_ORACLE_KEY")
+            .unwrap_or_else(|_| String::from("/tmp/poc_iot_oracle_key"));
         let poc_oracle_key = load_from_file(&poc_injector_kp_path)?;
 
         // poc_iot_injector server
-        let mut poc_iot_injector_server = Server::new(pool, poc_oracle_key).await?;
+        let mut poc_iot_injector_server =
+            Server::new(pool, poc_oracle_key, poc_receipt_txn_tx).await?;
 
-        poc_iot_injector_server
-            .run(shutdown_listener.clone())
-            .await?;
+        tokio::try_join!(
+            poc_iot_injector_server.run(&shutdown).map_err(Error::from),
+            poc_receipts.run(&shutdown).map_err(Error::from),
+            file_upload.run(&shutdown).map_err(Error::from),
+        )?;
+
+        tracing::info!("Shutting down poc_iot_injector server");
+
         Ok(())
     }
 }

--- a/poc_iot_injector/src/server.rs
+++ b/poc_iot_injector/src/server.rs
@@ -49,7 +49,7 @@ impl Server {
             pool: pool.clone(),
             keypair: Arc::new(keypair),
             txn_service: TransactionService::from_env()?,
-            iot_verifier_store: FileStore::from_env().await?,
+            iot_verifier_store: FileStore::from_env_with_prefix("INPUT").await?,
             last_poc_submission_ts,
             poc_receipt_txn_tx,
         };
@@ -170,12 +170,10 @@ async fn handle_txn_submission(
         };
         if txn_service.submit(wrapped_txn.clone(), &hash).await.is_ok() {
             tracing::debug!("txn submitted successfully, hash: {:?}", hash_b64_url);
-            Some(wrapped_txn)
+            return Some(wrapped_txn);
         } else {
             tracing::warn!("txn submission failed!, hash: {:?}", hash_b64_url);
-            None
         }
-    } else {
-        None
     }
+    None
 }

--- a/poc_iot_verifier/src/main.rs
+++ b/poc_iot_verifier/src/main.rs
@@ -29,6 +29,7 @@ async fn main() -> Result {
     let loader = loader::Loader::from_env().await?;
     let runner = runner::Runner::from_env().await?;
     let purger = purger::Purger::from_env().await?;
+
     tokio::try_join!(
         runner.run(&shutdown),
         loader.run(&shutdown),


### PR DESCRIPTION
# Summary
This adds support for writing poc receipt txns to s3 bucket once they have been submitted to the chain.

# Depends on
~~We should land https://github.com/helium/oracles/pull/135 prior to this one~~

# Caveats
- The if-else clauses could use some scrutiny
- Am I actually writing the txn correctly to S3? I mostly looked through poc_mobile_verifier for depositing the file
- The env var naming could also use some careful eyes