### PR TITLE
Changed file_sink missed tick behavior to Burst

### DIFF
--- a/file_store/src/file_sink.rs
+++ b/file_store/src/file_sink.rs
@@ -243,7 +243,7 @@ impl FileSink {
 
         let mut rollover_timer =
             time::interval(self.roll_time.to_std().expect("valid sink roll time"));
-        rollover_timer.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+        rollover_timer.set_missed_tick_behavior(time::MissedTickBehavior::Burst);
         loop {
             tokio::select! {
                 _ = shutdown.clone() => break,


### PR DESCRIPTION
Changing file_sink  missed tick behaviour to Burst, logically I don't think it makes sense to Delay a missing tick. Delay would mean we just wait 3 more minutes to check the time of the ActiveSink.  Better to check the time of the ActiveSink as soon as we can.  We will setup timing between ingest/verifier/rewards so that a large delay over the configured roll time could cause issues.