### PR TITLE
initial pass at removing node follower, prep verifier for solana integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,7 @@ dependencies = [
  "config",
  "futures",
  "h3ron",
+ "helium-crypto",
  "helium-proto",
  "http",
  "itertools",

--- a/density_scaler/Cargo.toml
+++ b/density_scaler/Cargo.toml
@@ -26,3 +26,4 @@ rust_decimal_macros = {workspace = true}
 config = {workspace = true}
 async-trait = {workspace = true}
 itertools = {workspace = true}
+helium-crypto = {workspace = true }

--- a/density_scaler/src/hex.rs
+++ b/density_scaler/src/hex.rs
@@ -60,6 +60,12 @@ impl SharedHexDensityMap {
     }
 }
 
+impl Default for SharedHexDensityMap {
+    fn default() -> Self {
+        Self(Arc::new(RwLock::new(HashMap::new())))
+    }
+}
+
 #[async_trait::async_trait]
 impl HexDensityMap for SharedHexDensityMap {
     async fn get(&self, hex: u64) -> Option<Decimal> {
@@ -112,6 +118,12 @@ impl GlobalHexMap {
             &mut self.clipped_hexes,
             starting_hexes,
         )
+    }
+}
+
+impl Default for GlobalHexMap {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/density_scaler/src/lib.rs
+++ b/density_scaler/src/lib.rs
@@ -1,5 +1,5 @@
 mod error;
-mod hex;
+pub mod hex;
 pub mod server;
 pub mod settings;
 

--- a/density_scaler/src/server.rs
+++ b/density_scaler/src/server.rs
@@ -1,71 +1,23 @@
 use crate::{
-    hex::{compute_hex_density_map, GlobalHexMap, HexDensityMap, SharedHexDensityMap},
-    Result, Settings,
+    hex::{HexDensityMap, SharedHexDensityMap},
+    Settings,
 };
-use chrono::{Duration, Utc};
-use futures::stream::StreamExt;
-use node_follower::{follower_service::FollowerService, gateway_resp::GatewayInfo};
-use tokio::time;
+use chrono::Duration;
 
 pub struct Server {
-    hex_density_map: SharedHexDensityMap,
-    follower: FollowerService,
-    trigger_interval: Duration,
+    pub hex_density_map: SharedHexDensityMap,
+    pub trigger_interval: Duration,
 }
 
 impl Server {
-    pub async fn from_settings(settings: Settings) -> Result<Self> {
-        let mut server = Self {
+    pub async fn from_settings(settings: Settings) -> Self {
+        Self {
             hex_density_map: SharedHexDensityMap::new(),
-            follower: FollowerService::from_settings(&settings.follower),
             trigger_interval: Duration::seconds(settings.trigger),
-        };
-
-        server.refresh_scaling_map().await?;
-
-        Ok(server)
+        }
     }
 
     pub fn hex_density_map(&self) -> impl HexDensityMap {
         self.hex_density_map.clone()
-    }
-
-    pub async fn run(&mut self, shutdown: &triggered::Listener) -> Result {
-        tracing::info!("starting density scaler process");
-
-        let mut trigger_timer = time::interval(
-            self.trigger_interval
-                .to_std()
-                .expect("valid interval in seconds"),
-        );
-
-        loop {
-            if shutdown.is_triggered() {
-                tracing::info!("stopping density scaler");
-                return Ok(());
-            }
-
-            tokio::select! {
-                _ = trigger_timer.tick() => self.refresh_scaling_map().await?,
-                _ = shutdown.clone() => return Ok(()),
-            }
-        }
-    }
-
-    pub async fn refresh_scaling_map(&mut self) -> Result {
-        tracing::info!("generating hex scaling map : starting {:?}", Utc::now());
-        let mut global_map = GlobalHexMap::new();
-        let mut gw_stream = self.follower.active_gateways().await?;
-        while let Some(GatewayInfo { location, .. }) = gw_stream.next().await {
-            if let Some(h3index) = location {
-                global_map.increment_unclipped(h3index)
-            }
-        }
-        global_map.reduce_global();
-        let new_map = compute_hex_density_map(&global_map);
-        tracing::info!("scaling factor map entries: {}", new_map.len());
-        self.hex_density_map.swap(new_map).await;
-        tracing::info!("completed hex scaling map : completed {:?}", Utc::now());
-        Ok(())
     }
 }

--- a/iot_verifier/src/gateway_cache.rs
+++ b/iot_verifier/src/gateway_cache.rs
@@ -1,41 +1,58 @@
-use crate::Settings;
+use crate::{helius, Settings};
+use futures::stream::TryStreamExt;
 use helium_crypto::PublicKeyBinary;
-use node_follower::{
-    follower_service::FollowerService,
-    gateway_resp::{GatewayInfo, GatewayInfoResolver},
-};
+use helius::GatewayInfo;
 use retainer::Cache;
+use sqlx::PgPool;
 use std::{sync::Arc, time::Duration};
 use tokio::task::JoinHandle;
 
-/// how long each cached items takes to expire ( 12 hours in seconds)
+// how long each cached items takes to expire ( 12 hours in seconds)
 const CACHE_TTL: Duration = Duration::from_secs(12 * (60 * 60));
 /// how often to evict expired items from the cache ( every 1 hour)
 const CACHE_EVICTION_FREQUENCY: Duration = Duration::from_secs(60 * 60);
 
+const HELIUS_DB_POOL_SIZE: usize = 100;
+
 pub struct GatewayCache {
-    pub follower_service: FollowerService,
+    pool: PgPool,
     pub cache: Arc<Cache<PublicKeyBinary, GatewayInfo>>,
     pub cache_monitor: JoinHandle<()>,
 }
+
+#[derive(thiserror::Error, Debug)]
+#[error("error creating gateway cache: {0}")]
+pub struct NewGatewayCacheError(#[from] db_store::Error);
 
 #[derive(thiserror::Error, Debug)]
 #[error("gateway not found: {0}")]
 pub struct GatewayNotFound(PublicKeyBinary);
 
 impl GatewayCache {
-    pub fn from_settings(settings: &Settings) -> Self {
-        let follower_service = FollowerService::from_settings(&settings.follower);
+    pub async fn from_settings(settings: &Settings) -> Result<Self, NewGatewayCacheError> {
+        let pool = settings.database.connect(HELIUS_DB_POOL_SIZE).await?;
         let cache = Arc::new(Cache::<PublicKeyBinary, GatewayInfo>::new());
         let clone = cache.clone();
         // monitor cache to handle evictions
         let cache_monitor =
             tokio::spawn(async move { clone.monitor(4, 0.25, CACHE_EVICTION_FREQUENCY).await });
-        Self {
-            follower_service,
+
+        Ok(Self {
+            pool,
             cache,
             cache_monitor,
+        })
+    }
+
+    pub async fn prewarm(&self) -> anyhow::Result<()> {
+        let sql = r#"SELECT address, location, elevation, gain, is_full_hotspot FROM gateways"#;
+        let mut rows = sqlx::query_as::<_, GatewayInfo>(sql).fetch(&self.pool);
+        while let Some(gateway) = rows.try_next().await? {
+            self.cache
+                .insert(gateway.address.clone(), gateway.clone(), CACHE_TTL)
+                .await;
         }
+        Ok(())
     }
 
     pub async fn resolve_gateway_info(
@@ -47,24 +64,16 @@ impl GatewayCache {
                 metrics::increment_counter!("oracles_iot_verifier_gateway_cache_hit");
                 Ok(hit.value().clone())
             }
-            _ => {
-                match self
-                    .follower_service
-                    .clone()
-                    .resolve_gateway_info(address)
-                    .await
-                {
-                    Ok(res) => {
-                        tracing::debug!("cache miss: {:?}", address);
-                        metrics::increment_counter!("oracles_iot_verifier_gateway_cache_miss");
-                        self.cache
-                            .insert(address.clone(), res.clone(), CACHE_TTL)
-                            .await;
-                        Ok(res)
-                    }
-                    _ => Err(GatewayNotFound(address.clone())),
+            _ => match GatewayInfo::resolve_gateway(&self.pool, address.as_ref()).await {
+                Ok(Some(res)) => {
+                    metrics::increment_counter!("oracles_iot_verifier_gateway_cache_miss");
+                    self.cache
+                        .insert(address.clone(), res.clone(), CACHE_TTL)
+                        .await;
+                    Ok(res)
                 }
-            }
+                _ => Err(GatewayNotFound(address.clone())),
+            },
         }
     }
 }

--- a/iot_verifier/src/helius.rs
+++ b/iot_verifier/src/helius.rs
@@ -1,0 +1,49 @@
+use helium_crypto::PublicKeyBinary;
+use sqlx::postgres::PgRow;
+use sqlx::{FromRow, Row};
+
+#[derive(Debug, Clone)]
+pub struct GatewayInfo {
+    pub address: PublicKeyBinary,
+    pub location: Option<u64>,
+    pub elevation: Option<i32>,
+    pub gain: i32,
+    pub is_full_hotspot: bool,
+}
+
+impl<'c> FromRow<'c, PgRow> for GatewayInfo {
+    fn from_row(row: &'c PgRow) -> Result<Self, sqlx::Error> {
+        Ok(GatewayInfo {
+            address: row.get(0),
+            //TODO: fix location, None value is not being handled here
+            location: Some(row.get::<i64, _>("location") as u64),
+            elevation: row.get(2),
+            gain: row.get(3),
+            is_full_hotspot: row.get(4),
+        })
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("report error: {0}")]
+pub struct SqlError(#[from] sqlx::Error);
+
+impl GatewayInfo {
+    pub async fn resolve_gateway<'c, E>(
+        executor: E,
+        id: &[u8],
+    ) -> Result<Option<GatewayInfo>, sqlx::Error>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
+        let result = sqlx::query_as::<_, Self>(
+            r#"
+            select address, location, elevation, gain, is_full_hotspot from gateways where address = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(executor)
+        .await?;
+        Ok(result)
+    }
+}

--- a/iot_verifier/src/last_beacon.rs
+++ b/iot_verifier/src/last_beacon.rs
@@ -1,8 +1,10 @@
 use chrono::{DateTime, Utc};
 use file_store::traits::TimestampDecode;
-use serde::{Deserialize, Serialize};
+use futures::stream::TryStreamExt;
+use helium_crypto::PublicKeyBinary;
+use std::collections::HashMap;
 
-#[derive(sqlx::FromRow, Deserialize, Serialize, Debug)]
+#[derive(sqlx::FromRow, Debug)]
 #[sqlx(type_name = "last_beacon")]
 pub struct LastBeacon {
     pub id: Vec<u8>,
@@ -15,6 +17,11 @@ pub enum LastBeaconError {
     DatabaseError(#[from] sqlx::Error),
     #[error("file store error: {0}")]
     FileStoreError(#[from] file_store::Error),
+}
+
+#[derive(Default)]
+pub struct LastBeacons {
+    pub beacon_map: HashMap<PublicKeyBinary, DateTime<Utc>>,
 }
 
 impl LastBeacon {
@@ -96,5 +103,22 @@ impl LastBeacon {
         .execute(executor)
         .await?;
         Ok(())
+    }
+
+    pub async fn get_all<'c, E>(executor: E) -> Result<LastBeacons, LastBeaconError>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
+        let mut beacon_map: HashMap<PublicKeyBinary, DateTime<Utc>> = HashMap::new();
+        let mut rows = sqlx::query_as::<_, Self>(
+            r#"
+            select * from last_beacon
+            "#,
+        )
+        .fetch(executor);
+        while let Some(last_beacon) = rows.try_next().await? {
+            beacon_map.insert(PublicKeyBinary::from(last_beacon.id), last_beacon.timestamp);
+        }
+        Ok(LastBeacons { beacon_map })
     }
 }

--- a/iot_verifier/src/lib.rs
+++ b/iot_verifier/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod entropy;
 pub mod entropy_loader;
 pub mod gateway_cache;
+pub mod helius;
 pub mod last_beacon;
 pub mod loader;
 pub mod meta;
@@ -8,6 +9,7 @@ pub mod metrics;
 pub mod poc;
 pub mod poc_report;
 pub mod purger;
+pub mod region_cache;
 pub mod reward_share;
 pub mod rewarder;
 pub mod runner;

--- a/iot_verifier/src/region_cache.rs
+++ b/iot_verifier/src/region_cache.rs
@@ -1,0 +1,79 @@
+use crate::Settings;
+use helium_crypto::PublicKeyBinary;
+use helium_proto::{BlockchainRegionParamV1, Region};
+use node_follower::{follower_service::FollowerService, gateway_resp::GatewayInfoResolver};
+use retainer::Cache;
+use std::time::Duration;
+
+const CACHE_TTL: u64 = 86400;
+
+#[derive(Debug, Clone)]
+pub struct RegionInfo {
+    pub address: PublicKeyBinary,
+    pub region: Region,
+    pub region_params: Vec<BlockchainRegionParamV1>,
+}
+
+pub struct RegionCache {
+    pub follower_service: FollowerService,
+    pub cache: Cache<PublicKeyBinary, RegionInfo>,
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("error creating region cache: {0}")]
+pub struct NewGatewayCacheError(#[from] db_store::Error);
+
+#[derive(thiserror::Error, Debug)]
+#[error("gateway not found: {0}")]
+pub struct GatewayNotFound(PublicKeyBinary);
+
+impl RegionCache {
+    pub async fn from_settings(settings: &Settings) -> Result<Self, NewGatewayCacheError> {
+        let follower_service = FollowerService::from_settings(&settings.follower);
+        let cache = Cache::<PublicKeyBinary, RegionInfo>::new();
+        Ok(Self {
+            follower_service,
+            cache,
+        })
+    }
+
+    // temporarily pulls region from the node follower
+    // TODO: to be replaced with RPC to config service or to solana. TBC
+    pub async fn resolve_region_info(
+        &self,
+        address: &PublicKeyBinary,
+    ) -> Result<RegionInfo, GatewayNotFound> {
+        match self.cache.get(address).await {
+            Some(hit) => {
+                metrics::increment_counter!("oracles_iot_verifier_region_cache_hit");
+                Ok(hit.value().clone())
+            }
+            _ => {
+                match self
+                    .follower_service
+                    .clone()
+                    .resolve_gateway_info(address)
+                    .await
+                {
+                    Ok(res) => {
+                        metrics::increment_counter!("oracles_iot_verifier_region_cache_miss");
+                        let region_info = RegionInfo {
+                            address: res.address.clone().into(),
+                            region: res.region,
+                            region_params: res.region_params,
+                        };
+                        self.cache
+                            .insert(
+                                address.clone(),
+                                region_info.clone(),
+                                Duration::from_secs(CACHE_TTL),
+                            )
+                            .await;
+                        Ok(region_info)
+                    }
+                    _ => Err(GatewayNotFound(address.clone())),
+                }
+            }
+        }
+    }
+}

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -18,6 +18,7 @@ pub struct Settings {
     #[serde(default = "default_base_stale_period")]
     pub base_stale_period: i64,
     pub database: db_store::Settings,
+    pub helius: db_store::Settings,
     pub follower: node_follower::Settings,
     pub ingest: file_store::Settings,
     pub entropy: file_store::Settings,


### PR DESCRIPTION
WIP branch...

Initial pass at replacing node follower usage in the IOT verifier and Density Scaler. 

Modifies density scaler to operate within IOT verifier context, similar to DenyList.  'runner' now marshals the gateway list ( which itself is pulled from helius populated postgres db ) and calls the scaler refresh directly with the refreshed hashmap.

Region data continues to be pulled from node follower temporarily via RPC.  This will be replaced with either a call to the config service or an RPC to helius ?  Previously the node data would have been returned from the follower as part of the gateway info and cached in the IOT verifier.  Given the gateway info now originates from helius and that helius does not manage region data, deriving region data is now distinct from gateway info.  Added a cache to store region data per gateway