### PR TITLE
Simplify db access in poc_mobile_verifier

### DIFF
--- a/db_store/src/lib.rs
+++ b/db_store/src/lib.rs
@@ -1,5 +1,7 @@
 use std::str::FromStr;
 
+pub mod meta;
+
 /// A key-value pair that is stored in the metadata table.
 pub struct MetaValue<T> {
     key: String,
@@ -12,6 +14,8 @@ pub enum MetaError {
     SqlError(#[from] sqlx::Error),
     #[error("Failed to decode meta value")]
     DecodeError,
+    #[error("not found")]
+    NotFound(String),
 }
 
 impl<T> MetaValue<T> {

--- a/db_store/src/lib.rs
+++ b/db_store/src/lib.rs
@@ -43,7 +43,7 @@ where
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
-        meta::save(exec, &self.key, &self.value.to_string()).await
+        meta::store(exec, &self.key, &self.value.to_string()).await
     }
 }
 
@@ -59,7 +59,7 @@ where
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres> + Copy,
     {
-        let result: Result<String, MetaError> = meta::get::<String>(exec, key).await;
+        let result: Result<String, MetaError> = meta::fetch::<String>(exec, key).await;
 
         match result {
             Ok(str_val) => {
@@ -83,7 +83,7 @@ where
     where
         E: sqlx::PgExecutor<'c>,
     {
-        meta::save(exec, &self.key, new_val.to_string()).await?;
+        meta::store(exec, &self.key, new_val.to_string()).await?;
         Ok(std::mem::replace(&mut self.value, new_val))
     }
 }

--- a/db_store/src/lib.rs
+++ b/db_store/src/lib.rs
@@ -14,7 +14,7 @@ pub enum MetaError {
     SqlError(#[from] sqlx::Error),
     #[error("Failed to decode meta value")]
     DecodeError,
-    #[error("not found")]
+    #[error("meta key not found {0}")]
     NotFound(String),
 }
 

--- a/db_store/src/lib.rs
+++ b/db_store/src/lib.rs
@@ -35,21 +35,6 @@ impl<T> MetaValue<T> {
     }
 }
 
-macro_rules! query_exec_timed {
-    ( $name:literal, $query:expr, $meth:ident, $exec:expr ) => {{
-        match poc_metrics::record_duration!(concat!($name, "_duration"), $query.$meth($exec).await) {
-            Ok(x) => {
-                metrics::increment_counter!(concat!($name, "_count"), "status" => "ok");
-                Ok(x)
-            }
-            Err(e) => {
-                metrics::increment_counter!(concat!($name, "_count"), "status" => "error");
-                Err(MetaError::SqlError(e))
-            }
-        }
-    }};
-}
-
 impl<T> MetaValue<T>
 where
     T: ToString,

--- a/db_store/src/meta.rs
+++ b/db_store/src/meta.rs
@@ -2,37 +2,49 @@ use std::str::FromStr;
 
 use crate::MetaError;
 
+macro_rules! query_exec_timed {
+    ( $name:literal, $query:expr, $meth:ident, $exec:expr ) => {{
+        match poc_metrics::record_duration!(concat!($name, "_duration"), $query.$meth($exec).await) {
+            Ok(x) => {
+                metrics::increment_counter!(concat!($name, "_count"), "status" => "ok");
+                Ok(x)
+            }
+            Err(e) => {
+                metrics::increment_counter!(concat!($name, "_count"), "status" => "error");
+                Err(MetaError::SqlError(e))
+            }
+        }
+    }};
+}
+
 pub async fn save<T>(exec: impl sqlx::PgExecutor<'_>, key: &str, value: T) -> Result<(), MetaError>
 where
     T: ToString,
 {
-    sqlx::query(
+    let query = sqlx::query(
         r#"
-        insert into meta(key, value)
-        values ($1, $2)
-        on conflict (key) do update set
-        value = EXCLUDED.value
-        "#,
+            insert into meta(key, value)
+            values ($1, $2)
+            on conflict (key) do update set
+            value = EXCLUDED.value
+            "#,
     )
     .bind(key)
-    .bind(value.to_string())
-    .execute(exec)
-    .await?;
-    Ok(())
+    .bind(value.to_string());
+    query_exec_timed!("db_store_meta_save", query, execute, exec).map(|_| ())
 }
 
 pub async fn get<T>(exec: impl sqlx::PgExecutor<'_>, key: &str) -> Result<T, MetaError>
 where
     T: FromStr,
 {
-    sqlx::query_scalar::<_, String>(
+    let query = sqlx::query_scalar::<_, String>(
         r#"
-        select value from meta where key = $1
-        "#,
+            select value from meta where key = $1
+            "#,
     )
-    .bind(key)
-    .fetch_optional(exec)
-    .await?
-    .ok_or_else(|| MetaError::NotFound(key.to_string()))
-    .and_then(|value| value.parse().map_err(|_| MetaError::DecodeError))
+    .bind(key);
+    query_exec_timed!("db_store_meta_get", query, fetch_optional, exec)?
+        .ok_or_else(|| MetaError::NotFound(key.to_string()))
+        .and_then(|value| value.parse().map_err(|_| MetaError::DecodeError))
 }

--- a/db_store/src/meta.rs
+++ b/db_store/src/meta.rs
@@ -33,6 +33,6 @@ where
     .bind(key)
     .fetch_optional(exec)
     .await?
-    .ok_or_else(|| MetaError::NotFound(format!("{} not found in meta table", key)))
+    .ok_or_else(|| MetaError::NotFound(key.to_string()))
     .and_then(|value| value.parse().map_err(|_| MetaError::DecodeError))
 }

--- a/db_store/src/meta.rs
+++ b/db_store/src/meta.rs
@@ -1,0 +1,38 @@
+use std::str::FromStr;
+
+use crate::MetaError;
+
+pub async fn save<T>(exec: impl sqlx::PgExecutor<'_>, key: &str, value: T) -> Result<(), MetaError>
+where
+    T: ToString,
+{
+    sqlx::query(
+        r#"
+        insert into meta(key, value)
+        values ($1, $2)
+        on conflict (key) do update set
+        value = EXCLUDED.value
+        "#,
+    )
+    .bind(key)
+    .bind(value.to_string())
+    .execute(exec)
+    .await?;
+    Ok(())
+}
+
+pub async fn get<T>(exec: impl sqlx::PgExecutor<'_>, key: &str) -> Result<T, MetaError>
+where
+    T: FromStr,
+{
+    sqlx::query_scalar::<_, String>(
+        r#"
+        select value from meta where key = $1
+        "#,
+    )
+    .bind(key)
+    .fetch_optional(exec)
+    .await?
+    .ok_or_else(|| MetaError::NotFound(format!("{} not found in meta table", key)))
+    .and_then(|value| value.parse().map_err(|_| MetaError::DecodeError))
+}

--- a/db_store/src/meta.rs
+++ b/db_store/src/meta.rs
@@ -17,7 +17,7 @@ macro_rules! query_exec_timed {
     }};
 }
 
-pub async fn save<T>(exec: impl sqlx::PgExecutor<'_>, key: &str, value: T) -> Result<(), MetaError>
+pub async fn store<T>(exec: impl sqlx::PgExecutor<'_>, key: &str, value: T) -> Result<(), MetaError>
 where
     T: ToString,
 {
@@ -31,10 +31,10 @@ where
     )
     .bind(key)
     .bind(value.to_string());
-    query_exec_timed!("db_store_meta_save", query, execute, exec).map(|_| ())
+    query_exec_timed!("db_store_meta_store", query, execute, exec).map(|_| ())
 }
 
-pub async fn get<T>(exec: impl sqlx::PgExecutor<'_>, key: &str) -> Result<T, MetaError>
+pub async fn fetch<T>(exec: impl sqlx::PgExecutor<'_>, key: &str) -> Result<T, MetaError>
 where
     T: FromStr,
 {
@@ -44,7 +44,7 @@ where
             "#,
     )
     .bind(key);
-    query_exec_timed!("db_store_meta_get", query, fetch_optional, exec)?
+    query_exec_timed!("db_store_meta_fetch", query, fetch_optional, exec)?
         .ok_or_else(|| MetaError::NotFound(key.to_string()))
         .and_then(|value| value.parse().map_err(|_| MetaError::DecodeError))
 }

--- a/poc_mobile_verifier/src/cli/server.rs
+++ b/poc_mobile_verifier/src/cli/server.rs
@@ -4,7 +4,6 @@ use crate::{
     error::Error,
     verifier::{Verifier, VerifierDaemon},
 };
-use db_store::MetaValue;
 use file_store::{file_sink, file_upload, FileStore, FileType};
 use futures_util::TryFutureExt;
 use helium_proto::services::{follower, Endpoint, Uri};
@@ -87,13 +86,6 @@ impl Cmd {
             env_var("VERIFICATIONS_PER_PERIOD", DEFAULT_VERIFICATIONS_PER_PERIOD)?;
         let file_store = FileStore::from_env_with_prefix("INPUT").await?;
 
-        let last_verified_end_time =
-            MetaValue::<i64>::fetch_or_insert_with(&pool, "last_verified_end_time", || 0).await?;
-        let last_rewarded_end_time =
-            MetaValue::<i64>::fetch_or_insert_with(&pool, "last_rewarded_end_time", || 0).await?;
-        let next_rewarded_end_time =
-            MetaValue::<i64>::fetch_or_insert_with(&pool, "next_rewarded_end_time", || 0).await?;
-
         let verifier = Verifier::new(file_store, follower).await?;
 
         let verifier_daemon = VerifierDaemon {
@@ -103,9 +95,6 @@ impl Cmd {
             subnet_rewards_tx,
             reward_period_hours,
             verifications_per_period,
-            last_verified_end_time,
-            last_rewarded_end_time,
-            next_rewarded_end_time,
             verifier,
         };
 

--- a/poc_mobile_verifier/src/verifier.rs
+++ b/poc_mobile_verifier/src/verifier.rs
@@ -170,31 +170,31 @@ pub struct VerifiedEpoch {
 }
 
 async fn last_verified_end_time(exec: impl PgExecutor<'_>) -> Result<DateTime<Utc>> {
-    Ok(Utc.timestamp(meta::get(exec, "last_verified_end_time").await?, 0))
+    Ok(Utc.timestamp(meta::fetch(exec, "last_verified_end_time").await?, 0))
 }
 
 async fn save_last_verified_end_time(exec: impl PgExecutor<'_>, value: &DateTime<Utc>) -> Result {
-    meta::save(exec, "last_verified_end_time", value.timestamp() as i64)
+    meta::store(exec, "last_verified_end_time", value.timestamp() as i64)
         .await
         .map_err(Error::from)
 }
 
 async fn last_rewarded_end_time(exec: impl PgExecutor<'_>) -> Result<DateTime<Utc>> {
-    Ok(Utc.timestamp(meta::get(exec, "last_rewarded_end_time").await?, 0))
+    Ok(Utc.timestamp(meta::fetch(exec, "last_rewarded_end_time").await?, 0))
 }
 
 async fn save_last_rewarded_end_time(exec: impl PgExecutor<'_>, value: &DateTime<Utc>) -> Result {
-    meta::save(exec, "last_rewarded_end_time", value.timestamp() as i64)
+    meta::store(exec, "last_rewarded_end_time", value.timestamp() as i64)
         .await
         .map_err(Error::from)
 }
 
 async fn next_rewarded_end_time(exec: impl PgExecutor<'_>) -> Result<DateTime<Utc>> {
-    Ok(Utc.timestamp(meta::get(exec, "next_rewarded_end_time").await?, 0))
+    Ok(Utc.timestamp(meta::fetch(exec, "next_rewarded_end_time").await?, 0))
 }
 
 async fn save_next_rewarded_end_time(exec: impl PgExecutor<'_>, value: &DateTime<Utc>) -> Result {
-    meta::save(exec, "next_rewarded_end_time", value.timestamp() as i64)
+    meta::store(exec, "next_rewarded_end_time", value.timestamp() as i64)
         .await
         .map_err(Error::from)
 }


### PR DESCRIPTION
So I wanted to simplify the db access and move the responsibility into a single entity.

Current downside, if the 3 values `last_verified_end_time`, `last_rewarded_end_time`, and `next_rewarded_end_time` are not in the meta table it will crash the server.