### PR TITLE
test speedtestavg into_iter timestamps/ordering

### DIFF
--- a/poc_mobile_verifier/src/speedtests.rs
+++ b/poc_mobile_verifier/src/speedtests.rs
@@ -569,4 +569,21 @@ mod test {
             SpeedtestTier::Acceptable
         );
     }
+
+    #[test]
+    fn check_speedtest_rolling_avg() {
+        let owner: PublicKey = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
+            .parse()
+            .expect("failed owner parse");
+        let speedtests = VecDeque::from(known_speedtests());
+        let avgs = SpeedtestAverages {
+            speedtests: HashMap::from([(owner, speedtests)]),
+        }
+        .into_iter();
+        for avg in avgs {
+            if let Some(first) = avg.speedtests.first() {
+                assert_eq!(avg.latest_timestamp, first.timestamp);
+            }
+        }
+    }
 }


### PR DESCRIPTION
tests functionality of the `SpeedtestAverages` impl of `IntoIter` to ensure the iterable `SpeedtestRollingAverages` all convert to storing the order of the speedtests under it's key of the same name with the newest at the front of a VecDeque when traversing from the right to the left and the timestamp of this first/left-most speedtest is also recorded as the `last_timestamp` field defined on the `SpeedtestRollingAverage` struct