### PR TITLE
Change timings of mobile pipeline

### DIFF
--- a/poc_ingest/src/server_5g.rs
+++ b/poc_ingest/src/server_5g.rs
@@ -1,5 +1,5 @@
 use crate::{Error, EventId, Result, Settings};
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use file_store::traits::MsgVerify;
 use file_store::{file_sink, file_sink_write, file_upload, FileType};
 use futures_util::TryFutureExt;
@@ -17,8 +17,8 @@ pub struct GrpcServer {
     heartbeat_report_tx: file_sink::MessageSender,
     speedtest_report_tx: file_sink::MessageSender,
     required_network: Network,
-}
 
+}
 impl GrpcServer {
     fn new(
         heartbeat_report_tx: file_sink::MessageSender,
@@ -117,6 +117,7 @@ pub async fn grpc_server(shutdown: triggered::Listener, settings: &Settings) -> 
         heartbeat_report_rx,
     )
     .deposits(Some(file_upload_tx.clone()))
+    .roll_time(Duration::minutes(15))
     .create()
     .await?;
 
@@ -128,6 +129,7 @@ pub async fn grpc_server(shutdown: triggered::Listener, settings: &Settings) -> 
         speedtest_report_rx,
     )
     .deposits(Some(file_upload_tx.clone()))
+    .roll_time(Duration::minutes(15))
     .create()
     .await?;
 

--- a/poc_ingest/src/server_5g.rs
+++ b/poc_ingest/src/server_5g.rs
@@ -17,7 +17,6 @@ pub struct GrpcServer {
     heartbeat_report_tx: file_sink::MessageSender,
     speedtest_report_tx: file_sink::MessageSender,
     required_network: Network,
-
 }
 impl GrpcServer {
     fn new(

--- a/poc_ingest/src/server_5g.rs
+++ b/poc_ingest/src/server_5g.rs
@@ -11,6 +11,8 @@ use helium_proto::services::poc_mobile::{
 use std::path::Path;
 use tonic::{metadata::MetadataValue, transport, Request, Response, Status};
 
+const INGEST_WAIT_DURATION_MINUTES: i64 = 15;
+
 pub type GrpcResult<T> = std::result::Result<Response<T>, Status>;
 
 pub struct GrpcServer {
@@ -116,7 +118,7 @@ pub async fn grpc_server(shutdown: triggered::Listener, settings: &Settings) -> 
         heartbeat_report_rx,
     )
     .deposits(Some(file_upload_tx.clone()))
-    .roll_time(Duration::minutes(15))
+    .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))
     .create()
     .await?;
 
@@ -128,7 +130,7 @@ pub async fn grpc_server(shutdown: triggered::Listener, settings: &Settings) -> 
         speedtest_report_rx,
     )
     .deposits(Some(file_upload_tx.clone()))
-    .roll_time(Duration::minutes(15))
+    .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))
     .create()
     .await?;
 

--- a/poc_mobile_verifier/deb/settings-template.toml
+++ b/poc_mobile_verifier/deb/settings-template.toml
@@ -12,6 +12,10 @@ cache = "/var/data/verfied-reports"
 # Verifications per rewards period. Default is 8
 # verifications = 8
 
+# Verification offset in minutes, verification will occur at the end of
+# the verification period + verification_offset_minutes; Default = 30
+# verification_offset_minutes = 30
+
 [database]
 
 # Url for database to write indexed rewards to

--- a/poc_mobile_verifier/src/cli/server.rs
+++ b/poc_mobile_verifier/src/cli/server.rs
@@ -1,8 +1,9 @@
 use crate::{
     error::Error,
     verifier::{Verifier, VerifierDaemon},
+    Result, Settings,
 };
-use crate::{Result, Settings};
+use chrono::Duration;
 use file_store::{file_sink, file_upload, FileStore, FileType};
 use futures_util::TryFutureExt;
 
@@ -36,6 +37,7 @@ impl Cmd {
             heartbeats_rx,
         )
         .deposits(Some(file_upload_tx.clone()))
+        .roll_time(Duration::minutes(15))
         .create()
         .await?;
 
@@ -47,6 +49,7 @@ impl Cmd {
             speedtest_avg_rx,
         )
         .deposits(Some(file_upload_tx.clone()))
+        .roll_time(Duration::minutes(15))
         .create()
         .await?;
 

--- a/poc_mobile_verifier/src/cli/server.rs
+++ b/poc_mobile_verifier/src/cli/server.rs
@@ -79,6 +79,7 @@ impl Cmd {
             subnet_rewards_tx,
             reward_period_hours,
             verifications_per_period,
+            verification_offset: settings.verification_offset_duration(),
             verifier,
         };
 

--- a/poc_mobile_verifier/src/settings.rs
+++ b/poc_mobile_verifier/src/settings.rs
@@ -1,4 +1,5 @@
 use crate::{Error, Result};
+use chrono::Duration;
 use config::{Config, Environment, File};
 use serde::Deserialize;
 use std::path::Path;
@@ -17,6 +18,10 @@ pub struct Settings {
     /// Verifications per rewards period. Default is 8
     #[serde(default = "default_verifications")]
     pub verifications: i32,
+    /// Verification offset in minutes, verification will occur at the end of
+    /// the verification period + verification_offset_minutes
+    #[serde(default = "default_verification_offset_minutes")]
+    pub verification_offset_minutes: i64,
     pub database: db_store::Settings,
     pub follower: node_follower::Settings,
     pub ingest: file_store::Settings,
@@ -34,6 +39,10 @@ pub fn default_reward_period() -> i64 {
 
 fn default_verifications() -> i32 {
     8
+}
+
+fn default_verification_offset_minutes() -> i64 {
+    30
 }
 
 impl Settings {
@@ -58,5 +67,9 @@ impl Settings {
             .build()
             .and_then(|config| config.try_deserialize())
             .map_err(Error::from)
+    }
+
+    pub fn verification_offset_duration(&self) -> Duration {
+        Duration::minutes(self.verification_offset_minutes)
     }
 }

--- a/poc_mobile_verifier/src/verifier.rs
+++ b/poc_mobile_verifier/src/verifier.rs
@@ -24,6 +24,7 @@ pub struct VerifierDaemon {
     pub subnet_rewards_tx: file_sink::MessageSender,
     pub reward_period_hours: i64,
     pub verifications_per_period: i32,
+    pub verification_offset: Duration,
     pub verifier: Verifier,
 }
 
@@ -43,6 +44,7 @@ impl VerifierDaemon {
                 last_verified_end_time(&self.pool).await?,
                 last_rewarded_end_time(&self.pool).await?,
                 next_rewarded_end_time(&self.pool).await?,
+                self.verification_offset,
             );
 
             if scheduler.should_verify(now) {

--- a/poc_mobile_verifier/src/verifier.rs
+++ b/poc_mobile_verifier/src/verifier.rs
@@ -128,6 +128,8 @@ impl VerifierDaemon {
             // Await the returned one shot to ensure that we wrote the file
             .await??;
 
+        file_sink::flush(&self.subnet_rewards_tx).await?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
1. mobile ingest will now wait up to 15 minutes before uploading `heartbeat_report` or `speedtest_report` to S3
2. poc_mobile_verifier will wait up to 15 minutes before uploading `validated_heartbeat` or `speedtest_avg` to S3
3. poc_mobile_verifier will now run verify and reward cycles offset from the period by 30 minutes. Example: for the verification period 01:00 to 04:00, verification will run at 04:30
4. poc_mobile_verifier will flush rewards file and upload to S3 at end of reward cycle, not waiting for the rolling period, since it is known that there is no more data.