### PR TITLE
PublicKeyBinary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -35,7 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.8",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -1131,7 +1131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -1169,17 +1169,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "3.2.0"
+name = "ct-codecs"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
-]
+checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
 
 [[package]]
 name = "cxx"
@@ -1361,16 +1354,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-dalek"
-version = "1.0.1"
-source = "git+https://github.com/helium/ed25519-dalek?branch=madninja/bump_rand#d9b58a5375dda817ddd96cf7260e74b6d1cfd1a6"
+name = "ed25519-compact"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3d382e8464107391c8706b4c14b087808ecb909f6c15c34114bc42e53a9e4c"
 dependencies = [
- "curve25519-dalek",
+ "ct-codecs",
  "ed25519",
- "rand",
- "serde",
- "sha2 0.9.9",
- "zeroize",
+ "getrandom",
 ]
 
 [[package]]
@@ -1393,7 +1384,7 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -1439,7 +1430,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1693,17 +1684,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
@@ -1732,7 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1875,17 +1855,18 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.5.0"
-source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.5.0#b0bd7910b7d6065d60c90465c5d679f54280470b"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7701cb46d87e69c557c5a26a5f71b0932e27bd9a08332fc707e0f8754ad5aa0"
 dependencies = [
  "base64",
  "bs58",
- "ed25519-dalek",
+ "ed25519-compact",
  "k256",
  "lazy_static",
  "multihash",
  "p256",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha2 0.10.6",
  "signature",
@@ -2511,9 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
+checksum = "15e5d911412e631e1de11eb313e4dd71f73fd964401102aab23d6c8327c431ba"
 dependencies = [
  "blake2b_simd",
  "blake2s_simd",
@@ -3231,7 +3212,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3241,16 +3222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -3259,7 +3231,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom",
 ]
 
 [[package]]
@@ -3286,7 +3258,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom",
  "redox_syscall",
  "thiserror",
 ]
@@ -3797,7 +3769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest 0.10.6",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -4608,12 +4580,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
@@ -4903,18 +4869,3 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ sqlx = {version = "0", features = [
   "macros",
   "runtime-tokio-rustls"
 ]}
-helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.5.0", features=["sqlx-postgres", "multisig"]}
 helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-crypto = {version = "0.6", features=["sqlx-postgres", "multisig"]}
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
 humantime = "2"
 metrics = "0"

--- a/denylist/src/denylist.rs
+++ b/denylist/src/denylist.rs
@@ -89,7 +89,7 @@ impl DenyList {
         Ok(())
     }
 
-    pub async fn check_key(&self, pub_key: &PublicKey) -> bool {
+    pub async fn check_key<K: AsRef<[u8]>>(&self, pub_key: K) -> bool {
         if self.filter.len() == 0 {
             tracing::warn!("empty denylist filter, rejecting key");
             return true;
@@ -125,9 +125,9 @@ pub fn filter_from_bin(bin: &Vec<u8>) -> Result<Xor32> {
     }
 }
 
-fn public_key_hash(public_key: &PublicKey) -> u64 {
+fn public_key_hash<R: AsRef<[u8]>>(public_key: R) -> u64 {
     let mut hasher = XxHash64::default();
-    hasher.write(&public_key.to_vec());
+    hasher.write(public_key.as_ref());
     hasher.finish()
 }
 

--- a/file_store/src/heartbeat.rs
+++ b/file_store/src/heartbeat.rs
@@ -3,20 +3,17 @@ use crate::{
     Error, Result,
 };
 use chrono::{DateTime, Utc};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_mobile::{CellHeartbeatIngestReportV1, CellHeartbeatReqV1};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CellHeartbeat {
-    #[serde(alias = "pubKey")]
-    pub pubkey: PublicKey,
+    pub pubkey: PublicKeyBinary,
     pub hotspot_type: String,
     pub cell_id: u32,
     pub timestamp: DateTime<Utc>,
-    #[serde(alias = "longitude")]
     pub lon: f64,
-    #[serde(alias = "latitude")]
     pub lat: f64,
     pub operation_mode: bool,
     pub cbsd_category: String,
@@ -42,7 +39,7 @@ impl TryFrom<CellHeartbeatReqV1> for CellHeartbeat {
     fn try_from(v: CellHeartbeatReqV1) -> Result<Self> {
         Ok(Self {
             timestamp: v.timestamp.to_timestamp()?,
-            pubkey: PublicKey::try_from(v.pub_key)?,
+            pubkey: v.pub_key.into(),
             hotspot_type: v.hotspot_type,
             cell_id: v.cell_id,
             lon: v.lon,

--- a/file_store/src/lora_beacon_report.rs
+++ b/file_store/src/lora_beacon_report.rs
@@ -5,15 +5,14 @@ use crate::{
     Error, Result,
 };
 use chrono::{DateTime, Utc};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_lora::{LoraBeaconIngestReportV1, LoraBeaconReportReqV1};
 use helium_proto::DataRate;
 use serde::Serialize;
 
 #[derive(Serialize, Clone, Debug)]
 pub struct LoraBeaconReport {
-    #[serde(alias = "pubKey")]
-    pub pub_key: PublicKey,
+    pub pub_key: PublicKeyBinary,
     pub local_entropy: Vec<u8>,
     pub remote_entropy: Vec<u8>,
     pub data: Vec<u8>,
@@ -87,7 +86,7 @@ impl From<LoraBeaconIngestReport> for LoraBeaconReportReqV1 {
     fn from(v: LoraBeaconIngestReport) -> Self {
         let timestamp = v.report.timestamp();
         Self {
-            pub_key: v.report.pub_key.to_vec(),
+            pub_key: v.report.pub_key.into(),
             local_entropy: v.report.local_entropy,
             remote_entropy: v.report.remote_entropy,
             data: v.report.data,
@@ -111,7 +110,7 @@ impl TryFrom<LoraBeaconReportReqV1> for LoraBeaconReport {
         let timestamp = v.timestamp()?;
 
         Ok(Self {
-            pub_key: PublicKey::try_from(v.pub_key)?,
+            pub_key: v.pub_key.into(),
             local_entropy: v.local_entropy,
             remote_entropy: v.remote_entropy,
             data: v.data,
@@ -130,7 +129,7 @@ impl From<LoraBeaconReport> for LoraBeaconReportReqV1 {
     fn from(v: LoraBeaconReport) -> Self {
         let timestamp = v.timestamp();
         Self {
-            pub_key: v.pub_key.to_vec(),
+            pub_key: v.pub_key.into(),
             local_entropy: v.local_entropy,
             remote_entropy: v.remote_entropy,
             data: v.data,

--- a/file_store/src/lora_witness_report.rs
+++ b/file_store/src/lora_witness_report.rs
@@ -5,15 +5,14 @@ use crate::{
     Error, Result,
 };
 use chrono::{DateTime, Utc};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_lora::{LoraWitnessIngestReportV1, LoraWitnessReportReqV1};
 use helium_proto::DataRate;
 use serde::Serialize;
 
 #[derive(Serialize, Clone, Debug)]
 pub struct LoraWitnessReport {
-    #[serde(alias = "pubKey")]
-    pub pub_key: PublicKey,
+    pub pub_key: PublicKeyBinary,
     pub data: Vec<u8>,
     pub timestamp: DateTime<Utc>,
     pub tmst: u32,
@@ -61,7 +60,7 @@ impl From<LoraWitnessIngestReport> for LoraWitnessReportReqV1 {
     fn from(v: LoraWitnessIngestReport) -> Self {
         let timestamp = v.report.timestamp();
         Self {
-            pub_key: v.report.pub_key.to_vec(),
+            pub_key: v.report.pub_key.into(),
             data: v.report.data,
             timestamp,
             signal: v.report.signal,
@@ -83,7 +82,7 @@ impl TryFrom<LoraWitnessReportReqV1> for LoraWitnessReport {
         let timestamp = v.timestamp()?;
 
         Ok(Self {
-            pub_key: PublicKey::try_from(v.pub_key)?,
+            pub_key: v.pub_key.into(),
             data: v.data,
             timestamp,
             signal: v.signal,
@@ -124,7 +123,7 @@ impl From<LoraWitnessReport> for LoraWitnessReportReqV1 {
     fn from(v: LoraWitnessReport) -> Self {
         let timestamp = v.timestamp();
         Self {
-            pub_key: v.pub_key.to_vec(),
+            pub_key: v.pub_key.into(),
             data: v.data,
             timestamp,
             signal: v.signal,

--- a/file_store/src/speedtest.rs
+++ b/file_store/src/speedtest.rs
@@ -3,19 +3,16 @@ use crate::{
     Error, Result,
 };
 use chrono::{DateTime, Utc};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_mobile::{SpeedtestIngestReportV1, SpeedtestReqV1};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct CellSpeedtest {
-    #[serde(alias = "pubKey")]
-    pub pubkey: PublicKey,
+    pub pubkey: PublicKeyBinary,
     pub serial: String,
     pub timestamp: DateTime<Utc>,
-    #[serde(alias = "uploadSpeed")]
     pub upload_speed: u64,
-    #[serde(alias = "downloadSpeed")]
     pub download_speed: u64,
     pub latency: u32,
 }
@@ -62,7 +59,7 @@ impl From<CellSpeedtest> for SpeedtestReqV1 {
     fn from(v: CellSpeedtest) -> Self {
         let timestamp = v.timestamp();
         SpeedtestReqV1 {
-            pub_key: v.pubkey.to_vec(),
+            pub_key: v.pubkey.into(),
             serial: v.serial,
             timestamp,
             upload_speed: v.upload_speed,
@@ -78,7 +75,7 @@ impl TryFrom<SpeedtestReqV1> for CellSpeedtest {
     fn try_from(value: SpeedtestReqV1) -> Result<Self> {
         let timestamp = value.timestamp()?;
         Ok(Self {
-            pubkey: PublicKey::try_from(value.pub_key)?,
+            pubkey: value.pub_key.into(),
             serial: value.serial,
             timestamp,
             upload_speed: value.upload_speed,

--- a/node_follower/src/follower_service.rs
+++ b/node_follower/src/follower_service.rs
@@ -3,7 +3,7 @@ use crate::{
     Error, GatewayInfoStream, Result, Settings,
 };
 use futures::stream::{self, StreamExt};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::{
     follower::{
         self, follower_gateway_resp_v1::Result as GatewayResult, FollowerGatewayReqV1,
@@ -23,14 +23,14 @@ pub struct FollowerService {
 
 #[async_trait::async_trait]
 impl GatewayInfoResolver for FollowerService {
-    async fn resolve_gateway_info(&mut self, address: &PublicKey) -> Result<GatewayInfo> {
+    async fn resolve_gateway_info(&mut self, address: &PublicKeyBinary) -> Result<GatewayInfo> {
         let req = FollowerGatewayReqV1 {
-            address: address.to_vec(),
+            address: address.clone().into(),
         };
         let res = self.client.find_gateway(req).await?.into_inner();
         match res.result {
             Some(GatewayResult::Info(gateway_info)) => Ok(gateway_info.try_into()?),
-            _ => Err(Error::GatewayNotFound(format!("{address}"))),
+            _ => Err(Error::GatewayNotFound(format!("{address:?}"))),
         }
     }
 }

--- a/node_follower/src/gateway_resp.rs
+++ b/node_follower/src/gateway_resp.rs
@@ -1,13 +1,13 @@
 use crate::{Error, Result};
 use async_trait::async_trait;
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::{
     services::follower::GatewayInfo as GatewayInfoProto, GatewayStakingMode, Region,
 };
 
 #[async_trait]
 pub trait GatewayInfoResolver {
-    async fn resolve_gateway_info(&mut self, address: &PublicKey) -> Result<GatewayInfo>;
+    async fn resolve_gateway_info(&mut self, address: &PublicKeyBinary) -> Result<GatewayInfo>;
 }
 
 #[derive(Debug, Clone)]

--- a/poc_iot_injector/src/receipt_txn.rs
+++ b/poc_iot_injector/src/receipt_txn.rs
@@ -106,7 +106,7 @@ fn construct_poc_witnesses(
 
         // NOTE: channel is irrelevant now
         let poc_witness = BlockchainPocWitnessV1 {
-            gateway: witness_report.report.pub_key.to_vec(),
+            gateway: witness_report.report.pub_key.into(),
             timestamp: witness_report.report.timestamp.timestamp() as u64,
             signal: witness_report.report.signal,
             packet_hash: witness_report.report.data,
@@ -136,7 +136,7 @@ fn construct_poc_receipt(beacon_report: LoraValidBeaconReport) -> Result<Blockch
 
     // NOTE: signal, origin, snr and addr_hash are irrelevant now
     Ok(BlockchainPocReceiptV1 {
-        gateway: beacon_report.report.pub_key.to_vec(),
+        gateway: beacon_report.report.pub_key.into(),
         timestamp: beacon_report.report.timestamp.timestamp() as u64,
         signal: 0,
         data: beacon_report.report.data,

--- a/poc_iot_verifier/src/gateway_cache.rs
+++ b/poc_iot_verifier/src/gateway_cache.rs
@@ -1,5 +1,5 @@
 use crate::{Error, Result, Settings};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use node_follower::{
     follower_service::FollowerService,
     gateway_resp::{GatewayInfo, GatewayInfoResolver},
@@ -11,20 +11,20 @@ const CACHE_TTL: u64 = 86400;
 
 pub struct GatewayCache {
     pub follower_service: FollowerService,
-    pub cache: Cache<PublicKey, GatewayInfo>,
+    pub cache: Cache<PublicKeyBinary, GatewayInfo>,
 }
 
 impl GatewayCache {
     pub async fn from_settings(settings: &Settings) -> Result<Self> {
         let follower_service = FollowerService::from_settings(&settings.follower)?;
-        let cache = Cache::<PublicKey, GatewayInfo>::new();
+        let cache = Cache::<PublicKeyBinary, GatewayInfo>::new();
         Ok(Self {
             follower_service,
             cache,
         })
     }
 
-    pub async fn resolve_gateway_info(&self, address: &PublicKey) -> Result<GatewayInfo> {
+    pub async fn resolve_gateway_info(&self, address: &PublicKeyBinary) -> Result<GatewayInfo> {
         match self.cache.get(address).await {
             Some(hit) => {
                 tracing::debug!("gateway cache hit: {:?}", address);
@@ -46,7 +46,7 @@ impl GatewayCache {
                             .await;
                         Ok(res)
                     }
-                    _ => Err(Error::GatewayNotFound(format!("{address}"))),
+                    _ => Err(Error::GatewayNotFound(format!("{address:?}"))),
                 }
             }
         }

--- a/poc_iot_verifier/src/last_beacon.rs
+++ b/poc_iot_verifier/src/last_beacon.rs
@@ -11,7 +11,7 @@ pub struct LastBeacon {
 }
 
 impl LastBeacon {
-    pub async fn insert_kv<'c, E>(executor: E, id: &Vec<u8>, val: &str) -> Result<Self>
+    pub async fn insert_kv<'c, E>(executor: E, id: &[u8], val: &str) -> Result<Self>
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
@@ -29,7 +29,7 @@ impl LastBeacon {
         .map_err(Error::from)
     }
 
-    pub async fn get<'c, E>(executor: E, id: &Vec<u8>) -> Result<Option<Self>>
+    pub async fn get<'c, E>(executor: E, id: &[u8]) -> Result<Option<Self>>
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
@@ -40,7 +40,7 @@ impl LastBeacon {
             .map_err(Error::from)
     }
 
-    pub async fn last_timestamp<'c, E>(executor: E, id: &Vec<u8>) -> Result<Option<DateTime<Utc>>>
+    pub async fn last_timestamp<'c, E>(executor: E, id: &[u8]) -> Result<Option<DateTime<Utc>>>
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
@@ -63,7 +63,7 @@ impl LastBeacon {
 
     pub async fn update_last_timestamp<'c, E>(
         executor: E,
-        id: &Vec<u8>,
+        id: &[u8],
         timestamp: DateTime<Utc>,
     ) -> Result
     where

--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -15,7 +15,7 @@ use file_store::{
     FileStore, FileType,
 };
 use futures::{stream, StreamExt};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::{
     services::poc_lora::{LoraBeaconIngestReportV1, LoraWitnessIngestReportV1},
     EntropyReportV1, Message,
@@ -329,7 +329,11 @@ impl Loader {
         }
     }
 
-    async fn check_valid_gateway(&self, pub_key: &PublicKey, gateway_cache: &GatewayCache) -> bool {
+    async fn check_valid_gateway(
+        &self,
+        pub_key: &PublicKeyBinary,
+        gateway_cache: &GatewayCache,
+    ) -> bool {
         if self.check_gw_denied(pub_key).await {
             tracing::debug!("dropping denied gateway : {:?}", &pub_key);
             return false;
@@ -341,11 +345,15 @@ impl Loader {
         true
     }
 
-    async fn check_unknown_gw(&self, pub_key: &PublicKey, gateway_cache: &GatewayCache) -> bool {
+    async fn check_unknown_gw(
+        &self,
+        pub_key: &PublicKeyBinary,
+        gateway_cache: &GatewayCache,
+    ) -> bool {
         gateway_cache.resolve_gateway_info(pub_key).await.is_err()
     }
 
-    async fn check_gw_denied(&self, pub_key: &PublicKey) -> bool {
+    async fn check_gw_denied(&self, pub_key: &PublicKeyBinary) -> bool {
         self.deny_list.check_key(pub_key).await
     }
 }

--- a/poc_iot_verifier/src/poc.rs
+++ b/poc_iot_verifier/src/poc.rs
@@ -112,7 +112,7 @@ impl Poc {
 
         // is beaconer allowed to beacon at this time ?
         // any irregularily timed beacons will be rejected
-        match LastBeacon::get(pool, &beaconer_pub_key.to_vec()).await? {
+        match LastBeacon::get(pool, beaconer_pub_key.as_ref()).await? {
             Some(last_beacon) => {
                 let interval_since_last_beacon = beacon_received_ts - last_beacon.timestamp;
                 if interval_since_last_beacon < Duration::seconds(BEACON_INTERVAL) {

--- a/poc_iot_verifier/src/runner.rs
+++ b/poc_iot_verifier/src/runner.rs
@@ -236,7 +236,7 @@ impl Runner {
                 tracing::debug!(
                     "valid beacon. entropy: {:?}, addr: {:?}",
                     beacon.data,
-                    beacon.pub_key.to_string()
+                    beacon.pub_key
                 );
                 // beacon is valid, verify the POC witnesses
                 if let Some(beacon_info) = beacon_verify_result.gateway_info {
@@ -289,7 +289,7 @@ impl Runner {
                 tracing::info!(
                     "invalid beacon. entropy: {:?}, addr: {:?}, reason: {:?}",
                     beacon.data,
-                    beacon.pub_key.to_string(),
+                    beacon.pub_key,
                     invalid_reason
                 );
                 self.handle_invalid_poc(
@@ -307,7 +307,7 @@ impl Runner {
                 tracing::info!(
                     "failed beacon. entropy: {:?}, addr: {:?}",
                     beacon.data,
-                    beacon.pub_key.to_string()
+                    beacon.pub_key
                 );
                 Report::update_attempts(&self.pool, &beacon_report.ingest_id(), Utc::now()).await?;
             }
@@ -389,7 +389,7 @@ impl Runner {
         lora_invalid_witness_tx: &MessageSender,
     ) -> Result {
         let received_timestamp = valid_beacon_report.received_timestamp;
-        let pub_key = valid_beacon_report.report.pub_key.to_vec();
+        let pub_key = valid_beacon_report.report.pub_key.clone();
         let beacon_id = valid_beacon_report.report.report_id(received_timestamp);
         let packet_data = valid_beacon_report.report.data.clone();
         let beacon_report_id = valid_beacon_report.report.report_id(received_timestamp);
@@ -431,8 +431,7 @@ impl Runner {
             }
         }
         // update timestamp of last beacon for the beaconer
-        LastBeacon::update_last_timestamp(&self.pool, &pub_key.to_vec(), received_timestamp)
-            .await?;
+        LastBeacon::update_last_timestamp(&self.pool, pub_key.as_ref(), received_timestamp).await?;
         Report::delete_poc(&self.pool, &packet_data).await?;
         Ok(())
     }

--- a/poc_mobile_verifier/src/heartbeats.rs
+++ b/poc_mobile_verifier/src/heartbeats.rs
@@ -4,7 +4,7 @@ use crate::cell_type::CellType;
 use chrono::{DateTime, NaiveDateTime, Timelike, Utc};
 use file_store::{file_sink, file_sink_write, heartbeat::CellHeartbeat};
 use futures::stream::{Stream, StreamExt};
-use helium_crypto::PublicKey;
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_mobile as proto;
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use rust_decimal_macros::dec;
@@ -13,7 +13,7 @@ use std::{collections::HashMap, ops::Range};
 
 #[derive(Clone)]
 pub struct Heartbeat {
-    pub hotspot_key: PublicKey,
+    pub hotspot_key: PublicKeyBinary,
     pub cbsd_id: String,
     pub reward_weight: Decimal,
     pub timestamp: NaiveDateTime,
@@ -22,7 +22,7 @@ pub struct Heartbeat {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct HeartbeatKey {
-    hotspot_key: PublicKey,
+    hotspot_key: PublicKeyBinary,
     cbsd_id: String,
 }
 
@@ -41,7 +41,7 @@ impl HeartbeatValue {
 }
 
 pub struct HeartbeatReward {
-    pub hotspot_key: PublicKey,
+    pub hotspot_key: PublicKeyBinary,
     pub cbsd_id: String,
     pub reward_weight: Decimal,
 }
@@ -58,7 +58,7 @@ impl Heartbeats {
     pub async fn validated(exec: impl sqlx::PgExecutor<'_>) -> Result<Self, sqlx::Error> {
         #[derive(sqlx::FromRow)]
         pub struct HeartbeatRow {
-            hotspot_key: PublicKey,
+            hotspot_key: PublicKeyBinary,
             cbsd_id: String,
             reward_weight: Decimal,
             hours_seen: [bool; 24],
@@ -168,7 +168,7 @@ impl Heartbeat {
             heartbeats_tx,
             proto::Heartbeat {
                 cbsd_id: self.cbsd_id.clone(),
-                pub_key: self.hotspot_key.to_vec(),
+                pub_key: self.hotspot_key.clone().into(),
                 reward_multiplier: self.reward_weight.to_f32().unwrap_or(0.0),
                 cell_type,
                 validity: self.validity as i32,


### PR DESCRIPTION
This switches internal structs to use PublicKeyBinary as mostly a drop in replacement for PublicKey. 

It also optimizes a number of clones away for report and ingest_id since that's just not needed. 

Requires https://github.com/helium/helium-crypto-rs/pull/41 to land, and versioned, and Cargo.toml to be updated here