### PR TITLE
Add support for constructing receipt txn from valid_poc file

### DIFF
--- a/poc_iot_injector/src/cli/construct.rs
+++ b/poc_iot_injector/src/cli/construct.rs
@@ -36,7 +36,7 @@ async fn process_msg(
     msg: prost::bytes::BytesMut,
     shared_key_clone: Arc<Keypair>,
 ) -> anyhow::Result<TxnDetails> {
-    if let Ok(txn_details) = handle_report_msg(msg.clone(), shared_key_clone) {
+    if let Ok(txn_details) = handle_report_msg(msg, shared_key_clone) {
         tracing::debug!("txn_bin: {:?}", txn_details.txn.encode_to_vec());
         Ok(txn_details)
     } else {

--- a/poc_iot_injector/src/cli/construct.rs
+++ b/poc_iot_injector/src/cli/construct.rs
@@ -1,0 +1,45 @@
+use crate::{
+    receipt_txn::{handle_report_msg, TxnDetails},
+    Settings,
+};
+use anyhow::bail;
+use file_store::file_source;
+use futures::stream::StreamExt;
+use helium_crypto::Keypair;
+use helium_proto::Message;
+use std::{path::PathBuf, sync::Arc};
+
+/// Construct raw poc receipt txns from a given lora_valid_poc file
+#[derive(Debug, clap::Args)]
+pub struct Cmd {
+    /// Required path to lora_valid_poc file
+    #[clap(long)]
+    in_path: PathBuf,
+}
+
+impl Cmd {
+    pub async fn run(&self, settings: &Settings) -> anyhow::Result<()> {
+        let mut file_stream = file_source::source([&self.in_path]);
+        let poc_oracle_key = settings.keypair()?;
+        let shared_key = Arc::new(poc_oracle_key);
+
+        while let Some(result) = file_stream.next().await {
+            let msg = result?;
+            process_msg(msg, shared_key.clone()).await?;
+        }
+
+        Ok(())
+    }
+}
+
+async fn process_msg(
+    msg: prost::bytes::BytesMut,
+    shared_key_clone: Arc<Keypair>,
+) -> anyhow::Result<TxnDetails> {
+    if let Ok(txn_details) = handle_report_msg(msg.clone(), shared_key_clone) {
+        tracing::debug!("txn_bin: {:?}", txn_details.txn.encode_to_vec());
+        Ok(txn_details)
+    } else {
+        bail!("unable to construct txn for msg")
+    }
+}

--- a/poc_iot_injector/src/cli/mod.rs
+++ b/poc_iot_injector/src/cli/mod.rs
@@ -1,2 +1,3 @@
+pub mod construct;
 pub mod generate;
 pub mod server;

--- a/poc_iot_injector/src/main.rs
+++ b/poc_iot_injector/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use poc_iot_injector::{
-    cli::{generate, server},
+    cli::{construct, generate, server},
     Settings,
 };
 use std::path;
@@ -11,6 +11,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 pub enum Cmd {
     Generate(generate::Cmd),
     Server(server::Cmd),
+    Construct(construct::Cmd),
 }
 
 impl Cmd {
@@ -18,6 +19,7 @@ impl Cmd {
         match self {
             Self::Generate(cmd) => cmd.run(&settings).await,
             Self::Server(cmd) => cmd.run(&settings).await,
+            Self::Construct(cmd) => cmd.run(&settings).await,
         }
     }
 }


### PR DESCRIPTION
# Summary

This adds a new CLI `construct` for basically constructing poc receipts txns from an input lora_valid_poc file. This is largely for debugging since we have the `generate` CLI as well but that has dependency on setting up local minio for FileStore.