### PR TITLE
Explicitly flush receipt sender

### DIFF
--- a/poc_iot_injector/src/server.rs
+++ b/poc_iot_injector/src/server.rs
@@ -147,10 +147,12 @@ async fn submit_txns(
                     tracing::info!("storing txn: {:?}", txn_details.hash_b64_url);
                     file_sink_write!("signed_poc_receipt_txn", receipt_sender, txn_details.txn)
                         .await?;
+                    file_sink::flush(receipt_sender).await?;
                 } else {
                     tracing::info!("storing txn: {:?}", txn_details.hash_b64_url);
                     file_sink_write!("signed_poc_receipt_txn", receipt_sender, txn_details.txn)
                         .await?;
+                    file_sink::flush(receipt_sender).await?;
                 }
                 Ok(())
             }


### PR DESCRIPTION
This seems like a correct thing to do after file_sink_write for a receipt txn is done.