### PR TITLE
Jg/density scaler settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,7 @@ name = "density-scaler"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "config",
  "futures",
  "h3ron 0.15.1",
  "helium-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,6 +1177,7 @@ dependencies = [
  "clap",
  "config",
  "csv",
+ "density-scaler",
  "futures",
  "futures-util",
  "helium-crypto",
@@ -1188,6 +1189,8 @@ dependencies = [
  "poc-metrics",
  "prost",
  "regex",
+ "rust_decimal",
+ "rust_decimal_macros",
  "serde",
  "serde_json",
  "sha2 0.10.6",
@@ -1619,7 +1622,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?rev=01cf4287e6ff501850fa9ebb7f22a0df19c2ba72#01cf4287e6ff501850fa9ebb7f22a0df19c2ba72"
+source = "git+https://github.com/helium/proto?branch=master#48cc8ed277fed81a3e197521460a780083fd761b"
 dependencies = [
  "bytes",
  "prost",
@@ -2530,6 +2533,7 @@ dependencies = [
  "clap",
  "config",
  "db-store",
+ "density-scaler",
  "file-store",
  "futures",
  "futures-util",
@@ -2567,6 +2571,7 @@ dependencies = [
  "cmake",
  "config",
  "db-store",
+ "density-scaler",
  "file-store",
  "futures",
  "futures-util",
@@ -2582,6 +2587,8 @@ dependencies = [
  "once_cell",
  "poc-metrics",
  "prost",
+ "rust_decimal",
+ "rust_decimal_macros",
  "serde",
  "serde_json",
  "sha2 0.10.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ sqlx = {version = "0", features = [
   "macros",
   "runtime-tokio-rustls"
 ]}
-helium-proto = {git = "https://github.com/helium/proto", rev = "01cf4287e6ff501850fa9ebb7f22a0df19c2ba72", features = ["services"]}
 helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.5.0", features=["sqlx-postgres"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
 humantime = "2"
 metrics = "0"
 metrics-exporter-prometheus = "0"
@@ -64,4 +64,4 @@ prost = "*"
 once_cell = "1"
 lazy_static = "1"
 config = {version="0", default-features=false, features=["toml"]}
-
+h3ron = "*"

--- a/density_scaler/Cargo.toml
+++ b/density_scaler/Cargo.toml
@@ -24,3 +24,4 @@ h3ron = {version = "0.15"}
 itertools = "*"
 rust_decimal = {workspace = true}
 rust_decimal_macros = {workspace = true}
+config = {workspace = true}

--- a/density_scaler/Cargo.toml
+++ b/density_scaler/Cargo.toml
@@ -20,7 +20,7 @@ helium-proto = {workspace = true}
 tonic = {workspace = true}
 http = {workspace = true}
 node-follower = { path = "../node_follower" }
-h3ron = {version = "0.15"}
+h3ron = {workspace = true}
 itertools = "*"
 rust_decimal = {workspace = true}
 rust_decimal_macros = {workspace = true}

--- a/density_scaler/src/error.rs
+++ b/density_scaler/src/error.rs
@@ -4,6 +4,8 @@ pub type Result<T = ()> = std::result::Result<T, Error>;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("config error")]
+    Config(#[from] config::ConfigError),
     #[error("env error")]
     Env(#[from] std::env::VarError),
     #[error("io error")]

--- a/density_scaler/src/hex.rs
+++ b/density_scaler/src/hex.rs
@@ -27,7 +27,7 @@ const DENSITY_TGT_RES: u8 = 4;
 const MAX_RES: u8 = 11;
 const USED_RES: Range<u8> = DENSITY_TGT_RES..MAX_RES;
 const SCALING_RES: Range<u8> = DENSITY_TGT_RES..MAX_RES + 2;
-const DEC_PRECISION: u32 = 4;
+pub const SCALING_PRECISION: u32 = 4;
 
 static HIP17_RES_CONFIG: [Option<HexResConfig>; 11] = [
     // Hex resolutions 0 - 3 and 11 and 12 are currently ignored when calculating density;
@@ -191,14 +191,14 @@ pub fn compute_scaling_map(global_map: &GlobalHexMap, scaling_map: &mut ScalingM
                 ) {
                     (Some(unclipped), Some(clipped)) => {
                         scale
-                            * (Decimal::new(*clipped as i64, DEC_PRECISION)
-                                / Decimal::new(*unclipped as i64, DEC_PRECISION))
+                            * (Decimal::new(*clipped as i64, SCALING_PRECISION)
+                                / Decimal::new(*unclipped as i64, SCALING_PRECISION))
                     }
                     _ => scale,
                 }
             })
         });
-        let trunc_scale = scale.round_dp(DEC_PRECISION);
+        let trunc_scale = scale.round_dp(SCALING_PRECISION);
         scaling_map.insert(&hex.h3index().to_string(), trunc_scale);
     }
 }

--- a/density_scaler/src/lib.rs
+++ b/density_scaler/src/lib.rs
@@ -5,6 +5,7 @@ pub mod server;
 pub mod settings;
 
 pub use error::{Error, Result};
+pub use hex::SCALING_PRECISION;
 pub use query::{query_channel, QueryReceiver, QuerySender};
 pub use server::Server;
 pub use settings::Settings;

--- a/density_scaler/src/lib.rs
+++ b/density_scaler/src/lib.rs
@@ -2,7 +2,9 @@ mod error;
 mod hex;
 pub mod query;
 pub mod server;
+pub mod settings;
 
 pub use error::{Error, Result};
 pub use query::{query_channel, QueryReceiver, QuerySender};
 pub use server::Server;
+pub use settings::Settings;

--- a/density_scaler/src/query.rs
+++ b/density_scaler/src/query.rs
@@ -8,7 +8,7 @@ pub struct QueryMsg {
     pub response: ResultSender,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct QuerySender(mpsc::Sender<QueryMsg>);
 pub struct QueryReceiver(mpsc::Receiver<QueryMsg>);
 

--- a/density_scaler/src/server.rs
+++ b/density_scaler/src/server.rs
@@ -8,8 +8,6 @@ use futures::stream::StreamExt;
 use node_follower::{follower_service::FollowerService, gateway_resp::GatewayInfo};
 use tokio::time;
 
-const DEFAULT_TRIGGER_INTERVAL_SECS: i64 = 1800; // 30 min
-
 pub struct Server {
     scaling_map: ScalingMap,
     follower: FollowerService,
@@ -28,7 +26,7 @@ impl Server {
     pub async fn run(
         &mut self,
         mut queries: QueryReceiver,
-        shutdown: triggered::Listener,
+        shutdown: &triggered::Listener,
     ) -> Result {
         tracing::info!("starting density scaler process");
 

--- a/density_scaler/src/settings.rs
+++ b/density_scaler/src/settings.rs
@@ -1,9 +1,6 @@
-use crate::{Error, Result};
-use config::{Config, Environment, File};
 use serde::Deserialize;
-use std::path::Path;
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Settings {
     /// RUST_LOG compatible settings string. Default to "density_scaler=debug"
     #[serde(default = "default_log")]
@@ -21,9 +18,4 @@ pub fn default_log() -> String {
 
 fn default_trigger_interval() -> i64 {
     1800
-}
-
-impl Settings {
-    /// Load Settings from a given path. Settings are loaded from a given
-    /// optional path and can be over
 }

--- a/density_scaler/src/settings.rs
+++ b/density_scaler/src/settings.rs
@@ -1,0 +1,29 @@
+use crate::{Error, Result};
+use config::{Config, Environment, File};
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    /// RUST_LOG compatible settings string. Default to "density_scaler=debug"
+    #[serde(default = "default_log")]
+    pub log: String,
+    /// Follower settings
+    pub follower: node_follower::Settings,
+    /// Trigger every X minutes. Defaults to 30 mins.
+    #[serde(default = "default_trigger_interval")]
+    pub trigger: i64,
+}
+
+pub fn default_log() -> String {
+    "density_scaler=debug".to_string()
+}
+
+fn default_trigger_interval() -> i64 {
+    1800
+}
+
+impl Settings {
+    /// Load Settings from a given path. Settings are loaded from a given
+    /// optional path and can be over
+}

--- a/file_store/Cargo.toml
+++ b/file_store/Cargo.toml
@@ -36,6 +36,9 @@ strum_macros = "0"
 sha2 = {workspace = true}
 metrics = {workspace = true }
 poc-metrics = { path = "../metrics" }
+rust_decimal = {workspace = true}
+rust_decimal_macros = {workspace = true}
+density-scaler = {path = "../density_scaler"}
 
 [dev-dependencies]
 base64 = "0"

--- a/file_store/src/lora_valid_poc.rs
+++ b/file_store/src/lora_valid_poc.rs
@@ -5,17 +5,22 @@ use crate::{
     Error, Result,
 };
 use chrono::{DateTime, Utc};
+use density_scaler::SCALING_PRECISION;
 use helium_proto::services::poc_lora::{
     LoraBeaconReportReqV1, LoraValidBeaconReportV1, LoraValidPocV1, LoraValidWitnessReportV1,
     LoraWitnessReportReqV1,
 };
+use rust_decimal::{prelude::ToPrimitive, Decimal};
+use rust_decimal_macros::dec;
 use serde::Serialize;
+
+const SCALE_MULTIPLIER: Decimal = dec!(100);
 
 #[derive(Serialize, Clone)]
 pub struct LoraValidBeaconReport {
     pub received_timestamp: DateTime<Utc>,
     pub location: Option<u64>,
-    pub hex_scale: f32,
+    pub hex_scale: Decimal,
     pub report: LoraBeaconReport,
 }
 
@@ -23,7 +28,7 @@ pub struct LoraValidBeaconReport {
 pub struct LoraValidWitnessReport {
     pub received_timestamp: DateTime<Utc>,
     pub location: Option<u64>,
-    pub hex_scale: f32,
+    pub hex_scale: Decimal,
     pub report: LoraWitnessReport,
 }
 
@@ -100,7 +105,7 @@ impl TryFrom<LoraValidBeaconReportV1> for LoraValidBeaconReport {
         Ok(Self {
             received_timestamp: v.timestamp()?,
             location: v.location.parse().ok(),
-            hex_scale: v.hex_scale,
+            hex_scale: Decimal::new(v.hex_scale as i64, SCALING_PRECISION),
             report: v
                 .report
                 .ok_or_else(|| Error::not_found("lora valid beacon report v1"))?
@@ -120,7 +125,7 @@ impl From<LoraValidBeaconReport> for LoraValidBeaconReportV1 {
                 .location
                 .map(|l| l.to_string())
                 .unwrap_or_else(String::new),
-            hex_scale: v.hex_scale,
+            hex_scale: (v.hex_scale * SCALE_MULTIPLIER).to_u32().unwrap_or(0),
             report: Some(report),
         }
     }
@@ -133,7 +138,7 @@ impl TryFrom<LoraValidWitnessReportV1> for LoraValidWitnessReport {
         Ok(Self {
             received_timestamp,
             location: v.location.parse().ok(),
-            hex_scale: v.hex_scale,
+            hex_scale: Decimal::new(v.hex_scale as i64, SCALING_PRECISION),
             report: v
                 .report
                 .ok_or_else(|| Error::not_found("lora valid witness port v1"))?
@@ -152,7 +157,7 @@ impl From<LoraValidWitnessReport> for LoraValidWitnessReportV1 {
                 .location
                 .map(|l| l.to_string())
                 .unwrap_or_else(String::new),
-            hex_scale: v.hex_scale,
+            hex_scale: (v.hex_scale * SCALE_MULTIPLIER).to_u32().unwrap_or(0),
             report: Some(report),
         }
     }

--- a/poc_iot_injector/Cargo.toml
+++ b/poc_iot_injector/Cargo.toml
@@ -36,6 +36,7 @@ poc-metrics = { path = "../metrics" }
 file-store = {path = "../file_store"}
 db-store = {path = "../db_store"}
 node-follower = {path = "../node_follower"}
+density-scaler = {path = "../density_scaler"}
 
 [package.metadata.deb]
 depends = "$auto"

--- a/poc_iot_injector/src/receipt_txn.rs
+++ b/poc_iot_injector/src/receipt_txn.rs
@@ -1,4 +1,5 @@
 use crate::{Error, Result};
+use density_scaler::SCALING_PRECISION;
 use helium_crypto::{Keypair, Sign};
 use helium_proto::{
     blockchain_txn::Txn,
@@ -128,8 +129,7 @@ fn construct_poc_witnesses(
                 ..
             } = witness_report_req;
 
-            let witness_hex_scale =
-                Decimal::from_f32_retain(witness_hex_scale).unwrap_or_else(|| dec!(1.0));
+            let witness_hex_scale = Decimal::new(witness_hex_scale as i64, SCALING_PRECISION);
             let reward_unit = poc_challengee_reward_unit(num_witnesses as u32)?;
             let reward_shares = witness_hex_scale * reward_unit;
             let reward_shares = reward_shares.to_u32().unwrap_or_default();
@@ -184,8 +184,7 @@ fn construct_poc_receipt(
                 ..
             } = beacon_report_req;
 
-            let beacon_hex_scale =
-                Decimal::from_f32_retain(beacon_hex_scale).unwrap_or_else(|| dec!(1.0));
+            let beacon_hex_scale = Decimal::new(beacon_hex_scale as i64, SCALING_PRECISION);
             let reward_unit = poc_challengee_reward_unit(num_witnesses)?;
             let reward_shares = (beacon_hex_scale * reward_unit)
                 .to_u32()

--- a/poc_iot_verifier/Cargo.toml
+++ b/poc_iot_verifier/Cargo.toml
@@ -35,10 +35,13 @@ metrics = {workspace = true}
 node-follower = { path = "../node_follower" }
 poc-metrics = { path = "../metrics" }
 db-store = {path = "../db_store"}
+density-scaler = {path = "../density_scaler/"}
 async-trait = "*"
-h3ron = "*"
+h3ron = {workspace = true}
 geo-types = "*"
 geo = "*"
 xorf = "*"
 lazy_static = {workspace = true}
 once_cell = {workspace = true}
+rust_decimal = {workspace = true}
+rust_decimal_macros = {workspace = true}

--- a/poc_iot_verifier/src/error.rs
+++ b/poc_iot_verifier/src/error.rs
@@ -40,6 +40,8 @@ pub enum Error {
     H3ron(#[from] h3ron::Error),
     #[error("vincenty error")]
     Geo(#[from] geo::vincenty_distance::FailedToConvergeError),
+    #[error("density scaler error")]
+    DensityScaler(#[from] density_scaler::Error),
 }
 
 #[derive(Error, Debug)]

--- a/poc_iot_verifier/src/settings.rs
+++ b/poc_iot_verifier/src/settings.rs
@@ -17,6 +17,7 @@ pub struct Settings {
     pub entropy: file_store::Settings,
     pub output: file_store::Settings,
     pub metrics: poc_metrics::Settings,
+    pub density_scaler: density_scaler::Settings,
 }
 
 pub fn default_log() -> String {

--- a/poc_mobile_verifier/src/subnetwork_rewards.rs
+++ b/poc_mobile_verifier/src/subnetwork_rewards.rs
@@ -8,7 +8,6 @@ use chrono::{DateTime, Utc};
 use file_store::{file_sink, file_sink_write};
 use helium_crypto::PublicKey;
 use rust_decimal::Decimal;
-use rust_decimal_macros::dec;
 use std::collections::HashMap;
 use std::ops::Range;
 use tokio::sync::oneshot;
@@ -43,11 +42,11 @@ impl SubnetworkRewards {
             .map(|(pubkey, mut shares)| {
                 let speedmultiplier = speedtests
                     .get_average(&pubkey)
-                    .map_or(dec!(0.0), |avg| avg.reward_multiplier());
+                    .map_or(Decimal::ZERO, |avg| avg.reward_multiplier());
                 shares *= speedmultiplier;
                 (pubkey, shares)
             })
-            .filter(|(_pubkey, shares)| shares > &dec!(0.0))
+            .filter(|(_pubkey, shares)| shares > &Decimal::ZERO)
             .collect();
 
         let (owner_shares, _missing_owner_shares) =


### PR DESCRIPTION
Configure the density scaler via the `config` crate like the rest of the Oracles and instantiate the density_scaler as a child process of the poc_iot_verifier in the main loop `tokio::try_join`; when verifying beacons and witnesses, submit  the candidate hotspot's location to the density scaler and await the return decimal, set as the scaling factor of the report