### PR TITLE
deny all rustc warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    env:
+      RUSTFLAGS: -D warnings
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Since the problem was rustc warnings sneaking through CI, I'm trying this as an alternative to #281 