### PR TITLE
reconcile iot reward shares with updated file_sink api

### DIFF
--- a/poc_iot_verifier/src/main.rs
+++ b/poc_iot_verifier/src/main.rs
@@ -83,7 +83,7 @@ impl Server {
             gateway_rewards_rx,
         )
         .deposits(Some(file_upload_tx.clone()))
-        .write_manifest(true)
+        .auto_commit(false)
         .create()
         .await?;
 
@@ -95,6 +95,7 @@ impl Server {
             reward_manifest_rx,
         )
         .deposits(Some(file_upload_tx.clone()))
+        .auto_commit(false)
         .create()
         .await?;
 

--- a/poc_iot_verifier/src/rewarder.rs
+++ b/poc_iot_verifier/src/rewarder.rs
@@ -63,9 +63,7 @@ impl Rewarder {
             .await??;
         }
 
-        let written_files = file_sink::fetch_manifest(&self.gateway_rewards_tx)
-            .await?
-            .await??;
+        let written_files = file_sink::commit(&self.gateway_rewards_tx).await?.await??;
 
         // Write the rewards manifest for the completed period
         file_sink_write!(
@@ -79,6 +77,8 @@ impl Rewarder {
         )
         .await?
         .await??;
+
+        file_sink::commit(&self.reward_manifest_tx).await?;
 
         let mut transaction = self.pool.begin().await?;
 


### PR DESCRIPTION
the PRs that introduced the IoT reward shares calculations in the IoT verifier got wires crossed with the one that updated the file_sink API to introduce more txn-like semantics to writing out files to the sink. This should fix that error that's currently breaking the main build.