### PR TITLE
Use the correct receipt sender for file_sink

### DIFF
--- a/poc_iot_injector/src/cli/server.rs
+++ b/poc_iot_injector/src/cli/server.rs
@@ -53,6 +53,8 @@ impl Cmd {
                 .map_err(Error::from),
         )?;
 
+        tracing::info!("Shutting down injector server");
+
         Ok(())
     }
 }

--- a/poc_iot_injector/src/cli/server.rs
+++ b/poc_iot_injector/src/cli/server.rs
@@ -32,7 +32,7 @@ impl Cmd {
         let store_base_path = std::path::Path::new(&settings.cache);
 
         // poc receipt txns
-        let (_poc_receipt_txn_tx, poc_receipt_txn_rx) = file_sink::message_channel(50);
+        let (poc_receipt_txn_tx, poc_receipt_txn_rx) = file_sink::message_channel(50);
         let mut poc_receipts = file_sink::FileSinkBuilder::new(
             FileType::SignedPocReceiptTxn,
             store_base_path,
@@ -43,7 +43,7 @@ impl Cmd {
         .await?;
 
         // poc_iot_injector server
-        let mut poc_iot_injector_server = Server::new(settings).await?;
+        let mut poc_iot_injector_server = Server::new(settings, poc_receipt_txn_tx).await?;
 
         tokio::try_join!(
             poc_receipts.run(&shutdown_listener).map_err(Error::from),


### PR DESCRIPTION
Fix for deploy attempt #2. Actually use the sender part of the file sink instead of creating a new one on the fly.