### PR TITLE
logging level tweaks and remove limit on beacon count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#48cc8ed277fed81a3e197521460a780083fd761b"
+source = "git+https://github.com/helium/proto?rev=01cf4287e6ff501850fa9ebb7f22a0df19c2ba72#01cf4287e6ff501850fa9ebb7f22a0df19c2ba72"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,6 +2576,7 @@ dependencies = [
  "helium-proto",
  "http-serde",
  "lazy_static",
+ "metrics",
  "node-follower",
  "once_cell",
  "poc-metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ sqlx = {version = "0", features = [
   "macros",
   "runtime-tokio-rustls"
 ]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", rev = "01cf4287e6ff501850fa9ebb7f22a0df19c2ba72", features = ["services"]}
 helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.5.0", features=["sqlx-postgres"]}
 humantime = "2"
 metrics = "0"

--- a/poc_iot_verifier/Cargo.toml
+++ b/poc_iot_verifier/Cargo.toml
@@ -31,6 +31,7 @@ chrono = { workspace = true }
 helium-proto = { workspace = true }
 helium-crypto = {workspace = true }
 file-store = { path = "../file_store" }
+metrics = {workspace = true}
 node-follower = { path = "../node_follower" }
 poc-metrics = { path = "../metrics" }
 db-store = {path = "../db_store"}
@@ -41,4 +42,3 @@ geo = "*"
 xorf = "*"
 lazy_static = {workspace = true}
 once_cell = {workspace = true}
-

--- a/poc_iot_verifier/src/poc_report.rs
+++ b/poc_iot_verifier/src/poc_report.rs
@@ -145,7 +145,6 @@ impl Report {
             and entropy.timestamp < (NOW() - INTERVAL '$1 SECONDS')
             and attempts < $2
             order by report_timestamp asc
-            limit 500
             "#,
         )
         .bind(ENTROPY_LIFESPAN + BEACON_PROCESSING_DELAY)

--- a/poc_iot_verifier/src/runner.rs
+++ b/poc_iot_verifier/src/runner.rs
@@ -145,7 +145,8 @@ impl Runner {
         // but a beacon could be valid whilst witnesses
         // can be a mix of both valid and invalid
         let beacon_len = db_beacon_reports.len();
-        tracing::info!("found {beacon_len} beacons ready for verification");
+        tracing::info!("{beacon_len} beacons ready for verification");
+        metrics::gauge!("oracles_poc_iot_verifier_beacons_ready", beacon_len as f64);
         for db_beacon in db_beacon_reports {
             let entropy_start_time = match db_beacon.timestamp {
                 Some(v) => v,
@@ -161,7 +162,11 @@ impl Runner {
 
             let db_witnesses = Report::get_witnesses_for_beacon(&self.pool, packet_data).await?;
             let witness_len = db_witnesses.len();
-            tracing::info!("found {witness_len} witness for beacon");
+            tracing::debug!("found {witness_len} witness for beacon");
+            metrics::gauge!(
+                "oracles_poc_iot_verifier_witnesses_per_beacon",
+                witness_len as f64
+            );
 
             // get the beacon and witness report PBs from the db reports
             let mut witnesses: Vec<LoraWitnessIngestReport> = Vec::new();


### PR DESCRIPTION
Downgrades logging of witness count to debug level to reduce noise at high report volume
Remove the limit on number of beacons to process
( might be warranted to reintroduce this at some point but i want to see the true report count per tick )