### PR TITLE
add prometheus exporter to mobile verifier

### DIFF
--- a/poc_mobile_verifier/src/cli/server.rs
+++ b/poc_mobile_verifier/src/cli/server.rs
@@ -20,6 +20,9 @@ pub struct Cmd {}
 
 impl Cmd {
     pub async fn run(self) -> Result {
+        // install prometheus metrics exporter
+        poc_metrics::install_metrics();
+
         let (shutdown_trigger, shutdown_listener) = triggered::trigger();
         tokio::spawn(async move {
             let _ = tokio::signal::ctrl_c().await;


### PR DESCRIPTION
the mobile verifier is currently not exporting metrics; we're going to want those