### PR TITLE
misc fixes

### DIFF
--- a/poc_iot_verifier/README.md
+++ b/poc_iot_verifier/README.md
@@ -49,3 +49,22 @@ The verifier requires the following environmental variables:
 - `VERIFIER_BUCKET`: The S3 bucket to output the verified reports to
 - `ENTROPY_BUCKET`: The S3 bucket containing the input entropy reports
 
+
+## Tunable Consts
+
+The verifier requires the following consts to be sanely set and via which its operation can be tuned
+
+- `BEACON_INTERVAL` (runner) : Interval at which beaconers are permitted to beacon
+- `ENTROPY_LIFESPAN` (entropy) : The valid lifespan of a piece of entropy
+- `REPORTS_POLL_TIME` (loader) : The cadence at which S3 is queried for new beacon & witness reports
+- `ENTROPY_POLL_TIME` ( loader) : The cadence at which S3 is queried for new entropy reports
+- `MAX_REPORT_AGE` (loader) : The max age of beacon & witness reports to load from s3. Anything older will be ignored
+- `BEACON_MAX_RETRY_ATTEMPTS` (poc_report) : The max number of times the verifier will attempt to verify a beacon
+- `WITNESS_MAX_RETRY_ATTEMPTS` (poc_report) : The max number of times the verifier will attempt to verify a witness
+- `BEACON_PROCESSING_DELAY` (poc_report) : A period of time added to ENTROPY_LIFESPAN after when any associated beacons using the relevant entropy will become ready for verification
+- `POC_DISTANCE_LIMIT` (poc) : The max valid witness distance from the beaconer
+- `REPORT_STALE_PERIOD` ( purger) : Any beacon or witness report in the DB & not verified after this period will be deemed stale and purged
+- `ENTROPY_STALE_PERIOD( purger) : Any entropy report in the DB after this period will be deemed stale and purged
+- `DB_POLL_TIME` ( purger) : The cadence at which the DB is queried for stale reports
+- `DB_POLL_TIME` ( runner ) : The cadence at which the DB is queried for 'ready' POCs
+

--- a/poc_iot_verifier/src/entropy.rs
+++ b/poc_iot_verifier/src/entropy.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// measurement in seconds of a piece of entropy
 /// its lifespan will be valid from entropy.timestamp to entropy.timestamp + ENTROPY_LIFESPAN
 /// any beacon or witness report received after this period and before the ENTROPY_STALE_PERIOD
-/// defined below will be rejected due to being outside of the entropy lifespan
+/// defined in the purger module will be rejected due to being outside of the entropy lifespan
 /// TODO: determine a sane value here
 pub const ENTROPY_LIFESPAN: i32 = 90;
 
@@ -45,6 +45,7 @@ impl Entropy {
             timestamp,
             version
         ) values ($1, $2, $3, $4)
+        on conflict (id) do nothing
             "#,
         )
         .bind(id)

--- a/poc_iot_verifier/src/entropy.rs
+++ b/poc_iot_verifier/src/entropy.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// any beacon or witness report received after this period and before the ENTROPY_STALE_PERIOD
 /// defined in the purger module will be rejected due to being outside of the entropy lifespan
 /// TODO: determine a sane value here
-pub const ENTROPY_LIFESPAN: i32 = 90;
+pub const ENTROPY_LIFESPAN: i64 = 90;
 
 #[derive(sqlx::Type, Serialize, Deserialize, Debug)]
 #[sqlx(type_name = "report_type", rename_all = "lowercase")]

--- a/poc_iot_verifier/src/last_beacon.rs
+++ b/poc_iot_verifier/src/last_beacon.rs
@@ -55,9 +55,7 @@ impl LastBeacon {
         .await?
         .and_then(|v| {
             v.parse::<u64>()
-                .map_or_else(|_| None, |secs| Some((secs + 10).to_timestamp()))
-            //TODO: remove the hardcoded + 10 above
-            //      fix resolution of datetime function, dropping millisecs resulting in files being reprocessed by loader
+                .map_or_else(|_| None, |secs| Some(secs.to_timestamp()))
         })
         .transpose()?;
         Ok(height)

--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -202,6 +202,7 @@ impl Loader {
                     }
                     false => {
                         // if a gateway doesnt exist then drop the report
+                        // dont even insert into DB
                         tracing::warn!(
                             "dropping witness report as gateway not found: {:?}",
                             &witness
@@ -232,12 +233,7 @@ impl Loader {
 
     // TODO: maybe store any found GW in the DB, save having to refetch later during validation ?
     async fn check_valid_gateway(&self, pub_key: &PublicKey) -> bool {
-        self
-            // TODO: I am cloning here to avoid having to use &mut self
-            //       as once i do that then i need to cascade the same
-            //       upwards through the stack
-            //       must be a better way to do this ?
-            .follower_service
+        self.follower_service
             .clone()
             .resolve_gateway_info(pub_key)
             .await

--- a/poc_iot_verifier/src/poc.rs
+++ b/poc_iot_verifier/src/poc.rs
@@ -99,16 +99,6 @@ impl Poc {
         };
         tracing::debug!("beacon info {:?}", beaconer_info);
 
-        // tmp hack below when testing locally with no actual real gateway
-        // replace beaconer_info declaration above with that below
-        // let beaconer_info = FollowerGatewayResp {
-        //     height: 130000,
-        //     location: String::from("location1"),
-        //     address: beacon.pub_key.clone(),
-        //     owner: beacon.pub_key.clone(),
-        //     staking_mode: GatewayStakingMode::Full as i32,
-        // };
-
         // verify the beaconer's remote entropy
         // if beacon received timestamp is outside of entopy start/end then reject the poc
         let beacon_received_time = self.beacon_report.received_timestamp;
@@ -266,16 +256,6 @@ impl Poc {
                 return Ok(resp);
             }
         };
-
-        // tmp hack below when testing locally with no actual real gateway
-        // replace witness_info declaration above with that below
-        // let witness_info = FollowerGatewayResp {
-        //     height: 130000,
-        //     location: String::from("location1"),
-        //     address: witness.pub_key.clone(),
-        //     owner: witness.pub_key.clone(),
-        //     staking_mode: GatewayStakingMode::Full as i32,
-        // };
 
         // check witness is permitted to participate in POC
         match witness_info.staking_mode {

--- a/poc_iot_verifier/src/poc.rs
+++ b/poc_iot_verifier/src/poc.rs
@@ -1,4 +1,4 @@
-use crate::{entropy::Entropy, Error, Result};
+use crate::{entropy::Entropy, entropy::ENTROPY_LIFESPAN, Error, Result};
 use chrono::{DateTime, Duration, Utc};
 use file_store::{
     lora_beacon_report::LoraBeaconIngestReport, lora_invalid_poc::LoraInvalidWitnessReport,
@@ -20,9 +20,6 @@ pub const C: f64 = 2.998e8;
 /// R is the (average) radius of the earth
 pub const R: f64 = 6.371e6;
 
-/// measurement in seconds of an entropy
-/// TODO: determine a sane value here, set high for testing
-const ENTROPY_LIFESPAN: i64 = 60;
 /// max permitted distance of a witness from a beaconer measured in KM
 const POC_DISTANCE_LIMIT: i32 = 100;
 

--- a/poc_iot_verifier/src/poc_report.rs
+++ b/poc_iot_verifier/src/poc_report.rs
@@ -16,7 +16,7 @@ const WITNESS_MAX_RETRY_ATTEMPTS: i16 = 5; //TODO: determine a sane value here
 //    for that beacon, if a witness comes in after the beacon has been processed
 //    then it does not get verified as part of the overall POC but instead will
 //    end up being deemed stale )
-const BEACON_PROCESSING_DELAY: i32 = 60;
+const BEACON_PROCESSING_DELAY: i64 = 60;
 
 #[derive(sqlx::Type, Serialize, Deserialize, Debug)]
 #[sqlx(type_name = "reporttype", rename_all = "lowercase")]

--- a/poc_iot_verifier/src/runner.rs
+++ b/poc_iot_verifier/src/runner.rs
@@ -214,15 +214,6 @@ impl Runner {
                 }
             };
 
-            // tmp hack below when testing locally with no entropy server
-            // replace entropy_info declaration above with that below
-            // let entropy_info = Entropy {
-            //     id: entropy_hash.clone(),
-            //     data: entropy_hash.clone(),
-            //     timestamp: Utc::now() - Duration::seconds(40000),
-            //     created_at: Utc::now(),
-            // };
-
             //
             // top level checks complete, verify the POC reports
             //


### PR DESCRIPTION

- fix ambiguous columns issue on report query
- Adds on conflict clause to ignore duplicate poc report and entropy report inserts
- Adds max age for consuming events from s3 ( beacon/witness report or entropy report ).  Ignore reports outside of this age
- Adds check to incoming beacon and witness reports to identify if unknown gateway.  If true the drop the report
- Code tidy up