### PR TITLE
Send incoming buf on write if there is no sink

### DIFF
--- a/file_store/src/file_sink.rs
+++ b/file_store/src/file_sink.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use chrono::{DateTime, Duration, Utc};
 use futures::SinkExt;
 use std::{
-    io, mem,
+    mem,
     path::{Path, PathBuf},
 };
 use tokio::{
@@ -405,24 +405,20 @@ impl FileSink {
                     let prev_path = active_sink.path.clone();
                     self.deposit_sink(&prev_path).await?;
                     self.active_sink = Some(self.new_sink().await?);
+                } else {
+                    active_sink.transport.send(buf).await?;
+                    active_sink.size += buf_len;
                 }
             }
-            // No sink, make a new one
+            // No sink, make a new one and send the incoming buf.
             None => {
-                self.active_sink = Some(self.new_sink().await?);
+                let mut new_sink = self.new_sink().await?;
+                new_sink.transport.send(buf).await?;
+                new_sink.size += buf_len;
+                self.active_sink = Some(new_sink);
             }
         }
-
-        if let Some(active_sink) = self.active_sink.as_mut() {
-            active_sink.transport.send(buf).await?;
-            active_sink.size += buf_len;
-            Ok(())
-        } else {
-            Err(Error::from(io::Error::new(
-                io::ErrorKind::Other,
-                "sink not available",
-            )))
-        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
I _think_ this is more correct, we don't have to return an `Error` if there's no sink when we're trying to write an incoming buf. We just make a new one, send the incoming data and attach that to `FileSink`.