### PR TITLE
Add an additional setting for txn submission

### DIFF
--- a/poc_iot_injector/pkg/deb/settings-template.toml
+++ b/poc_iot_injector/pkg/deb/settings-template.toml
@@ -15,6 +15,11 @@ keypair = "/path/to/key_pair"
 #
 # last_poc_submission = 0
 
+# Whether to do txn submission to mainnet
+#
+# do_submission = false
+
+
 [database]
 
 # Url for database to write indexed rewards to

--- a/poc_iot_injector/src/receipt_txn.rs
+++ b/poc_iot_injector/src/receipt_txn.rs
@@ -21,11 +21,18 @@ const HIP15_TX_REWARD_UNIT_CAP: Decimal = dec!(2.0);
 
 type PocPath = Vec<BlockchainPocPathElementV1>;
 
+#[derive(Clone)]
+pub struct TxnDetails {
+    pub txn: BlockchainTxn,
+    pub hash: Vec<u8>,
+    pub hash_b64_url: String,
+}
+
 pub fn handle_report_msg(
     msg: prost::bytes::BytesMut,
     keypair: Arc<Keypair>,
     timestamp: i64,
-) -> Result<(BlockchainTxn, Vec<u8>, String)> {
+) -> Result<TxnDetails> {
     // Path is always single element, till we decide to change it at some point.
     let mut path: PocPath = Vec::with_capacity(1);
 
@@ -46,7 +53,11 @@ pub fn handle_report_msg(
         path.push(path_element);
 
         let (bare_txn, hash, hash_b64_url) = construct_bare_txn(path, timestamp, &keypair)?;
-        Ok((wrap_txn(bare_txn), hash, hash_b64_url))
+        Ok(TxnDetails {
+            txn: wrap_txn(bare_txn),
+            hash,
+            hash_b64_url,
+        })
     } else {
         Err(Error::TxnConstruction)
     }

--- a/poc_iot_injector/src/server.rs
+++ b/poc_iot_injector/src/server.rs
@@ -1,5 +1,6 @@
 use crate::{
-    receipt_txn::handle_report_msg, Error, Result, Settings, LOADER_WORKERS, STORE_WORKERS,
+    receipt_txn::{handle_report_msg, TxnDetails},
+    Result, Settings, LOADER_WORKERS, STORE_WORKERS,
 };
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use db_store::MetaValue;
@@ -7,7 +8,6 @@ use file_store::{file_sink, file_sink_write, FileStore, FileType};
 use futures::stream::{self, StreamExt};
 use futures::TryStreamExt;
 use helium_crypto::Keypair;
-use helium_proto::BlockchainTxn;
 use node_follower::txn_service::TransactionService;
 use sqlx::{Pool, Postgres};
 use std::sync::Arc;
@@ -22,6 +22,7 @@ pub struct Server {
     last_poc_submission_ts: MetaValue<i64>,
     tick_time: StdDuration,
     receipt_sender: file_sink::MessageSender,
+    do_submission: bool,
 }
 
 impl Server {
@@ -29,6 +30,7 @@ impl Server {
         let pool = settings.database.connect(10).await?;
         let keypair = settings.keypair()?;
         let tick_time = settings.trigger_interval();
+        let do_submission = settings.do_submission;
         let (receipt_sender, _) = file_sink::message_channel(50);
 
         // Check meta for last_poc_submission_ts, if not found, use the env var and insert it
@@ -46,6 +48,7 @@ impl Server {
             iot_verifier_store: FileStore::from_settings(&settings.verifier).await?,
             last_poc_submission_ts,
             receipt_sender,
+            do_submission,
         };
         Ok(result)
     }
@@ -87,6 +90,7 @@ impl Server {
             &self.receipt_sender,
             after_utc,
             before_utc,
+            self.do_submission,
         )
         .await?;
 
@@ -110,6 +114,7 @@ async fn submit_txns(
     receipt_sender: &file_sink::MessageSender,
     after_utc: DateTime<Utc>,
     before_utc: DateTime<Utc>,
+    do_submission: bool,
 ) -> Result {
     let file_list = store
         .list_all(FileType::LoraValidPoc, after_utc, before_utc)
@@ -123,10 +128,31 @@ async fn submit_txns(
             let mut shared_txn_service = txn_service.clone();
             let shared_key = keypair.clone();
             async move {
-                if let Ok(txn) =
-                    handle_txn_submission(msg, shared_key, &mut shared_txn_service, before_ts).await
-                {
-                    file_sink_write!("signed_poc_receipt_txn", receipt_sender, txn).await?;
+                match (
+                    handle_report_msg(msg, shared_key.clone(), before_ts),
+                    do_submission,
+                ) {
+                    (Ok(txn_details), true) => {
+                        // do txn submission
+                        if handle_txn_submission(txn_details.clone(), &mut shared_txn_service)
+                            .await
+                            .is_ok()
+                        {
+                            // and write it out
+                            file_sink_write!(
+                                "signed_poc_receipt_txn",
+                                receipt_sender,
+                                txn_details.txn
+                            )
+                            .await?;
+                        }
+                    }
+                    (Ok(txn_details), false) => {
+                        // only write the transaction, no submission
+                        file_sink_write!("signed_poc_receipt_txn", receipt_sender, txn_details.txn)
+                            .await?;
+                    }
+                    (Err(e), _) => tracing::error!("Unexpected error: {:?}", e),
                 }
                 Ok(())
             }
@@ -136,17 +162,23 @@ async fn submit_txns(
 }
 
 async fn handle_txn_submission(
-    msg: prost::bytes::BytesMut,
-    shared_key: Arc<Keypair>,
+    txn_details: TxnDetails,
     txn_service: &mut TransactionService,
-    before_ts: i64,
-) -> Result<BlockchainTxn> {
-    let (txn, hash, hash_b64_url) = handle_report_msg(msg, shared_key, before_ts)?;
-    if txn_service.submit(txn.clone(), &hash).await.is_ok() {
-        tracing::debug!("txn submitted successfully, hash: {:?}", hash_b64_url);
-        Ok(txn)
+) -> Result {
+    if txn_service
+        .submit(txn_details.txn, &txn_details.hash)
+        .await
+        .is_ok()
+    {
+        tracing::debug!(
+            "txn submitted successfully, hash: {:?}",
+            txn_details.hash_b64_url
+        );
     } else {
-        tracing::warn!("txn submission failed!, hash: {:?}", hash_b64_url);
-        Err(Error::TxnSubmission(hash_b64_url))
+        tracing::warn!(
+            "txn submission failed!, hash: {:?}",
+            txn_details.hash_b64_url
+        );
     }
+    Ok(())
 }

--- a/poc_iot_injector/src/settings.rs
+++ b/poc_iot_injector/src/settings.rs
@@ -18,6 +18,9 @@ pub struct Settings {
     /// unix epoch)
     #[serde(default = "default_last_poc_submission")]
     pub last_poc_submission: i64,
+    #[serde(default = "default_do_submission")]
+    /// Whether to submit txns to mainnet, default: false
+    pub do_submission: bool,
     pub database: db_store::Settings,
     pub transactions: node_follower::Settings,
     pub verifier: file_store::Settings,
@@ -33,6 +36,10 @@ pub fn default_log() -> String {
 
 pub fn default_last_poc_submission() -> i64 {
     0
+}
+
+pub fn default_do_submission() -> bool {
+    false
 }
 
 fn default_trigger_interval() -> u64 {


### PR DESCRIPTION
This adds an extra setting `do_submission` boolean flag to specify whether to submit txn to mainnet. Mostly because we want to start the injector but don't really want to start submitting txns to mainnet just yet.