### PR TITLE
filtering 0-rewards from reward results

### DIFF
--- a/poc_mobile_verifier/src/subnetwork_rewards.rs
+++ b/poc_mobile_verifier/src/subnetwork_rewards.rs
@@ -47,13 +47,7 @@ impl SubnetworkRewards {
                 shares *= speedmultiplier;
                 (pubkey, shares)
             })
-            .filter_map(|(pubkey, shares)| {
-                if shares > dec!(0.0) {
-                    Some((pubkey, shares))
-                } else {
-                    None
-                }
-            })
+            .filter(|(_pubkey, shares)| shares > &dec!(0.0))
             .collect();
 
         let (owner_shares, _missing_owner_shares) =
@@ -274,6 +268,9 @@ mod test {
         let owner3: PublicKey = "112DJZiXvZ8FduiWrEi8siE3wJX6hpRjjtwbavyXUDkgutEUSLAE"
             .parse()
             .expect("failed owner3 parse");
+        let owner4: PublicKey = "112p1GbUtRLyfFaJr1XF8fH7yz9cSZ4exbrSpVDeu67DeGb31QUL"
+            .parse()
+            .expect("failed owner4 parse");
 
         // init hotspots
         let gw1: PublicKey = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
@@ -297,6 +294,9 @@ mod test {
         let gw7: PublicKey = "11HdwRpQDrYM7LJtRGSzRF3vY2iwuumx1Z2MUhBYAVTwZdSh6Bi"
             .parse()
             .expect("failed gw7 parse");
+        let gw8: PublicKey = "112qDCKek7fePg6wTpEnbLp3uD7TTn8MBH7PGKtmAaUcG1vKQ9eZ"
+            .parse()
+            .expect("failed gw8 parse");
 
         // link gws to owners
         let mut owners = HashMap::new();
@@ -307,6 +307,7 @@ mod test {
         owners.insert(gw5.clone(), owner2.clone());
         owners.insert(gw6.clone(), owner3.clone());
         owners.insert(gw7.clone(), owner3.clone());
+        owners.insert(gw8.clone(), owner4.clone());
         let resolver = MapResolver { owners };
 
         // init cells and cell_types
@@ -485,6 +486,7 @@ mod test {
         assert_eq!(*owner_rewards.get(&owner1).unwrap(), 99_715_099_715_100);
         assert_eq!(*owner_rewards.get(&owner2).unwrap(), 299_145_299_145_299);
         assert_eq!(*owner_rewards.get(&owner3).unwrap(), 17_806_267_806_268);
+        assert_eq!(owner_rewards.get(&owner4), None);
 
         let mut total = 0;
         for val in owner_rewards.values() {


### PR DESCRIPTION
we don't want to be including subnetwork reward entries in the final proto submitted to the reward server that have 0 shares b/c the owner/hotspot was disqualified for not meeting speedtest criteria (frequency and number of data points). this filter operation will weed out any subnetwork reward share entries that would not be receiving rewards for a given period.