### PR TITLE
org and route request auth on config service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "constant_time_eq"
@@ -1126,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -1144,6 +1150,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -1260,7 +1276,7 @@ dependencies = [
 name = "denylist"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bincode",
  "bytes",
  "chrono",
@@ -1279,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
  "const-oid",
 ]
@@ -1334,9 +1350,9 @@ checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -1346,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "signature",
 ]
@@ -1372,18 +1388,16 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.6",
  "ff",
  "generic-array",
  "group",
- "hkdf",
  "rand_core",
  "sec1",
  "subtle",
@@ -1426,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
 dependencies = [
  "rand_core",
  "subtle",
@@ -1441,7 +1455,7 @@ dependencies = [
  "async-compression",
  "aws-config",
  "aws-sdk-s3",
- "base64",
+ "base64 0.13.1",
  "blake3",
  "bytes",
  "chrono",
@@ -1707,9 +1721,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
 dependencies = [
  "ff",
  "rand_core",
@@ -1803,7 +1817,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -1855,10 +1869,11 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.6.1"
-source = "git+https://github.com/helium/helium-crypto-rs?branch=main#a28268c9e17dc5551f33f7672fbdf0d7f4ef6755"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffbb2b8d00aa39d12669a551275448ecd1ca68f6407c0386dd8de0b35ece653"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "bs58",
  "ed25519-compact",
  "k256",
@@ -1916,7 +1931,17 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -2085,7 +2110,7 @@ name = "ingest"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "chrono",
  "clap 3.2.23",
  "config",
@@ -2125,7 +2150,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "clap 3.2.23",
  "config",
  "db-store",
@@ -2156,7 +2181,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "blake3",
  "chrono",
  "clap 3.2.23",
@@ -2304,14 +2329,15 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.11.6"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sec1",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -2529,7 +2555,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "chrono",
  "clap 3.2.23",
  "config",
@@ -2568,7 +2594,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "chrono",
  "clap 3.2.23",
  "config",
@@ -2773,13 +2799,14 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "19736d80675fbe9fe33426268150b951a3fb8f5cfca2a23a17c85ef3adb24e3b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sec1",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -2936,7 +2963,7 @@ name = "poc-iot-injector"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "chrono",
  "clap 3.2.23",
  "config",
@@ -3314,7 +3341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3366,7 +3393,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "chrono",
  "clap 3.2.23",
  "config",
@@ -3400,12 +3427,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
 dependencies = [
  "crypto-bigint",
- "hmac",
+ "hmac 0.11.0",
  "zeroize",
 ]
 
@@ -3575,7 +3602,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -3630,11 +3657,10 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
 dependencies = [
- "base16ct",
  "der",
  "generic-array",
  "subtle",
@@ -3802,11 +3828,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.9.0",
  "rand_core",
 ]
 
@@ -3885,7 +3911,7 @@ checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
 dependencies = [
  "ahash 0.7.6",
  "atoi",
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "byteorder",
  "bytes",
@@ -3903,7 +3929,7 @@ dependencies = [
  "hashlink",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "indexmap",
  "itoa 1.0.4",
  "libc",
@@ -4291,7 +4317,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.5.17",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ sqlx = {version = "0", features = [
   "macros",
   "runtime-tokio-rustls"
 ]}
-helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", branch = "main", features=["sqlx-postgres", "multisig"]}
+helium-crypto = {version = "0.6.3", features=["sqlx-postgres", "multisig"]}
 helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
 humantime = "2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,11 @@ services:
       CFG_LISTEN: 0.0.0.0:8080
       CFG_METRICS_ENDPOINT: 0.0.0.0:19000
       CFG_NETWORK: mainnet
+      CFG_ADMIN: ${CONFIG_ADMIN_PUBKEY}
+      CFG_KEYPAIR: /config-signing-key.bin
       CFG_LOG: info
+    volumes:
+      - ${CONFIG_SIGNING_KEY}:/config-signing-key.bin:ro
 
   postgres:
     image: postgres:latest

--- a/file_store/src/traits/msg_verify.rs
+++ b/file_store/src/traits/msg_verify.rs
@@ -1,7 +1,11 @@
 use crate::{Error, Result};
 use helium_crypto::{PublicKey, Verify};
 use helium_proto::services::{
-    iot_config::{OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgDisableReqV1},
+    iot_config::{
+        OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgDisableReqV1, RouteCreateReqV1,
+        RouteDeleteReqV1, RouteDevaddrsReqV1, RouteEuisReqV1, RouteGetReqV1, RouteListReqV1,
+        RouteStreamReqV1, RouteUpdateReqV1,
+    },
     poc_lora::{LoraBeaconReportReqV1, LoraWitnessReportReqV1},
 };
 use helium_proto::{
@@ -35,6 +39,14 @@ impl_msg_verify!(DataTransferSessionReqV1, signature);
 impl_msg_verify!(OrgCreateHeliumReqV1, signature);
 impl_msg_verify!(OrgCreateRoamerReqV1, signature);
 impl_msg_verify!(OrgDisableReqV1, signature);
+impl_msg_verify!(RouteStreamReqV1, signature);
+impl_msg_verify!(RouteListReqV1, signature);
+impl_msg_verify!(RouteGetReqV1, signature);
+impl_msg_verify!(RouteCreateReqV1, signature);
+impl_msg_verify!(RouteUpdateReqV1, signature);
+impl_msg_verify!(RouteDeleteReqV1, signature);
+impl_msg_verify!(RouteEuisReqV1, signature);
+impl_msg_verify!(RouteDevaddrsReqV1, signature);
 
 #[cfg(test)]
 mod test {

--- a/iot_config/src/main.rs
+++ b/iot_config/src/main.rs
@@ -8,7 +8,7 @@ use iot_config::{
     gateway_service::GatewayService, org_service::OrgService, route_service::RouteService,
     session_key_service::SessionKeyFilterService, settings::Settings,
 };
-use std::{path::PathBuf, time::Duration};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::signal;
 use tonic::transport;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -71,10 +71,12 @@ impl Daemon {
             shutdown_trigger.trigger()
         });
 
+        let admin_pubkey = Arc::new(settings.admin_pubkey()?);
+        let _signing_keypair = Arc::new(settings.signing_keypair()?);
         let listen_addr = settings.listen_addr()?;
 
         let gateway_svc = GatewayService {};
-        let org_svc = OrgService::new(settings).await?;
+        let org_svc = OrgService::new(admin_pubkey.clone(), settings).await?;
         let route_svc = RouteService::new(settings).await?;
         let session_key_filter_svc = SessionKeyFilterService {};
 

--- a/iot_config/src/main.rs
+++ b/iot_config/src/main.rs
@@ -71,12 +71,11 @@ impl Daemon {
             shutdown_trigger.trigger()
         });
 
-        let admin_pubkey = Arc::new(settings.admin_pubkey()?);
         let _signing_keypair = Arc::new(settings.signing_keypair()?);
         let listen_addr = settings.listen_addr()?;
 
         let gateway_svc = GatewayService {};
-        let org_svc = OrgService::new(admin_pubkey.clone(), settings).await?;
+        let org_svc = OrgService::new(settings).await?;
         let route_svc = RouteService::new(settings).await?;
         let session_key_filter_svc = SessionKeyFilterService {};
 

--- a/iot_config/src/org_service.rs
+++ b/iot_config/src/org_service.rs
@@ -7,19 +7,18 @@ use helium_proto::services::iot_config::{
     OrgEnableReqV1, OrgEnableResV1, OrgGetReqV1, OrgListReqV1, OrgListResV1, OrgResV1, OrgV1,
 };
 use sqlx::{Pool, Postgres};
-use std::sync::Arc;
 use tonic::{Request, Response, Status};
 
 pub struct OrgService {
-    admin_pubkey: Arc<PublicKey>,
+    admin_pubkey: PublicKey,
     pool: Pool<Postgres>,
     required_network: Network,
 }
 
 impl OrgService {
-    pub async fn new(admin_pubkey: Arc<PublicKey>, settings: &Settings) -> Result<Self> {
+    pub async fn new(settings: &Settings) -> Result<Self> {
         Ok(Self {
-            admin_pubkey,
+            admin_pubkey: settings.admin_pubkey()?,
             pool: settings.database.connect(10).await?,
             required_network: settings.network,
         })

--- a/iot_config/src/org_service.rs
+++ b/iot_config/src/org_service.rs
@@ -7,16 +7,19 @@ use helium_proto::services::iot_config::{
     OrgEnableReqV1, OrgEnableResV1, OrgGetReqV1, OrgListReqV1, OrgListResV1, OrgResV1, OrgV1,
 };
 use sqlx::{Pool, Postgres};
+use std::sync::Arc;
 use tonic::{Request, Response, Status};
 
 pub struct OrgService {
+    admin_pubkey: Arc<PublicKey>,
     pool: Pool<Postgres>,
     required_network: Network,
 }
 
 impl OrgService {
-    pub async fn new(settings: &Settings) -> Result<Self> {
+    pub async fn new(admin_pubkey: Arc<PublicKey>, settings: &Settings) -> Result<Self> {
         Ok(Self {
+            admin_pubkey,
             pool: settings.database.connect(10).await?,
             required_network: settings.network,
         })
@@ -26,26 +29,26 @@ impl OrgService {
         if self.required_network == public_key.network {
             Ok(public_key)
         } else {
-            Err(Status::invalid_argument("invalid network"))
+            Err(Status::invalid_argument(format!(
+                "invalid network: {}",
+                public_key.network
+            )))
         }
     }
 
     fn verify_public_key(&self, bytes: &[u8]) -> Result<PublicKey, Status> {
-        PublicKey::try_from(bytes).map_err(|_| Status::invalid_argument("invalid public key"))
+        PublicKey::try_from(bytes)
+            .map_err(|_| Status::invalid_argument(format!("invalid public key: {bytes:?}")))
     }
 
-    fn verify_signature<R>(
-        &self,
-        public_key: PublicKey,
-        request: R,
-    ) -> Result<(PublicKey, R), Status>
+    fn verify_admin_signature<R>(&self, request: R) -> Result<R, Status>
     where
         R: MsgVerify,
     {
         request
-            .verify(&public_key)
-            .map_err(|_| Status::invalid_argument("invalid signature"))?;
-        Ok((public_key, request))
+            .verify(&self.admin_pubkey)
+            .map_err(|_| Status::permission_denied("invalid admin signature"))?;
+        Ok(request)
     }
 }
 
@@ -84,15 +87,20 @@ impl iot_config::Org for OrgService {
     async fn create_helium(&self, request: Request<OrgCreateHeliumReqV1>) -> GrpcResult<OrgResV1> {
         let request = request.into_inner();
 
-        let (_, req) = self
-            .verify_public_key(request.signer.as_ref())
-            .and_then(|pub_key| self.verify_network(pub_key))
-            .and_then(|pub_key| self.verify_signature(pub_key, request))?;
+        let req = self.verify_admin_signature(request)?;
 
-        self.verify_public_key(req.owner.as_ref())
-            .and_then(|pub_key| self.verify_network(pub_key))?;
-        self.verify_public_key(req.payer.as_ref())
-            .and_then(|pub_key| self.verify_network(pub_key))?;
+        let verify_keys: Vec<&[u8]> = vec![req.owner.as_ref(), req.payer.as_ref()];
+
+        _ = verify_keys
+            .iter()
+            .map(|key| {
+                self.verify_public_key(key)
+                    .and_then(|pub_key| self.verify_network(pub_key))
+                    .map_err(|err| {
+                        Status::invalid_argument(format!("failed pubkey validation: {err}"))
+                    })
+            })
+            .collect::<Result<Vec<PublicKey>, Status>>()?;
 
         let requested_addrs = req.devaddrs;
         let devaddr_range = org::next_helium_devaddr(&self.pool)
@@ -118,15 +126,18 @@ impl iot_config::Org for OrgService {
     async fn create_roamer(&self, request: Request<OrgCreateRoamerReqV1>) -> GrpcResult<OrgResV1> {
         let request = request.into_inner();
 
-        let (_, req) = self
-            .verify_public_key(request.signer.as_ref())
-            .and_then(|pub_key| self.verify_network(pub_key))
-            .and_then(|pub_key| self.verify_signature(pub_key, request))?;
-
-        self.verify_public_key(req.owner.as_ref())
-            .and_then(|pub_key| self.verify_network(pub_key))?;
-        self.verify_public_key(req.payer.as_ref())
-            .and_then(|pub_key| self.verify_network(pub_key))?;
+        let req = self.verify_admin_signature(request)?;
+        let verify_keys: Vec<&[u8]> = vec![req.owner.as_ref(), req.payer.as_ref()];
+        _ = verify_keys
+            .iter()
+            .map(|key| {
+                self.verify_public_key(key)
+                    .and_then(|pub_key| self.verify_network(pub_key))
+                    .map_err(|err| {
+                        Status::invalid_argument(format!("failed pubkey validation: {err}"))
+                    })
+            })
+            .collect::<Result<Vec<PublicKey>, Status>>()?;
 
         let net_id = lora_field::net_id(req.net_id);
         let devaddr_range = net_id

--- a/iot_config/src/settings.rs
+++ b/iot_config/src/settings.rs
@@ -16,6 +16,10 @@ pub struct Settings {
     /// Listen address. Required. Default is 0.0.0.0:8080
     #[serde(default = "default_listen_addr")]
     pub listen: String,
+    /// File from which to load config server signing keypair
+    pub keypair: String,
+    /// File from which to load config server admin operator public key
+    pub admin: String,
     /// Network required in all public keys: mainnet | testnet
     pub network: Network,
     pub database: db_store::Settings,
@@ -56,5 +60,15 @@ impl Settings {
 
     pub fn listen_addr(&self) -> Result<SocketAddr, AddrParseError> {
         SocketAddr::from_str(&self.listen)
+    }
+
+    pub fn signing_keypair(&self) -> Result<helium_crypto::Keypair, Box<helium_crypto::Error>> {
+        let data = std::fs::read(&self.keypair).map_err(helium_crypto::Error::from)?;
+        Ok(helium_crypto::Keypair::try_from(&data[..])?)
+    }
+
+    pub fn admin_pubkey(&self) -> Result<helium_crypto::PublicKey, Box<helium_crypto::Error>> {
+        let data = std::fs::read(&self.admin).map_err(helium_crypto::Error::from)?;
+        Ok(helium_crypto::PublicKey::try_from(&data[..])?)
     }
 }

--- a/iot_config/src/settings.rs
+++ b/iot_config/src/settings.rs
@@ -18,7 +18,7 @@ pub struct Settings {
     pub listen: String,
     /// File from which to load config server signing keypair
     pub keypair: String,
-    /// File from which to load config server admin operator public key
+    /// B58 encoded public key of the admin keypair
     pub admin: String,
     /// Network required in all public keys: mainnet | testnet
     pub network: Network,
@@ -67,8 +67,7 @@ impl Settings {
         Ok(helium_crypto::Keypair::try_from(&data[..])?)
     }
 
-    pub fn admin_pubkey(&self) -> Result<helium_crypto::PublicKey, Box<helium_crypto::Error>> {
-        let data = std::fs::read(&self.admin).map_err(helium_crypto::Error::from)?;
-        Ok(helium_crypto::PublicKey::try_from(&data[..])?)
+    pub fn admin_pubkey(&self) -> Result<helium_crypto::PublicKey, helium_crypto::Error> {
+        helium_crypto::PublicKey::from_str(&self.admin)
     }
 }


### PR DESCRIPTION
adds basic admin validation of requests to create organization entities; lays foundation for further admin pubkey validation of routing and session key filter management requests.

also consolidates proper deserialization and network validation for submitted owner/payer and delegate keys

implements http2 keepalive interval and timeout for grpc server to prevent long-lived streams from being culled by the load balancer