### PR TITLE
Add support to squish witnesses per receipt

### DIFF
--- a/poc_iot_injector/pkg/settings-template.toml
+++ b/poc_iot_injector/pkg/settings-template.toml
@@ -19,6 +19,9 @@ keypair = "/path/to/key_pair"
 #
 # do_submission = false
 
+# Number of witnesses allowed per receipt
+#
+# max_witnesses_per_receipt = 14
 
 [database]
 

--- a/poc_iot_injector/src/cli/generate.rs
+++ b/poc_iot_injector/src/cli/generate.rs
@@ -32,6 +32,7 @@ impl Cmd {
             .await?;
 
         let poc_oracle_key = settings.keypair()?;
+        let max_witnesses_per_receipt = settings.max_witnesses_per_receipt;
         let shared_key = Arc::new(poc_oracle_key);
 
         let mut success_counter = 0;
@@ -43,7 +44,9 @@ impl Cmd {
 
         while let Some(msg) = files.next().await {
             let shared_key_clone = shared_key.clone();
-            if let Ok(txn_details) = handle_report_msg(msg.clone(), shared_key_clone) {
+            if let Ok(txn_details) =
+                handle_report_msg(msg.clone(), shared_key_clone, max_witnesses_per_receipt)
+            {
                 tracing::debug!("txn_bin: {:?}", txn_details.txn.encode_to_vec());
                 success_counter += 1;
             } else {

--- a/poc_iot_injector/src/receipt_txn.rs
+++ b/poc_iot_injector/src/receipt_txn.rs
@@ -72,11 +72,8 @@ fn maybe_squish_witnesses(
     }
 
     // Seed a random number from the poc_id for shuffling the witnesses
-    let mut hasher = Sha256::new();
-    hasher.update(poc_id);
-    let mut seed: [u8; 32] = [0; 32];
-    seed.copy_from_slice(&hasher.finalize());
-    let mut rng = StdRng::from_seed(seed);
+    let seed = Sha256::digest(poc_id);
+    let mut rng = StdRng::from_seed(seed.into());
 
     // Shuffle and truncate witnesses
     poc_witnesses.shuffle(&mut rng);

--- a/poc_iot_injector/src/receipt_txn.rs
+++ b/poc_iot_injector/src/receipt_txn.rs
@@ -7,6 +7,7 @@ use helium_proto::{
     blockchain_txn::Txn, BlockchainPocPathElementV1, BlockchainPocReceiptV1,
     BlockchainPocWitnessV1, BlockchainTxn, BlockchainTxnPocReceiptsV2, Message,
 };
+use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
@@ -31,12 +32,18 @@ pub enum TxnConstructionError {
 pub fn handle_report_msg(
     msg: prost::bytes::BytesMut,
     keypair: Arc<Keypair>,
+    max_witnesses_per_receipt: u64,
 ) -> Result<TxnDetails, TxnConstructionError> {
     // Path is always single element, till we decide to change it at some point.
     let mut path: PocPath = Vec::with_capacity(1);
     let lora_valid_poc = LoraValidPoc::decode(msg)?;
 
-    let poc_witnesses = construct_poc_witnesses(lora_valid_poc.witness_reports);
+    let mut poc_witnesses = construct_poc_witnesses(lora_valid_poc.witness_reports);
+    maybe_squish_witnesses(
+        &mut poc_witnesses,
+        &lora_valid_poc.poc_id,
+        max_witnesses_per_receipt as usize,
+    );
 
     let (poc_receipt, beacon_received_ts) = construct_poc_receipt(lora_valid_poc.beacon_report);
 
@@ -52,6 +59,28 @@ pub fn handle_report_msg(
         hash,
         hash_b64_url,
     })
+}
+
+/// Maybe squish poc_witnesses if the length is >= max_witnesses_per_receipt
+fn maybe_squish_witnesses(
+    poc_witnesses: &mut Vec<BlockchainPocWitnessV1>,
+    poc_id: &Vec<u8>,
+    max_witnesses_per_receipt: usize,
+) {
+    if poc_witnesses.len() <= max_witnesses_per_receipt {
+        return;
+    }
+
+    // Seed a random number from the poc_id for shuffling the witnesses
+    let mut hasher = Sha256::new();
+    hasher.update(poc_id);
+    let mut seed: [u8; 32] = [0; 32];
+    seed.copy_from_slice(&hasher.finalize());
+    let mut rng = StdRng::from_seed(seed);
+
+    // Shuffle and truncate witnesses
+    poc_witnesses.shuffle(&mut rng);
+    poc_witnesses.truncate(max_witnesses_per_receipt)
 }
 
 fn wrap_txn(txn: BlockchainTxnPocReceiptsV2) -> BlockchainTxn {
@@ -173,4 +202,52 @@ fn sign_txn(
     let mut txn = txn.clone();
     txn.signature = vec![];
     Ok(keypair.sign(&txn.encode_to_vec())?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_witnesses_per_receipt_test() {
+        let poc_witness = BlockchainPocWitnessV1 {
+            gateway: vec![],
+            timestamp: 123,
+            signal: 0,
+            packet_hash: vec![],
+            signature: vec![],
+            snr: 0.0,
+            frequency: 0.0,
+            datarate: "dr".to_string(),
+            channel: 0,
+            reward_shares: 0,
+        };
+        let poc_id: Vec<u8> = vec![0];
+        let max_witnesses_per_receipt = 14;
+
+        let mut to_be_squished_witnesses = vec![poc_witness.clone(); 20];
+        assert_eq!(20, to_be_squished_witnesses.len());
+        maybe_squish_witnesses(
+            &mut to_be_squished_witnesses,
+            &poc_id,
+            max_witnesses_per_receipt,
+        );
+        assert_eq!(14, to_be_squished_witnesses.len());
+        let mut non_squished_witnesses = vec![poc_witness.clone(); 14];
+        assert_eq!(14, non_squished_witnesses.len());
+        maybe_squish_witnesses(
+            &mut non_squished_witnesses,
+            &poc_id,
+            max_witnesses_per_receipt,
+        );
+        assert_eq!(14, non_squished_witnesses.len());
+        let mut non_squished_witnesses2 = vec![poc_witness; 10];
+        assert_eq!(10, non_squished_witnesses2.len());
+        maybe_squish_witnesses(
+            &mut non_squished_witnesses2,
+            &poc_id,
+            max_witnesses_per_receipt,
+        );
+        assert_eq!(10, non_squished_witnesses2.len());
+    }
 }

--- a/poc_iot_injector/src/settings.rs
+++ b/poc_iot_injector/src/settings.rs
@@ -2,7 +2,7 @@ use config::{Config, Environment, File};
 use serde::Deserialize;
 use std::{path::Path, time::Duration};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Settings {
     /// RUST_LOG compatible settings string. Defsault to
     /// "poc_iot_injector=debug,poc_store=info"

--- a/poc_iot_injector/src/settings.rs
+++ b/poc_iot_injector/src/settings.rs
@@ -24,6 +24,8 @@ pub struct Settings {
     pub transactions: node_follower::Settings,
     pub verifier: file_store::Settings,
     pub metrics: poc_metrics::Settings,
+    #[serde(default = "default_max_witnesses_per_receipt")]
+    pub max_witnesses_per_receipt: u64,
     /// Local folder for storing intermediate files
     pub cache: String,
     pub output: file_store::Settings,
@@ -43,6 +45,10 @@ pub fn default_do_submission() -> bool {
 
 fn default_trigger_interval() -> u64 {
     1800
+}
+
+pub fn default_max_witnesses_per_receipt() -> u64 {
+    14
 }
 
 impl Settings {


### PR DESCRIPTION
- Add `max_witnesses_per_receipt` setting. Default = 14.
- Maybe squish poc_witnesses if the length of witnesses is > max_witnesses_per_receipt. Seed a random number from the poc_id for shuffling the witnesses and truncating the witnesses