### PR TITLE
fix loader sliding window

### DIFF
--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -143,7 +143,9 @@ impl Loader {
         if window_width > REPORTS_POLL_TIME {
             tracing::warn!("stretched sliding window, after: {after}, before: {before}, width: {window_width}, tick_time: {:?}", REPORTS_POLL_TIME);
         } else {
-            tracing::info!("sliding window, after: {after}, before: {before}, width: {window_width}");
+            tracing::info!(
+                "sliding window, after: {after}, before: {before}, width: {window_width}"
+            );
         }
 
         // serially load each file type starting with entropy


### PR DESCRIPTION
This fixes an issue encountered on mainnet whereby the processing of report files loaded from s3 takes longer than the tick time resulting in some s3 files being skipped.

The sliding window used by the loader had a fixed width in minutes,  equal to our tick time and a max age for its starting position equal to tick time * 2.   Normally the start point for the window is the end point of the window position during the previous tick.  However when the processing of a previous batch of files exceeds the tick time the next window start point would be greater than the max age and the window would be shuffled forwards, skipping some time and any files on s3 for that skipped period.

With this fix the sliding window start point continues to be the endpoint of the previous window position but the max age is now 3X that of our tick time.  The end point of the window is now stretchable, so that if a previous processing run takes longer than the tick, the window will be stretched from its starting point up until Now() - REPORTS_TICK_TIME ( 15 mins by default currently ).  The window will only be shuffled forward in the event we accumulate an ongoing delay which see the window start point exceed the max age ( 3X tick time ).

The stretching of the window should only really serve to address sporadic instances of the loader taking longer to process a batch of files than expected.   If the window width is being  stretched continually or in most instances then the tick time is wrong and we are not allocating sufficient time to process files.  We should increase tick time at that point.

