### PR TITLE
Fix poc_report join query and add entropy_start_time migration

### DIFF
--- a/poc_iot_verifier/migrations/6_add_entropy_start_time.sql
+++ b/poc_iot_verifier/migrations/6_add_entropy_start_time.sql
@@ -1,0 +1,1 @@
+alter table poc_report add entropy_start_time timestamptz default now() not null;

--- a/poc_iot_verifier/migrations/6_add_entropy_start_time.sql
+++ b/poc_iot_verifier/migrations/6_add_entropy_start_time.sql
@@ -1,1 +1,7 @@
+-- :up
+
 alter table poc_report add entropy_start_time timestamptz default now() not null;
+
+-- :down
+
+alter table poc_report drop entropy_start_time;

--- a/poc_iot_verifier/migrations/6_entropy_start_time.down.sql
+++ b/poc_iot_verifier/migrations/6_entropy_start_time.down.sql
@@ -1,0 +1,1 @@
+alter table poc_report drop entropy_start_time;

--- a/poc_iot_verifier/migrations/6_entropy_start_time.up.sql
+++ b/poc_iot_verifier/migrations/6_entropy_start_time.up.sql
@@ -1,7 +1,1 @@
--- :up
-
 alter table poc_report add entropy_start_time timestamptz default now() not null;
-
--- :down
-
-alter table poc_report drop entropy_start_time;

--- a/poc_iot_verifier/src/poc_report.rs
+++ b/poc_iot_verifier/src/poc_report.rs
@@ -127,7 +127,7 @@ impl Report {
     {
         sqlx::query_as::<_, Self>(
             r#"
-            select  id,
+            select poc_report.id,
                 poc_report.remote_entropy,
                 poc_report.packet_data,
                 poc_report.report_data,
@@ -136,8 +136,8 @@ impl Report {
                 poc_report.attempts,
                 poc_report.report_timestamp,
                 poc_report.last_processed,
-                poc_report.created_at
-                entropy.timestamp
+                poc_report.created_at,
+                poc_report.entropy_start_time
             from poc_report
             left join entropy on poc_report.remote_entropy=entropy.data
             where poc_report.report_type = 'beacon' and status = 'pending'


### PR DESCRIPTION
Fixes some bugs with the `poc_report` query we found during deployment.