### PR TITLE
adding a bootstrap timestamp to iot verifier meta table

### DIFF
--- a/poc_iot_verifier/migrations/6_gateway_shares.sql
+++ b/poc_iot_verifier/migrations/6_gateway_shares.sql
@@ -6,7 +6,7 @@ create table gateway_shares (
     reward_unit decimal not null,
     -- id of the associated valid poc report
     poc_id bytea not null,
-    primary key(hotspot_key, id)
+    primary key(hotspot_key, poc_id)
 );
 
 create index idx_hotspot_key on gateway_shares (hotspot_key);

--- a/poc_iot_verifier/migrations/7_bootstrap_reward_time.sql
+++ b/poc_iot_verifier/migrations/7_bootstrap_reward_time.sql
@@ -1,0 +1,7 @@
+insert into meta
+    (key, value)
+values
+    ('last_rewarded_end_time', '1671499800000')
+on conflict
+    (key)
+do nothing;


### PR DESCRIPTION
the iot verifier reward schedule needs to be kicked off with a value in the database that allows it to gauge at the next reward interval if it's time to process rewards again or not. we determined the best approach was to add a one-time entry to the database via a migration