### PR TITLE
IoT Packet Verifier using tokio and file_store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "db_store",
     "file_store",
     "mobile_rewards",
+    "iot_packet_verifier",
     "poc_mobile_verifier",
     "entropy",
     "poc_iot_verifier",

--- a/file_store/src/file_info.rs
+++ b/file_store/src/file_info.rs
@@ -95,6 +95,7 @@ pub const CELL_HEARTBEAT_INGEST_REPORT: &str = "heartbeat_report";
 pub const CELL_SPEEDTEST_INGEST_REPORT: &str = "speedtest_report";
 pub const ENTROPY: &str = "entropy";
 pub const SUBNETWORK_REWARDS: &str = "subnetwork_rewards";
+pub const SUBNETWORK_DEBITS: &str = "subnetwork_debits";
 pub const ENTROPY_REPORT: &str = "entropy_report";
 pub const LORA_BEACON_INGEST_REPORT: &str = "lora_beacon_ingest_report";
 pub const LORA_WITNESS_INGEST_REPORT: &str = "lora_witness_ingest_report";
@@ -104,6 +105,7 @@ pub const LORA_INVALID_WITNESS_REPORT: &str = "lora_invalid_witness";
 pub const SPEEDTEST_AVG: &str = "speedtest_avg";
 pub const VALIDATED_HEARTBEAT: &str = "validated_heartbeat";
 pub const SIGNED_POC_RECEIPT_TXN: &str = "signed_poc_receipt_txn";
+pub const IOT_PACKET_REPORT: &str = "packetreport";
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Copy, strum::EnumCount)]
 #[serde(rename_all = "snake_case")]
@@ -112,6 +114,7 @@ pub enum FileType {
     CellSpeedtest = 1,
     Entropy = 2,
     SubnetworkRewards = 3,
+    SubnetworkDebits,
     CellHeartbeatIngestReport,
     CellSpeedtestIngestReport,
     EntropyReport,
@@ -123,6 +126,7 @@ pub enum FileType {
     SpeedtestAvg,
     ValidatedHeartbeat,
     SignedPocReceiptTxn,
+    IotPacketReport,
 }
 
 impl fmt::Display for FileType {
@@ -134,6 +138,7 @@ impl fmt::Display for FileType {
             Self::CellSpeedtestIngestReport => CELL_SPEEDTEST_INGEST_REPORT,
             Self::Entropy => ENTROPY,
             Self::SubnetworkRewards => SUBNETWORK_REWARDS,
+            Self::SubnetworkDebits => SUBNETWORK_DEBITS,
             Self::EntropyReport => ENTROPY_REPORT,
             Self::LoraBeaconIngestReport => LORA_BEACON_INGEST_REPORT,
             Self::LoraWitnessIngestReport => LORA_WITNESS_INGEST_REPORT,
@@ -143,6 +148,7 @@ impl fmt::Display for FileType {
             Self::SpeedtestAvg => SPEEDTEST_AVG,
             Self::ValidatedHeartbeat => VALIDATED_HEARTBEAT,
             Self::SignedPocReceiptTxn => SIGNED_POC_RECEIPT_TXN,
+            Self::IotPacketReport => IOT_PACKET_REPORT,
         };
         f.write_str(s)
     }
@@ -157,6 +163,7 @@ impl FileType {
             Self::CellSpeedtestIngestReport => CELL_SPEEDTEST_INGEST_REPORT,
             Self::Entropy => ENTROPY,
             Self::SubnetworkRewards => SUBNETWORK_REWARDS,
+            Self::SubnetworkDebits => SUBNETWORK_DEBITS,
             Self::EntropyReport => ENTROPY_REPORT,
             Self::LoraBeaconIngestReport => LORA_BEACON_INGEST_REPORT,
             Self::LoraWitnessIngestReport => LORA_WITNESS_INGEST_REPORT,
@@ -166,6 +173,7 @@ impl FileType {
             Self::SpeedtestAvg => SPEEDTEST_AVG,
             Self::ValidatedHeartbeat => VALIDATED_HEARTBEAT,
             Self::SignedPocReceiptTxn => SIGNED_POC_RECEIPT_TXN,
+            Self::IotPacketReport => IOT_PACKET_REPORT,
         }
     }
 }
@@ -180,6 +188,7 @@ impl FromStr for FileType {
             CELL_SPEEDTEST_INGEST_REPORT => Self::CellSpeedtestIngestReport,
             ENTROPY => Self::Entropy,
             SUBNETWORK_REWARDS => Self::SubnetworkRewards,
+            SUBNETWORK_DEBITS => Self::SubnetworkDebits,
             ENTROPY_REPORT => Self::EntropyReport,
             LORA_BEACON_INGEST_REPORT => Self::LoraBeaconIngestReport,
             LORA_WITNESS_INGEST_REPORT => Self::LoraWitnessIngestReport,
@@ -189,6 +198,7 @@ impl FromStr for FileType {
             SPEEDTEST_AVG => Self::SpeedtestAvg,
             VALIDATED_HEARTBEAT => Self::ValidatedHeartbeat,
             SIGNED_POC_RECEIPT_TXN => Self::SignedPocReceiptTxn,
+            IOT_PACKET_REPORT => Self::IotPacketReport,
             _ => return Err(Error::from(io::Error::from(io::ErrorKind::InvalidInput))),
         };
         Ok(result)

--- a/iot_packet_verifier/Cargo.toml
+++ b/iot_packet_verifier/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "iot-packet-verifier"
+version = "0.1.0"
+description = "Verify LoRaWAN traffic for Helium Packet-Router (HPR) operations"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "iot_packet_verifier"
+path = "src/main.rs"
+doc = false
+
+# FIXME: re-enable
+# [[bin]]
+# name = "iot_packet_verifier_server"
+# path = "src/cli/server.rs"
+# doc = false
+
+[features]
+# Generate protobuf files via: cargo test --features=sample-data
+sample-data = ["async-compression", "futures-util"]
+
+[dependencies]
+async-compression = {version="*", optional=true}
+# bytes = "*"
+chrono = {workspace=true}
+clap = {workspace=true}
+config = {workspace=true}
+futures = {workspace=true}
+#futures-core = "*"
+# FIXME use of futures-util is deprecated
+futures-util = {workspace=true, optional=true}
+
+helium-crypto = {workspace=true}
+
+# FIXME
+# helium-proto = {workspace=true}
+#helium-proto = {git="https://github.com/helium/proto", branch="dpezely/packet-verifier", features=["services"]}
+helium-proto = {path="../../../helium/proto", features=["services"]}
+
+# lazy_static = {workspace=true}
+
+file-store = {path="../file_store"}
+poc-metrics = {path="../metrics"}
+
+prost = {workspace=true}
+
+serde = {workspace=true}
+#serde_json = {workspace=true}
+thiserror = {workspace=true}
+tokio = {workspace=true}
+#tokio-stream = {version="0", features=["fs"]}
+tokio-util = "0"
+tonic = {workspace=true}
+tracing = {workspace=true}
+tracing-subscriber = {workspace=true}
+triggered = {workspace=true}

--- a/iot_packet_verifier/Cargo.toml
+++ b/iot_packet_verifier/Cargo.toml
@@ -11,47 +11,20 @@ name = "iot_packet_verifier"
 path = "src/main.rs"
 doc = false
 
-# FIXME: re-enable
-# [[bin]]
-# name = "iot_packet_verifier_server"
-# path = "src/cli/server.rs"
-# doc = false
-
-[features]
-# Generate protobuf files via: cargo test --features=sample-data
-sample-data = ["async-compression", "futures-util"]
-
 [dependencies]
 async-compression = {version="*", optional=true}
-# bytes = "*"
 chrono = {workspace=true}
 clap = {workspace=true}
 config = {workspace=true}
-futures = {workspace=true}
-#futures-core = "*"
-# FIXME use of futures-util is deprecated
-futures-util = {workspace=true, optional=true}
-
-helium-crypto = {workspace=true}
-
-# FIXME
-# helium-proto = {workspace=true}
-#helium-proto = {git="https://github.com/helium/proto", branch="dpezely/packet-verifier", features=["services"]}
-helium-proto = {path="../../../helium/proto", features=["services"]}
-
-# lazy_static = {workspace=true}
-
 file-store = {path="../file_store"}
+futures = {workspace=true}
+helium-crypto = {workspace=true}
+helium-proto = {workspace=true}
 poc-metrics = {path="../metrics"}
-
 prost = {workspace=true}
-
 serde = {workspace=true}
-#serde_json = {workspace=true}
 thiserror = {workspace=true}
 tokio = {workspace=true}
-#tokio-stream = {version="0", features=["fs"]}
-tokio-util = "0"
 tonic = {workspace=true}
 tracing = {workspace=true}
 tracing-subscriber = {workspace=true}

--- a/iot_packet_verifier/README.md
+++ b/iot_packet_verifier/README.md
@@ -1,0 +1,20 @@
+# IoT Packet Verifier
+
+IoT Packet Verifier (PV) interacts with the
+[Helium Packet Router](https://github.com/helium/helium-packet-router/) (HPR)
+for the business side of LoRaWAN traffic accounting.
+
+HPR reports each routable packet publicly, which persists in S3 permanently
+and considered read-only thereafter.
+
+PV reads those reports and similarly publishes bookkeeping records to S3
+from which the Injector credits rewards to gateway owners for providing the
+network.  It debits Data Credits (DC) of customers using the network.
+
+The Config Server (CS) provides current customers' OUIs, NetIDs and their
+associated wallet public address.  It also gets public keys of each gateway
+and wallets of their owners.
+
+PV notifies CS of OUIs for which HPR should cease routing when an associated
+wallet contain an insufficient balance.  PV also monitors for wallets
+becoming funded again.

--- a/iot_packet_verifier/src/error.rs
+++ b/iot_packet_verifier/src/error.rs
@@ -1,0 +1,59 @@
+use thiserror::Error;
+
+pub type Result<T = ()> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("config error")]
+    Config(#[from] config::ConfigError),
+    #[error("custom error")]
+    Custom(String),
+    #[error("decode error")]
+    Decode(#[from] DecodeError),
+    #[error("io error")]
+    Io(#[from] std::io::Error),
+    #[error("metrics error")]
+    Metrics(#[from] poc_metrics::Error),
+    #[error("not found")]
+    NotFound(String),
+    #[error("service error")]
+    Service(#[from] helium_proto::services::Error),
+    #[error("store error")]
+    Store(#[from] file_store::Error),
+}
+
+#[derive(Error, Debug)]
+pub enum DecodeError {
+    #[error("prost error")]
+    Prost(#[from] helium_proto::DecodeError),
+    /* DELETE ME...
+    #[error("parse int error")]
+    ParseInt(#[from] std::num::ParseIntError),
+    #[error("datetime error")]
+    Chrono(#[from] chrono::ParseError),
+    #[error("invalid decimals in {0}, only 8 allowed")]
+    Decimals(String),
+    */
+}
+
+impl Error {
+    pub fn not_found<E: ToString>(msg: E) -> Self {
+        Self::NotFound(msg.to_string())
+    }
+    pub fn custom<E: ToString>(msg: E) -> Self {
+        Self::Custom(msg.to_string())
+    }
+}
+
+macro_rules! from_err {
+    ($to_type:ty, $from_type:ty) => {
+        impl From<$from_type> for Error {
+            fn from(v: $from_type) -> Self {
+                Self::from(<$to_type>::from(v))
+            }
+        }
+    };
+}
+
+// Decode Errors
+from_err!(DecodeError, prost::DecodeError);

--- a/iot_packet_verifier/src/lib.rs
+++ b/iot_packet_verifier/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod error;
+pub mod loader;
+pub mod runner;
+pub mod settings;
+
+pub use error::{Error, Result};
+pub use settings::Settings;

--- a/iot_packet_verifier/src/loader.rs
+++ b/iot_packet_verifier/src/loader.rs
@@ -1,0 +1,134 @@
+use crate::{Result, Settings};
+use chrono::{DateTime, NaiveDateTime, Utc};
+use helium_crypto::public_key::PublicKey;
+use helium_proto::services::router::PacketRouterPacketReportV1;
+use helium_proto::Message;
+use file_store::{FileStore, FileType};
+use futures::{stream, StreamExt};
+use tokio::time;
+
+/// cadence for how often to look for new beacon and witness reports from s3 bucket
+const REPORTS_POLL_TIME: time::Duration = time::Duration::from_secs(63);
+
+pub struct Loader {
+    /// Where to read reports from Helium Packet Router
+    ingest_store: FileStore,
+    // FIXME add results store for persisting our results
+    // FIXME add follower service for resolving gateway pubkey or OUI to owner
+}
+
+impl Loader {
+    pub async fn from_settings(settings: &Settings) -> Result<Self> {
+        tracing::info!("from_settings");
+        let ingest_store = FileStore::from_settings(&settings.ingest).await?;
+        Ok(Self {
+            ingest_store,
+        })
+    }
+
+    pub async fn run(&self, shutdown: &triggered::Listener) -> Result {
+        tracing::info!("started loader");
+
+        let mut report_timer = time::interval(REPORTS_POLL_TIME);
+        report_timer.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+
+        let store = &self.ingest_store;
+        loop {
+            if shutdown.is_triggered() {
+                break;
+            }
+            tokio::select! {
+                _ = shutdown.clone() => {
+                    tracing::info!("shutdown requested");
+                    break
+                },
+                _ = report_timer.tick() => match self.process_events(&store, shutdown.clone()).await {
+                    Ok(()) => (),
+                    Err(err) => {
+                        tracing::error!("fatal report loader error: {err:?}");
+                    }
+                },
+            }
+        }
+        tracing::info!("stopping loader");
+        Ok(())
+    }
+
+    /// Iterate through Helium Packet Router "packetreport" protobuf files in S3.
+    pub async fn process_events(&self, store: &FileStore, shutdown: triggered::Listener) -> Result {
+        let file_type = FileType::IotPacketReport;
+        // FIXME: get prev timestamp from persisted state, otherwise processes all.
+        let last_time =
+            DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(1666777888, 9), Utc);
+        let infos = store.list_all(file_type, last_time, None).await?;
+        if infos.is_empty() {
+            tracing::info!("no ingest {file_type} files to process from: {last_time}");
+            return Ok(());
+        }
+        let last_time = infos.last().map(|v| v.timestamp);
+        let infos_len = infos.len();
+        tracing::info!("processing {infos_len} {file_type} files");
+        let handler = store
+        // FIXME: increase concurrency beyond hardcoded `1`
+            .source_unordered(1, stream::iter(infos).map(Ok).boxed())
+            .for_each_concurrent(1, |msg| async move {
+                match msg {
+                    Err(err) => tracing::warn!("skipping entry in {file_type} stream: {err:?}"),
+                    Ok(buf) => match self.store_update(&buf).await {
+                        Ok(()) => {
+                            tracing::info!("UPDATED last_time={last_time:?}"); // DELETE ME
+                            ()
+                        },
+                        Err(err) => {
+                            tracing::warn!("failed to update store: {err:?}")
+                        }
+                    }
+                }
+            });
+        tokio::select! {
+            _ = handler => {
+                tracing::info!("completed processing {infos_len} {file_type} files");
+                // FIXME update last_timestamp
+                Ok(())
+            },
+            _ = shutdown.clone() => Ok(()),
+        }
+    }
+
+    pub async fn store_update(&self, buf: &[u8]) -> Result {
+        let decoded = PacketRouterPacketReportV1::decode(buf)?;
+        self.update_counters(&decoded);
+        Ok(())
+    }
+
+    pub fn update_counters(&self, ingest: &PacketRouterPacketReportV1) {
+        let PacketRouterPacketReportV1 {
+            oui,
+            net_id,
+            gateway,
+            payload_hash,
+            ..
+        } = ingest;
+        println!(
+            "updating: oui={} netid=0x{:04x} hash=0x{}...",
+            oui,
+            net_id,
+            &payload_hash[0..5].iter().map(|x| format!("{x:02x}")).collect::<String>()
+        );
+        if let Ok(pubkeybin) = PublicKey::from_bytes(gateway) {
+            println!("pubkeybin={:?}", pubkeybin);
+            /* FIXME send msg instead
+            let _gw_count = counters
+                .gateway
+                .entry(pubkey)
+                .and_modify(|n| *n += 1)
+                .or_insert(1);
+            let _oui_count = counters
+                .oui
+                .entry(oui.to_owned())
+                .and_modify(|n| *n += 1)
+                .or_insert(1);
+            */
+        }
+    }
+}

--- a/iot_packet_verifier/src/main.rs
+++ b/iot_packet_verifier/src/main.rs
@@ -1,0 +1,71 @@
+use clap::Parser;
+use iot_packet_verifier::{loader, runner, Result, Settings};
+use std::path;
+use tokio::signal;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[derive(Debug, clap::Parser)]
+#[clap(version = env!("CARGO_PKG_VERSION"))]
+#[clap(about = env!("CARGO_PKG_DESCRIPTION"))]
+pub struct Cli {
+    /// Optional settings.toml file for configuration.
+    /// Environemnt vars override settings in .toml file.
+    #[clap(short='c')]
+    config: Option<path::PathBuf>,
+
+    #[clap(subcommand)]
+    cmd: Cmd,
+}
+
+impl Cli {
+    pub async fn run(self) -> Result {
+        let settings = Settings::new(self.config)?;
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::EnvFilter::new(&settings.log))
+            .with(tracing_subscriber::fmt::layer())
+            .init();
+        self.cmd.run(settings).await
+   }
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub enum Cmd {
+    /// Stream processing of IoT Packet Reports in S3 from HPR
+    Server(Server),
+}
+
+impl Cmd {
+    pub async fn run(&self, settings: Settings) -> Result {
+        match self {
+            Self::Server(cmd) => cmd.run(&settings).await,
+        }
+    }
+}
+
+#[derive(clap::Args, Debug)]
+pub struct Server {}
+
+impl Server {
+    pub async fn run(&self, settings: &Settings) -> Result {
+        // Configure shutdown trigger
+        let (shutdown_trigger, shutdown_listener) = triggered::trigger();
+        tokio::spawn(async move {
+            let _ = signal::ctrl_c().await;
+            shutdown_trigger.trigger()
+        });
+
+        let runner = runner::Runner::from_settings(settings).await?;
+        let loader = loader::Loader::from_settings(settings).await?;
+        tokio::try_join!(
+            runner.run(&shutdown_listener),
+            loader.run(&shutdown_listener),
+        )
+        .map(|_| ())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result {
+    let cli = Cli::parse();
+    cli.run().await
+}

--- a/iot_packet_verifier/src/main.rs
+++ b/iot_packet_verifier/src/main.rs
@@ -10,7 +10,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 pub struct Cli {
     /// Optional settings.toml file for configuration.
     /// Environemnt vars override settings in .toml file.
-    #[clap(short='c')]
+    #[clap(short = 'c')]
     config: Option<path::PathBuf>,
 
     #[clap(subcommand)]
@@ -25,7 +25,7 @@ impl Cli {
             .with(tracing_subscriber::fmt::layer())
             .init();
         self.cmd.run(settings).await
-   }
+    }
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -43,10 +43,22 @@ impl Cmd {
 }
 
 #[derive(clap::Args, Debug)]
-pub struct Server {}
+pub struct Server {
+    /* FIXME: add timestamp fields for begin/end range
+    /// Required timestamp of range start (inclusive)
+    #[clap(long)]
+    after: NaiveDateTime,
+    /// Required timestamp of range end (inclusive)
+    #[clap(long)]
+    before: NaiveDateTime,
+    */
+}
 
 impl Server {
     pub async fn run(&self, settings: &Settings) -> Result {
+        // Install the prometheus metrics exporter
+        // FIXME poc_metrics::start_metrics(&settings.metrics)?;
+
         // Configure shutdown trigger
         let (shutdown_trigger, shutdown_listener) = triggered::trigger();
         tokio::spawn(async move {
@@ -56,6 +68,7 @@ impl Server {
 
         let runner = runner::Runner::from_settings(settings).await?;
         let loader = loader::Loader::from_settings(settings).await?;
+        // FIXME add upload to S3
         tokio::try_join!(
             runner.run(&shutdown_listener),
             loader.run(&shutdown_listener),

--- a/iot_packet_verifier/src/runner.rs
+++ b/iot_packet_verifier/src/runner.rs
@@ -1,0 +1,144 @@
+/// Run the primary counters.
+/// See a packet, count a packet for billing purposes.
+
+use crate::{Result, Settings};
+//use chrono::{Duration, Utc};
+use file_store::{file_sink, file_sink::MessageSender, file_sink_write, file_upload, FileType};
+use helium_crypto::public_key::PublicKey;
+// helium/proto/src/blockchain_txn_subnetwork_rewards_v1.proto
+use helium_proto::SubnetworkReward;
+//FIXME use node_follower::follower_service;
+use std::collections::HashMap;
+use std::path::Path;
+use tokio::time;
+
+/// Organizational ID associated with each customer, used as input:
+#[allow(clippy::upper_case_acronyms)]
+type OUI = u32;
+
+/// Cadence in seconds when to persist file upload and reset counters
+const POLL_TIME: time::Duration = time::Duration::from_secs(303);
+
+/// Simple per-packet traffic counting.
+#[derive(Debug, Default)]
+pub struct PacketCounters {
+    pub gateway: HashMap<PublicKey, u32>,
+    pub oui: HashMap<OUI, u32>,
+}
+
+impl PacketCounters {
+    pub fn new() -> Self {
+        Self {
+            gateway: HashMap::new(),
+            oui: HashMap::new(),
+        }
+    }
+}
+
+pub struct Runner {
+    counters: PacketCounters,
+    settings: Settings,
+}
+
+impl Runner {
+    pub async fn from_settings(settings: &Settings) -> Result<Self> {
+        let counters = PacketCounters::new();
+        let settings = settings.clone();
+        Ok(Self {
+            counters,
+            settings,
+        })
+    }
+
+    pub async fn run(&self, shutdown: &triggered::Listener) -> Result {
+        tracing::info!("starting runner");
+
+        let mut timer = time::interval(POLL_TIME);
+        timer.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+
+        let rewards_path = Path::new(&self.settings.rewards.bucket);
+        let debits_path = Path::new(&self.settings.debits.bucket);
+        let (rewards_tx, rewards_rx) = file_sink::message_channel(50);
+        let (debits_tx, debits_rx) = file_sink::message_channel(50);
+        let (rewards_upload_tx, rewards_upload_rx) = file_upload::message_channel();
+        let (debits_upload_tx, debits_upload_rx) = file_upload::message_channel();
+        let rewards_upload =
+            file_upload::FileUpload::from_settings(&self.settings.rewards, rewards_upload_rx).await?;
+        let mut rewards_sink =
+            file_sink::FileSinkBuilder::new(FileType::SubnetworkRewards, rewards_path, rewards_rx)
+        .deposits(Some(rewards_upload_tx.clone()))
+        .create()
+        .await?;
+        let debits_upload =
+            file_upload::FileUpload::from_settings(&self.settings.debits, debits_upload_rx).await?;
+        let mut debits_sink =
+            file_sink::FileSinkBuilder::new(FileType::SubnetworkDebits, debits_path, debits_rx)
+        .deposits(Some(debits_upload_tx.clone()))
+        .create()
+        .await?;
+
+        let shutdown2 = shutdown.clone();
+        let shutdown3 = shutdown.clone();
+        let shutdown4 = shutdown.clone();
+        let shutdown5 = shutdown.clone();
+        tokio::spawn(async move { rewards_sink.run(&shutdown2).await });
+        tokio::spawn(async move { rewards_upload.run(&shutdown3).await });
+        tokio::spawn(async move { debits_sink.run(&shutdown4).await });
+        tokio::spawn(async move { debits_upload.run(&shutdown5).await });
+        loop {
+            if shutdown.is_triggered() {
+                break;
+            }
+            tokio::select! {
+                _ = shutdown.clone() => {
+                    tracing::info!("shutdown requested");
+                    break
+                },
+                _ = timer.tick() =>
+                    match self.handle_tick(rewards_tx.clone(), debits_tx.clone()).await {
+                        Ok(()) => (),
+                        Err(err) => {
+                            tracing::error!("fatal runner error: {err:?}");
+                            return Err(err)
+                        }
+                    }
+            }
+        }
+        tracing::info!("stopping runner");
+        Ok(())
+    }
+
+    /// Handle crediting gateway owners with rewards for providing the
+    /// network and debiting DC from OUI owners for using the network.
+    async fn handle_tick(&self, rewards_tx: MessageSender, debits_tx: MessageSender) -> Result {
+        for (pubkeybin, count) in self.counters.gateway.iter() {
+            // FIXME resolve pubkeybin to owner via follower_service
+            let protobuf = SubnetworkReward {
+                account: pubkeybin.into(),
+                amount: self.calc_rewards(*count),
+            };
+            let _ = file_sink_write!("credit_rewards", &rewards_tx, protobuf).await?;
+        }
+        for (oui, count) in self.counters.oui.iter() {
+            // FIXME resolve OUI to owner via follower_service
+            let protobuf = SubnetworkReward {
+                account: oui.to_be_bytes().to_vec(),
+                amount: self.calc_debits(*count),
+            };
+            let _ = file_sink_write!("debit_dc", &debits_tx, protobuf).await?;
+        }
+        Ok(())
+    }
+
+    /// Calculate rewards to credit gateway's owner for providing the network.
+    pub fn calc_rewards(&self, counter: u32) -> u64 {
+        // FIXME use multiplier from settings.toml
+        counter as u64
+    }
+
+    /// Calculate DC to debit from OUI's owner for using the network.
+    pub fn calc_debits(&self, counter: u32) -> u64 {
+        // FIXME use multiplier from settings.toml
+        counter as u64
+    }
+}

--- a/iot_packet_verifier/src/runner.rs
+++ b/iot_packet_verifier/src/runner.rs
@@ -1,6 +1,5 @@
 /// Run the primary counters.
 /// See a packet, count a packet for billing purposes.
-
 use crate::{Result, Settings};
 //use chrono::{Duration, Utc};
 use file_store::{file_sink, file_sink::MessageSender, file_sink_write, file_upload, FileType};
@@ -44,10 +43,7 @@ impl Runner {
     pub async fn from_settings(settings: &Settings) -> Result<Self> {
         let counters = PacketCounters::new();
         let settings = settings.clone();
-        Ok(Self {
-            counters,
-            settings,
-        })
+        Ok(Self { counters, settings })
     }
 
     pub async fn run(&self, shutdown: &triggered::Listener) -> Result {
@@ -63,19 +59,20 @@ impl Runner {
         let (rewards_upload_tx, rewards_upload_rx) = file_upload::message_channel();
         let (debits_upload_tx, debits_upload_rx) = file_upload::message_channel();
         let rewards_upload =
-            file_upload::FileUpload::from_settings(&self.settings.rewards, rewards_upload_rx).await?;
+            file_upload::FileUpload::from_settings(&self.settings.rewards, rewards_upload_rx)
+                .await?;
         let mut rewards_sink =
             file_sink::FileSinkBuilder::new(FileType::SubnetworkRewards, rewards_path, rewards_rx)
-        .deposits(Some(rewards_upload_tx.clone()))
-        .create()
-        .await?;
+                .deposits(Some(rewards_upload_tx.clone()))
+                .create()
+                .await?;
         let debits_upload =
             file_upload::FileUpload::from_settings(&self.settings.debits, debits_upload_rx).await?;
         let mut debits_sink =
             file_sink::FileSinkBuilder::new(FileType::SubnetworkDebits, debits_path, debits_rx)
-        .deposits(Some(debits_upload_tx.clone()))
-        .create()
-        .await?;
+                .deposits(Some(debits_upload_tx.clone()))
+                .create()
+                .await?;
 
         let shutdown2 = shutdown.clone();
         let shutdown3 = shutdown.clone();
@@ -90,10 +87,7 @@ impl Runner {
                 break;
             }
             tokio::select! {
-                _ = shutdown.clone() => {
-                    tracing::info!("shutdown requested");
-                    break
-                },
+                _ = shutdown.clone() => break,
                 _ = timer.tick() =>
                     match self.handle_tick(rewards_tx.clone(), debits_tx.clone()).await {
                         Ok(()) => (),

--- a/iot_packet_verifier/src/settings.rs
+++ b/iot_packet_verifier/src/settings.rs
@@ -1,0 +1,93 @@
+use crate::error::{Error, Result};
+use config::{Config, Environment, File};
+use serde::Deserialize;
+use std::{io, path::Path, str::FromStr};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Calculations {
+    /// How much to credit a gateway's owner for providing the network.
+    /// This value gets multiplied by the count of IoT packets that
+    /// traversed the associated gateways.
+    pub rewards_multiplier: u64,
+    pub rewards_units: Units,
+
+    /// How much to debit from a gateway's owner for using the network.
+    /// This value gets multiplied by the count of IoT packets that
+    /// from devices addressing the associated OUI's destinations.
+    pub debits_multiplier: u64,
+    pub debits_units: Units,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all="UPPERCASE")]
+pub enum Units {
+    DC,                         // Data Credits
+    HNT,                        // in units of Bones
+    IOT,
+    MOBILE,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Settings {
+    /// RUST_LOG compatible setings string.
+    #[serde(default="default_log")]
+    pub log: String,
+    pub calculations: Calculations,
+    pub ingest: file_store::Settings,
+    // FIXME pub follower: file_store::Settings,
+    pub rewards: file_store::Settings,
+    pub debits: file_store::Settings,
+    // FIXME pub metrics: file_store::Settings,
+}
+
+/// Env vars have same name as entries in the settings.toml file
+/// but in uppercase and prefixed as specified by this Rust var's
+/// value.
+pub const ENV_VAR_PREFIX: &str = "IOT_PACKET_VERIFIER";
+
+pub const DC: &str = "DC";
+pub const HNT: &str = "HNT";
+pub const IOT: &str = "IOT";
+pub const MOBILE: &str = "MOBILE";
+
+pub fn default_log() -> String {
+    "iot_packet_verifier=debug,file_store=info".to_string()
+}
+
+impl Settings {
+    /// Load settings from a given path.  Settings may be loaded via
+    /// optional path and be overridden using environment variables.
+    ///
+    /// Env vars have same name as entries in the settings.toml file
+    /// but in uppercase and prefixed as specified by the value of
+    /// const &str `ENV_VAR_PREFIX`.
+    pub fn new<P: AsRef<Path>>(path: Option<P>) -> Result<Self> {
+        let mut builder = Config::builder();
+
+        if let Some(file) = path {
+            // Add optional settings file
+            builder = builder
+                .add_source(File::with_name(&file.as_ref().to_string_lossy()).required(false));
+        }
+        // Add settings from env vars
+        builder
+            .add_source(Environment::with_prefix(ENV_VAR_PREFIX).separator("_"))
+            .build()
+            .and_then(|config| config.try_deserialize())
+            .map_err(Error::from)
+    }
+}
+
+impl FromStr for Units {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self> {
+        let result = match s.to_uppercase().as_str() {
+            DC => Self::DC,
+            HNT => Self::HNT,
+            IOT => Self::IOT,
+            MOBILE => Self::MOBILE,
+            _ => return Err(Error::from(io::Error::from(io::ErrorKind::InvalidInput)))
+        };
+        Ok(result)
+    }
+}

--- a/iot_packet_verifier/src/settings.rs
+++ b/iot_packet_verifier/src/settings.rs
@@ -19,10 +19,10 @@ pub struct Calculations {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Hash)]
-#[serde(rename_all="UPPERCASE")]
+#[serde(rename_all = "UPPERCASE")]
 pub enum Units {
-    DC,                         // Data Credits
-    HNT,                        // in units of Bones
+    DC,  // Data Credits
+    HNT, // in units of Bones
     IOT,
     MOBILE,
 }
@@ -30,7 +30,7 @@ pub enum Units {
 #[derive(Clone, Debug, Deserialize)]
 pub struct Settings {
     /// RUST_LOG compatible setings string.
-    #[serde(default="default_log")]
+    #[serde(default = "default_log")]
     pub log: String,
     pub calculations: Calculations,
     pub ingest: file_store::Settings,
@@ -86,7 +86,7 @@ impl FromStr for Units {
             HNT => Self::HNT,
             IOT => Self::IOT,
             MOBILE => Self::MOBILE,
-            _ => return Err(Error::from(io::Error::from(io::ErrorKind::InvalidInput)))
+            _ => return Err(Error::from(io::Error::from(io::ErrorKind::InvalidInput))),
         };
         Ok(result)
     }


### PR DESCRIPTION
This PR adds the IoT Packet Verifier oracle.

- Applies only to LoRaWAN packets (**unrelated** to proof-of-coverage)
- approximate flow:
  + Helium Packet-Router (HPR) generates reports of traffic it sees
  + HPR publishes reports to S3
  + This oracle treats those reports as read-only inputs for stream processing
  + Outputs from this oracle get written to another bucket in S3
- This is v0 / MVP and behavior limited to: "see a packet, count a packet"
- Use same idioms and patterns as other oracles in this repo
  + e.g., `tokio` and `../file-store/`
  + Optional config may be specified via `settings.toml`
- This PR supersedes https://github.com/helium/oracles/pull/59
- Original ticket: https://github.com/helium/helium-packet-router/issues/43

Example usage:
```bash
iot_packet_verifier -c settings.toml server
```