### PR TITLE
file store and file ggsink improvements

### DIFF
--- a/file_store/src/file_sink.rs
+++ b/file_store/src/file_sink.rs
@@ -435,8 +435,6 @@ impl FileSink {
                     if self.auto_commit {
                         self.commit().await?;
                     }
-                    // let prev_path = active_sink.path.clone();
-                    // self.deposit_sink(&prev_path).await?;
                     self.new_sink().await?;
                 }
             }

--- a/file_store/src/file_store.rs
+++ b/file_store/src/file_store.rs
@@ -1,5 +1,6 @@
 use crate::{
-    error::DecodeError, BytesMutStream, Error, FileInfo, FileInfoStream, FileType, Result, Settings,
+    error::DecodeError, BytesMutStream, Error, FileInfo, FileInfoStream, FileType, Result,
+    Settings, Stream,
 };
 use aws_config::meta::region::{ProvideRegion, RegionProviderChain};
 use aws_sdk_s3::{types::ByteStream, Client, Endpoint, Region};
@@ -13,6 +14,11 @@ use std::str::FromStr;
 pub struct FileStore {
     pub(crate) bucket: String,
     client: Client,
+}
+
+pub struct FileData {
+    pub info: FileInfo,
+    pub stream: BytesMutStream,
 }
 
 impl FileStore {
@@ -198,6 +204,25 @@ impl FileStore {
             })
             .boxed()
     }
+
+    pub fn stream_files<A, B, F>(&self, file_type: F, after: A, before: B) -> Stream<FileData>
+    where
+        F: Into<FileType> + Copy,
+        A: Into<Option<DateTime<Utc>>> + Copy,
+        B: Into<Option<DateTime<Utc>>> + Copy,
+    {
+        let client = self.client.clone();
+        let bucket = self.bucket.clone();
+
+        self.list(file_type, after, before)
+            .map_ok(move |info| get_byte_stream_with_info(client.clone(), bucket.clone(), info))
+            .try_buffered(2)
+            .map_ok(|(info, stream)| FileData {
+                info,
+                stream: stream_source(stream),
+            })
+            .boxed()
+    }
 }
 
 fn stream_source(stream: ByteStream) -> BytesMutStream {
@@ -226,6 +251,21 @@ where
         .key(key)
         .send()
         .map_ok(|output| output.body)
+        .map_err(Error::s3_error)
+        .await
+}
+
+async fn get_byte_stream_with_info(
+    client: Client,
+    bucket: String,
+    info: FileInfo,
+) -> Result<(FileInfo, ByteStream)> {
+    client
+        .get_object()
+        .bucket(bucket)
+        .key(&info.key)
+        .send()
+        .map_ok(|output| (info, output.body))
         .map_err(Error::s3_error)
         .await
 }

--- a/poc_mobile_verifier/src/cli/server.rs
+++ b/poc_mobile_verifier/src/cli/server.rs
@@ -61,7 +61,7 @@ impl Cmd {
             radio_rewards_rx,
         )
         .deposits(Some(file_upload_tx.clone()))
-        .write_manifest(true)
+        .auto_commit(false)
         .create()
         .await?;
 
@@ -73,6 +73,7 @@ impl Cmd {
             reward_manifest_rx,
         )
         .deposits(Some(file_upload_tx.clone()))
+        .auto_commit(false)
         .create()
         .await?;
 

--- a/poc_mobile_verifier/src/verifier.rs
+++ b/poc_mobile_verifier/src/verifier.rs
@@ -124,9 +124,7 @@ impl VerifierDaemon {
                 .await??;
         }
 
-        let written_files = file_sink::fetch_manifest(&self.radio_rewards_tx)
-            .await?
-            .await??;
+        let written_files = file_sink::commit(&self.radio_rewards_tx).await?.await??;
 
         // Write out the manifest file
         file_sink_write!(
@@ -141,7 +139,7 @@ impl VerifierDaemon {
         .await?
         .await??;
 
-        file_sink::flush(&self.reward_manifest_tx).await?;
+        file_sink::commit(&self.reward_manifest_tx).await?;
 
         let mut transaction = self.pool.begin().await?;
 


### PR DESCRIPTION
file_store: Add file `stream_files` which will return a stream FileData which contains the stream of bytes in the file.
file_sink: Added optional transaction semantics

Everything should be backwards compatible.