### PR TITLE
Lint all targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --release -- -Dclippy::all
+          args: --release --all-targets -- -Dclippy::all
 
       - name: Run tests
         run: cargo test -r

--- a/poc_mobile_verifier/src/owner_shares.rs
+++ b/poc_mobile_verifier/src/owner_shares.rs
@@ -203,7 +203,7 @@ mod test {
         mbps * 125000
     }
 
-    fn cell_type_weight(cbsd_id: &String) -> Decimal {
+    fn cell_type_weight(cbsd_id: &str) -> Decimal {
         CellType::from_cbsd_id(cbsd_id)
             .expect("unable to get cell_type")
             .reward_weight()
@@ -631,24 +631,24 @@ mod test {
             owner1.clone(),
             RadioShares {
                 shares: vec![RadioShare {
-                    hotspot_key: gw1.clone(),
-                    cbsd_id: c1.clone(),
+                    hotspot_key: gw1,
+                    cbsd_id: c1,
                     amount: dec!(10.0),
                 }],
             },
         );
         shares.insert(
-            owner2.clone(),
+            owner2,
             RadioShares {
                 shares: vec![
                     RadioShare {
                         hotspot_key: gw2.clone(),
-                        cbsd_id: c2.clone(),
+                        cbsd_id: c2,
                         amount: dec!(-1.0),
                     },
                     RadioShare {
-                        hotspot_key: gw2.clone(),
-                        cbsd_id: c3.clone(),
+                        hotspot_key: gw2,
+                        cbsd_id: c3,
                         amount: dec!(0.0),
                     },
                 ],

--- a/poc_mobile_verifier/src/scheduler.rs
+++ b/poc_mobile_verifier/src/scheduler.rs
@@ -113,8 +113,8 @@ mod tests {
 
         let now = dt(2022, 10, 1, 1, 0, 0);
 
-        assert_eq!(false, scheduler.should_verify(now));
-        assert_eq!(false, scheduler.should_reward(now));
+        assert!(!scheduler.should_verify(now));
+        assert!(!scheduler.should_reward(now));
         assert_eq!(
             standard_duration(150).unwrap(),
             scheduler.sleep_duration(now).unwrap()
@@ -138,8 +138,8 @@ mod tests {
             dt(2022, 10, 1, 0, 0, 0)..dt(2022, 10, 1, 3, 0, 0),
             scheduler.verification_period
         );
-        assert_eq!(true, scheduler.should_verify(now));
-        assert_eq!(false, scheduler.should_reward(now));
+        assert!(scheduler.should_verify(now));
+        assert!(!scheduler.should_reward(now));
         assert_eq!(
             standard_duration(180).unwrap(),
             scheduler.sleep_duration(now).unwrap()
@@ -163,8 +163,8 @@ mod tests {
             dt(2022, 10, 1, 21, 0, 0)..dt(2022, 10, 2, 0, 0, 0),
             scheduler.verification_period
         );
-        assert_eq!(true, scheduler.should_verify(now));
-        assert_eq!(true, scheduler.should_reward(now));
+        assert!(scheduler.should_verify(now));
+        assert!(scheduler.should_reward(now));
         assert_eq!(
             standard_duration(180).unwrap(),
             scheduler.sleep_duration(now).unwrap()
@@ -188,8 +188,8 @@ mod tests {
             dt(2022, 10, 1, 22, 0, 0)..dt(2022, 10, 2, 0, 0, 0),
             scheduler.verification_period
         );
-        assert_eq!(true, scheduler.should_verify(now));
-        assert_eq!(true, scheduler.should_reward(now));
+        assert!(scheduler.should_verify(now));
+        assert!(scheduler.should_reward(now));
         assert_eq!(
             standard_duration(180).unwrap(),
             scheduler.sleep_duration(now).unwrap()
@@ -213,8 +213,8 @@ mod tests {
             dt(2022, 10, 1, 12, 0, 0)..dt(2022, 10, 1, 15, 0, 0),
             scheduler.verification_period
         );
-        assert_eq!(true, scheduler.should_verify(now));
-        assert_eq!(false, scheduler.should_reward(now));
+        assert!(scheduler.should_verify(now));
+        assert!(!scheduler.should_reward(now));
         assert_eq!(
             standard_duration(0).unwrap(),
             scheduler.sleep_duration(now).unwrap()
@@ -238,8 +238,8 @@ mod tests {
             dt(2022, 10, 1, 12, 0, 0)..dt(2022, 10, 1, 15, 0, 0),
             scheduler.verification_period
         );
-        assert_eq!(true, scheduler.should_verify(now));
-        assert_eq!(false, scheduler.should_reward(now));
+        assert!(scheduler.should_verify(now));
+        assert!(!scheduler.should_reward(now));
         assert_eq!(
             standard_duration(0).unwrap(),
             scheduler.sleep_duration(now).unwrap()
@@ -263,8 +263,8 @@ mod tests {
             dt(2022, 10, 1, 0, 0, 0)..dt(2022, 10, 1, 3, 0, 0),
             scheduler.verification_period
         );
-        assert_eq!(false, scheduler.should_verify(now));
-        assert_eq!(false, scheduler.should_reward(now));
+        assert!(!scheduler.should_verify(now));
+        assert!(!scheduler.should_reward(now));
         assert_eq!(
             standard_duration(15).unwrap(),
             scheduler.sleep_duration(now).unwrap()

--- a/poc_mobile_verifier/src/speedtests.rs
+++ b/poc_mobile_verifier/src/speedtests.rs
@@ -576,8 +576,8 @@ mod test {
     fn check_speedtest_without_lapsed() {
         let speedtest_cutoff = Duration::hours(10);
         let contiguos_speedtests = known_speedtests();
-        let contiguous_speedtests: Vec<&Speedtest> =
-            speedtests_without_lapsed(contiguos_speedtests.iter(), speedtest_cutoff).collect();
+        let contiguous_speedtests =
+            speedtests_without_lapsed(contiguos_speedtests.iter(), speedtest_cutoff);
 
         let disjoint_speedtests = vec![
             Speedtest::new(
@@ -599,10 +599,10 @@ mod test {
                 40,
             ),
         ];
-        let disjoint_speedtests: Vec<&Speedtest> =
-            speedtests_without_lapsed(disjoint_speedtests.iter(), speedtest_cutoff).collect();
+        let disjoint_speedtests =
+            speedtests_without_lapsed(disjoint_speedtests.iter(), speedtest_cutoff);
 
-        assert_eq!(contiguous_speedtests.len(), 8);
-        assert_eq!(disjoint_speedtests.len(), 1);
+        assert_eq!(contiguous_speedtests.count(), 8);
+        assert_eq!(disjoint_speedtests.count(), 1);
     }
 }


### PR DESCRIPTION
There are quite a few Clippy warnings for tests. This PR is two-phase: 

1. [x] turn on `--all-targets` for the Clippy CI step and make sure the build fails
    https://github.com/helium/oracles/actions/runs/3634343994/jobs/6132332422#step:7:341
3. [x] push fixes and ensure CI succeeds.
