### PR TITLE
Add support for storing receipt txns on S3

### DIFF
--- a/file_store/src/file_info.rs
+++ b/file_store/src/file_info.rs
@@ -103,6 +103,7 @@ pub const LORA_INVALID_BEACON_REPORT: &str = "lora_invalid_beacon";
 pub const LORA_INVALID_WITNESS_REPORT: &str = "lora_invalid_witness";
 pub const SPEEDTEST_AVG: &str = "speedtest_avg";
 pub const VALIDATED_HEARTBEAT: &str = "validated_heartbeat";
+pub const SIGNED_POC_RECEIPT_TXN: &str = "signed_poc_receipt_txn";
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Copy, strum::EnumCount)]
 #[serde(rename_all = "snake_case")]
@@ -121,6 +122,7 @@ pub enum FileType {
     LoraInvalidWitnessReport,
     SpeedtestAvg,
     ValidatedHeartbeat,
+    SignedPocReceiptTxn,
 }
 
 impl fmt::Display for FileType {
@@ -140,6 +142,7 @@ impl fmt::Display for FileType {
             Self::LoraInvalidWitnessReport => LORA_INVALID_WITNESS_REPORT,
             Self::SpeedtestAvg => SPEEDTEST_AVG,
             Self::ValidatedHeartbeat => VALIDATED_HEARTBEAT,
+            Self::SignedPocReceiptTxn => SIGNED_POC_RECEIPT_TXN,
         };
         f.write_str(s)
     }
@@ -162,6 +165,7 @@ impl FileType {
             Self::LoraInvalidWitnessReport => LORA_INVALID_WITNESS_REPORT,
             Self::SpeedtestAvg => SPEEDTEST_AVG,
             Self::ValidatedHeartbeat => VALIDATED_HEARTBEAT,
+            Self::SignedPocReceiptTxn => SIGNED_POC_RECEIPT_TXN,
         }
     }
 }
@@ -184,6 +188,7 @@ impl FromStr for FileType {
             LORA_INVALID_WITNESS_REPORT => Self::LoraInvalidWitnessReport,
             SPEEDTEST_AVG => Self::SpeedtestAvg,
             VALIDATED_HEARTBEAT => Self::ValidatedHeartbeat,
+            SIGNED_POC_RECEIPT_TXN => Self::SignedPocReceiptTxn,
             _ => return Err(Error::from(io::Error::from(io::ErrorKind::InvalidInput))),
         };
         Ok(result)

--- a/poc_iot_injector/src/error.rs
+++ b/poc_iot_injector/src/error.rs
@@ -30,6 +30,8 @@ pub enum Error {
     DbError(#[from] db_store::Error),
     #[error("follower error")]
     Follower(#[from] node_follower::Error),
+    #[error("txn construction error")]
+    TxnConstruction,
 }
 
 #[derive(Error, Debug)]

--- a/poc_iot_injector/src/error.rs
+++ b/poc_iot_injector/src/error.rs
@@ -32,6 +32,8 @@ pub enum Error {
     Follower(#[from] node_follower::Error),
     #[error("txn construction error")]
     TxnConstruction,
+    #[error("txn submission error, hash: {0}")]
+    TxnSubmission(String),
 }
 
 #[derive(Error, Debug)]

--- a/poc_iot_injector/src/receipt_txn.rs
+++ b/poc_iot_injector/src/receipt_txn.rs
@@ -1,11 +1,12 @@
 use crate::{Error, Result};
 use helium_crypto::{Keypair, Sign};
 use helium_proto::{
+    blockchain_txn::Txn,
     services::poc_lora::{
         LoraBeaconReportReqV1, LoraValidBeaconReportV1, LoraValidPocV1, LoraValidWitnessReportV1,
         LoraWitnessReportReqV1,
     },
-    BlockchainPocPathElementV1, BlockchainPocReceiptV1, BlockchainPocWitnessV1,
+    BlockchainPocPathElementV1, BlockchainPocReceiptV1, BlockchainPocWitnessV1, BlockchainTxn,
     BlockchainTxnPocReceiptsV2, Message,
 };
 use rust_decimal::{prelude::ToPrimitive, Decimal, MathematicalOps};
@@ -24,7 +25,7 @@ pub fn handle_report_msg(
     msg: prost::bytes::BytesMut,
     keypair: Arc<Keypair>,
     timestamp: i64,
-) -> Result<Option<(BlockchainTxnPocReceiptsV2, Vec<u8>, String)>> {
+) -> Result<(BlockchainTxn, Vec<u8>, String)> {
     // Path is always single element, till we decide to change it at some point.
     let mut path: PocPath = Vec::with_capacity(1);
 
@@ -44,13 +45,20 @@ pub fn handle_report_msg(
 
         path.push(path_element);
 
-        Ok(Some(construct_txn(path, timestamp, &keypair)?))
+        let (bare_txn, hash, hash_b64_url) = construct_bare_txn(path, timestamp, &keypair)?;
+        Ok((wrap_txn(bare_txn), hash, hash_b64_url))
     } else {
-        Ok(None)
+        Err(Error::TxnConstruction)
     }
 }
 
-fn construct_txn(
+fn wrap_txn(txn: BlockchainTxnPocReceiptsV2) -> BlockchainTxn {
+    BlockchainTxn {
+        txn: Some(Txn::PocReceiptsV2(txn)),
+    }
+}
+
+fn construct_bare_txn(
     path: PocPath,
     timestamp: i64,
     keypair: &Keypair,

--- a/poc_iot_injector/src/server.rs
+++ b/poc_iot_injector/src/server.rs
@@ -27,7 +27,7 @@ impl Server {
         let pool = settings.database.connect(10).await?;
         let keypair = settings.keypair()?;
         let tick_time = settings.trigger_interval();
-        let (receipt_sender, _) = settings.receipt_sender_receiver();
+        let (receipt_sender, _) = file_sink::message_channel(50);
 
         // Check meta for last_poc_submission_ts, if not found, use the env var and insert it
         let last_poc_submission_ts =

--- a/poc_iot_injector/src/settings.rs
+++ b/poc_iot_injector/src/settings.rs
@@ -1,6 +1,5 @@
 use crate::{Error, Result};
 use config::{Config, Environment, File};
-use file_store::file_sink;
 use serde::Deserialize;
 use std::{path::Path, time::Duration};
 
@@ -71,11 +70,5 @@ impl Settings {
 
     pub fn trigger_interval(&self) -> Duration {
         Duration::from_secs(self.trigger)
-    }
-
-    pub fn receipt_sender_receiver(
-        &self,
-    ) -> (file_sink::MessageSender, file_sink::MessageReceiver) {
-        file_sink::message_channel(50)
     }
 }

--- a/poc_iot_injector/src/settings.rs
+++ b/poc_iot_injector/src/settings.rs
@@ -1,5 +1,6 @@
 use crate::{Error, Result};
 use config::{Config, Environment, File};
+use file_store::file_sink;
 use serde::Deserialize;
 use std::{path::Path, time::Duration};
 
@@ -22,6 +23,9 @@ pub struct Settings {
     pub transactions: node_follower::Settings,
     pub verifier: file_store::Settings,
     pub metrics: poc_metrics::Settings,
+    /// Local folder for storing intermediate files
+    pub cache: String,
+    pub output: file_store::Settings,
 }
 
 pub fn default_log() -> String {
@@ -67,5 +71,11 @@ impl Settings {
 
     pub fn trigger_interval(&self) -> Duration {
         Duration::from_secs(self.trigger)
+    }
+
+    pub fn receipt_sender_receiver(
+        &self,
+    ) -> (file_sink::MessageSender, file_sink::MessageReceiver) {
+        file_sink::message_channel(50)
     }
 }

--- a/poc_mobile_verifier/src/subnetwork_rewards.rs
+++ b/poc_mobile_verifier/src/subnetwork_rewards.rs
@@ -8,7 +8,6 @@ use chrono::{DateTime, Utc};
 use file_store::{file_sink, file_sink_write};
 use helium_crypto::PublicKey;
 use rust_decimal::Decimal;
-use rust_decimal_macros::dec;
 use std::collections::HashMap;
 use std::ops::Range;
 use tokio::sync::oneshot;

--- a/poc_mobile_verifier/src/subnetwork_rewards.rs
+++ b/poc_mobile_verifier/src/subnetwork_rewards.rs
@@ -8,6 +8,7 @@ use chrono::{DateTime, Utc};
 use file_store::{file_sink, file_sink_write};
 use helium_crypto::PublicKey;
 use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use std::collections::HashMap;
 use std::ops::Range;
 use tokio::sync::oneshot;


### PR DESCRIPTION
# Summary
This adds support for writing poc receipt txns to s3 bucket once they have been submitted to the chain.

# Caveats
- The if-else clauses could use some scrutiny
- Am I actually writing the txn correctly to S3? I mostly looked through poc_mobile_verifier for depositing the file

# TODO:
- [x] ~~Test with minio. There seems to be a potential bug with file_upload, it just stops after uploading one file to my local minio cluster. Still investigating.~~ We have decided not to do the local upload testing since it's not really meaningful.