### PR TITLE
add metrics to cover denied and unknown gateways dropped during loading

### DIFF
--- a/iot_verifier/src/metrics.rs
+++ b/iot_verifier/src/metrics.rs
@@ -2,7 +2,8 @@ use std::cell::RefCell;
 
 const LOADER_BEACON_COUNTER: &str = "oracles_iot_verifier_loader_beacon";
 const LOADER_WITNESS_COUNTER: &str = "oracles_iot_verifier_loader_witness";
-const INVALID_BEACON_COUNTER: &str = "iot_verifier_invalid_beacon_report";
+const LOADER_DROPPED_BEACON_COUNTER: &str = "iot_verifier_dropped_beacon";
+const LOADER_DROPPED_WITNESS_COUNTER: &str = "iot_verifier_dropped_witness";
 const INVALID_WITNESS_COUNTER: &str = "iot_verifier_invalid_witness_report";
 const BEACON_GUAGE: &str = "oracles_iot_verifier_num_beacons";
 
@@ -17,8 +18,12 @@ impl Metrics {
         metrics::counter!(LOADER_WITNESS_COUNTER, count);
     }
 
-    pub fn count_loader_invalid_beacons(count: u64, labels: &[(&'static str, &'static str)]) {
-        metrics::counter!(INVALID_BEACON_COUNTER, count, labels);
+    pub fn count_loader_dropped_beacons(count: u64, labels: &[(&'static str, &'static str)]) {
+        metrics::counter!(LOADER_DROPPED_BEACON_COUNTER, count, labels);
+    }
+
+    pub fn count_loader_dropped_witnesses(count: u64, labels: &[(&'static str, &'static str)]) {
+        metrics::counter!(LOADER_DROPPED_WITNESS_COUNTER, count, labels);
     }
 
     pub fn count_loader_invalid_witnesses(count: u64, labels: &[(&'static str, &'static str)]) {
@@ -98,14 +103,14 @@ impl LoaderMetricTracker {
         }
 
         if beacons_denied > 0 {
-            Metrics::count_loader_invalid_beacons(
+            Metrics::count_loader_dropped_beacons(
                 beacons_denied,
                 &[("status", "ok"), ("reason", "denied")],
             );
         }
 
         if beacons_unknown > 0 {
-            Metrics::count_loader_invalid_beacons(
+            Metrics::count_loader_dropped_beacons(
                 beacons_unknown,
                 &[("status", "ok"), ("reason", "gateway not found")],
             );
@@ -123,14 +128,14 @@ impl LoaderMetricTracker {
         }
 
         if witnesses_denied > 0 {
-            Metrics::count_loader_invalid_witnesses(
+            Metrics::count_loader_dropped_witnesses(
                 witnesses_denied,
                 &[("status", "ok"), ("reason", "denied")],
             );
         }
 
         if witnesses_unknown > 0 {
-            Metrics::count_loader_invalid_witnesses(
+            Metrics::count_loader_dropped_witnesses(
                 witnesses_unknown,
                 &[("status", "ok"), ("reason", "gateway not found")],
             );

--- a/iot_verifier/src/metrics.rs
+++ b/iot_verifier/src/metrics.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 
 const LOADER_BEACON_COUNTER: &str = "oracles_iot_verifier_loader_beacon";
 const LOADER_WITNESS_COUNTER: &str = "oracles_iot_verifier_loader_witness";
+const INVALID_BEACON_COUNTER: &str = "iot_verifier_invalid_beacon_report";
 const INVALID_WITNESS_COUNTER: &str = "iot_verifier_invalid_witness_report";
 const BEACON_GUAGE: &str = "oracles_iot_verifier_num_beacons";
 
@@ -14,6 +15,10 @@ impl Metrics {
 
     pub fn count_loader_witnesses(count: u64) {
         metrics::counter!(LOADER_WITNESS_COUNTER, count);
+    }
+
+    pub fn count_loader_invalid_beacons(count: u64, labels: &[(&'static str, &'static str)]) {
+        metrics::counter!(INVALID_BEACON_COUNTER, count, labels);
     }
 
     pub fn count_loader_invalid_witnesses(count: u64, labels: &[(&'static str, &'static str)]) {
@@ -36,8 +41,12 @@ impl Metrics {
 #[derive(Default)]
 pub struct LoaderMetricTracker {
     beacons: RefCell<u64>,
+    beacons_denied: RefCell<u64>,
+    beacons_unknown: RefCell<u64>,
     witnesses: RefCell<u64>,
     witnesses_no_beacon: RefCell<u64>,
+    witnesses_denied: RefCell<u64>,
+    witnesses_unknown: RefCell<u64>,
 }
 
 impl LoaderMetricTracker {
@@ -49,6 +58,14 @@ impl LoaderMetricTracker {
         *self.beacons.borrow_mut() += 1;
     }
 
+    pub fn increment_beacons_denied(&self) {
+        *self.beacons_denied.borrow_mut() += 1;
+    }
+
+    pub fn increment_beacons_unknown(&self) {
+        *self.beacons_unknown.borrow_mut() += 1;
+    }
+
     pub fn increment_witnesses(&self) {
         *self.witnesses.borrow_mut() += 1;
     }
@@ -57,14 +74,41 @@ impl LoaderMetricTracker {
         *self.witnesses_no_beacon.borrow_mut() += 1;
     }
 
+    pub fn increment_witnesses_denied(&self) {
+        *self.witnesses_denied.borrow_mut() += 1;
+    }
+
+    pub fn increment_witnesses_unknown(&self) {
+        *self.witnesses_unknown.borrow_mut() += 1;
+    }
+
     pub fn record_metrics(self) {
         let beacons = self.beacons.into_inner();
+        let beacons_denied = self.beacons_denied.into_inner();
+        let beacons_unknown = self.beacons_unknown.into_inner();
+
         let witnesses = self.witnesses.into_inner();
         let witnesses_no_beacon = self.witnesses_no_beacon.into_inner();
+        let witnesses_denied = self.witnesses_denied.into_inner();
+        let witnesses_unknown = self.witnesses_unknown.into_inner();
 
         if beacons > 0 {
             Metrics::count_loader_beacons(beacons);
             Metrics::increment_num_beacons_by(beacons);
+        }
+
+        if beacons_denied > 0 {
+            Metrics::count_loader_invalid_beacons(
+                beacons_denied,
+                &[("status", "ok"), ("reason", "denied")],
+            );
+        }
+
+        if beacons_unknown > 0 {
+            Metrics::count_loader_invalid_beacons(
+                beacons_unknown,
+                &[("status", "ok"), ("reason", "gateway not found")],
+            );
         }
 
         if witnesses > 0 {
@@ -75,6 +119,20 @@ impl LoaderMetricTracker {
             Metrics::count_loader_invalid_witnesses(
                 witnesses_no_beacon,
                 &[("status", "ok"), ("reason", "no_associated_beacon_data")],
+            );
+        }
+
+        if witnesses_denied > 0 {
+            Metrics::count_loader_invalid_witnesses(
+                witnesses_denied,
+                &[("status", "ok"), ("reason", "denied")],
+            );
+        }
+
+        if witnesses_unknown > 0 {
+            Metrics::count_loader_invalid_witnesses(
+                witnesses_unknown,
+                &[("status", "ok"), ("reason", "gateway not found")],
             );
         }
     }

--- a/iot_verifier/src/metrics.rs
+++ b/iot_verifier/src/metrics.rs
@@ -1,11 +1,11 @@
 use std::cell::RefCell;
 
-const LOADER_BEACON_COUNTER: &str = "oracles_iot_verifier_loader_beacon";
-const LOADER_WITNESS_COUNTER: &str = "oracles_iot_verifier_loader_witness";
-const LOADER_DROPPED_BEACON_COUNTER: &str = "iot_verifier_dropped_beacon";
-const LOADER_DROPPED_WITNESS_COUNTER: &str = "iot_verifier_dropped_witness";
-const INVALID_WITNESS_COUNTER: &str = "iot_verifier_invalid_witness_report";
-const BEACON_GUAGE: &str = "oracles_iot_verifier_num_beacons";
+const LOADER_BEACON_COUNTER: &str = concat!(env!("CARGO_PKG_NAME"), "_", "loader_beacon");
+const LOADER_WITNESS_COUNTER: &str = concat!(env!("CARGO_PKG_NAME"), "_", "loader_witness");
+const LOADER_DROPPED_BEACON_COUNTER: &str = concat!(env!("CARGO_PKG_NAME"), "_", "dropped_beacon");
+const LOADER_DROPPED_WITNESS_COUNTER: &str =
+    concat!(env!("CARGO_PKG_NAME"), "_", "dropped_witness");
+const BEACON_GUAGE: &str = concat!(env!("CARGO_PKG_NAME"), "_", "num_beacons");
 
 pub struct Metrics;
 
@@ -24,10 +24,6 @@ impl Metrics {
 
     pub fn count_loader_dropped_witnesses(count: u64, labels: &[(&'static str, &'static str)]) {
         metrics::counter!(LOADER_DROPPED_WITNESS_COUNTER, count, labels);
-    }
-
-    pub fn count_loader_invalid_witnesses(count: u64, labels: &[(&'static str, &'static str)]) {
-        metrics::counter!(INVALID_WITNESS_COUNTER, count, labels);
     }
 
     pub fn num_beacons(count: u64) {
@@ -112,7 +108,7 @@ impl LoaderMetricTracker {
         if beacons_unknown > 0 {
             Metrics::count_loader_dropped_beacons(
                 beacons_unknown,
-                &[("status", "ok"), ("reason", "gateway not found")],
+                &[("status", "ok"), ("reason", "gateway_not_found")],
             );
         }
 
@@ -121,7 +117,7 @@ impl LoaderMetricTracker {
         }
 
         if witnesses_no_beacon > 0 {
-            Metrics::count_loader_invalid_witnesses(
+            Metrics::count_loader_dropped_witnesses(
                 witnesses_no_beacon,
                 &[("status", "ok"), ("reason", "no_associated_beacon_data")],
             );
@@ -137,7 +133,7 @@ impl LoaderMetricTracker {
         if witnesses_unknown > 0 {
             Metrics::count_loader_dropped_witnesses(
                 witnesses_unknown,
-                &[("status", "ok"), ("reason", "gateway not found")],
+                &[("status", "ok"), ("reason", "gateway_not_found")],
             );
         }
     }


### PR DESCRIPTION
Adds metrics to track the number of reports we drop to the floor due to:

1. Gateway being on the deny list 
2. Gateway not found 
3. Witness report not having any associated beacon data 