### PR TITLE
push lapsed speedtests filter to write/reward time

### DIFF
--- a/poc_mobile_verifier/src/verifier.rs
+++ b/poc_mobile_verifier/src/verifier.rs
@@ -90,8 +90,11 @@ impl VerifierDaemon {
             heartbeat.save(&mut transaction).await?;
         }
 
-        for speedtest in speedtests.into_iter() {
+        for speedtest in speedtests.clone().without_lapsed().into_iter() {
             speedtest.write(&self.speedtest_avg_tx).await?;
+        }
+
+        for speedtest in speedtests.into_iter() {
             speedtest.save(&mut transaction).await?;
         }
 
@@ -115,7 +118,11 @@ impl VerifierDaemon {
 
         let rewards = self
             .verifier
-            .reward_epoch(&scheduler.reward_period, heartbeats, speedtests)
+            .reward_epoch(
+                &scheduler.reward_period,
+                heartbeats,
+                speedtests.without_lapsed(),
+            )
             .await?;
 
         let mut transaction = self.pool.begin().await?;


### PR DESCRIPTION
we need to save up to 6 (current maximum data points for calculating speedtest averages) in the database but still ensure that speedtests that have a lapse period greater than the allowable window are _not_ included in average calculations when determining rewards and are _not_ written in reports to the verifier output bucket.

the following extends the maximum window the database looks for when querying saved speedtests for performing average calculations from 12 to 48 hours to ensure we capture a minimum of 2 speedtests if they are present (with a generous buffer to allow for randomness in the speedtest submission logic) as well as to filter out speedtests from the speedtest averages data structure before performing a write of average reports to s3 and calculating reward share weights. when speedtests have a gap of more than 48 hours between submissions starting from the most recent and working backward through the list, all previous speedtests are dropped.