### PR TITLE
update proto for new region; scaling factor debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#37abff2b35290818d2f542336b5523269631f60d"
+source = "git+https://github.com/helium/proto?branch=master#80dc9c4ba1bc3b6d3c9fed6b696eaa128f2e1de2"
 dependencies = [
  "bytes",
  "prost",

--- a/density_scaler/src/server.rs
+++ b/density_scaler/src/server.rs
@@ -21,9 +21,7 @@ impl Server {
             trigger_interval: Duration::seconds(settings.trigger),
         };
 
-        tracing::info!("generating hex scaling map : starting {:?}", Utc::now());
         server.refresh_scaling_map().await?;
-        tracing::info!("completed hex scaling map : completed {:?}", Utc::now());
 
         Ok(server)
     }
@@ -55,6 +53,7 @@ impl Server {
     }
 
     pub async fn refresh_scaling_map(&mut self) -> Result {
+        tracing::info!("generating hex scaling map : starting {:?}", Utc::now());
         let mut global_map = GlobalHexMap::new();
         let mut gw_stream = self.follower.active_gateways().await?;
         while let Some(GatewayInfo { location, .. }) = gw_stream.next().await {
@@ -64,7 +63,9 @@ impl Server {
         }
         global_map.reduce_global();
         let new_map = compute_hex_density_map(&global_map);
+        tracing::info!("scaling factor map entries: {}", new_map.len());
         self.hex_density_map.swap(new_map).await;
+        tracing::info!("completed hex scaling map : completed {:?}", Utc::now());
         Ok(())
     }
 }


### PR DESCRIPTION
this change pulls in an update to the helium-proto dependency with support for a missing region (`RU864`) as well as moves/increases some debugging statements surrounding the construction of the hex scaling factor map the density_scaler produces for IoT PoC calculations