### PR TITLE
Support both grpc and rest api for poc_entropy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=madninja/poc_entropy#9edd556a78618278ec8c700555aa45949d932812"
+source = "git+https://github.com/helium/proto?branch=master#dc3b7bbbf1f946b4d70c3d592df036ea3e57e61c"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,12 +556,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744864363a200a5e724a7e61bc8c11b6628cf2e3ec519c8a1a48e609a8156b40"
+checksum = "678c5130a507ae3a7c797f9a17393c14849300b8440eac47cdb90a5bdcb3a543"
 dependencies = [
  "async-trait",
- "axum-core 0.3.0",
+ "axum-core 0.3.2",
  "bitflags",
  "bytes",
  "futures-util",
@@ -570,7 +570,7 @@ dependencies = [
  "http-body",
  "hyper",
  "itoa 1.0.4",
- "matchit 0.6.0",
+ "matchit 0.7.0",
  "memchr",
  "mime",
  "percent-encoding",
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
+checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1867,7 +1867,7 @@ dependencies = [
  "p256",
  "rand_core",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "signature",
  "sqlx",
  "thiserror",
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#816871e55d1cc28b086cce90fedf011e43671798"
+source = "git+https://github.com/helium/proto?branch=madninja/poc_entropy#9edd556a78618278ec8c700555aa45949d932812"
 dependencies = [
  "bytes",
  "prost",
@@ -2101,7 +2101,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "thiserror",
  "tokio",
  "tonic",
@@ -2187,7 +2187,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -2395,9 +2395,9 @@ checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "matchit"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfc802da7b1cf80aefffa0c7b2f77247c8b32206cc83c270b61264f5b360a80"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "md-5"
@@ -2901,7 +2901,7 @@ name = "poc-entropy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum 0.6.0",
+ "axum 0.6.3",
  "base64",
  "bs58",
  "chrono",
@@ -2924,7 +2924,8 @@ dependencies = [
  "sha2 0.10.6",
  "thiserror",
  "tokio",
- "tower-http",
+ "tonic",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "triggered",
@@ -3387,7 +3388,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -4363,7 +4364,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ sqlx = {version = "0", features = [
   "runtime-tokio-rustls"
 ]}
 helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", branch = "main", features=["sqlx-postgres", "multisig"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "madninja/poc_entropy", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
 humantime = "2"
 metrics = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ sqlx = {version = "0", features = [
   "runtime-tokio-rustls"
 ]}
 helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", branch = "main", features=["sqlx-postgres", "multisig"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "madninja/poc_entropy", features = ["services"]}
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
 humantime = "2"
 metrics = "0"

--- a/poc_entropy/Cargo.toml
+++ b/poc_entropy/Cargo.toml
@@ -16,15 +16,16 @@ serde_json = {workspace = true}
 base64 = {workspace = true}
 sha2 = {workspace = true}
 http = {workspace = true}
-hyper = "*"
-axum = { version = "0", features = ["headers"] }
+tonic = {workspace = true}
+hyper = "0"
+axum = { version = "0.6.3", features = ["headers"] }
 jsonrpsee = { version = "0", features = ["async-client", "http-client"] }
-tower-http = {version = "*", features = ["trace"]}
+tower = {version = "0.4" }
 triggered = {workspace = true}
 futures = {workspace = true}
 futures-util = {workspace = true}
 prost = {workspace = true}
-bs58 = "*"
+bs58 = "0"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 metrics = {workspace = true }

--- a/poc_entropy/src/entropy_generator.rs
+++ b/poc_entropy/src/entropy_generator.rs
@@ -31,6 +31,16 @@ pub struct Entropy {
     pub data: Vec<u8>,
 }
 
+impl From<Entropy> for EntropyReportV1 {
+    fn from(value: Entropy) -> Self {
+        Self {
+            version: value.version,
+            timestamp: value.timestamp as u64,
+            data: value.data,
+        }
+    }
+}
+
 fn ser_base64<T, S>(key: &T, serializer: S) -> std::result::Result<S::Ok, S::Error>
 where
     T: AsRef<[u8]>,

--- a/poc_entropy/src/lib.rs
+++ b/poc_entropy/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod entropy_generator;
+pub mod multiplex_service;
 pub mod server;
 pub mod settings;
 

--- a/poc_entropy/src/multiplex_service.rs
+++ b/poc_entropy/src/multiplex_service.rs
@@ -1,3 +1,6 @@
+// From
+// https://github.com/tokio-rs/axum/blob/main/examples/rest-grpc-multiplex/src/multiplex_service.rs
+
 use axum::{body::BoxBody, http::header::CONTENT_TYPE, response::IntoResponse};
 use futures::{future::BoxFuture, ready};
 use hyper::{Body, Request, Response};

--- a/poc_entropy/src/multiplex_service.rs
+++ b/poc_entropy/src/multiplex_service.rs
@@ -1,0 +1,114 @@
+use axum::{body::BoxBody, http::header::CONTENT_TYPE, response::IntoResponse};
+use futures::{future::BoxFuture, ready};
+use hyper::{Body, Request, Response};
+use std::{
+    convert::Infallible,
+    task::{Context, Poll},
+};
+use tower::Service;
+
+pub struct MultiplexService<A, B> {
+    rest: A,
+    rest_ready: bool,
+    grpc: B,
+    grpc_ready: bool,
+}
+
+impl<A, B> MultiplexService<A, B> {
+    pub fn new(rest: A, grpc: B) -> Self {
+        Self {
+            rest,
+            rest_ready: false,
+            grpc,
+            grpc_ready: false,
+        }
+    }
+}
+
+impl<A, B> Clone for MultiplexService<A, B>
+where
+    A: Clone,
+    B: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            rest: self.rest.clone(),
+            grpc: self.grpc.clone(),
+            // the cloned services probably wont be ready
+            rest_ready: false,
+            grpc_ready: false,
+        }
+    }
+}
+
+impl<A, B> Service<Request<Body>> for MultiplexService<A, B>
+where
+    A: Service<Request<Body>, Error = Infallible>,
+    A::Response: IntoResponse,
+    A::Future: Send + 'static,
+    B: Service<Request<Body>, Error = Infallible>,
+    B::Response: IntoResponse,
+    B::Future: Send + 'static,
+{
+    type Response = Response<BoxBody>;
+    type Error = Infallible;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // drive readiness for each inner service and record which is ready
+        loop {
+            match (self.rest_ready, self.grpc_ready) {
+                (true, true) => {
+                    return Ok(()).into();
+                }
+                (false, _) => {
+                    ready!(self.rest.poll_ready(cx))?;
+                    self.rest_ready = true;
+                }
+                (_, false) => {
+                    ready!(self.grpc.poll_ready(cx))?;
+                    self.grpc_ready = true;
+                }
+            }
+        }
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        // require users to call `poll_ready` first, if they don't we're allowed to panic
+        // as per the `tower::Service` contract
+        assert!(
+            self.grpc_ready,
+            "grpc service not ready. Did you forget to call `poll_ready`?"
+        );
+        assert!(
+            self.rest_ready,
+            "rest service not ready. Did you forget to call `poll_ready`?"
+        );
+
+        // if we get a grpc request call the grpc service, otherwise call the rest service
+        // when calling a service it becomes not-ready so we have drive readiness again
+        if is_grpc_request(&req) {
+            self.grpc_ready = false;
+            let future = self.grpc.call(req);
+            Box::pin(async move {
+                let res = future.await?;
+                Ok(res.into_response())
+            })
+        } else {
+            self.rest_ready = false;
+            let future = self.rest.call(req);
+            Box::pin(async move {
+                let res = future.await?;
+                Ok(res.into_response())
+            })
+        }
+    }
+}
+
+fn is_grpc_request<B>(req: &Request<B>) -> bool {
+    req.headers()
+        .get(CONTENT_TYPE)
+        .map(|content_type| content_type.as_bytes())
+        .filter(|content_type| content_type.starts_with(b"application/grpc"))
+        .is_some()
+}


### PR DESCRIPTION
As part of migrating to grpc only for entropy, this PR supports both REST and GRPC requests for poc_entropy against the same host/port. It will allow gateway-rs to request entropy over grpc.

Note that this implementation serves both GRPC and REST requests over the same port, and auto-dispatches to the right handler based on request headers.

Once the majority of hotspots have upgraded to a gateway-rs release that includes https://github.com/helium/gateway-rs/pull/348 the reset service  can be removed and tls termination decommissioned. 

While they are not however, the entropy service needs to continue to be available on `http://entropy.helium.io` as well as `https://entropy.helium.io`. See the [current and new setup change](https://github.com/helium/gateway-rs/pull/348/files#diff-7d0e50ed26deeac75e40220c36a9c73affb9a034f8e446339b15d98eba7300a6L36-R36) in gateway-rs 