### PR TITLE
Make beacon_interval & beacon_interval_tolerance configurable

### DIFF
--- a/iot_verifier/pkg/settings-template.toml
+++ b/iot_verifier/pkg/settings-template.toml
@@ -11,6 +11,11 @@ cache = "/var/data/iot-verified"
 #
 # denylist_url = "https://api.github.com/repos/helium/denylist/releases/latest"
 
+# Default beacon interval ( 6 hours) (in seconds)
+beacon_interval = 21600
+
+# Default beacon interval tolerance ( 10 minutes) (in seconds)
+beacon_interval_tolerance = 600
 
 [database]
 

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -45,6 +45,8 @@ const HIP15_TX_REWARD_UNIT_CAP: Decimal = Decimal::TWO;
 pub struct Runner {
     pool: PgPool,
     settings: Settings,
+    beacon_interval: ChronoDuration,
+    beacon_interval_tolerance: ChronoDuration,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -60,9 +62,13 @@ pub enum RunnerError {
 impl Runner {
     pub async fn from_settings(settings: &Settings) -> Result<Self, NewRunnerError> {
         let pool = settings.database.connect(RUNNER_DB_POOL_SIZE).await?;
+        let beacon_interval = ChronoDuration::seconds(settings.beacon_interval);
+        let beacon_interval_tolerance = ChronoDuration::seconds(settings.beacon_interval_tolerance);
         Ok(Self {
             pool,
             settings: settings.clone(),
+            beacon_interval,
+            beacon_interval_tolerance,
         })
     }
 
@@ -233,7 +239,13 @@ impl Runner {
 
         // verify POC beacon
         let beacon_verify_result = poc
-            .verify_beacon(hex_density_map.clone(), gateway_cache, &self.pool)
+            .verify_beacon(
+                hex_density_map.clone(),
+                gateway_cache,
+                &self.pool,
+                self.beacon_interval,
+                self.beacon_interval_tolerance,
+            )
             .await?;
         match beacon_verify_result.result {
             VerificationStatus::Valid => {

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -62,8 +62,8 @@ pub enum RunnerError {
 impl Runner {
     pub async fn from_settings(settings: &Settings) -> Result<Self, NewRunnerError> {
         let pool = settings.database.connect(RUNNER_DB_POOL_SIZE).await?;
-        let beacon_interval = ChronoDuration::seconds(settings.beacon_interval);
-        let beacon_interval_tolerance = ChronoDuration::seconds(settings.beacon_interval_tolerance);
+        let beacon_interval = settings.beacon_interval();
+        let beacon_interval_tolerance = settings.beacon_interval_tolerance();
         Ok(Self {
             pool,
             settings: settings.clone(),

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -34,17 +34,17 @@ pub struct Settings {
     pub reward_offset_minutes: i64,
     #[serde(default = "default_max_witnesses_per_poc")]
     pub max_witnesses_per_poc: u64,
-    /// beacon_interval (in seconds)
+    /// The cadence at which hotspots are permitted to beacon (in seconds)
     #[serde(default = "default_beacon_interval")]
     pub beacon_interval: i64,
-    /// beacon_interval_tolerance (in seconds)
+    /// Tolerance applied to beacon intervals within which beacons will be accepted (in seconds)
     #[serde(default = "default_beacon_interval_tolerance")]
     pub beacon_interval_tolerance: i64,
 }
 
 // Default: 10 minutes
 pub fn default_beacon_interval_tolerance() -> i64 {
-    10 * 60 * 60
+    10 * 60
 }
 
 // Default: 6 hours

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -98,4 +98,12 @@ impl Settings {
     pub fn reward_offset_duration(&self) -> Duration {
         Duration::minutes(self.reward_offset_minutes)
     }
+
+    pub fn beacon_interval(&self) -> Duration {
+        Duration::seconds(self.beacon_interval)
+    }
+
+    pub fn beacon_interval_tolerance(&self) -> Duration {
+        Duration::seconds(self.beacon_interval_tolerance)
+    }
 }

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -34,6 +34,22 @@ pub struct Settings {
     pub reward_offset_minutes: i64,
     #[serde(default = "default_max_witnesses_per_poc")]
     pub max_witnesses_per_poc: u64,
+    /// beacon_interval (in seconds)
+    #[serde(default = "default_beacon_interval")]
+    pub beacon_interval: i64,
+    /// beacon_interval_tolerance (in seconds)
+    #[serde(default = "default_beacon_interval_tolerance")]
+    pub beacon_interval_tolerance: i64,
+}
+
+// Default: 10 minutes
+pub fn default_beacon_interval_tolerance() -> i64 {
+    10 * 60 * 60
+}
+
+// Default: 6 hours
+pub fn default_beacon_interval() -> i64 {
+    6 * 60 * 60
 }
 
 pub fn default_log() -> String {


### PR DESCRIPTION
This removes the constant `BEACON_INTERVA`L and `BEACON_INTERVAL_TOLERANCE` and makes it configurable via settings.