### PR TITLE
loader optimisations and fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,6 +2929,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "triggered",
+ "twox-hash",
  "xorf",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -35,7 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.8",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -1131,7 +1131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -1169,17 +1169,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "3.2.0"
+name = "ct-codecs"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
-]
+checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
 
 [[package]]
 name = "cxx"
@@ -1361,16 +1354,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-dalek"
-version = "1.0.1"
-source = "git+https://github.com/helium/ed25519-dalek?branch=madninja/bump_rand#d9b58a5375dda817ddd96cf7260e74b6d1cfd1a6"
+name = "ed25519-compact"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3d382e8464107391c8706b4c14b087808ecb909f6c15c34114bc42e53a9e4c"
 dependencies = [
- "curve25519-dalek",
+ "ct-codecs",
  "ed25519",
- "rand",
- "serde",
- "sha2 0.9.9",
- "zeroize",
+ "getrandom",
 ]
 
 [[package]]
@@ -1393,7 +1384,7 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -1439,7 +1430,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1693,17 +1684,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
@@ -1732,7 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1875,17 +1855,18 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.5.0"
-source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.5.0#b0bd7910b7d6065d60c90465c5d679f54280470b"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7701cb46d87e69c557c5a26a5f71b0932e27bd9a08332fc707e0f8754ad5aa0"
 dependencies = [
  "base64",
  "bs58",
- "ed25519-dalek",
+ "ed25519-compact",
  "k256",
  "lazy_static",
  "multihash",
  "p256",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha2 0.10.6",
  "signature",
@@ -2512,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
+checksum = "15e5d911412e631e1de11eb313e4dd71f73fd964401102aab23d6c8327c431ba"
 dependencies = [
  "blake2b_simd",
  "blake2s_simd",
@@ -3235,7 +3216,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3245,16 +3226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -3263,7 +3235,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom",
 ]
 
 [[package]]
@@ -3290,7 +3262,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom",
  "redox_syscall",
  "thiserror",
 ]
@@ -3801,7 +3773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest 0.10.6",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -4612,12 +4584,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
@@ -4907,18 +4873,3 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ sqlx = {version = "0", features = [
   "macros",
   "runtime-tokio-rustls"
 ]}
-helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.5.0", features=["sqlx-postgres", "multisig"]}
 helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-crypto = {version = "0.6", features=["sqlx-postgres", "multisig"]}
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
 humantime = "2"
 metrics = "0"

--- a/denylist/src/denylist.rs
+++ b/denylist/src/denylist.rs
@@ -89,7 +89,7 @@ impl DenyList {
         Ok(())
     }
 
-    pub async fn check_key(&self, pub_key: &PublicKey) -> bool {
+    pub async fn check_key<K: AsRef<[u8]>>(&self, pub_key: K) -> bool {
         if self.filter.len() == 0 {
             tracing::warn!("empty denylist filter, rejecting key");
             return true;
@@ -125,9 +125,9 @@ pub fn filter_from_bin(bin: &Vec<u8>) -> Result<Xor32> {
     }
 }
 
-fn public_key_hash(public_key: &PublicKey) -> u64 {
+fn public_key_hash<R: AsRef<[u8]>>(public_key: R) -> u64 {
     let mut hasher = XxHash64::default();
-    hasher.write(&public_key.to_vec());
+    hasher.write(public_key.as_ref());
     hasher.finish()
 }
 

--- a/file_store/src/file_store.rs
+++ b/file_store/src/file_store.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::DecodeError, BytesMutStream, Error, FileInfo, FileInfoStream, FileType, Result,
-    Settings, Stream,
+    Settings,
 };
 use aws_config::meta::region::{ProvideRegion, RegionProviderChain};
 use aws_sdk_s3::{types::ByteStream, Client, Endpoint, Region};
@@ -244,20 +244,5 @@ where
         .map_ok(|output| output.body)
         .map_err(Error::s3_error)
         .fuse()
-        .await
-}
-
-async fn get_byte_stream_with_info(
-    client: Client,
-    bucket: String,
-    info: FileInfo,
-) -> Result<(FileInfo, ByteStream)> {
-    client
-        .get_object()
-        .bucket(bucket)
-        .key(&info.key)
-        .send()
-        .map_ok(|output| (info, output.body))
-        .map_err(Error::s3_error)
         .await
 }

--- a/file_store/src/file_store.rs
+++ b/file_store/src/file_store.rs
@@ -180,7 +180,6 @@ impl FileStore {
         let client = self.client.clone();
         infos
             .map_ok(move |info| get_byte_stream(client.clone(), bucket.clone(), info.key))
-            .fuse()
             .try_buffered(2)
             .flat_map(|stream| match stream {
                 Ok(stream) => stream_source(stream),

--- a/file_store/src/file_store.rs
+++ b/file_store/src/file_store.rs
@@ -1,6 +1,5 @@
 use crate::{
-    error::DecodeError, BytesMutStream, Error, FileInfo, FileInfoStream, FileType, Result,
-    Settings,
+    error::DecodeError, BytesMutStream, Error, FileInfo, FileInfoStream, FileType, Result, Settings,
 };
 use aws_config::meta::region::{ProvideRegion, RegionProviderChain};
 use aws_sdk_s3::{types::ByteStream, Client, Endpoint, Region};

--- a/file_store/src/heartbeat.rs
+++ b/file_store/src/heartbeat.rs
@@ -3,20 +3,17 @@ use crate::{
     Error, Result,
 };
 use chrono::{DateTime, Utc};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_mobile::{CellHeartbeatIngestReportV1, CellHeartbeatReqV1};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CellHeartbeat {
-    #[serde(alias = "pubKey")]
-    pub pubkey: PublicKey,
+    pub pubkey: PublicKeyBinary,
     pub hotspot_type: String,
     pub cell_id: u32,
     pub timestamp: DateTime<Utc>,
-    #[serde(alias = "longitude")]
     pub lon: f64,
-    #[serde(alias = "latitude")]
     pub lat: f64,
     pub operation_mode: bool,
     pub cbsd_category: String,
@@ -42,7 +39,7 @@ impl TryFrom<CellHeartbeatReqV1> for CellHeartbeat {
     fn try_from(v: CellHeartbeatReqV1) -> Result<Self> {
         Ok(Self {
             timestamp: v.timestamp.to_timestamp()?,
-            pubkey: PublicKey::try_from(v.pub_key)?,
+            pubkey: v.pub_key.into(),
             hotspot_type: v.hotspot_type,
             cell_id: v.cell_id,
             lon: v.lon,

--- a/file_store/src/lora_beacon_report.rs
+++ b/file_store/src/lora_beacon_report.rs
@@ -5,15 +5,14 @@ use crate::{
     Error, Result,
 };
 use chrono::{DateTime, Utc};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_lora::{LoraBeaconIngestReportV1, LoraBeaconReportReqV1};
 use helium_proto::DataRate;
 use serde::Serialize;
 
 #[derive(Serialize, Clone, Debug)]
 pub struct LoraBeaconReport {
-    #[serde(alias = "pubKey")]
-    pub pub_key: PublicKey,
+    pub pub_key: PublicKeyBinary,
     pub local_entropy: Vec<u8>,
     pub remote_entropy: Vec<u8>,
     pub data: Vec<u8>,
@@ -87,7 +86,7 @@ impl From<LoraBeaconIngestReport> for LoraBeaconReportReqV1 {
     fn from(v: LoraBeaconIngestReport) -> Self {
         let timestamp = v.report.timestamp();
         Self {
-            pub_key: v.report.pub_key.to_vec(),
+            pub_key: v.report.pub_key.into(),
             local_entropy: v.report.local_entropy,
             remote_entropy: v.report.remote_entropy,
             data: v.report.data,
@@ -111,7 +110,7 @@ impl TryFrom<LoraBeaconReportReqV1> for LoraBeaconReport {
         let timestamp = v.timestamp()?;
 
         Ok(Self {
-            pub_key: PublicKey::try_from(v.pub_key)?,
+            pub_key: v.pub_key.into(),
             local_entropy: v.local_entropy,
             remote_entropy: v.remote_entropy,
             data: v.data,
@@ -130,7 +129,7 @@ impl From<LoraBeaconReport> for LoraBeaconReportReqV1 {
     fn from(v: LoraBeaconReport) -> Self {
         let timestamp = v.timestamp();
         Self {
-            pub_key: v.pub_key.to_vec(),
+            pub_key: v.pub_key.into(),
             local_entropy: v.local_entropy,
             remote_entropy: v.remote_entropy,
             data: v.data,

--- a/file_store/src/lora_witness_report.rs
+++ b/file_store/src/lora_witness_report.rs
@@ -5,15 +5,14 @@ use crate::{
     Error, Result,
 };
 use chrono::{DateTime, Utc};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_lora::{LoraWitnessIngestReportV1, LoraWitnessReportReqV1};
 use helium_proto::DataRate;
 use serde::Serialize;
 
 #[derive(Serialize, Clone, Debug)]
 pub struct LoraWitnessReport {
-    #[serde(alias = "pubKey")]
-    pub pub_key: PublicKey,
+    pub pub_key: PublicKeyBinary,
     pub data: Vec<u8>,
     pub timestamp: DateTime<Utc>,
     pub tmst: u32,
@@ -61,7 +60,7 @@ impl From<LoraWitnessIngestReport> for LoraWitnessReportReqV1 {
     fn from(v: LoraWitnessIngestReport) -> Self {
         let timestamp = v.report.timestamp();
         Self {
-            pub_key: v.report.pub_key.to_vec(),
+            pub_key: v.report.pub_key.into(),
             data: v.report.data,
             timestamp,
             signal: v.report.signal,
@@ -83,7 +82,7 @@ impl TryFrom<LoraWitnessReportReqV1> for LoraWitnessReport {
         let timestamp = v.timestamp()?;
 
         Ok(Self {
-            pub_key: PublicKey::try_from(v.pub_key)?,
+            pub_key: v.pub_key.into(),
             data: v.data,
             timestamp,
             signal: v.signal,
@@ -124,7 +123,7 @@ impl From<LoraWitnessReport> for LoraWitnessReportReqV1 {
     fn from(v: LoraWitnessReport) -> Self {
         let timestamp = v.timestamp();
         Self {
-            pub_key: v.pub_key.to_vec(),
+            pub_key: v.pub_key.into(),
             data: v.data,
             timestamp,
             signal: v.signal,

--- a/file_store/src/speedtest.rs
+++ b/file_store/src/speedtest.rs
@@ -3,19 +3,16 @@ use crate::{
     Error, Result,
 };
 use chrono::{DateTime, Utc};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_mobile::{SpeedtestIngestReportV1, SpeedtestReqV1};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct CellSpeedtest {
-    #[serde(alias = "pubKey")]
-    pub pubkey: PublicKey,
+    pub pubkey: PublicKeyBinary,
     pub serial: String,
     pub timestamp: DateTime<Utc>,
-    #[serde(alias = "uploadSpeed")]
     pub upload_speed: u64,
-    #[serde(alias = "downloadSpeed")]
     pub download_speed: u64,
     pub latency: u32,
 }
@@ -62,7 +59,7 @@ impl From<CellSpeedtest> for SpeedtestReqV1 {
     fn from(v: CellSpeedtest) -> Self {
         let timestamp = v.timestamp();
         SpeedtestReqV1 {
-            pub_key: v.pubkey.to_vec(),
+            pub_key: v.pubkey.into(),
             serial: v.serial,
             timestamp,
             upload_speed: v.upload_speed,
@@ -78,7 +75,7 @@ impl TryFrom<SpeedtestReqV1> for CellSpeedtest {
     fn try_from(value: SpeedtestReqV1) -> Result<Self> {
         let timestamp = value.timestamp()?;
         Ok(Self {
-            pubkey: PublicKey::try_from(value.pub_key)?,
+            pubkey: value.pub_key.into(),
             serial: value.serial,
             timestamp,
             upload_speed: value.upload_speed,

--- a/node_follower/src/follower_service.rs
+++ b/node_follower/src/follower_service.rs
@@ -3,7 +3,7 @@ use crate::{
     Error, GatewayInfoStream, Result, Settings,
 };
 use futures::stream::{self, StreamExt};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::{
     follower::{
         self, follower_gateway_resp_v1::Result as GatewayResult, FollowerGatewayReqV1,
@@ -23,14 +23,14 @@ pub struct FollowerService {
 
 #[async_trait::async_trait]
 impl GatewayInfoResolver for FollowerService {
-    async fn resolve_gateway_info(&mut self, address: &PublicKey) -> Result<GatewayInfo> {
+    async fn resolve_gateway_info(&mut self, address: &PublicKeyBinary) -> Result<GatewayInfo> {
         let req = FollowerGatewayReqV1 {
-            address: address.to_vec(),
+            address: address.clone().into(),
         };
         let res = self.client.find_gateway(req).await?.into_inner();
         match res.result {
             Some(GatewayResult::Info(gateway_info)) => Ok(gateway_info.try_into()?),
-            _ => Err(Error::GatewayNotFound(format!("{address}"))),
+            _ => Err(Error::GatewayNotFound(format!("{address:?}"))),
         }
     }
 }

--- a/node_follower/src/gateway_resp.rs
+++ b/node_follower/src/gateway_resp.rs
@@ -1,13 +1,13 @@
 use crate::{Error, Result};
 use async_trait::async_trait;
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::{
     services::follower::GatewayInfo as GatewayInfoProto, GatewayStakingMode, Region,
 };
 
 #[async_trait]
 pub trait GatewayInfoResolver {
-    async fn resolve_gateway_info(&mut self, address: &PublicKey) -> Result<GatewayInfo>;
+    async fn resolve_gateway_info(&mut self, address: &PublicKeyBinary) -> Result<GatewayInfo>;
 }
 
 #[derive(Debug, Clone)]

--- a/poc_iot_injector/src/receipt_txn.rs
+++ b/poc_iot_injector/src/receipt_txn.rs
@@ -104,7 +104,7 @@ fn construct_poc_witnesses(
 
         // NOTE: channel is irrelevant now
         let poc_witness = BlockchainPocWitnessV1 {
-            gateway: witness_report.report.pub_key.to_vec(),
+            gateway: witness_report.report.pub_key.into(),
             timestamp: witness_report.report.timestamp.timestamp() as u64,
             signal: witness_report.report.signal,
             packet_hash: witness_report.report.data,
@@ -138,7 +138,7 @@ fn construct_poc_receipt(beacon_report: LoraValidBeaconReport) -> (BlockchainPoc
     // NOTE: signal, origin, snr and addr_hash are irrelevant now
     (
         BlockchainPocReceiptV1 {
-            gateway: beacon_report.report.pub_key.to_vec(),
+            gateway: beacon_report.report.pub_key.into(),
             timestamp: beacon_report.report.timestamp.timestamp() as u64,
             signal: 0,
             data: beacon_report.report.data,

--- a/poc_iot_verifier/Cargo.toml
+++ b/poc_iot_verifier/Cargo.toml
@@ -50,3 +50,4 @@ denylist = {path = "../denylist"}
 rust_decimal = {workspace = true, features = ["maths"]}
 rust_decimal_macros = {workspace = true}
 humantime = {workspace = true}
+twox-hash = {workspace = true}

--- a/poc_iot_verifier/migrations/3_poc_report.sql
+++ b/poc_iot_verifier/migrations/3_poc_report.sql
@@ -23,25 +23,9 @@ create table poc_report (
     created_at timestamptz default now()
 );
 
-
-CREATE INDEX idx_poc_report_id
-ON poc_report(id);
-
 CREATE INDEX idx_poc_report_packet_data
 ON poc_report(packet_data);
 
 CREATE INDEX idx_poc_report_report_type
 ON poc_report(report_type);
-
-CREATE INDEX idx_poc_report_status
-ON poc_report(status);
-
-CREATE INDEX idx_poc_report_created_at
-ON poc_report(created_at);
-
-CREATE INDEX idx_poc_report_attempts
-ON poc_report(attempts);
-
-CREATE INDEX idx_poc_report_report_type_status_created_at
-ON poc_report (report_type,status,created_at);
 

--- a/poc_iot_verifier/migrations/3_poc_report.sql
+++ b/poc_iot_verifier/migrations/3_poc_report.sql
@@ -1,5 +1,6 @@
 create type lorastatus AS enum (
     'pending',
+    'ready',
     'valid',
     'invalid'
 );
@@ -28,4 +29,17 @@ ON poc_report(packet_data);
 
 CREATE INDEX idx_poc_report_report_type
 ON poc_report(report_type);
+
+CREATE INDEX idx_poc_report_status
+ON poc_report(status);
+
+CREATE INDEX idx_poc_report_created_at
+ON poc_report(created_at);
+
+CREATE INDEX idx_poc_report_attempts
+ON poc_report(attempts);
+
+CREATE INDEX idx_poc_report_report_type_status_created_at
+ON poc_report (report_type,status,created_at);
+
 

--- a/poc_iot_verifier/src/entropy_loader.rs
+++ b/poc_iot_verifier/src/entropy_loader.rs
@@ -1,0 +1,154 @@
+use crate::{entropy::Entropy, meta::Meta, Result, Settings};
+use blake3::hash;
+use chrono::{Duration as ChronoDuration, Utc};
+use file_store::{traits::TimestampDecode, FileStore, FileType};
+use futures::{stream, StreamExt};
+use helium_proto::{EntropyReportV1, Message};
+use sqlx::PgPool;
+use tokio::time::{self, MissedTickBehavior};
+
+const ENTROPY_META_NAME: &str = "entropy_report";
+/// cadence for how often to look for entropy from s3 buckets
+const ENTROPY_POLL_TIME: u64 = 60 * 5;
+
+const STORE_WORKERS: usize = 100;
+const LOADER_DB_POOL_SIZE: usize = STORE_WORKERS * 4;
+
+pub struct EntropyLoader {
+    entropy_store: FileStore,
+    pool: PgPool,
+}
+
+impl EntropyLoader {
+    pub async fn from_settings(settings: &Settings) -> Result<Self> {
+        tracing::info!("from_settings verifier entropy loader");
+        let pool = settings.database.connect(LOADER_DB_POOL_SIZE).await?;
+        let entropy_store = FileStore::from_settings(&settings.entropy).await?;
+        Ok(Self {
+            pool,
+            entropy_store,
+        })
+    }
+
+    pub async fn run(&mut self, shutdown: &triggered::Listener) -> Result {
+        tracing::info!("started verifier entropy loader");
+        let mut report_timer = time::interval(time::Duration::from_secs(ENTROPY_POLL_TIME));
+        report_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        loop {
+            if shutdown.is_triggered() {
+                break;
+            }
+            tokio::select! {
+                _ = shutdown.clone() => break,
+                _ = report_timer.tick() => match self.handle_entropy_tick().await {
+                    Ok(()) => (),
+                    Err(err) => {
+                        tracing::error!("fatal entropy loader error, entropy_tick triggered: {err:?}");
+                    }
+                }
+            }
+        }
+        tracing::info!("stopping verifier entropy_loader");
+        Ok(())
+    }
+
+    async fn handle_entropy_tick(&self) -> Result {
+        tracing::info!("handling entropy tick");
+        let now = Utc::now();
+        // the loader loads files from s3 via a sliding window
+        // its start point is Now() - (ENTROPY_POLL_TIME * 3)
+        // as such data being loaded is always stale by a time equal to ENTROPY_POLL_TIME
+
+        // if there is NO last timestamp in the DB, we will start our sliding window from this point
+        let window_default_lookback = now - ChronoDuration::seconds(60 * 60);
+        // if there IS a last timestamp in the DB, we will use it as the starting point for our sliding window
+        // but cap it at the max below.
+        let window_max_lookback = now - ChronoDuration::seconds(60 * 60 * 2);
+        let after = Meta::last_timestamp(&self.pool, ENTROPY_META_NAME)
+            .await?
+            .unwrap_or(window_default_lookback)
+            .max(window_max_lookback);
+
+        let before = now;
+        let window_width = (before - after).num_minutes() as u64;
+        tracing::info!(
+            "entropy sliding window, after: {after}, before: {before}, width: {window_width}"
+        );
+        match self
+            .process_events(FileType::EntropyReport, &self.entropy_store, after, before)
+            .await
+        {
+            Ok(()) => (),
+            Err(err) => tracing::warn!(
+                "error whilst processing {:?} from s3, error: {err:?}",
+                FileType::EntropyReport
+            ),
+        }
+        Meta::update_last_timestamp(&self.pool, ENTROPY_META_NAME, Some(before)).await?;
+        tracing::info!("completed handling entropy tick");
+        Ok(())
+    }
+
+    async fn process_events(
+        &self,
+        file_type: FileType,
+        store: &FileStore,
+        after: chrono::DateTime<Utc>,
+        before: chrono::DateTime<Utc>,
+    ) -> Result {
+        tracing::info!(
+            "checking for new ingest files of type {file_type} after {after} and before {before}"
+        );
+        let infos = store.list_all(file_type, after, before).await?;
+        if infos.is_empty() {
+            tracing::info!("no available ingest files of type {file_type}");
+            return Ok(());
+        }
+
+        let infos_len = infos.len();
+        tracing::info!("processing {infos_len} ingest files of type {file_type}");
+        store
+            .source(stream::iter(infos).map(Ok).boxed())
+            .for_each_concurrent(STORE_WORKERS, |msg| async move {
+                match msg {
+                    Err(err) => tracing::warn!("skipping report of type {file_type} due to error {err:?}"),
+                    Ok(buf) => match self
+                        .handle_report(file_type, &buf)
+                        .await
+                    {
+                        Ok(()) => (),
+                        Err(err) => {
+                            tracing::warn!("error whilst handling incoming report of type: {file_type}, error: {err:?}")
+                        }
+                    },
+                }
+            })
+            .await;
+        tracing::info!("completed processing {infos_len} files of type {file_type}");
+        Ok(())
+    }
+
+    async fn handle_report(&self, file_type: FileType, buf: &[u8]) -> Result {
+        match file_type {
+            FileType::EntropyReport => {
+                let event = EntropyReportV1::decode(buf)?;
+                tracing::debug!("entropy report: {:?}", event);
+                let id = hash(&event.data).as_bytes().to_vec();
+                Entropy::insert_into(
+                    &self.pool,
+                    &id,
+                    &event.data,
+                    &event.timestamp.to_timestamp()?,
+                    event.version as i32,
+                )
+                .await?;
+                metrics::increment_counter!("oracles_poc_iot_verifier_loader_entropy");
+                Ok(())
+            }
+            _ => {
+                tracing::warn!("ignoring unexpected filetype: {file_type:?}");
+                Ok(())
+            }
+        }
+    }
+}

--- a/poc_iot_verifier/src/entropy_loader.rs
+++ b/poc_iot_verifier/src/entropy_loader.rs
@@ -68,8 +68,7 @@ impl EntropyLoader {
             .await?
             .unwrap_or(window_default_lookback)
             .max(window_max_lookback);
-
-        let before = now;
+        let before = now - ChronoDuration::seconds(60 * 10);
         let window_width = (before - after).num_minutes() as u64;
         tracing::info!(
             "entropy sliding window, after: {after}, before: {before}, width: {window_width}"

--- a/poc_iot_verifier/src/entropy_loader.rs
+++ b/poc_iot_verifier/src/entropy_loader.rs
@@ -9,9 +9,9 @@ use tokio::time::{self, MissedTickBehavior};
 
 const ENTROPY_META_NAME: &str = "entropy_report";
 /// cadence for how often to look for entropy from s3 buckets
-const ENTROPY_POLL_TIME: u64 = 60 * 5;
+const ENTROPY_POLL_TIME: u64 = 60 * 10;
 
-const STORE_WORKERS: usize = 100;
+const STORE_WORKERS: usize = 10;
 const LOADER_DB_POOL_SIZE: usize = STORE_WORKERS * 4;
 
 pub struct EntropyLoader {

--- a/poc_iot_verifier/src/entropy_loader.rs
+++ b/poc_iot_verifier/src/entropy_loader.rs
@@ -9,7 +9,7 @@ use tokio::time::{self, MissedTickBehavior};
 
 const ENTROPY_META_NAME: &str = "entropy_report";
 /// cadence for how often to look for entropy from s3 buckets
-const ENTROPY_POLL_TIME: i64 = 60 * 10;
+const ENTROPY_POLL_TIME: i64 = 60 * 5;
 
 const STORE_WORKERS: usize = 10;
 const LOADER_DB_POOL_SIZE: usize = STORE_WORKERS * 4;
@@ -28,7 +28,7 @@ pub enum NewLoaderError {
 }
 
 impl EntropyLoader {
-    pub async fn from_settings(settings: &Settings) ->Result<Self, NewLoaderError> {
+    pub async fn from_settings(settings: &Settings) -> Result<Self, NewLoaderError> {
         tracing::info!("from_settings verifier entropy loader");
         let pool = settings.database.connect(LOADER_DB_POOL_SIZE).await?;
         let entropy_store = FileStore::from_settings(&settings.entropy).await?;

--- a/poc_iot_verifier/src/gateway_cache.rs
+++ b/poc_iot_verifier/src/gateway_cache.rs
@@ -53,7 +53,7 @@ impl GatewayCache {
                             .await;
                         Ok(res)
                     }
-                    _ => Err(GatewayNotFound(address.clone()))
+                    _ => Err(GatewayNotFound(address.clone())),
                 }
             }
         }

--- a/poc_iot_verifier/src/last_beacon.rs
+++ b/poc_iot_verifier/src/last_beacon.rs
@@ -18,15 +18,11 @@ pub enum LastBeaconError {
 }
 
 impl LastBeacon {
-<<<<<<< HEAD
     pub async fn insert_kv<'c, E>(
         executor: E,
-        id: &Vec<u8>,
+        id: &[u8],
         val: &str,
     ) -> Result<Self, LastBeaconError>
-=======
-    pub async fn insert_kv<'c, E>(executor: E, id: &[u8], val: &str) -> Result<Self>
->>>>>>> d8049b8 (Use helium_crypto PublicKeyBinary)
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
@@ -43,11 +39,7 @@ impl LastBeacon {
         .await?)
     }
 
-<<<<<<< HEAD
-    pub async fn get<'c, E>(executor: E, id: &Vec<u8>) -> Result<Option<Self>, LastBeaconError>
-=======
-    pub async fn get<'c, E>(executor: E, id: &[u8]) -> Result<Option<Self>>
->>>>>>> d8049b8 (Use helium_crypto PublicKeyBinary)
+    pub async fn get<'c, E>(executor: E, id: &[u8]) -> Result<Option<Self>, LastBeaconError>
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
@@ -59,14 +51,10 @@ impl LastBeacon {
         )
     }
 
-<<<<<<< HEAD
     pub async fn last_timestamp<'c, E>(
         executor: E,
-        id: &Vec<u8>,
+        id: &[u8],
     ) -> Result<Option<DateTime<Utc>>, LastBeaconError>
-=======
-    pub async fn last_timestamp<'c, E>(executor: E, id: &[u8]) -> Result<Option<DateTime<Utc>>>
->>>>>>> d8049b8 (Use helium_crypto PublicKeyBinary)
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {

--- a/poc_iot_verifier/src/last_beacon.rs
+++ b/poc_iot_verifier/src/last_beacon.rs
@@ -18,11 +18,15 @@ pub enum LastBeaconError {
 }
 
 impl LastBeacon {
+<<<<<<< HEAD
     pub async fn insert_kv<'c, E>(
         executor: E,
         id: &Vec<u8>,
         val: &str,
     ) -> Result<Self, LastBeaconError>
+=======
+    pub async fn insert_kv<'c, E>(executor: E, id: &[u8], val: &str) -> Result<Self>
+>>>>>>> d8049b8 (Use helium_crypto PublicKeyBinary)
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
@@ -39,7 +43,11 @@ impl LastBeacon {
         .await?)
     }
 
+<<<<<<< HEAD
     pub async fn get<'c, E>(executor: E, id: &Vec<u8>) -> Result<Option<Self>, LastBeaconError>
+=======
+    pub async fn get<'c, E>(executor: E, id: &[u8]) -> Result<Option<Self>>
+>>>>>>> d8049b8 (Use helium_crypto PublicKeyBinary)
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
@@ -51,10 +59,14 @@ impl LastBeacon {
         )
     }
 
+<<<<<<< HEAD
     pub async fn last_timestamp<'c, E>(
         executor: E,
         id: &Vec<u8>,
     ) -> Result<Option<DateTime<Utc>>, LastBeaconError>
+=======
+    pub async fn last_timestamp<'c, E>(executor: E, id: &[u8]) -> Result<Option<DateTime<Utc>>>
+>>>>>>> d8049b8 (Use helium_crypto PublicKeyBinary)
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
@@ -77,7 +89,7 @@ impl LastBeacon {
 
     pub async fn update_last_timestamp<'c, E>(
         executor: E,
-        id: &Vec<u8>,
+        id: &[u8],
         timestamp: DateTime<Utc>,
     ) -> Result<(), LastBeaconError>
     where

--- a/poc_iot_verifier/src/lib.rs
+++ b/poc_iot_verifier/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod entropy;
+pub mod entropy_loader;
 pub mod gateway_cache;
 pub mod last_beacon;
 pub mod loader;

--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -1,7 +1,7 @@
 use crate::{
     gateway_cache::GatewayCache,
     meta::Meta,
-    poc_report::{InsertBindings, Report, ReportType},
+    poc_report::{InsertBindings, Report, ReportType, LoraStatus},
     Settings,
 };
 use chrono::DateTime;
@@ -336,6 +336,7 @@ impl Loader {
                             buf: buf.to_vec(),
                             received_ts: beacon.received_timestamp,
                             report_type: ReportType::Beacon,
+                            status: LoraStatus::Pending,
                         };
                         metrics::increment_counter!("oracles_poc_iot_verifier_loader_beacon");
                         if let Some(xor_data) = xor_data {
@@ -370,6 +371,7 @@ impl Loader {
                                         buf: buf.to_vec(),
                                         received_ts: witness.received_timestamp,
                                         report_type: ReportType::Witness,
+                                        status: LoraStatus::Ready,
                                     };
                                     metrics::increment_counter!(
                                         "oracles_poc_iot_verifier_loader_witness"

--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -23,9 +23,9 @@ use tokio::time::{self, MissedTickBehavior};
 
 const REPORTS_META_NAME: &str = "report";
 /// cadence for how often to look for  reports from s3 buckets
-const REPORTS_POLL_TIME: u64 = 60 * 15;
+const REPORTS_POLL_TIME: u64 = 60 * 30;
 
-const STORE_WORKERS: usize = 200;
+const STORE_WORKERS: usize = 100;
 // DB pool size if the store worker count multiplied by the number of file types
 // since they're processed concurrently
 const LOADER_DB_POOL_SIZE: usize = STORE_WORKERS * 4;

--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -140,8 +140,8 @@ impl Loader {
         let before = now - ChronoDuration::seconds(REPORTS_POLL_TIME as i64);
         let window_width = (before - after).num_minutes() as u64;
         tracing::info!("sliding window, after: {after}, before: {before}, width: {window_width}");
-        _ = self.process_window(gateway_cache, after, before);
-        Meta::update_last_timestamp(&self.pool, REPORTS_META_NAME, Some(before)).await?;
+        _ = self.process_window(gateway_cache, after, before).await;
+        _ = Meta::update_last_timestamp(&self.pool, REPORTS_META_NAME, Some(before)).await;
         tracing::info!("completed handling poc_report tick");
         Ok(())
     }

--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -216,6 +216,7 @@ impl Loader {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn process_events(
         &self,
         file_type: FileType,

--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -12,7 +12,7 @@ use file_store::{
     traits::IngestId, FileStore, FileType,
 };
 use futures::{stream, StreamExt};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::{
     services::poc_lora::{LoraBeaconIngestReportV1, LoraWitnessIngestReportV1},
     Message,
@@ -297,7 +297,11 @@ impl Loader {
         }
     }
 
-    async fn check_valid_gateway(&self, pub_key: &PublicKey, gateway_cache: &GatewayCache) -> bool {
+    async fn check_valid_gateway(
+        &self,
+        pub_key: &PublicKeyBinary,
+        gateway_cache: &GatewayCache,
+    ) -> bool {
         if self.check_gw_denied(pub_key).await {
             tracing::debug!("dropping denied gateway : {:?}", &pub_key);
             return false;
@@ -309,11 +313,15 @@ impl Loader {
         true
     }
 
-    async fn check_unknown_gw(&self, pub_key: &PublicKey, gateway_cache: &GatewayCache) -> bool {
+    async fn check_unknown_gw(
+        &self,
+        pub_key: &PublicKeyBinary,
+        gateway_cache: &GatewayCache,
+    ) -> bool {
         gateway_cache.resolve_gateway_info(pub_key).await.is_err()
     }
 
-    async fn check_gw_denied(&self, pub_key: &PublicKey) -> bool {
+    async fn check_gw_denied(&self, pub_key: &PublicKeyBinary) -> bool {
         self.deny_list.check_key(pub_key).await
     }
 }

--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -1,7 +1,7 @@
 use crate::{
     gateway_cache::GatewayCache,
     meta::Meta,
-    poc_report::{InsertBindings, Report, ReportType, LoraStatus},
+    poc_report::{InsertBindings, LoraStatus, Report, ReportType},
     Settings,
 };
 use chrono::DateTime;

--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -1,24 +1,21 @@
 use crate::{
-    entropy::Entropy,
     gateway_cache::GatewayCache,
     meta::Meta,
     poc_report::{Report, ReportType},
     Settings,
 };
-use blake3::hash;
+use chrono::DateTime;
 use chrono::{Duration as ChronoDuration, Utc};
 use denylist::DenyList;
 use file_store::{
-    lora_beacon_report::LoraBeaconIngestReport,
-    lora_witness_report::LoraWitnessIngestReport,
-    traits::{IngestId, TimestampDecode},
-    FileStore, FileType,
+    lora_beacon_report::LoraBeaconIngestReport, lora_witness_report::LoraWitnessIngestReport,
+    traits::IngestId, FileStore, FileType,
 };
 use futures::{stream, StreamExt};
 use helium_crypto::PublicKey;
 use helium_proto::{
     services::poc_lora::{LoraBeaconIngestReportV1, LoraWitnessIngestReportV1},
-    EntropyReportV1, Message,
+    Message,
 };
 use sqlx::PgPool;
 use std::time::Duration;
@@ -28,15 +25,13 @@ const REPORTS_META_NAME: &str = "report";
 /// cadence for how often to look for  reports from s3 buckets
 const REPORTS_POLL_TIME: u64 = 60 * 15;
 
-const LOADER_WORKERS: usize = 25;
-const STORE_WORKERS: usize = 100;
+const STORE_WORKERS: usize = 200;
 // DB pool size if the store worker count multiplied by the number of file types
 // since they're processed concurrently
 const LOADER_DB_POOL_SIZE: usize = STORE_WORKERS * 4;
 
 pub struct Loader {
     ingest_store: FileStore,
-    entropy_store: FileStore,
     pool: PgPool,
     deny_list_latest_url: String,
     deny_list_trigger_interval: Duration,
@@ -58,12 +53,10 @@ impl Loader {
         tracing::info!("from_settings verifier loader");
         let pool = settings.database.connect(LOADER_DB_POOL_SIZE).await?;
         let ingest_store = FileStore::from_settings(&settings.ingest).await?;
-        let entropy_store = FileStore::from_settings(&settings.entropy).await?;
         let deny_list = DenyList::new()?;
         Ok(Self {
             pool,
             ingest_store,
-            entropy_store,
             deny_list_latest_url: settings.denylist.denylist_url.clone(),
             deny_list_trigger_interval: settings.denylist.trigger_interval(),
             deny_list,
@@ -134,56 +127,34 @@ impl Loader {
 
         // if there is NO last timestamp in the DB, we will start our sliding window from this point
         let window_default_lookback = now - ChronoDuration::seconds(REPORTS_POLL_TIME as i64 * 2);
-        // if there IS a last timestamp in the DB, we will use it as the starting point for our sliding window
-        // but cap it at the max below.  this ensures should the verifier go down or get stuck for a period
-        // we do not attempt to load too much history which could result in it not catching up again
-        let window_max_lookback = now - ChronoDuration::seconds(REPORTS_POLL_TIME as i64 * 3);
-
+        // NOTE: Atm we never look back more than window_default_lookback
+        // The experience has been that once we start processing a window longer than default
+        // we never recover the time and end up stuck on a window of the extended size
+        // The option is here however to extend the window size should it be needed
+        let window_max_lookback = now - ChronoDuration::seconds(REPORTS_POLL_TIME as i64 * 2);
         let after = Meta::last_timestamp(&self.pool, REPORTS_META_NAME)
             .await?
             .unwrap_or(window_default_lookback)
             .max(window_max_lookback);
 
-        // the sliding window end point is always Now() - REPORTS_POLL_TIME
-        // this can result in the window width being stretched in the scenario
-        // whereby the previous loading run took longer than REPORTS_POLL_TIME to complete
-        // in such a scenario the window start point will be that of the previous run's end point
-        // and the width will be stretch from that point up until Now() - REPORTS_POLL_TIME
-        // If we continue to take longer than the tick time and the window width keeps stretching
-        // then the `window_max_lookback` cap will kick in at some point
         let before = now - ChronoDuration::seconds(REPORTS_POLL_TIME as i64);
-        let window_width = (after - before).num_minutes() as u64;
-        if window_width > REPORTS_POLL_TIME {
-            tracing::warn!("stretched sliding window, after: {after}, before: {before}, width: {window_width}, tick_time: {:?}", REPORTS_POLL_TIME);
-        } else {
-            tracing::info!(
-                "sliding window, after: {after}, before: {before}, width: {window_width}"
-            );
-        }
+        let window_width = (before - after).num_minutes() as u64;
+        tracing::info!("sliding window, after: {after}, before: {before}, width: {window_width}");
+        _ = self.process_window(gateway_cache, after, before);
+        Meta::update_last_timestamp(&self.pool, REPORTS_META_NAME, Some(before)).await?;
+        tracing::info!("completed handling poc_report tick");
+        Ok(())
+    }
 
-        // serially load each file type starting with entropy
-        // beacons & witnesses dep on entropy
-        // and ideally we wouldnt want to process a beacon
-        // until witnesses are present in the db
-        // otherwise we end up dropping those witnesses
-        // serially loading each type ensures we have some order
-        match self
-            .process_events(
-                FileType::EntropyReport,
-                &self.entropy_store,
-                gateway_cache,
-                after,
-                before,
-            )
-            .await
-        {
-            Ok(()) => (),
-            Err(err) => tracing::warn!(
-                "error whilst processing {:?} from s3, error: {err:?}",
-                FileType::EntropyReport
-            ),
-        }
-
+    async fn process_window(
+        &self,
+        gateway_cache: &GatewayCache,
+        after: DateTime<Utc>,
+        before: DateTime<Utc>,
+    ) -> Result {
+        // serially load witnesses and beacons for this window
+        // ideally we dont want to process a beacon
+        // until any associated witnesses are present in the db
         match self
             .process_events(
                 FileType::LoraWitnessIngestReport,
@@ -217,8 +188,6 @@ impl Loader {
                 FileType::LoraBeaconIngestReport
             ),
         }
-        Meta::update_last_timestamp(&self.pool, REPORTS_META_NAME, Some(before)).await?;
-        tracing::info!("completed handling report tick");
         Ok(())
     }
 
@@ -320,21 +289,6 @@ impl Loader {
                     }
                     false => Ok(()),
                 }
-            }
-            FileType::EntropyReport => {
-                let event = EntropyReportV1::decode(buf)?;
-                tracing::debug!("entropy report: {:?}", event);
-                let id = hash(&event.data).as_bytes().to_vec();
-                Entropy::insert_into(
-                    &self.pool,
-                    &id,
-                    &event.data,
-                    &event.timestamp.to_timestamp()?,
-                    event.version as i32,
-                )
-                .await?;
-                metrics::increment_counter!("oracles_poc_iot_verifier_loader_entropy");
-                Ok(())
             }
             _ => {
                 tracing::warn!("ignoring unexpected filetype: {file_type:?}");

--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -18,9 +18,7 @@ use helium_proto::{
     Message,
 };
 use sqlx::PgPool;
-use std::sync::Arc;
-use std::{ops::DerefMut, time::Duration};
-use tokio::sync::Mutex;
+use std::{cell::RefCell, time::Duration};
 use tokio::time::{self, MissedTickBehavior};
 
 const REPORTS_META_NAME: &str = "report";
@@ -210,7 +208,7 @@ impl Loader {
         tracing::info!("processing {infos_len} ingest files of type {file_type}");
 
         stream::iter(infos)
-            .for_each_concurrent(4, |file_info| async move {
+            .for_each_concurrent(10, |file_info| async move {
                 match self
                     .process_file(store, file_info.clone(), gateway_cache)
                     .await
@@ -240,13 +238,13 @@ impl Loader {
         gateway_cache: &GatewayCache,
     ) -> anyhow::Result<()> {
         let file_type = file_info.file_type;
-        let tx = Arc::new(Mutex::new(self.pool.begin().await?));
+        let tx = RefCell::new(self.pool.begin().await?);
 
         store
             .stream_file(file_info.clone())
             .await?
             .chunks(300)
-            .for_each_concurrent(100, |msgs| async {
+            .for_each_concurrent(10, |msgs| async {
                 let mut inserts = Vec::new();
                 for msg in msgs {
                     match msg {
@@ -266,13 +264,13 @@ impl Loader {
                     }
                 }
 
-                match Report::bulk_insert(tx.clone().lock().await.deref_mut(), inserts).await {
+                match Report::bulk_insert(&mut *tx.borrow_mut(), inserts).await {
                     Ok(_) => (),
                     Err(err) => tracing::warn!("error whilst inserting report to db,  error: {err:?}"),
                 }
             }).await;
 
-        Arc::try_unwrap(tx).unwrap().into_inner().commit().await?;
+        tx.into_inner().commit().await?;
 
         Ok(())
     }

--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -9,7 +9,7 @@ use chrono::{Duration as ChronoDuration, Utc};
 use denylist::DenyList;
 use file_store::{
     lora_beacon_report::LoraBeaconIngestReport, lora_witness_report::LoraWitnessIngestReport,
-    traits::IngestId, FileStore, FileType,
+    traits::IngestId, FileInfo, FileStore, FileType,
 };
 use futures::{stream, StreamExt};
 use helium_crypto::PublicKeyBinary;
@@ -223,20 +223,51 @@ impl Loader {
         }
         let infos_len = infos.len();
         tracing::info!("processing {infos_len} ingest files of type {file_type}");
-        store
-            .source(stream::iter(infos).map(Ok).boxed())
-            .chunks(300)
-            .for_each_concurrent(STORE_WORKERS, |msgs| async move {
-                let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
-                    REPORT_INSERT_SQL
-                );
-                let mut inserts = Vec::new();
-                for msg in msgs {
-                    match msg {
-                        Err(err) => tracing::warn!(
-                            "skipping report of type {file_type} due to error {err:?}"),
-                        Ok(buf) => {
-                            match self.handle_report(file_type, &buf, gateway_cache).await
+
+        stream::iter(infos)
+            .for_each_concurrent(10, |file_info| async move {
+                match self
+                    .process_file(store, file_info.clone(), gateway_cache)
+                    .await
+                {
+                    Ok(()) => tracing::debug!(
+                        "completed processing file of type {}, ts: {}",
+                        &file_type,
+                        file_info.timestamp
+                    ),
+                    Err(err) => tracing::warn!(
+                        "error whilst processing file of type {}, ts: {}, err: {err:?}",
+                        &file_type,
+                        file_info.timestamp
+                    ),
+                };
+            })
+            .await;
+
+        tracing::info!("completed processing {infos_len} files of type {file_type}");
+        Ok(())
+    }
+
+    async fn process_file(
+        &self,
+        store: &FileStore,
+        file_info: FileInfo,
+        gateway_cache: &GatewayCache,
+    ) -> Result {
+        let file_type = file_info.file_type;
+        let mut tx = self.pool.begin().await?;
+
+        let mut stream = store.stream_file(file_info.clone()).await?.chunks(300);
+        while let Some(msgs) = stream.next().await {
+            let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(REPORT_INSERT_SQL);
+            let mut inserts = Vec::new();
+            for msg in msgs {
+                match msg {
+                    Err(err) => {
+                        tracing::warn!("skipping report of type {file_type} due to error {err:?}")
+                    }
+                    Ok(buf) => {
+                        match self.handle_report(file_type, &buf, gateway_cache).await
                             {
                                 Ok(Some(bindings)) =>  inserts.push(bindings),
                                 Ok(None) => (),
@@ -244,30 +275,25 @@ impl Loader {
                                     "error whilst handling incoming report of type: {file_type}, error: {err:?}")
 
                             }
-                        }
                     }
                 }
-                query_builder
-                .push_values(inserts, |mut b, insert|
-                    {
-                        b.push_bind(insert.id)
-                        .push_bind(insert.remote_entropy)
-                        .push_bind(insert.packet_data)
-                        .push_bind(insert.buf)
-                        .push_bind(insert.received_ts)
-                        .push_bind(insert.report_type);
-                    }
-                );
-                let query = query_builder.build();
-                match query.execute(&self.pool).await
-                {
-                    Ok(_) => (),
-                    Err(err) => tracing::warn!(
-                        "error whilst inserting report to db,  error: {err:?}"),
-                }
-            })
-            .await;
-        tracing::info!("completed processing {infos_len} files of type {file_type}");
+            }
+            query_builder.push_values(inserts, |mut b, insert| {
+                b.push_bind(insert.id)
+                    .push_bind(insert.remote_entropy)
+                    .push_bind(insert.packet_data)
+                    .push_bind(insert.buf)
+                    .push_bind(insert.received_ts)
+                    .push_bind(insert.report_type);
+            });
+            let query = query_builder.build();
+            match query.execute(&mut tx).await {
+                Ok(_) => (),
+                Err(err) => tracing::warn!("error whilst inserting report to db,  error: {err:?}"),
+            }
+        }
+
+        tx.commit().await?;
         Ok(())
     }
 

--- a/poc_iot_verifier/src/main.rs
+++ b/poc_iot_verifier/src/main.rs
@@ -121,7 +121,6 @@ impl Server {
                 density_scaler.hex_density_map(),
                 &shutdown
             ),
-            loader.run(&shutdown, &gateway_cache),
             entropy_loader.run(&shutdown),
             loader.run(&shutdown, &gateway_cache),
             purger.run(&shutdown),

--- a/poc_iot_verifier/src/main.rs
+++ b/poc_iot_verifier/src/main.rs
@@ -3,7 +3,10 @@ use clap::Parser;
 use density_scaler::Server as DensityScaler;
 use file_store::{file_sink, file_upload, FileType};
 use futures::TryFutureExt;
-use poc_iot_verifier::{gateway_cache::GatewayCache, loader, entropy_loader, purger, rewarder::Rewarder, runner, Settings};
+use poc_iot_verifier::{
+    entropy_loader, gateway_cache::GatewayCache, loader, purger, rewarder::Rewarder, runner,
+    Settings,
+};
 use std::path;
 use tokio::signal;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};

--- a/poc_iot_verifier/src/main.rs
+++ b/poc_iot_verifier/src/main.rs
@@ -123,6 +123,7 @@ impl Server {
             ),
             loader.run(&shutdown, &gateway_cache),
             entropy_loader.run(&shutdown),
+            loader.run(&shutdown, &gateway_cache),
             purger.run(&shutdown),
             rewarder.run(&shutdown),
             density_scaler.run(&shutdown).map_err(Error::from),

--- a/poc_iot_verifier/src/poc.rs
+++ b/poc_iot_verifier/src/poc.rs
@@ -123,6 +123,25 @@ impl Poc {
         };
         tracing::debug!("beacon info {:?}", beaconer_info);
 
+        // verify the beaconer's remote entropy
+        // if beacon received timestamp is outside of entopy start/end then reject the poc
+        if beacon_received_ts < self.entropy_start || beacon_received_ts > self.entropy_end {
+            tracing::debug!(
+                "beacon verification failed, reason: {:?}. beacon_received_ts: {:?}, entropy_start_time: {:?}, entropy_end_time: {:?}",
+                InvalidReason::BadEntropy,
+                beacon_received_ts,
+                self.entropy_start,
+                self.entropy_end
+            );
+            let resp = VerifyBeaconResult {
+                result: VerificationStatus::Invalid,
+                invalid_reason: Some(InvalidReason::BadEntropy),
+                gateway_info: Some(beaconer_info),
+                hex_scale: None,
+            };
+            return Ok(resp);
+        }
+
         // is beaconer allowed to beacon at this time ?
         // any irregularily timed beacons will be rejected
         match LastBeacon::get(pool, beaconer_pub_key.as_ref()).await? {
@@ -147,25 +166,6 @@ impl Poc {
             None => {
                 tracing::debug!("no last beacon timestamp available for this beaconer, ignoring ");
             }
-        }
-
-        // verify the beaconer's remote entropy
-        // if beacon received timestamp is outside of entopy start/end then reject the poc
-        if beacon_received_ts < self.entropy_start || beacon_received_ts > self.entropy_end {
-            tracing::debug!(
-                "beacon verification failed, reason: {:?}. beacon_received_ts: {:?}, entropy_start_time: {:?}, entropy_end_time: {:?}",
-                InvalidReason::BadEntropy,
-                beacon_received_ts,
-                self.entropy_start,
-                self.entropy_end
-            );
-            let resp = VerifyBeaconResult {
-                result: VerificationStatus::Invalid,
-                invalid_reason: Some(InvalidReason::BadEntropy),
-                gateway_info: Some(beaconer_info),
-                hex_scale: None,
-            };
-            return Ok(resp);
         }
 
         //check beaconer has an asserted location

--- a/poc_iot_verifier/src/poc.rs
+++ b/poc_iot_verifier/src/poc.rs
@@ -148,7 +148,7 @@ impl Poc {
             Some(last_beacon) => {
                 let interval_since_last_beacon = beacon_received_ts - last_beacon.timestamp;
                 if interval_since_last_beacon < Duration::seconds(BEACON_INTERVAL) {
-                    tracing::info!(
+                    tracing::debug!(
                         "beacon verification failed, reason:
                         IrregularInterval. Seconds since last beacon {:?}, entropy: {:?}",
                         interval_since_last_beacon.num_seconds(),

--- a/poc_iot_verifier/src/poc.rs
+++ b/poc_iot_verifier/src/poc.rs
@@ -125,7 +125,7 @@ impl Poc {
 
         // is beaconer allowed to beacon at this time ?
         // any irregularily timed beacons will be rejected
-        match LastBeacon::get(pool, &beaconer_pub_key.to_vec()).await? {
+        match LastBeacon::get(pool, beaconer_pub_key.as_ref()).await? {
             Some(last_beacon) => {
                 let interval_since_last_beacon = beacon_received_ts - last_beacon.timestamp;
                 if interval_since_last_beacon < Duration::seconds(BEACON_INTERVAL) {

--- a/poc_iot_verifier/src/poc.rs
+++ b/poc_iot_verifier/src/poc.rs
@@ -148,7 +148,7 @@ impl Poc {
             Some(last_beacon) => {
                 let interval_since_last_beacon = beacon_received_ts - last_beacon.timestamp;
                 if interval_since_last_beacon < Duration::seconds(BEACON_INTERVAL) {
-                    tracing::debug!(
+                    tracing::info!(
                         "beacon verification failed, reason:
                         IrregularInterval. Seconds since last beacon {:?}, entropy: {:?}",
                         interval_since_last_beacon.num_seconds(),

--- a/poc_iot_verifier/src/poc_report.rs
+++ b/poc_iot_verifier/src/poc_report.rs
@@ -209,7 +209,7 @@ impl Report {
             inner join entropy on poc_report.remote_entropy=entropy.data
             where poc_report.report_type = 'beacon' and status = 'ready'
             and entropy.timestamp < $1
-            and poc_report.attempts < $3
+            and poc_report.attempts < $2
             order by poc_report.created_at asc
             limit 25000
             "#,

--- a/poc_iot_verifier/src/poc_report.rs
+++ b/poc_iot_verifier/src/poc_report.rs
@@ -13,7 +13,7 @@ const REPORT_INSERT_SQL: &str = "insert into poc_report (
     packet_data,
     report_data,
     report_timestamp,
-    report_type
+    report_type,
     status
 ) ";
 

--- a/poc_iot_verifier/src/poc_report.rs
+++ b/poc_iot_verifier/src/poc_report.rs
@@ -16,7 +16,7 @@ const WITNESS_MAX_RETRY_ATTEMPTS: i16 = 5; //TODO: determine a sane value here
 //    for that beacon, if a witness comes in after the beacon has been processed
 //    then it does not get verified as part of the overall POC but instead will
 //    end up being deemed stale )
-const BEACON_PROCESSING_DELAY: i64 = 60 * 5;
+const BEACON_PROCESSING_DELAY: i64 = 0;
 
 #[derive(sqlx::Type, Serialize, Deserialize, Debug)]
 #[sqlx(type_name = "reporttype", rename_all = "lowercase")]

--- a/poc_iot_verifier/src/purger.rs
+++ b/poc_iot_verifier/src/purger.rs
@@ -118,7 +118,6 @@ impl Purger {
                     Ok(()) => (),
                     Err(err) => {
                         tracing::error!("fatal purger error: {err:?}");
-                        return Err(err)
                     }
                 }
             }

--- a/poc_iot_verifier/src/purger.rs
+++ b/poc_iot_verifier/src/purger.rs
@@ -28,7 +28,7 @@ const PURGER_DB_POOL_SIZE: usize = PURGER_WORKERS * 4;
 // opportunity to be verified and after this point extremely unlikely to ever be verified
 // successfully
 // this value will be added to the env var BASE_STALE_PERIOD to determine final setting
-const BEACON_STALE_PERIOD: i64 = 60 * 90;
+const BEACON_STALE_PERIOD: i64 = 60 * 30;
 /// the period in seconds after when a witness report in the DB will be deemed stale
 // extend witness stale period beyond that of beacons
 // witnesses are inserted into the DB up to 10 mins before beacons
@@ -139,9 +139,8 @@ impl Purger {
         tracing::info!(
             "starting query get_stale_pending_beacons with stale period: {beacon_stale_period}"
         );
-        let stale_beacons =
-            Report::get_stale_pending_beacons(&self.pool, beacon_stale_period).await?;
-        tracing::info!("completed query get_stale_pending_beacons");
+        let stale_beacons = Report::get_stale_beacons(&self.pool, beacon_stale_period).await?;
+        tracing::info!("completed query get_stale_beacons");
         tracing::info!("purging {:?} stale beacons", stale_beacons.len());
 
         let tx = Mutex::new(self.pool.begin().await?);
@@ -169,9 +168,8 @@ impl Purger {
         tracing::info!(
             "starting query get_stale_pending_witnesses with stale period: {witness_stale_period}"
         );
-        let stale_witnesses =
-            Report::get_stale_pending_witnesses(&self.pool, witness_stale_period).await?;
-        tracing::info!("completed query get_stale_pending_witnesses");
+        let stale_witnesses = Report::get_stale_witnesses(&self.pool, witness_stale_period).await?;
+        tracing::info!("completed query get_stale_witnesses");
         let num_stale_witnesses = stale_witnesses.len();
         tracing::info!("purging {num_stale_witnesses} stale witnesses");
 
@@ -220,7 +218,10 @@ impl Purger {
             report: beacon.clone(),
         }
         .into();
-        tracing::debug!("purging beacon with date: {received_timestamp}");
+        tracing::debug!(
+            "purging beacon with entropy: {:?}, time: {received_timestamp}",
+            db_beacon.remote_entropy
+        );
         file_sink_write!(
             "invalid_beacon",
             lora_invalid_beacon_tx,
@@ -250,7 +251,10 @@ impl Purger {
             participant_side: InvalidParticipantSide::Witness,
         }
         .into();
-        tracing::debug!("purging witness with date: {received_timestamp}");
+        tracing::debug!(
+            "purging witness with packet data: {:?}, time: {received_timestamp}",
+            db_witness.packet_data
+        );
         file_sink_write!(
             "invalid_witness_report",
             lora_invalid_witness_tx,

--- a/poc_iot_verifier/src/reward_share.rs
+++ b/poc_iot_verifier/src/reward_share.rs
@@ -2,7 +2,7 @@ use crate::poc_report::ReportType;
 use chrono::{DateTime, Duration, Utc};
 use file_store::{lora_valid_poc::LoraValidPoc, traits::TimestampEncode};
 use futures::stream::TryStreamExt;
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_lora as proto;
 use lazy_static::lazy_static;
 use rust_decimal::prelude::*;
@@ -35,7 +35,7 @@ fn get_scheduled_tokens(duration: Duration) -> (Decimal, Decimal) {
 
 #[derive(sqlx::FromRow)]
 pub struct GatewayShare {
-    pub hotspot_key: PublicKey,
+    pub hotspot_key: PublicKeyBinary,
     pub reward_type: ReportType,
     pub reward_timestamp: DateTime<Utc>,
     pub hex_scale: Decimal,
@@ -120,7 +120,7 @@ impl RewardShares {
 
 #[derive(Default)]
 pub struct GatewayShares {
-    pub shares: HashMap<PublicKey, RewardShares>,
+    pub shares: HashMap<PublicKeyBinary, RewardShares>,
 }
 
 impl GatewayShares {
@@ -185,7 +185,7 @@ impl GatewayShares {
             .into_iter()
             .map(
                 move |(hotspot_key, reward_shares)| proto::GatewayRewardShare {
-                    hotspot_key: hotspot_key.to_vec(),
+                    hotspot_key: hotspot_key.into(),
                     beacon_amount: compute_rewards(
                         beacon_rewards_per_share,
                         reward_shares.beacon_shares,
@@ -229,22 +229,22 @@ mod test {
 
     #[test]
     fn test_reward_share_calculation() {
-        let gw1: PublicKey = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
+        let gw1: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
             .parse()
             .expect("failed gw1 parse");
-        let gw2: PublicKey = "11sctWiP9r5wDJVuDe1Th4XSL2vaawaLLSQF8f8iokAoMAJHxqp"
+        let gw2: PublicKeyBinary = "11sctWiP9r5wDJVuDe1Th4XSL2vaawaLLSQF8f8iokAoMAJHxqp"
             .parse()
             .expect("failed gw2 parse");
-        let gw3: PublicKey = "112DJZiXvZ8FduiWrEi8siE3wJX6hpRjjtwbavyXUDkgutEUSLAE"
+        let gw3: PublicKeyBinary = "112DJZiXvZ8FduiWrEi8siE3wJX6hpRjjtwbavyXUDkgutEUSLAE"
             .parse()
             .expect("failed gw3 parse");
-        let gw4: PublicKey = "112p1GbUtRLyfFaJr1XF8fH7yz9cSZ4exbrSpVDeu67DeGb31QUL"
+        let gw4: PublicKeyBinary = "112p1GbUtRLyfFaJr1XF8fH7yz9cSZ4exbrSpVDeu67DeGb31QUL"
             .parse()
             .expect("failed gw4 parse");
-        let gw5: PublicKey = "112j1iw1sV2B2Tz2DxPSeum9Cmc5kMKNdDTDg1zDRsdwuvZueq3B"
+        let gw5: PublicKeyBinary = "112j1iw1sV2B2Tz2DxPSeum9Cmc5kMKNdDTDg1zDRsdwuvZueq3B"
             .parse()
             .expect("failed gw5 parse");
-        let gw6: PublicKey = "11fCasUk9XvU15ktsMMH64J9E7XuqQ2L5FJPv8HZMCDG6kdZ3SC"
+        let gw6: PublicKeyBinary = "11fCasUk9XvU15ktsMMH64J9E7XuqQ2L5FJPv8HZMCDG6kdZ3SC"
             .parse()
             .expect("failed gw6 parse");
 
@@ -260,7 +260,7 @@ mod test {
         let now = Utc::now();
         let reward_period = (now - Duration::minutes(10))..now;
 
-        let rewards: HashMap<PublicKey, proto::GatewayRewardShare> = gw_shares
+        let rewards: HashMap<PublicKeyBinary, proto::GatewayRewardShare> = gw_shares
             .into_gateway_reward_shares(&reward_period)
             .map(|reward| {
                 (

--- a/poc_iot_verifier/src/runner.rs
+++ b/poc_iot_verifier/src/runner.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 use tokio::time::{self, MissedTickBehavior};
 
 /// the cadence in seconds at which the DB is polled for ready POCs
-const DB_POLL_TIME: time::Duration = time::Duration::from_secs(60);
+const DB_POLL_TIME: time::Duration = time::Duration::from_secs(30);
 const BEACON_WORKERS: usize = 100;
 const RUNNER_DB_POOL_SIZE: usize = BEACON_WORKERS * 4;
 
@@ -84,7 +84,7 @@ impl Runner {
             lora_invalid_beacon_rx,
         )
         .deposits(Some(file_upload_tx.clone()))
-        .roll_time(ChronoDuration::minutes(15))
+        .roll_time(ChronoDuration::minutes(5))
         .create()
         .await?;
 
@@ -94,7 +94,7 @@ impl Runner {
             lora_invalid_witness_rx,
         )
         .deposits(Some(file_upload_tx.clone()))
-        .roll_time(ChronoDuration::minutes(15))
+        .roll_time(ChronoDuration::minutes(5))
         .create()
         .await?;
 
@@ -104,7 +104,7 @@ impl Runner {
             lora_valid_poc_rx,
         )
         .deposits(Some(file_upload_tx.clone()))
-        .roll_time(ChronoDuration::minutes(10))
+        .roll_time(ChronoDuration::minutes(2))
         .create()
         .await?;
 
@@ -287,7 +287,7 @@ impl Runner {
                     .invalid_reason else {
                         anyhow::bail!("invalid_reason is None");
                     };
-                tracing::info!(
+                tracing::debug!(
                     "invalid beacon. entropy: {:?}, addr: {:?}, reason: {:?}",
                     beacon.data,
                     beacon.pub_key,

--- a/poc_iot_verifier/src/runner.rs
+++ b/poc_iot_verifier/src/runner.rs
@@ -236,7 +236,7 @@ impl Runner {
                 tracing::debug!(
                     "valid beacon. entropy: {:?}, addr: {:?}",
                     beacon.data,
-                    beacon.pub_key.to_string()
+                    beacon.pub_key
                 );
                 // beacon is valid, verify the POC witnesses
                 if let Some(beacon_info) = beacon_verify_result.gateway_info {
@@ -290,7 +290,7 @@ impl Runner {
                 tracing::info!(
                     "invalid beacon. entropy: {:?}, addr: {:?}, reason: {:?}",
                     beacon.data,
-                    beacon.pub_key.to_string(),
+                    beacon.pub_key,
                     invalid_reason
                 );
                 self.handle_invalid_poc(
@@ -308,7 +308,7 @@ impl Runner {
                 tracing::info!(
                     "failed beacon. entropy: {:?}, addr: {:?}",
                     beacon.data,
-                    beacon.pub_key.to_string()
+                    beacon.pub_key
                 );
                 Report::update_attempts(&self.pool, &beacon_report.ingest_id(), Utc::now()).await?;
             }
@@ -390,7 +390,7 @@ impl Runner {
         lora_invalid_witness_tx: &MessageSender,
     ) -> anyhow::Result<()> {
         let received_timestamp = valid_beacon_report.received_timestamp;
-        let pub_key = valid_beacon_report.report.pub_key.to_vec();
+        let pub_key = valid_beacon_report.report.pub_key.clone();
         let beacon_id = valid_beacon_report.report.report_id(received_timestamp);
         let packet_data = valid_beacon_report.report.data.clone();
         let beacon_report_id = valid_beacon_report.report.report_id(received_timestamp);
@@ -440,8 +440,7 @@ impl Runner {
             }
         }
         // update timestamp of last beacon for the beaconer
-        LastBeacon::update_last_timestamp(&self.pool, &pub_key.to_vec(), received_timestamp)
-            .await?;
+        LastBeacon::update_last_timestamp(&self.pool, pub_key.as_ref(), received_timestamp).await?;
         Report::delete_poc(&self.pool, &packet_data).await?;
         Ok(())
     }

--- a/poc_mobile_verifier/src/heartbeats.rs
+++ b/poc_mobile_verifier/src/heartbeats.rs
@@ -4,7 +4,7 @@ use crate::cell_type::CellType;
 use chrono::{DateTime, NaiveDateTime, Timelike, Utc};
 use file_store::{file_sink, file_sink_write, heartbeat::CellHeartbeat};
 use futures::stream::{Stream, StreamExt};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_mobile as proto;
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use rust_decimal_macros::dec;
@@ -13,7 +13,7 @@ use std::{collections::HashMap, ops::Range};
 
 #[derive(Clone)]
 pub struct Heartbeat {
-    pub hotspot_key: PublicKey,
+    pub hotspot_key: PublicKeyBinary,
     pub cbsd_id: String,
     pub reward_weight: Decimal,
     pub timestamp: NaiveDateTime,
@@ -22,7 +22,7 @@ pub struct Heartbeat {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct HeartbeatKey {
-    hotspot_key: PublicKey,
+    hotspot_key: PublicKeyBinary,
     cbsd_id: String,
 }
 
@@ -41,7 +41,7 @@ impl HeartbeatValue {
 }
 
 pub struct HeartbeatReward {
-    pub hotspot_key: PublicKey,
+    pub hotspot_key: PublicKeyBinary,
     pub cbsd_id: String,
     pub reward_weight: Decimal,
 }
@@ -58,7 +58,7 @@ impl Heartbeats {
     pub async fn validated(exec: impl sqlx::PgExecutor<'_>) -> Result<Self, sqlx::Error> {
         #[derive(sqlx::FromRow)]
         pub struct HeartbeatRow {
-            hotspot_key: PublicKey,
+            hotspot_key: PublicKeyBinary,
             cbsd_id: String,
             reward_weight: Decimal,
             hours_seen: [bool; 24],
@@ -168,7 +168,7 @@ impl Heartbeat {
             heartbeats_tx,
             proto::Heartbeat {
                 cbsd_id: self.cbsd_id.clone(),
-                pub_key: self.hotspot_key.to_vec(),
+                pub_key: self.hotspot_key.clone().into(),
                 reward_multiplier: self.reward_weight.to_f32().unwrap_or(0.0),
                 cell_type,
                 validity: self.validity as i32,


### PR DESCRIPTION
This adds a bunch of optimisations to the loading of reports.  The main optimisations include:

1.  PublicKeyBinary: default public key to binary type rather than the full public key type ( this change is applied to all oracles )
2. Bulk insert of beacon and witness reports to DB and handle inserts via a transaction
3. Use an xor filter of beacon packet data, use filter to verify witness reports have an associated beacon before inserting to DB.  If no associated beacon report drop the witness report.  This siphons out a significant amount of spurious witness reports from clients
4. Process file load per file and add transaction support.  Concurrently process reports on a per file basis

Some misc other changes include
1. Separate loading of entropy and reports.  run each in this own thread
2. Various tidy up