### PR TITLE
IoT Config service gateway region params rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,7 +1274,7 @@ dependencies = [
  "chrono",
  "config",
  "futures",
- "h3ron 0.16.0",
+ "h3ron",
  "helium-proto",
  "http",
  "itertools",
@@ -1682,21 +1682,6 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0943f2fcf1e21429a6d3a9842308ee363a6d9018fda475c47c564156d44eef3"
-dependencies = [
- "float_next_after",
- "geo-types",
- "geographiclib-rs",
- "log",
- "num-traits",
- "robust",
- "rstar",
-]
-
-[[package]]
-name = "geo"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b684179d4c034f9e6718692601a7ec77e4a3b654dbc09b5e4fd342f0e48f2ba1"
@@ -1803,26 +1788,12 @@ dependencies = [
 
 [[package]]
 name = "h3ron"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d52875c47f35a0db141bef968682165623e7d1671a0da40b87f581a3a953fd"
-dependencies = [
- "ahash 0.8.2",
- "geo 0.22.1",
- "geo-types",
- "h3ron-h3-sys",
- "hashbrown 0.12.3",
- "thiserror",
-]
-
-[[package]]
-name = "h3ron"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d71b40c852263f760233f189e324930e1672276f1c91fe079bd9fd58e590600"
 dependencies = [
  "ahash 0.8.2",
- "geo 0.23.0",
+ "geo",
  "geo-types",
  "h3ron-h3-sys",
  "hashbrown 0.12.3",
@@ -1993,11 +1964,12 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hextree"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b441cd933ac3eadde9f01898ef12bb3d4560fbe1aeaf3eb2e5bff5bdd7715a17"
+checksum = "0a6ffc35fc0fb2af599742de1938d44cd18b0ae7cf7a7faf4b067f43cc863902"
 dependencies = [
- "h3ron 0.15.1",
+ "bitfield",
+ "thiserror",
 ]
 
 [[package]]
@@ -2271,9 +2243,9 @@ dependencies = [
  "file-store",
  "futures",
  "futures-util",
- "geo 0.23.0",
+ "geo",
  "geo-types",
- "h3ron 0.16.0",
+ "h3ron",
  "helium-crypto",
  "helium-proto",
  "http-serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2192,6 +2192,7 @@ dependencies = [
  "helium-proto",
  "metrics",
  "metrics-exporter-prometheus",
+ "node-follower",
  "poc-metrics",
  "prost",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,7 +1274,7 @@ dependencies = [
  "chrono",
  "config",
  "futures",
- "h3ron",
+ "h3ron 0.16.0",
  "helium-proto",
  "http",
  "itertools",
@@ -1676,6 +1682,21 @@ dependencies = [
 
 [[package]]
 name = "geo"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0943f2fcf1e21429a6d3a9842308ee363a6d9018fda475c47c564156d44eef3"
+dependencies = [
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar",
+]
+
+[[package]]
+name = "geo"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b684179d4c034f9e6718692601a7ec77e4a3b654dbc09b5e4fd342f0e48f2ba1"
@@ -1782,12 +1803,26 @@ dependencies = [
 
 [[package]]
 name = "h3ron"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d52875c47f35a0db141bef968682165623e7d1671a0da40b87f581a3a953fd"
+dependencies = [
+ "ahash 0.8.2",
+ "geo 0.22.1",
+ "geo-types",
+ "h3ron-h3-sys",
+ "hashbrown 0.12.3",
+ "thiserror",
+]
+
+[[package]]
+name = "h3ron"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d71b40c852263f760233f189e324930e1672276f1c91fe079bd9fd58e590600"
 dependencies = [
  "ahash 0.8.2",
- "geo",
+ "geo 0.23.0",
  "geo-types",
  "h3ron-h3-sys",
  "hashbrown 0.12.3",
@@ -1955,6 +1990,15 @@ name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
+name = "hextree"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b441cd933ac3eadde9f01898ef12bb3d4560fbe1aeaf3eb2e5bff5bdd7715a17"
+dependencies = [
+ "h3ron 0.15.1",
+]
 
 [[package]]
 name = "hkdf"
@@ -2190,6 +2234,8 @@ dependencies = [
  "futures-util",
  "helium-crypto",
  "helium-proto",
+ "hextree",
+ "libflate",
  "metrics",
  "metrics-exporter-prometheus",
  "node-follower",
@@ -2225,9 +2271,9 @@ dependencies = [
  "file-store",
  "futures",
  "futures-util",
- "geo",
+ "geo 0.23.0",
  "geo-types",
- "h3ron",
+ "h3ron 0.16.0",
  "helium-crypto",
  "helium-proto",
  "http-serde",
@@ -2393,6 +2439,26 @@ name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+
+[[package]]
+name = "libflate"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05605ab2bce11bcfc0e9c635ff29ef8b2ea83f29be257ee7d730cac3ee373093"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
+dependencies = [
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libm"
@@ -3542,6 +3608,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "robust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,8 @@ sqlx = {version = "0", features = [
   "runtime-tokio-rustls"
 ]}
 helium-crypto = {version = "0.6.3", features=["sqlx-postgres", "multisig"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "jg/config-region-admin", features = ["services"]}
+hextree = "*"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
 humantime = "2"
 metrics = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ sqlx = {version = "0", features = [
   "runtime-tokio-rustls"
 ]}
 helium-crypto = {version = "0.6.3", features=["sqlx-postgres", "multisig"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "jg/config-region-admin", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
 hextree = "*"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
 humantime = "2"

--- a/file_store/src/traits/msg_verify.rs
+++ b/file_store/src/traits/msg_verify.rs
@@ -2,8 +2,8 @@ use crate::{Error, Result};
 use helium_crypto::{PublicKey, Verify};
 use helium_proto::services::{
     iot_config::{
-        OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgDisableReqV1, RouteCreateReqV1,
-        RouteDeleteDevaddrRangesReqV1, RouteDeleteEuisReqV1, RouteDeleteReqV1,
+        GatewayRegionParamsReqV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgDisableReqV1,
+        RouteCreateReqV1, RouteDeleteDevaddrRangesReqV1, RouteDeleteEuisReqV1, RouteDeleteReqV1,
         RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1, RouteGetReqV1, RouteListReqV1,
         RouteStreamReqV1, RouteUpdateDevaddrRangesReqV1, RouteUpdateEuisReqV1, RouteUpdateReqV1,
     },
@@ -52,6 +52,7 @@ impl_msg_verify!(RouteUpdateEuisReqV1, signature);
 impl_msg_verify!(RouteGetDevaddrRangesReqV1, signature);
 impl_msg_verify!(RouteUpdateDevaddrRangesReqV1, signature);
 impl_msg_verify!(RouteDeleteDevaddrRangesReqV1, signature);
+impl_msg_verify!(GatewayRegionParamsReqV1, signature);
 
 #[cfg(test)]
 mod test {

--- a/file_store/src/traits/msg_verify.rs
+++ b/file_store/src/traits/msg_verify.rs
@@ -2,7 +2,7 @@ use crate::{Error, Result};
 use helium_crypto::{PublicKey, Verify};
 use helium_proto::services::{
     iot_config::{
-        GatewayRegionParamsReqV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgDisableReqV1,
+        GatewayRegionParamsReqV1, LoadRegionReqV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgDisableReqV1,
         RouteCreateReqV1, RouteDeleteDevaddrRangesReqV1, RouteDeleteEuisReqV1, RouteDeleteReqV1,
         RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1, RouteGetReqV1, RouteListReqV1,
         RouteStreamReqV1, RouteUpdateDevaddrRangesReqV1, RouteUpdateEuisReqV1, RouteUpdateReqV1,
@@ -53,6 +53,7 @@ impl_msg_verify!(RouteGetDevaddrRangesReqV1, signature);
 impl_msg_verify!(RouteUpdateDevaddrRangesReqV1, signature);
 impl_msg_verify!(RouteDeleteDevaddrRangesReqV1, signature);
 impl_msg_verify!(GatewayRegionParamsReqV1, signature);
+impl_msg_verify!(LoadRegionReqV1, signature);
 
 #[cfg(test)]
 mod test {

--- a/file_store/src/traits/msg_verify.rs
+++ b/file_store/src/traits/msg_verify.rs
@@ -2,10 +2,11 @@ use crate::{Error, Result};
 use helium_crypto::{PublicKey, Verify};
 use helium_proto::services::{
     iot_config::{
-        GatewayRegionParamsReqV1, LoadRegionReqV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgDisableReqV1,
-        RouteCreateReqV1, RouteDeleteDevaddrRangesReqV1, RouteDeleteEuisReqV1, RouteDeleteReqV1,
-        RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1, RouteGetReqV1, RouteListReqV1,
-        RouteStreamReqV1, RouteUpdateDevaddrRangesReqV1, RouteUpdateEuisReqV1, RouteUpdateReqV1,
+        GatewayRegionParamsReqV1, LoadRegionReqV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1,
+        OrgDisableReqV1, RouteCreateReqV1, RouteDeleteDevaddrRangesReqV1, RouteDeleteEuisReqV1,
+        RouteDeleteReqV1, RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1, RouteGetReqV1,
+        RouteListReqV1, RouteStreamReqV1, RouteUpdateDevaddrRangesReqV1, RouteUpdateEuisReqV1,
+        RouteUpdateReqV1,
     },
     poc_lora::{LoraBeaconReportReqV1, LoraWitnessReportReqV1},
 };

--- a/iot_config/Cargo.toml
+++ b/iot_config/Cargo.toml
@@ -18,6 +18,8 @@ futures = {workspace = true}
 futures-util = {workspace = true}
 helium-crypto = {workspace = true}
 helium-proto = {workspace = true}
+hextree = {workspace = true}
+libflate = "1"
 metrics = {workspace = true}
 metrics-exporter-prometheus = {workspace = true}
 node-follower = {path = "../node_follower"}

--- a/iot_config/Cargo.toml
+++ b/iot_config/Cargo.toml
@@ -20,6 +20,7 @@ helium-crypto = {workspace = true}
 helium-proto = {workspace = true}
 metrics = {workspace = true}
 metrics-exporter-prometheus = {workspace = true}
+node-follower = {path = "../node_follower"}
 poc-metrics = {path = "../metrics"}
 prost = {workspace = true}
 serde = {workspace = true}

--- a/iot_config/migrations/4_regions.sql
+++ b/iot_config/migrations/4_regions.sql
@@ -1,0 +1,10 @@
+create table regions (
+    region int primary key not null,
+    params bytea not null,
+    indexes bytea,
+
+    inserted_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+select trigger_updated_at('regions');

--- a/iot_config/pkg/settings-template.toml
+++ b/iot_config/pkg/settings-template.toml
@@ -26,3 +26,17 @@ chain = "postgres://postgres:postgres@127.0.0.1:5432/chain_db"
 # Endpoint for metrics. Default below
 #
 # endpoint = "127.0.0.1:19000"
+
+[follower]
+
+# Local grpc url to node follower for gateway location lookups
+#[serde(with = "http_serde::uri", default = "default_url")]
+# url = http://127.0.0.1:8080
+# Start block to begin streaming followed transactions
+block = 0
+# Connect timeout for follower in seconds. Default 5
+# connect = 5
+# RPC timeout for follower in seconds. Default 5
+# rpc = 5
+# Batch size for gateway stream results. Default 100
+# batch = 100

--- a/iot_config/src/gateway_service.rs
+++ b/iot_config/src/gateway_service.rs
@@ -1,28 +1,45 @@
-use crate::{GrpcResult, Settings};
+use crate::{region_map, GrpcResult, Settings};
 use anyhow::Result;
 use file_store::traits::MsgVerify;
 use helium_crypto::{Keypair, PublicKey, Sign};
 use helium_proto::{
-    services::iot_config::{self, GatewayRegionParamsReqV1, GatewayRegionParamsResV1, LoadRegionReqV1, LoadRegionResV1},
+    services::iot_config::{
+        self, GatewayRegionParamsReqV1, GatewayRegionParamsResV1, LoadRegionReqV1, LoadRegionResV1,
+    },
     Message,
 };
 use node_follower::{
     follower_service::FollowerService,
     gateway_resp::{GatewayInfo, GatewayInfoResolver},
 };
+use sqlx::{Pool, Postgres};
 use tonic::{Request, Response, Status};
 
 pub struct GatewayService {
+    admin_pubkey: PublicKey,
     follower_service: FollowerService,
+    pool: Pool<Postgres>,
     signing_key: Keypair,
 }
 
 impl GatewayService {
-    pub fn new(settings: &Settings) -> Result<Self> {
+    pub async fn new(settings: &Settings) -> Result<Self> {
         Ok(Self {
+            admin_pubkey: settings.admin_pubkey()?,
             follower_service: FollowerService::from_settings(&settings.follower),
+            pool: settings.database.connect(10).await?,
             signing_key: settings.signing_keypair()?,
         })
+    }
+
+    fn verify_admin_signature<R>(&self, request: R) -> Result<R, Status>
+    where
+        R: MsgVerify,
+    {
+        request
+            .verify(&self.admin_pubkey)
+            .map_err(|_| Status::permission_denied("invalid admin signature"))?;
+        Ok(request)
     }
 }
 
@@ -65,7 +82,27 @@ impl iot_config::Gateway for GatewayService {
         Ok(Response::new(resp))
     }
 
-    async fn load_region(&self, _request: Request<LoadRegionReqV1>) -> GrpcResult<LoadRegionResV1> {
-        unimplemented!()
+    async fn load_region(&self, request: Request<LoadRegionReqV1>) -> GrpcResult<LoadRegionResV1> {
+        let request = request.into_inner();
+        let req = self.verify_admin_signature(request)?;
+
+        let params = match req.params {
+            Some(params) => params,
+            None => return Err(Status::invalid_argument("missing region")),
+        };
+
+        region_map::persist_params(req.region, params, &self.pool)
+            .await
+            .map_err(|_| Status::internal("region params save failed"))?;
+
+        if let Some(indexes) = req.hex_indexes {
+            region_map::persist_indexes(req.region, &indexes, &self.pool)
+                .await
+                .map_err(|_| Status::internal("region indexes save failed"))?;
+        } else {
+            tracing::debug!("h3 region index update skipped")
+        };
+
+        Ok(Response::new(LoadRegionResV1 {}))
     }
 }

--- a/iot_config/src/gateway_service.rs
+++ b/iot_config/src/gateway_service.rs
@@ -11,6 +11,7 @@ use helium_proto::{
     },
     Message, Region,
 };
+use hextree::Cell;
 use node_follower::{
     follower_service::FollowerService,
     gateway_resp::{GatewayInfo, GatewayInfoResolver},
@@ -71,7 +72,12 @@ impl iot_config::Gateway for GatewayService {
             .await
             .map_err(|_| Status::internal("gateway lookup error"))?;
 
-        let location = location.ok_or_else(|| Status::internal("gateway location undefined"))?;
+        let location = {
+            let location =
+                location.ok_or_else(|| Status::internal("gateway location undefined"))?;
+            Cell::from_raw(location)
+                .map_err(|_| Status::internal("gateway location is not a valid h3 index"))?
+        };
 
         let region = self
             .region_map

--- a/iot_config/src/gateway_service.rs
+++ b/iot_config/src/gateway_service.rs
@@ -1,18 +1,68 @@
-use crate::GrpcResult;
-use helium_proto::services::iot_config::{
-    self, GatewayRegionParamsReqV1, GatewayRegionParamsResV1, LoadRegionReqV1, LoadRegionResV1,
+use crate::{GrpcResult, Settings};
+use anyhow::Result;
+use file_store::traits::MsgVerify;
+use helium_crypto::{Keypair, PublicKey, Sign};
+use helium_proto::{
+    services::iot_config::{self, GatewayRegionParamsReqV1, GatewayRegionParamsResV1, LoadRegionReqV1, LoadRegionResV1},
+    Message,
 };
-use tonic::Request;
+use node_follower::{
+    follower_service::FollowerService,
+    gateway_resp::{GatewayInfo, GatewayInfoResolver},
+};
+use tonic::{Request, Response, Status};
 
-pub struct GatewayService {}
+pub struct GatewayService {
+    follower_service: FollowerService,
+    signing_key: Keypair,
+}
+
+impl GatewayService {
+    pub fn new(settings: &Settings) -> Result<Self> {
+        Ok(Self {
+            follower_service: FollowerService::from_settings(&settings.follower),
+            signing_key: settings.signing_keypair()?,
+        })
+    }
+}
 
 #[tonic::async_trait]
 impl iot_config::Gateway for GatewayService {
     async fn region_params(
         &self,
-        _request: Request<GatewayRegionParamsReqV1>,
+        request: Request<GatewayRegionParamsReqV1>,
     ) -> GrpcResult<GatewayRegionParamsResV1> {
-        unimplemented!()
+        let request = request.into_inner();
+
+        let pubkey = PublicKey::try_from(request.address.clone())
+            .map_err(|_| Status::invalid_argument("invalid gateway address"))?;
+        request
+            .verify(&pubkey)
+            .map_err(|_| Status::permission_denied("invalid request signature"))?;
+
+        let GatewayInfo { location, gain, .. } = self
+            .follower_service
+            .clone()
+            .resolve_gateway_info(&pubkey.into())
+            .await
+            .map_err(|_| Status::internal("gateway lookup error"))?;
+
+        match location {
+            Some(hex) => tracing::info!("Gateway located at hex index {hex}"),
+            None => tracing::info!("Gateway location undefined"),
+        }
+
+        let mut resp = GatewayRegionParamsResV1 {
+            region: helium_proto::Region::Us915.into(),
+            params: None,
+            gain: gain as u64,
+            signature: vec![],
+        };
+        resp.signature = self
+            .signing_key
+            .sign(&resp.encode_to_vec())
+            .map_err(|_| Status::internal("resp signing error"))?;
+        Ok(Response::new(resp))
     }
 
     async fn load_region(&self, _request: Request<LoadRegionReqV1>) -> GrpcResult<LoadRegionResV1> {

--- a/iot_config/src/lib.rs
+++ b/iot_config/src/lib.rs
@@ -2,6 +2,7 @@ pub mod gateway_service;
 pub mod lora_field;
 pub mod org;
 pub mod org_service;
+pub mod region_map;
 pub mod route;
 pub mod route_service;
 pub mod session_key_service;

--- a/iot_config/src/main.rs
+++ b/iot_config/src/main.rs
@@ -64,9 +64,6 @@ impl Daemon {
         let pool = settings.database.connect(10).await?;
         sqlx::migrate!().run(&pool).await?;
 
-        let rows = sqlx::query(r#"select * from regions"#).fetch_all(&pool).await?;
-        tracing::error!("REGION RECORDS {}", rows.len());
-
         // Configure shutdown trigger
         let (shutdown_trigger, shutdown_listener) = triggered::trigger();
         tokio::spawn(async move {

--- a/iot_config/src/main.rs
+++ b/iot_config/src/main.rs
@@ -8,7 +8,7 @@ use iot_config::{
     gateway_service::GatewayService, org_service::OrgService, route_service::RouteService,
     session_key_service::SessionKeyFilterService, settings::Settings,
 };
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{path::PathBuf, time::Duration};
 use tokio::signal;
 use tonic::transport;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -71,10 +71,9 @@ impl Daemon {
             shutdown_trigger.trigger()
         });
 
-        let _signing_keypair = Arc::new(settings.signing_keypair()?);
         let listen_addr = settings.listen_addr()?;
 
-        let gateway_svc = GatewayService {};
+        let gateway_svc = GatewayService::new(settings)?;
         let org_svc = OrgService::new(settings).await?;
         let route_svc = RouteService::new(settings).await?;
         let session_key_filter_svc = SessionKeyFilterService {};

--- a/iot_config/src/region_map.rs
+++ b/iot_config/src/region_map.rs
@@ -1,10 +1,96 @@
-use helium_proto::{BlockchainRegionParamsV1, Message};
+use futures::stream::TryStreamExt;
+use helium_proto::{BlockchainRegionParamsV1, Message, Region};
+use hextree::{
+    compaction::EqCompactor,
+    h3ron::{FromH3Index, H3Cell},
+    HexTreeMap,
+};
+use libflate::gzip::Decoder;
+use std::{io::Read, sync::Arc};
+use tokio::sync::RwLock;
 
-pub async fn persist_params(
+pub struct RegionMap(Arc<RwLock<HexTreeMap<(Region, BlockchainRegionParamsV1), EqCompactor>>>);
+
+impl RegionMap {
+    pub fn new() -> Self {
+        Self(Arc::new(RwLock::new(HexTreeMap::with_compactor(
+            EqCompactor,
+        ))))
+    }
+
+    pub async fn get(&self, cell: H3Cell) -> Option<(Region, BlockchainRegionParamsV1)> {
+        self.0.read().await.get(cell).cloned()
+    }
+
+    pub async fn take(&self) -> HexTreeMap<(Region, BlockchainRegionParamsV1), EqCompactor> {
+        self.0.read().await.clone()
+    }
+
+    pub async fn swap(&self, new_map: HexTreeMap<(Region, BlockchainRegionParamsV1), EqCompactor>) {
+        *self.0.write().await = new_map
+    }
+}
+
+impl Default for RegionMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum RegionMapError {
+    #[error("region map database error")]
+    DbFetch(#[from] sqlx::Error),
+    #[error("params decode error")]
+    ParamsDecode(#[from] helium_proto::DecodeError),
+    #[error("indices gunzip error")]
+    IdxGunzip(#[from] std::io::Error),
+    #[error("unsupported region error: {0}")]
+    UnsupportedRegion(i32),
+}
+
+#[derive(sqlx::FromRow)]
+pub struct HexRegion {
+    pub region: i32,
+    pub params: Vec<u8>,
+    pub indexes: Vec<u8>,
+}
+
+pub async fn build_region_map(
+    db: impl sqlx::PgExecutor<'_>,
+) -> Result<HexTreeMap<(Region, BlockchainRegionParamsV1), EqCompactor>, RegionMapError> {
+    let mut region_map = HexTreeMap::with_compactor(EqCompactor);
+
+    let mut regions = sqlx::query_as::<_, HexRegion>("select * from regions").fetch(db);
+
+    while let Some(region_row) = regions.try_next().await? {
+        let region = region_row.region;
+        let region = Region::from_i32(region).ok_or(RegionMapError::UnsupportedRegion(region))?;
+        let params = BlockchainRegionParamsV1::decode(region_row.params.as_slice())?;
+        let encoded_idxs = region_row.indexes;
+        let mut idx_decoder = Decoder::new(&encoded_idxs[..])?;
+        let mut buf = Vec::new();
+        idx_decoder.read_to_end(&mut buf)?;
+
+        let mut idx_buf = [0_u8; 8];
+        for chunk in buf.chunks(8) {
+            idx_buf.as_mut_slice().copy_from_slice(chunk);
+            let idx = u64::from_le_bytes(idx_buf);
+            region_map.insert(H3Cell::from_h3index(idx), (region, params.clone()));
+        }
+    }
+
+    Ok(region_map)
+}
+
+pub async fn update_region(
     region: i32,
     params: BlockchainRegionParamsV1,
-    db: impl sqlx::PgExecutor<'_>,
-) -> Result<(), sqlx::Error> {
+    indexes: &[u8],
+    db: impl sqlx::PgExecutor<'_> + sqlx::Acquire<'_, Database = sqlx::Postgres> + Copy,
+) -> Result<HexRegion, sqlx::Error> {
+    let mut transaction = db.begin().await?;
+
     sqlx::query(
         r#"
         insert into regions (region, params)
@@ -14,28 +100,33 @@ pub async fn persist_params(
     )
     .bind(region)
     .bind(params.encode_to_vec())
-    .execute(db)
+    .execute(&mut transaction)
     .await?;
 
-    Ok(())
-}
+    if !indexes.is_empty() {
+        sqlx::query(
+            r#"
+            insert into regions (region, indexes)
+            values ($1, $2)
+            on conflict (region) do update set indexes = excluded.indexes
+            "#,
+        )
+        .bind(region)
+        .bind(indexes)
+        .execute(&mut transaction)
+        .await?;
+    }
 
-pub async fn persist_indexes(
-    region: i32,
-    indexes: &[u8],
-    db: impl sqlx::PgExecutor<'_>,
-) -> Result<(), sqlx::Error> {
-    sqlx::query(
+    let updated_region = sqlx::query_as::<_, HexRegion>(
         r#"
-        insert into regions (region, indexes)
-        values ($1, $2)
-        on conflict (region) do update set indexes = excluded.indexes
+        select * from regions where region = $1
         "#,
     )
     .bind(region)
-    .bind(indexes)
-    .execute(db)
+    .fetch_one(&mut transaction)
     .await?;
 
-    Ok(())
+    transaction.commit().await?;
+
+    Ok(updated_region)
 }

--- a/iot_config/src/region_map.rs
+++ b/iot_config/src/region_map.rs
@@ -1,0 +1,41 @@
+use helium_proto::{BlockchainRegionParamsV1, Message};
+
+pub async fn persist_params(
+    region: i32,
+    params: BlockchainRegionParamsV1,
+    db: impl sqlx::PgExecutor<'_>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        insert into regions (region, params)
+        values ($1, $2)
+        on conflict (region) do update set params = excluded.params
+        "#,
+    )
+    .bind(region)
+    .bind(params.encode_to_vec())
+    .execute(db)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn persist_indexes(
+    region: i32,
+    indexes: &[u8],
+    db: impl sqlx::PgExecutor<'_>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        insert into regions (region, indexes)
+        values ($1, $2)
+        on conflict (region) do update set indexes = excluded.indexes
+        "#,
+    )
+    .bind(region)
+    .bind(indexes)
+    .execute(db)
+    .await?;
+
+    Ok(())
+}

--- a/iot_config/src/settings.rs
+++ b/iot_config/src/settings.rs
@@ -24,6 +24,8 @@ pub struct Settings {
     pub network: Network,
     pub database: db_store::Settings,
     pub metrics: poc_metrics::Settings,
+    /// Helium blockchain node client for gateway location lookups
+    pub follower: node_follower::Settings,
 }
 
 pub fn default_log() -> String {


### PR DESCRIPTION
Implements the gRPC APIs for IoT gateways to connect and request their asserted location's region and region params, as well as the API for the admin user of the Config service to (re)load region params and region hex lists into the config server, persisting them to the DB

- Loading region params changes and region hex index lists to the service requires the request being signed by the registered "admin" keypair
- [x] final approval and merging of https://github.com/helium/proto/pull/270, followed by updating the oracles cargo file to revert the proto reference back to master branch is a pre-requisite to merging
- Region params and H3idx lists of region hex res 7 indexes are persisted to the DB as bytea fields, in-memory they are wrapped together in a `RegionMap` struct that consists of a `HexTreeMap<Region, EqCompactor>` (for efficient mapping of each asserted location's lorawan region), and a `HashMap<Region, BlockchainRegionParamsV1>`