### PR TITLE
move reward unit calculations to iot verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#48cc8ed277fed81a3e197521460a780083fd761b"
+source = "git+https://github.com/helium/proto?branch=master#37abff2b35290818d2f542336b5523269631f60d"
 dependencies = [
  "bytes",
  "prost",

--- a/file_store/src/lora_valid_poc.rs
+++ b/file_store/src/lora_valid_poc.rs
@@ -11,10 +11,9 @@ use helium_proto::services::poc_lora::{
     LoraWitnessReportReqV1,
 };
 use rust_decimal::{prelude::ToPrimitive, Decimal};
-use rust_decimal_macros::dec;
 use serde::Serialize;
 
-const SCALE_MULTIPLIER: Decimal = dec!(100);
+const SCALE_MULTIPLIER: Decimal = Decimal::ONE_HUNDRED;
 
 #[derive(Serialize, Clone, Debug)]
 pub struct LoraValidBeaconReport {
@@ -22,6 +21,7 @@ pub struct LoraValidBeaconReport {
     pub location: Option<u64>,
     pub hex_scale: Decimal,
     pub report: LoraBeaconReport,
+    pub reward_unit: Decimal,
 }
 
 #[derive(Serialize, Clone, Debug)]
@@ -30,6 +30,7 @@ pub struct LoraValidWitnessReport {
     pub location: Option<u64>,
     pub hex_scale: Decimal,
     pub report: LoraWitnessReport,
+    pub reward_unit: Decimal,
 }
 
 #[derive(Serialize, Clone, Debug)]
@@ -110,6 +111,7 @@ impl TryFrom<LoraValidBeaconReportV1> for LoraValidBeaconReport {
                 .report
                 .ok_or_else(|| Error::not_found("lora valid beacon report v1"))?
                 .try_into()?,
+            reward_unit: Decimal::new(v.reward_unit as i64, SCALING_PRECISION),
         })
     }
 }
@@ -127,6 +129,7 @@ impl From<LoraValidBeaconReport> for LoraValidBeaconReportV1 {
                 .unwrap_or_else(String::new),
             hex_scale: (v.hex_scale * SCALE_MULTIPLIER).to_u32().unwrap_or(0),
             report: Some(report),
+            reward_unit: (v.reward_unit * SCALE_MULTIPLIER).to_u32().unwrap_or(0),
         }
     }
 }
@@ -143,6 +146,7 @@ impl TryFrom<LoraValidWitnessReportV1> for LoraValidWitnessReport {
                 .report
                 .ok_or_else(|| Error::not_found("lora valid witness port v1"))?
                 .try_into()?,
+            reward_unit: Decimal::new(v.reward_unit as i64, SCALING_PRECISION),
         })
     }
 }
@@ -159,6 +163,7 @@ impl From<LoraValidWitnessReport> for LoraValidWitnessReportV1 {
                 .unwrap_or_else(String::new),
             hex_scale: (v.hex_scale * SCALE_MULTIPLIER).to_u32().unwrap_or(0),
             report: Some(report),
+            reward_unit: (v.reward_unit * SCALE_MULTIPLIER).to_u32().unwrap_or(0),
         }
     }
 }

--- a/poc_iot_injector/Cargo.toml
+++ b/poc_iot_injector/Cargo.toml
@@ -8,7 +8,7 @@ authors.workspace = true
 
 [dependencies]
 rand = "*"
-rust_decimal = { version = "1", features = [ "maths" ] }
+rust_decimal = {workspace = true}
 config = {workspace = true}
 clap = {workspace = true}
 thiserror = {workspace = true}

--- a/poc_iot_verifier/Cargo.toml
+++ b/poc_iot_verifier/Cargo.toml
@@ -44,5 +44,5 @@ poc-metrics = { path = "../metrics" }
 db-store = {path = "../db_store"}
 density-scaler = {path = "../density_scaler/"}
 denylist = {path = "../denylist"}
-rust_decimal = {workspace = true}
+rust_decimal = {workspace = true, features = ["maths"]}
 rust_decimal_macros = {workspace = true}

--- a/poc_iot_verifier/src/error.rs
+++ b/poc_iot_verifier/src/error.rs
@@ -44,6 +44,8 @@ pub enum Error {
     DenyList(#[from] denylist::Error),
     #[error("density scaler query sender not found")]
     DensityScalerQuerySenderMissing,
+    #[error("invalid exponent {0} error")]
+    InvalidExponent(String),
 }
 
 #[derive(Error, Debug)]

--- a/poc_iot_verifier/src/poc.rs
+++ b/poc_iot_verifier/src/poc.rs
@@ -65,6 +65,14 @@ pub struct VerifyWitnessesResult {
     pub failed_witnesses: Vec<LoraInvalidWitnessReport>,
 }
 
+impl VerifyWitnessesResult {
+    pub fn update_reward_units(&mut self, reward_units: Decimal) {
+        self.valid_witnesses
+            .iter_mut()
+            .for_each(|witness| witness.reward_unit = reward_units)
+    }
+}
+
 impl Poc {
     pub async fn new(
         beacon_report: LoraBeaconIngestReport,
@@ -235,6 +243,9 @@ impl Poc {
                         location: gw_info.location,
                         hex_scale: scaling_factor,
                         report: witness_report.report,
+                        // default reward units to zero until we've got the full count of
+                        // valid, non-failed witnesses for the final validated poc report
+                        reward_unit: Decimal::ZERO,
                     };
                     valid_witnesses.push(valid_witness)
                 }

--- a/poc_iot_verifier/src/runner.rs
+++ b/poc_iot_verifier/src/runner.rs
@@ -25,6 +25,8 @@ use helium_proto::{
     Message,
 };
 use node_follower::follower_service::FollowerService;
+use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal_macros::dec;
 use sqlx::PgPool;
 use std::path::Path;
 use tokio::time;
@@ -33,6 +35,10 @@ use tokio::time;
 const DB_POLL_TIME: time::Duration = time::Duration::from_secs(30);
 const LOADER_WORKERS: usize = 10;
 const LOADER_DB_POOL_SIZE: usize = 2 * LOADER_WORKERS;
+
+const WITNESS_REDUNDANCY: u32 = 4;
+const POC_REWARD_DECAY_RATE: Decimal = dec!(0.8);
+const HIP15_TX_REWARD_UNIT_CAP: Decimal = Decimal::TWO;
 
 pub struct Runner {
     pool: PgPool,
@@ -209,7 +215,7 @@ impl Runner {
                     );
                     // beacon is valid, verify the POC witnesses
                     if let Some(beacon_info) = beacon_verify_result.gateway_info {
-                        let verified_witnesses_result =
+                        let mut verified_witnesses_result =
                             poc.verify_witnesses(&beacon_info, density_queries).await?;
                         // check if there are any failed witnesses
                         // if so update the DB attempts count
@@ -231,11 +237,18 @@ impl Runner {
                             continue;
                         };
 
+                        let witness_reward_units = poc_challengee_reward_unit(
+                            verified_witnesses_result.valid_witnesses.len() as u32,
+                        )?;
+
+                        verified_witnesses_result.update_reward_units(witness_reward_units);
+
                         let valid_beacon_report = LoraValidBeaconReport {
                             received_timestamp: beacon_received_ts,
                             location: beacon_info.location,
                             hex_scale: beacon_verify_result.hex_scale.unwrap_or_default(),
                             report: beacon.clone(),
+                            reward_unit: witness_reward_units,
                         };
                         self.handle_valid_poc(
                             beacon,
@@ -421,5 +434,21 @@ impl Runner {
             }
         }
         Ok(())
+    }
+}
+
+fn poc_challengee_reward_unit(num_witnesses: u32) -> Result<Decimal> {
+    if num_witnesses == 0 {
+        Ok(Decimal::ZERO)
+    } else if num_witnesses < WITNESS_REDUNDANCY {
+        Ok(Decimal::from(WITNESS_REDUNDANCY / num_witnesses))
+    } else {
+        let exp = WITNESS_REDUNDANCY - num_witnesses;
+        if let Some(to_sub) = POC_REWARD_DECAY_RATE.checked_powu(exp as u64) {
+            let unnormalized = Decimal::TWO - to_sub;
+            Ok(std::cmp::min(HIP15_TX_REWARD_UNIT_CAP, unnormalized))
+        } else {
+            Err(Error::InvalidExponent(exp.to_string()))
+        }
     }
 }


### PR DESCRIPTION
We need to continue to calculate the total IoT reward shares as a factor (in part) of the number of witnesses to a PoC event but should be doing so in the IoT Verifier so as to be able to keep the logic in the (temporary) IoT receipt Injector light and to allow for easily calculating the full reward shares within the verifier when submitting to the reward indexer for Solana integration.

This change migrates the calculation of the reward unit value from the injector to the verifier. It adds the value as a new field on the valid beacon and witness structs as well as the accompanying proto definitions as part of this dependent PR https://github.com/helium/proto/pull/234