### PR TITLE
Timing related tweaks and conflict support for bulk inserts

### DIFF
--- a/iot_verifier/src/poc.rs
+++ b/iot_verifier/src/poc.rs
@@ -29,7 +29,8 @@ pub const C: f64 = 2.998e8;
 pub const R: f64 = 6.371e6;
 
 /// the cadence in seconds at which hotspots are permitted to beacon
-const BEACON_INTERVAL: i64 = (10 * 60) - 10; // 10 mins ( minus 10 sec tolerance )
+/// 6 hours with 10 min tolerance
+const BEACON_INTERVAL: i64 = (60 * 60 * 6) - (10 * 60);
 /// max permitted distance of a witness from a beaconer measured in KM
 const POC_DISTANCE_LIMIT: i32 = 100;
 

--- a/iot_verifier/src/poc.rs
+++ b/iot_verifier/src/poc.rs
@@ -782,12 +782,9 @@ mod tests {
             timestamp: now - *BEACON_INTERVAL,
         });
         // last beacon was BEACON_INTERVAL in the past, expectation pass
-        assert_eq!(Ok(()), verify_beacon_schedule(&last_beacon, now));
+        assert!(verify_beacon_schedule(&last_beacon, now).is_ok());
         // last beacon was BEACON_INTERVAL + 1hr in the past, expectation pass
-        assert_eq!(
-            Ok(()),
-            verify_beacon_schedule(&last_beacon, now + Duration::minutes(60))
-        );
+        assert!(verify_beacon_schedule(&last_beacon, now + Duration::minutes(60)).is_ok());
         // last beacon was BEACON_INTERVAL - 1 hr, too soon after our last beacon,
         // expectation fail
         assert_eq!(
@@ -805,15 +802,13 @@ mod tests {
         );
         // last beacon was just inside of our tolerance period by 2 mins
         // expectation pass
-        assert_eq!(
-            Ok(()),
-            verify_beacon_schedule(
-                &last_beacon,
-                now - (*BEACON_INTERVAL_TOLERANCE - Duration::minutes(2))
-            )
-        );
+        assert!(verify_beacon_schedule(
+            &last_beacon,
+            now - (*BEACON_INTERVAL_TOLERANCE - Duration::minutes(2))
+        )
+        .is_ok());
         //we dont have any last beacon data, expectation pass
-        assert_eq!(Ok(()), verify_beacon_schedule(&None, now));
+        assert!(verify_beacon_schedule(&None, now).is_ok());
     }
 
     #[test]
@@ -821,10 +816,7 @@ mod tests {
         let now = Utc::now();
         let entropy_start = now - Duration::seconds(60);
         let entropy_end = now - Duration::seconds(10);
-        assert_eq!(
-            Ok(()),
-            verify_entropy(entropy_start, entropy_end, now - Duration::seconds(30))
-        );
+        assert!(verify_entropy(entropy_start, entropy_end, now - Duration::seconds(30)).is_ok());
         assert_eq!(
             Err(InvalidReason::EntropyExpired),
             verify_entropy(entropy_start, entropy_end, now - Duration::seconds(1))
@@ -838,14 +830,14 @@ mod tests {
     #[test]
     fn test_verify_location() {
         let location = 631252734740306943;
-        assert_eq!(Ok(()), verify_gw_location(Some(location)));
+        assert!(verify_gw_location(Some(location)).is_ok());
         assert_eq!(Err(InvalidReason::NotAsserted), verify_gw_location(None));
     }
 
     #[test]
     fn test_verify_capability() {
-        assert_eq!(Ok(()), verify_gw_capability(GatewayStakingMode::Full));
-        assert_eq!(Ok(()), verify_gw_capability(GatewayStakingMode::Light));
+        assert!(verify_gw_capability(GatewayStakingMode::Full).is_ok());
+        assert!(verify_gw_capability(GatewayStakingMode::Light).is_ok());
         assert_eq!(
             Err(InvalidReason::InvalidCapability),
             verify_gw_capability(GatewayStakingMode::Dataonly)
@@ -859,7 +851,7 @@ mod tests {
                 .unwrap();
         let key2 = PublicKeyBinary::from_str("11z69eJ3czc92k6snrfR9ek7g2uRWXosFbnG9v4bXgwhfUCivUo")
             .unwrap();
-        assert_eq!(Ok(()), verify_self_witness(&key1, &key2));
+        assert!(verify_self_witness(&key1, &key2).is_ok());
         assert_eq!(
             Err(InvalidReason::SelfWitness),
             verify_self_witness(&key1, &key1)
@@ -876,8 +868,9 @@ mod tests {
         let witness2_freq = beacon_freq + (1000 * 100);
         // over the tolerance level
         let witness3_freq = beacon_freq + (1000 * 110);
-        assert_eq!(Ok(()), verify_witness_freq(beacon_freq, witness1_freq));
-        assert_eq!(Ok(()), verify_witness_freq(beacon_freq, witness2_freq));
+
+        assert!(verify_witness_freq(beacon_freq, witness1_freq).is_ok());
+        assert!(verify_witness_freq(beacon_freq, witness2_freq).is_ok());
         assert_eq!(
             Err(InvalidReason::InvalidFrequency),
             verify_witness_freq(beacon_freq, witness3_freq)
@@ -889,10 +882,7 @@ mod tests {
         let beacon_region = Region::Us915;
         let witness1_region = Region::Us915;
         let witness2_region = Region::Eu868;
-        assert_eq!(
-            Ok(()),
-            verify_witness_region(beacon_region, witness1_region)
-        );
+        assert!(verify_witness_region(beacon_region, witness1_region).is_ok());
         assert_eq!(
             Err(InvalidReason::InvalidRegion),
             verify_witness_region(beacon_region, witness2_region)
@@ -904,10 +894,7 @@ mod tests {
         let beacon_loc = 631615575095659519; // malta
         let witness1_loc = 631615575095699519; // malta and a lil out from the beaconer
         let witness2_loc = 631278052025960447; // armenia
-        assert_eq!(
-            Ok(()),
-            verify_witness_distance(Some(beacon_loc), Some(witness1_loc))
-        );
+        assert!(verify_witness_distance(Some(beacon_loc), Some(witness1_loc)).is_ok());
         assert_eq!(
             Err(InvalidReason::MaxDistanceExceeded),
             verify_witness_distance(Some(beacon_loc), Some(witness2_loc))
@@ -926,18 +913,15 @@ mod tests {
         let beacon1_gain = 80;
         let witness1_signal = -1060;
         let witness1_freq = 904700032;
-        assert_eq!(
-            Ok(()),
-            verify_witness_rssi(
-                witness1_signal,
-                witness1_freq,
-                beacon1_tx_power,
-                beacon1_gain,
-                Some(beacon_loc),
-                Some(witness1_loc),
-            )
-        );
-
+        assert!(verify_witness_rssi(
+            witness1_signal,
+            witness1_freq,
+            beacon1_tx_power,
+            beacon1_gain,
+            Some(beacon_loc),
+            Some(witness1_loc),
+        )
+        .is_ok());
         let beacon2_tx_power = 27;
         let beacon2_gain = 12;
         let witness2_signal = -19;
@@ -960,7 +944,7 @@ mod tests {
         let beacon_data = "data1".as_bytes().to_vec();
         let witness1_data = "data1".as_bytes().to_vec();
         let witness2_data = "data2".as_bytes().to_vec();
-        assert_eq!(Ok(()), verify_witness_data(&beacon_data, &witness1_data));
+        assert!(verify_witness_data(&beacon_data, &witness1_data).is_ok());
         assert_eq!(
             Err(InvalidReason::InvalidPacket),
             verify_witness_data(&beacon_data, &witness2_data)

--- a/iot_verifier/src/poc_report.rs
+++ b/iot_verifier/src/poc_report.rs
@@ -16,7 +16,7 @@ const REPORT_INSERT_SQL: &str = "insert into poc_report (
     report_type,
     status
 ) ";
-const REPORT_INSERT_CONFLICT_SQL: &str = " on conflict (id) do nothing ";
+const REPORT_INSERT_CONFLICT_SQL: &str = " on conflict (poc_report.id) do nothing ";
 
 #[derive(sqlx::Type, Serialize, Deserialize, Debug)]
 #[sqlx(type_name = "reporttype", rename_all = "lowercase")]

--- a/iot_verifier/src/poc_report.rs
+++ b/iot_verifier/src/poc_report.rs
@@ -16,7 +16,6 @@ const REPORT_INSERT_SQL: &str = "insert into poc_report (
     report_type,
     status
 ) ";
-const REPORT_INSERT_CONFLICT_SQL: &str = " on conflict (poc_report.id) do nothing ";
 
 #[derive(sqlx::Type, Serialize, Deserialize, Debug)]
 #[sqlx(type_name = "reporttype", rename_all = "lowercase")]
@@ -124,7 +123,8 @@ impl Report {
                 .push_bind(insert.report_type)
                 .push_bind(insert.status);
         });
-        query_builder.push(REPORT_INSERT_CONFLICT_SQL);
+        // append conflict strategy to each insert row
+        query_builder.push(" on conflict (poc_report.id) do nothing ");
         let query = query_builder.build();
         query
             .execute(executor)

--- a/iot_verifier/src/poc_report.rs
+++ b/iot_verifier/src/poc_report.rs
@@ -16,6 +16,7 @@ const REPORT_INSERT_SQL: &str = "insert into poc_report (
     report_type,
     status
 ) ";
+const REPORT_INSERT_CONFLICT_SQL: &str = " on conflict (id) do nothing ";
 
 #[derive(sqlx::Type, Serialize, Deserialize, Debug)]
 #[sqlx(type_name = "reporttype", rename_all = "lowercase")]
@@ -123,7 +124,7 @@ impl Report {
                 .push_bind(insert.report_type)
                 .push_bind(insert.status);
         });
-
+        query_builder.push(REPORT_INSERT_CONFLICT_SQL);
         let query = query_builder.build();
         query
             .execute(executor)

--- a/iot_verifier/src/purger.rs
+++ b/iot_verifier/src/purger.rs
@@ -28,12 +28,9 @@ const PURGER_DB_POOL_SIZE: usize = PURGER_WORKERS * 4;
 // opportunity to be verified and after this point extremely unlikely to ever be verified
 // successfully
 // this value will be added to the env var BASE_STALE_PERIOD to determine final setting
-const BEACON_STALE_PERIOD: i64 = 60 * 30;
+const BEACON_STALE_PERIOD: i64 = 60 * 45;
 /// the period in seconds after when a witness report in the DB will be deemed stale
-// extend witness stale period beyond that of beacons
-// witnesses are inserted into the DB up to 10 mins before beacons
-// due to the loader sequentially loading witnesses then beacons
-const WITNESS_STALE_PERIOD: i64 = BEACON_STALE_PERIOD + (15 * 60);
+const WITNESS_STALE_PERIOD: i64 = 60 * 45;
 /// the period of time in seconds after which entropy will be deemed stale
 /// and purged from the DB
 // this value should be > that beacon stale period to allow for any beacon


### PR DESCRIPTION
- Adds conflict strategy for bulk inserts. If the verifier is abruptly shutdown or crashes there is a potential to reload reports which were previously loaded.  Without the `conflict` strategy we get a lot of noisy errors polluting the logs
- Extends expected beacon interval from 10 mins to 6 hours and define beacon intervals as duration rather than i64s
- Explicitly define beacon interval tolerance and enhance related test
- Set interval before a stale beacon or witness report is purged to the same value