### PR TITLE
Fix witness error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#c7094737694d22245f9db6977868355ae99b6e74"
+source = "git+https://github.com/helium/proto?branch=andymck/extend-invalid-reason-generic-error#08a19674a2dc9daafa4c0d6495e4f7b46652262b"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=andymck/extend-invalid-reason-generic-error#08a19674a2dc9daafa4c0d6495e4f7b46652262b"
+source = "git+https://github.com/helium/proto?branch=master#22d06927367597b305b83a3743a8ba952a4dbfa3"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ sqlx = {version = "0", features = [
   "macros",
   "runtime-tokio-rustls"
 ]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "andymck/extend-invalid-reason-generic-error", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
 helium-crypto = {version = "0.6", features=["sqlx-postgres", "multisig"]}
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
 humantime = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ sqlx = {version = "0", features = [
   "macros",
   "runtime-tokio-rustls"
 ]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "andymck/extend-invalid-reason-generic-error", features = ["services"]}
 helium-crypto = {version = "0.6", features=["sqlx-postgres", "multisig"]}
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
 humantime = "2"

--- a/iot_verifier/src/gateway_cache.rs
+++ b/iot_verifier/src/gateway_cache.rs
@@ -34,7 +34,6 @@ impl GatewayCache {
     ) -> Result<GatewayInfo, GatewayNotFound> {
         match self.cache.get(address).await {
             Some(hit) => {
-                tracing::debug!("gateway cache hit: {:?}", address);
                 metrics::increment_counter!("oracles_iot_verifier_gateway_cache_hit");
                 Ok(hit.value().clone())
             }

--- a/iot_verifier/src/poc.rs
+++ b/iot_verifier/src/poc.rs
@@ -197,11 +197,10 @@ impl Poc {
                         }
                         VerificationStatus::Failed => {
                             // if a witness check returns failed it suggests something
-                            // unexpected has occurred. propogate this back to caller
-                            // and allow it to do its things
+                            // unexpected has occurred. Fail the witness
                             let failed_reason = invalid_reason_or_default(
                                 witness_result.invalid_reason,
-                                InvalidReason::GenericError,
+                                InvalidReason::UnknownError,
                             );
                             if let Ok(failed_witness) = self
                                 .failed_witness_report(failed_reason, witness_report)
@@ -214,7 +213,7 @@ impl Poc {
                 }
                 Err(_) => {
                     if let Ok(failed_witness) = self
-                        .failed_witness_report(InvalidReason::GenericError, witness_report)
+                        .failed_witness_report(InvalidReason::UnknownError, witness_report)
                         .await
                     {
                         failed_witnesses.push(failed_witness)

--- a/iot_verifier/src/poc.rs
+++ b/iot_verifier/src/poc.rs
@@ -230,11 +230,7 @@ impl Poc {
         tracing::debug!("witness info {:?}", beaconer_info);
         // run the witness verifications
         match self
-            .do_witness_verifications(
-                &witness_info,
-                witness_report,
-                beaconer_info,
-            )
+            .do_witness_verifications(&witness_info, witness_report, beaconer_info)
             .await
         {
             Ok(()) => {
@@ -298,7 +294,7 @@ impl Poc {
             witness_report.report.frequency,
         )?;
         verify_witness_region(beaconer_info.region, witness_info.region)?;
-        verify_witness_distance(beaconer_info.location,witness_info.location)?;
+        verify_witness_distance(beaconer_info.location, witness_info.location)?;
         verify_witness_rssi(
             witness_report.report.signal,
             witness_report.report.frequency,
@@ -316,14 +312,11 @@ impl Poc {
         witness_result: VerifyWitnessResult,
         witness_report: LoraWitnessIngestReport,
     ) -> LoraValidWitnessReport {
-        let gw_info = witness_result
-            .gateway_info.unwrap();
+        let gw_info = witness_result.gateway_info.unwrap();
         LoraValidWitnessReport {
             received_timestamp: witness_report.received_timestamp,
             location: gw_info.location,
-            hex_scale: witness_result
-                .hex_scale
-                .unwrap(),
+            hex_scale: witness_result.hex_scale.unwrap(),
             report: witness_report.report,
             // default reward units to zero until we've got the full count of
             // valid, non-failed witnesses for the final validated poc report
@@ -338,8 +331,7 @@ impl Poc {
     ) -> LoraInvalidWitnessReport {
         LoraInvalidWitnessReport {
             received_timestamp: witness_report.received_timestamp,
-            reason: witness_result
-                .invalid_reason.unwrap(),
+            reason: witness_result.invalid_reason.unwrap(),
             report: witness_report.report,
             participant_side: InvalidParticipantSide::Witness,
         }
@@ -352,9 +344,7 @@ impl Poc {
     ) -> LoraInvalidWitnessReport {
         LoraInvalidWitnessReport {
             received_timestamp: witness_report.received_timestamp,
-            reason: witness_result
-                .invalid_reason
-                .unwrap(),
+            reason: witness_result.invalid_reason.unwrap(),
             report: witness_report.report,
             participant_side: InvalidParticipantSide::Witness,
         }
@@ -509,7 +499,10 @@ fn verify_witness_region(beacon_region: Region, witness_region: Region) -> Gener
 }
 
 /// verify witness does not exceed max distance from beaconer
-fn verify_witness_distance(beacon_loc: Option<u64>, witness_loc: Option<u64>) -> GenericVerifyResult {
+fn verify_witness_distance(
+    beacon_loc: Option<u64>,
+    witness_loc: Option<u64>,
+) -> GenericVerifyResult {
     // other verifications handle location checks but dont assume
     // we have a valid location passed in here
     // if no location for either beaconer or witness then default
@@ -772,7 +765,10 @@ mod tests {
         let beacon_loc = 631615575095659519; // malta
         let witness1_loc = 631615575095699519; // malta and a lil out from the beaconer
         let witness2_loc = 631278052025960447; // armenia
-        assert_eq!(Ok(()), verify_witness_distance(Some(beacon_loc), Some(witness1_loc)));
+        assert_eq!(
+            Ok(()),
+            verify_witness_distance(Some(beacon_loc), Some(witness1_loc))
+        );
         assert_eq!(
             Err(InvalidReason::MaxDistanceExceeded),
             verify_witness_distance(Some(beacon_loc), Some(witness2_loc))
@@ -816,7 +812,6 @@ mod tests {
                 beacon2_gain,
                 Some(beacon_loc),
                 Some(witness2_loc),
-
             )
         );
     }

--- a/iot_verifier/src/poc.rs
+++ b/iot_verifier/src/poc.rs
@@ -211,7 +211,8 @@ impl Poc {
                         }
                     }
                 }
-                Err(_) => {
+                Err(err) => {
+                    tracing::warn!("Unexpected error verifying witness: {err:?}");
                     if let Ok(failed_witness) = self
                         .failed_witness_report(InvalidReason::UnknownError, witness_report)
                         .await

--- a/iot_verifier/src/purger.rs
+++ b/iot_verifier/src/purger.rs
@@ -210,10 +210,6 @@ impl Purger {
             report: beacon.clone(),
         }
         .into();
-        tracing::debug!(
-            "purging beacon with entropy: {:?}, time: {received_timestamp}",
-            db_beacon.remote_entropy
-        );
         file_sink_write!(
             "invalid_beacon",
             lora_invalid_beacon_tx,
@@ -243,10 +239,6 @@ impl Purger {
             participant_side: InvalidParticipantSide::Witness,
         }
         .into();
-        tracing::debug!(
-            "purging witness with packet data: {:?}, time: {received_timestamp}",
-            db_witness.packet_data
-        );
         file_sink_write!(
             "invalid_witness_report",
             lora_invalid_witness_tx,

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -219,7 +219,6 @@ impl Runner {
 
         let db_witnesses = Report::get_witnesses_for_beacon(&self.pool, packet_data).await?;
         let witness_len = db_witnesses.len();
-        tracing::debug!("found {witness_len} witness for beacon");
         metrics::gauge!(
             "oracles_iot_verifier_witnesses_per_beacon",
             witness_len as f64
@@ -241,11 +240,6 @@ impl Runner {
             .await?;
         match beacon_verify_result.result {
             VerificationStatus::Valid => {
-                tracing::debug!(
-                    "valid beacon. entropy: {:?}, addr: {:?}",
-                    beacon.data,
-                    beacon.pub_key
-                );
                 // beacon is valid, verify the POC witnesses
                 if let Some(beacon_info) = beacon_verify_result.gateway_info {
                     let mut verified_witnesses_result = poc
@@ -297,12 +291,6 @@ impl Runner {
                     .invalid_reason else {
                         anyhow::bail!("invalid_reason is None");
                     };
-                tracing::debug!(
-                    "invalid beacon. entropy: {:?}, addr: {:?}, reason: {:?}",
-                    beacon.data,
-                    beacon.pub_key,
-                    invalid_reason
-                );
                 self.handle_invalid_poc(
                     &beacon_report,
                     witnesses,
@@ -344,6 +332,12 @@ impl Runner {
             report: beacon.clone(),
         };
         let invalid_poc_proto: LoraInvalidBeaconReportV1 = invalid_poc.into();
+        tracing::debug!(
+            "invalid poc.  beaconer: {:?}, reason: {:?}, witness count:{:?}",
+            beacon_report.report.pub_key,
+            invalid_reason,
+            witness_reports.len()
+        );
         // save invalid poc to s3, if write fails update attempts and go no further
         // allow the poc to be reprocessed next tick
         match file_sink_write!(
@@ -406,6 +400,12 @@ impl Runner {
         let beacon_id = valid_beacon_report.report.report_id(received_timestamp);
         let packet_data = valid_beacon_report.report.data.clone();
         let beacon_report_id = valid_beacon_report.report.report_id(received_timestamp);
+        tracing::debug!(
+            "valid poc.  beaconer: {:?}, valid witness count:  {:?}  invalid witness count: {:?}",
+            pub_key,
+            witnesses_result.valid_witnesses.len(),
+            witnesses_result.invalid_witnesses.len()
+        );
         let valid_poc: LoraValidPoc = LoraValidPoc {
             poc_id: beacon_id,
             beacon_report: valid_beacon_report,

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -177,13 +177,15 @@ impl Runner {
                 let tx3 = lora_valid_poc_tx.clone();
                 let hdm = hex_density_map.clone();
                 async move {
+                    let beacon_id = db_beacon.id.clone();
                     match self
                         .handle_beacon_report(db_beacon, tx1, tx2, tx3, gateway_cache, hdm)
                         .await
                     {
                         Ok(()) => (),
                         Err(err) => {
-                            tracing::warn!("failed to handle beacon: {err:?}")
+                            tracing::warn!("failed to handle beacon: {err:?}");
+                            _ = Report::update_attempts(&self.pool, &beacon_id, Utc::now()).await;
                         }
                     }
                 }


### PR DESCRIPTION
This addresses an issue with how the refactored POC module handled errors after the prior merged `anyhow` changes.

If the handling of any one of N witnesses for a beacon resulted in an error ( such as when a witness has no asserted location ) then that would halt any further processing of remaining witnesses and also result in the beacon itself failing to complete verification.

The DB would also not be updated to bump the `attempts` count on either the failing witness or associated beacon and thus the POC would get stuck in a loop of being verified and failing each tick until they end up being purged by the purger.

Thus this PR makes the following logic assumptions:

1.   `poc::verify_beacon` and `poc::verify_witnesses` will return Result<VerifyResult, VerificationError>.  VerificationError is only returned in the event the verification cannot proceed/complete.  In such a scenario, the caller which in this case is the runner will update the attempts count for the beacon in the DB.  Once it exceeds MAX_ATTEMPTS it will not be reselected again for verification
2. An error which occurs whilst verifying any one individual witness will not block verification of subsequent witnesses and will not propagate an error back to the caller ( ie the runner )
3. If an individual verification ( such as verify_gw_location or verify_witness_distance etc ) cannot derive the data it requires in order to complete verification ( such as the gateway location ) then it will not throw an error but instead return an expected result which renders the verification result as `InValid` and in handled within the poc::verify_witnesses API itself.

