### PR TITLE
correctly convert decimals back and forth

### DIFF
--- a/file_store/src/lora_valid_poc.rs
+++ b/file_store/src/lora_valid_poc.rs
@@ -11,9 +11,10 @@ use helium_proto::services::poc_lora::{
     LoraWitnessReportReqV1,
 };
 use rust_decimal::{prelude::ToPrimitive, Decimal};
+use rust_decimal_macros::dec;
 use serde::Serialize;
 
-const SCALE_MULTIPLIER: Decimal = Decimal::ONE_HUNDRED;
+const SCALE_MULTIPLIER: Decimal = dec!(10000);
 
 #[derive(Serialize, Clone, Debug)]
 pub struct LoraValidBeaconReport {


### PR DESCRIPTION
this change corrects a mismatch in the amount of precision being applied to hex scaling factors and reward units when they are serialized to protobuf as u32s for transit over the wire and then back again to decimals on the other side.

we are applying 4 places of decimal precision when creating the decimal value but when converting to a u32 we have not been multiplying by the correct factor to re-initialize the desired decimal value on the other side of the report proto conversion