### PR TITLE
Delete heartbeats if a radio was moved to a new hotspot

### DIFF
--- a/poc_mobile_verifier/src/heartbeats.rs
+++ b/poc_mobile_verifier/src/heartbeats.rs
@@ -202,9 +202,9 @@ impl Heartbeat {
             return Ok(false);
         }
 
-        sqlx::query("DELETE FROM heartbeats WHERE hotspot_key != $1 AND cbsd_id = $2")
-            .bind(&self.hotspot_key)
+        sqlx::query("DELETE FROM heartbeats WHERE cbsd_id = $1 AND hotspot_key != $2 ")
             .bind(&self.cbsd_id)
+            .bind(&self.hotspot_key)
             .execute(&mut *exec)
             .await?;
 


### PR DESCRIPTION
This prevents an owner from cheating by switching a radio to another hotspot during a reward period 