### PR TITLE
Hold on to locks as little as necessary

### DIFF
--- a/poc_iot_verifier/src/loader.rs
+++ b/poc_iot_verifier/src/loader.rs
@@ -342,11 +342,8 @@ impl Loader {
                         };
                         metrics::increment_counter!("oracles_poc_iot_verifier_loader_beacon");
                         if let Some(xor_data) = xor_data {
-                            xor_data
-                                .lock()
-                                .await
-                                .deref_mut()
-                                .push(filter_key_hash(&beacon.report.data))
+                            let key_hash = filter_key_hash(&beacon.report.data);
+                            xor_data.lock().await.deref_mut().push(key_hash)
                         };
                         Ok(Some(res))
                     }


### PR DESCRIPTION
I'm pretty sure that moving the call to `filter_key_hash` to before lock acquire time makes sense, if perhaps with little runtime benefit.

The bigger question is how locks are used in purger. From what I can see, the current use of [`for_each_concurrent`]() is not concurrent at all since the closures are all serialized on [acquiring a lock]()