### PR TITLE
move hex scaling factor to validation check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#80dc9c4ba1bc3b6d3c9fed6b696eaa128f2e1de2"
+source = "git+https://github.com/helium/proto?branch=master#cd67ce3cba964e693c33376de5cd0127be9c1baf"
 dependencies = [
  "bytes",
  "prost",

--- a/density_scaler/src/error.rs
+++ b/density_scaler/src/error.rs
@@ -6,16 +6,12 @@ pub type Result<T = ()> = std::result::Result<T, Error>;
 pub enum Error {
     #[error("config error")]
     Config(#[from] config::ConfigError),
-    #[error("env error")]
-    Env(#[from] std::env::VarError),
     #[error("io error")]
     Io(#[from] std::io::Error),
     #[error("encode error")]
     Encode(#[from] EncodeError),
     #[error("decode error")]
     Decode(#[from] DecodeError),
-    #[error("query channel error")]
-    QueryChannel,
     #[error("not found")]
     NotFound(String),
     #[error("follower error")]
@@ -41,10 +37,6 @@ pub enum EncodeError {
 impl Error {
     pub fn not_found<E: ToString>(msg: E) -> Self {
         Self::NotFound(msg.to_string())
-    }
-
-    pub fn channel() -> Self {
-        Self::QueryChannel
     }
 }
 


### PR DESCRIPTION
This makes hex scaling factor another validation check, requiring for the density scaler to have found a valid scaling factor decimal for the asserted gateway's hex location. Depends on https://github.com/helium/proto/pull/241 being merged to clean up the branch reference in the root cargo file.

Also performs some minor error handling cleanup related to the previous channel-based implementation of the density scaler.