### PR TITLE
Use existing structs for constructing valid pocs

### DIFF
--- a/file_store/src/lora_valid_poc.rs
+++ b/file_store/src/lora_valid_poc.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 
 const SCALE_MULTIPLIER: Decimal = dec!(100);
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct LoraValidBeaconReport {
     pub received_timestamp: DateTime<Utc>,
     pub location: Option<u64>,
@@ -24,7 +24,7 @@ pub struct LoraValidBeaconReport {
     pub report: LoraBeaconReport,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct LoraValidWitnessReport {
     pub received_timestamp: DateTime<Utc>,
     pub location: Option<u64>,
@@ -32,7 +32,7 @@ pub struct LoraValidWitnessReport {
     pub report: LoraWitnessReport,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct LoraValidPoc {
     pub poc_id: Vec<u8>,
     pub beacon_report: LoraValidBeaconReport,

--- a/poc_iot_injector/src/server.rs
+++ b/poc_iot_injector/src/server.rs
@@ -84,7 +84,7 @@ impl Server {
             0,
         ));
         let before_utc = Utc::now();
-        tracing::debug!(
+        tracing::info!(
             "handling poc_tick, after_utc: {:?}, before_utc: {:?}",
             after_utc,
             before_utc
@@ -101,6 +101,7 @@ impl Server {
         )
         .await?;
 
+        tracing::info!("updating last_poc_submission_ts to {:?}", before_utc);
         // NOTE: All the poc_receipt txns for the corresponding after-before period will be
         // submitted above, may take a while to do that but we need to
         // update_last_poc_submission_ts once we're done doing it. This should ensure that we have
@@ -139,10 +140,13 @@ async fn submit_txns(
                 let txn_details = handle_report_msg(msg, shared_key, before_ts)?;
                 tracing::debug!("txn_details: {:?}", txn_details);
                 if do_submission {
+                    tracing::info!("submitting txn: {:?}", txn_details.hash_b64_url);
                     handle_txn_submission(txn_details.clone(), &mut shared_txn_service).await?;
+                    tracing::info!("storing txn: {:?}", txn_details.hash_b64_url);
                     file_sink_write!("signed_poc_receipt_txn", receipt_sender, txn_details.txn)
                         .await?;
                 } else {
+                    tracing::info!("storing txn: {:?}", txn_details.hash_b64_url);
                     file_sink_write!("signed_poc_receipt_txn", receipt_sender, txn_details.txn)
                         .await?;
                 }


### PR DESCRIPTION
# Summary

This removes a bunch of hand rolled decoding done for valid pocs. It now just uses the existing structs in file_store to do the same.

# Problem

Still doesn't seem to be working. Error when dumping the valid_poc file using file store is the same when running the injector on prod:

```bash
cargo run --release -- -c settings.toml dump lora_valid_poc lora_valid_poc.1668036372924.gz
    Finished release [optimized] target(s) in 0.26s
     Running `/home/rahul/dev/oracles/target/release/file-store -c settings.toml dump lora_valid_poc /home/rahul/dev/oracle-output/valid-pocs/lora_valid_poc.1668036372924.gz`
Error: Decode(Prost(DecodeError { description: "invalid wire type: ThirtyTwoBit (expected Varint)", stack: [("LoraValidBeaconReportV1", "hex_scale"), ("LoraValidPocV1", "beacon_report")] }))
```

I think its because of the recent changes done to proto to represent hex_scale as u32 but its put in as a `Decimal` in the `LoraValidBeaconReport` and `LoraValidWitnessReport` structs. I'm not sure what's going on at the time of construction of these though. Will be digging further.

# Solution

iot-verifier is being redeployed with the updated protos, this should get injector back running as well.