### PR TITLE
configure loader windows via settings

### DIFF
--- a/file_store/src/cli/info.rs
+++ b/file_store/src/cli/info.rs
@@ -66,12 +66,6 @@ impl Cmd {
     }
 }
 
-impl MsgTimestamp<Result<DateTime<Utc>>> for EntropyReportV1 {
-    fn timestamp(&self) -> Result<DateTime<Utc>> {
-        self.timestamp.to_timestamp()
-    }
-}
-
 impl MsgTimestamp<Result<DateTime<Utc>>> for PriceReportV1 {
     fn timestamp(&self) -> Result<DateTime<Utc>> {
         self.timestamp.to_timestamp()

--- a/file_store/src/entropy_report.rs
+++ b/file_store/src/entropy_report.rs
@@ -1,0 +1,43 @@
+use crate::{
+    traits::{MsgDecode, MsgTimestamp, TimestampDecode, TimestampEncode},
+    Error, Result,
+};
+use chrono::{DateTime, Utc};
+use helium_proto::EntropyReportV1;
+use serde::Serialize;
+
+#[derive(Serialize, Clone)]
+pub struct EntropyReport {
+    pub data: Vec<u8>,
+    pub timestamp: DateTime<Utc>,
+    pub version: u32,
+}
+
+impl MsgTimestamp<u64> for EntropyReport {
+    fn timestamp(&self) -> u64 {
+        self.timestamp.encode_timestamp_millis()
+    }
+}
+
+impl MsgTimestamp<Result<DateTime<Utc>>> for EntropyReportV1 {
+    fn timestamp(&self) -> Result<DateTime<Utc>> {
+        self.timestamp.to_timestamp_millis()
+    }
+}
+
+impl MsgDecode for EntropyReport {
+    type Msg = EntropyReportV1;
+}
+
+impl TryFrom<EntropyReportV1> for EntropyReport {
+    type Error = Error;
+
+    fn try_from(v: EntropyReportV1) -> Result<Self> {
+        let timestamp = v.timestamp()?;
+        Ok(Self {
+            data: v.data,
+            version: v.version,
+            timestamp,
+        })
+    }
+}

--- a/file_store/src/lib.rs
+++ b/file_store/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod entropy_report;
 mod error;
 mod file_info;
 pub mod file_info_poller;

--- a/iot_verifier/migrations/11_files_processed.sql
+++ b/iot_verifier/migrations/11_files_processed.sql
@@ -1,0 +1,6 @@
+CREATE TABLE files_processed (
+	file_name VARCHAR PRIMARY KEY,
+	file_type VARCHAR NOT NULL,
+	file_timestamp TIMESTAMPTZ NOT NULL,
+	processed_at TIMESTAMPTZ NOT NULL
+);

--- a/iot_verifier/pkg/settings-template.toml
+++ b/iot_verifier/pkg/settings-template.toml
@@ -1,6 +1,6 @@
 
 # log settings for the application (RUST_LOG format). Default below
-# 
+#
 # log = "iot-verifier=debug,poc_store=info"
 
 # Cache location for generated verified reports; Required
@@ -16,6 +16,40 @@ beacon_interval = 21600
 
 # Default beacon interval tolerance ( 10 minutes) (in seconds)
 beacon_interval_tolerance = 600
+
+# window width for the  poc report loader ( in seconds )
+# NOTE: the window width should be as a minimum equal to the ingestor roll up period
+#       any less and the verifier will potentially miss incoming reports
+poc_loader_window_width = 300
+
+# cadence for how often to look for poc reports from s3 buckets ( in seconds )
+# in normal operational mode the poll time should be set same as that of the window width
+# however, if for example we are loading historic data, ie looking back 24hours, we will want
+# the loader to be catching up as quickly as possible and so we will want to poll more often
+# in order to iterate quickly over the historic data
+# the average time it takes to load the data available within the window width needs to be
+# considered here, the poll time should be at least equal to that plus some percentage
+# if in doubt, keep this same value as poc_loader_window_width
+poc_loader_poll_time = 300
+
+# window width for the entropy report loader ( in seconds )
+poc_loader_entropy_window_width = 300
+
+# the lifespan of a piece of entropy ( in seconds )
+poc_entropy_lifespan = 180
+
+# cadence for how often to look for entropy reports from s3 buckets ( in seconds )
+# in normal operational mode the poll time should be set same as that of the entropy window width
+# however, if for example we are loading historic data, ie looking back 24hours, we will want
+# the loader to be catching up as quickly as possible and so we will want to poll more often
+# in order to iterate quickly over the historic data
+# the average time it takes to load the data available within with window width needs to be
+# considered here
+poc_loader_entropy_poll_time = 300
+
+# max window age for the entropy and poc report loader ( in seconds )
+# the starting point of the window will never be older than NOW - max_age
+poc_loader_window_max_lookback_age = 3600
 
 [database]
 

--- a/iot_verifier/pkg/settings-template.toml
+++ b/iot_verifier/pkg/settings-template.toml
@@ -32,24 +32,15 @@ poc_loader_window_width = 300
 # if in doubt, keep this same value as poc_loader_window_width
 poc_loader_poll_time = 300
 
-# window width for the entropy report loader ( in seconds )
-poc_loader_entropy_window_width = 300
+# max window age for the entropy and poc report loader ( in seconds )
+# the starting point of the window will never be older than NOW - max_age
+poc_loader_window_max_lookback_age = 3600
 
 # the lifespan of a piece of entropy ( in seconds )
 poc_entropy_lifespan = 180
 
-# cadence for how often to look for entropy reports from s3 buckets ( in seconds )
-# in normal operational mode the poll time should be set same as that of the entropy window width
-# however, if for example we are loading historic data, ie looking back 24hours, we will want
-# the loader to be catching up as quickly as possible and so we will want to poll more often
-# in order to iterate quickly over the historic data
-# the average time it takes to load the data available within with window width needs to be
-# considered here
-poc_loader_entropy_poll_time = 300
-
-# max window age for the entropy and poc report loader ( in seconds )
-# the starting point of the window will never be older than NOW - max_age
-poc_loader_window_max_lookback_age = 3600
+# File store poll interval for incoming entropy reports, in seconds
+entropy_interval = 300
 
 [database]
 

--- a/iot_verifier/pkg/settings-template.toml
+++ b/iot_verifier/pkg/settings-template.toml
@@ -34,7 +34,7 @@ poc_loader_poll_time = 300
 
 # max window age for the entropy and poc report loader ( in seconds )
 # the starting point of the window will never be older than NOW - max_age
-poc_loader_window_max_lookback_age = 3600
+loader_window_max_lookback_age = 3600
 
 # the lifespan of a piece of entropy ( in seconds )
 poc_entropy_lifespan = 180

--- a/iot_verifier/pkg/settings-template.toml
+++ b/iot_verifier/pkg/settings-template.toml
@@ -37,7 +37,7 @@ poc_loader_poll_time = 300
 loader_window_max_lookback_age = 3600
 
 # the lifespan of a piece of entropy ( in seconds )
-poc_entropy_lifespan = 180
+entropy_lifespan = 180
 
 # File store poll interval for incoming entropy reports, in seconds
 entropy_interval = 300

--- a/iot_verifier/src/entropy.rs
+++ b/iot_verifier/src/entropy.rs
@@ -75,11 +75,11 @@ impl Entropy {
         .await?)
     }
 
-    pub async fn purge<'c, 'q, E>(executor: E, stale_period: i64) -> Result<(), EntropyError>
+    pub async fn purge<'c, 'q, E>(executor: E, stale_period: Duration) -> Result<(), EntropyError>
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres> + Clone,
     {
-        let stale_time = Utc::now() - Duration::seconds(stale_period);
+        let stale_time = Utc::now() - stale_period;
         sqlx::query(
             r#"
             delete from entropy

--- a/iot_verifier/src/entropy_loader.rs
+++ b/iot_verifier/src/entropy_loader.rs
@@ -23,7 +23,6 @@ impl EntropyLoader {
         mut receiver: Receiver<FileInfoStream<EntropyReport>>,
         shutdown: &triggered::Listener,
     ) -> anyhow::Result<()> {
-        tracing::info!("started verifier entropy loader");
         loop {
             if shutdown.is_triggered() {
                 break;

--- a/iot_verifier/src/entropy_loader.rs
+++ b/iot_verifier/src/entropy_loader.rs
@@ -1,21 +1,12 @@
-use crate::{entropy::Entropy, meta::Meta, Settings};
+use crate::entropy::Entropy;
 use blake3::hash;
-use chrono::{Duration as ChronoDuration, Utc};
-use file_store::{traits::TimestampDecode, FileStore, FileType};
-use futures::{stream, StreamExt};
-use helium_proto::{EntropyReportV1, Message};
+use file_store::{entropy_report::EntropyReport, file_info_poller::FileInfoStream};
+use futures::{StreamExt, TryStreamExt};
 use sqlx::PgPool;
-use tokio::time::{self, MissedTickBehavior};
-
-const ENTROPY_META_NAME: &str = "entropy_report";
-const STORE_WORKERS: usize = 10;
+use tokio::sync::mpsc::Receiver;
 
 pub struct EntropyLoader {
-    entropy_store: FileStore,
-    pool: PgPool,
-    poll_time: time::Duration,
-    window_width: ChronoDuration,
-    max_lookback_age: ChronoDuration,
+    pub pool: PgPool,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -27,36 +18,20 @@ pub enum NewLoaderError {
 }
 
 impl EntropyLoader {
-    pub async fn from_settings(settings: &Settings, pool: PgPool) -> Result<Self, NewLoaderError> {
-        tracing::info!("from_settings verifier entropy loader");
-        let entropy_store = FileStore::from_settings(&settings.entropy).await?;
-        let poll_time = settings.poc_loader_entropy_poll_time();
-        let window_width = settings.poc_loader_entropy_window_width();
-        let max_lookback_age = settings.poc_loader_window_max_lookback_age();
-        Ok(Self {
-            pool,
-            entropy_store,
-            poll_time,
-            window_width,
-            max_lookback_age,
-        })
-    }
-
-    pub async fn run(&mut self, shutdown: &triggered::Listener) -> anyhow::Result<()> {
+    pub async fn run(
+        &mut self,
+        mut receiver: Receiver<FileInfoStream<EntropyReport>>,
+        shutdown: &triggered::Listener,
+    ) -> anyhow::Result<()> {
         tracing::info!("started verifier entropy loader");
-        let mut report_timer = time::interval(self.poll_time);
-        report_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
         loop {
             if shutdown.is_triggered() {
                 break;
             }
             tokio::select! {
                 _ = shutdown.clone() => break,
-                _ = report_timer.tick() => match self.handle_entropy_tick().await {
-                    Ok(()) => (),
-                    Err(err) => {
-                        tracing::error!("entropy loader error: {err:?}");
-                    }
+                msg = receiver.recv() => if let Some(stream) =  msg {
+                    self.handle_report(stream).await?;
                 }
             }
         }
@@ -64,105 +39,31 @@ impl EntropyLoader {
         Ok(())
     }
 
-    async fn handle_entropy_tick(&self) -> anyhow::Result<()> {
-        tracing::info!("handling entropy tick");
-        let now = Utc::now();
-        // the loader loads files from s3 via a sliding window
-        // if there is no last timestamp in the meta db, the window start point will be
-        // Now() - (window_width * 3)
-        // as such data loading is always behind by a value equal to window_width * 2
-        let window_default_lookback = now - (self.window_width * 3);
-        // cap the starting point of the window at the max below.
-        let window_max_lookback = now - self.max_lookback_age;
-        let after = Meta::last_timestamp(&self.pool, ENTROPY_META_NAME)
-            .await?
-            .unwrap_or(window_default_lookback)
-            .max(window_max_lookback);
-        let before_max = after + self.window_width;
-        let before = (now - (self.window_width * 2)).min(before_max);
-        let window_width = (before - after).num_minutes() as u64;
-        tracing::info!(
-            "entropy sliding window, after: {after}, before: {before}, width: {window_width}"
-        );
-        // contain any errors whilst processing the window
-        // any required recovery should happen within process_window
-        // and after processing the window we should always updated last timestamp
-        // in order to advance our sliding window
-        match self
-            .process_window(FileType::EntropyReport, &self.entropy_store, after, before)
-            .await
-        {
-            Ok(()) => (),
-            Err(err) => tracing::warn!(
-                "error whilst processing window for {:?}, error: {err:?}",
-                FileType::EntropyReport
-            ),
-        }
-        Meta::update_last_timestamp(&self.pool, ENTROPY_META_NAME, Some(before)).await?;
-        tracing::info!("completed handling entropy tick");
-        Ok(())
-    }
-
-    async fn process_window(
+    async fn handle_report(
         &self,
-        file_type: FileType,
-        store: &FileStore,
-        after: chrono::DateTime<Utc>,
-        before: chrono::DateTime<Utc>,
+        file_info_stream: FileInfoStream<EntropyReport>,
     ) -> anyhow::Result<()> {
-        tracing::info!(
-            "checking for new ingest files of type {file_type} after {after} and before {before}"
-        );
-        let infos = store.list_all(file_type, after, before).await?;
-        if infos.is_empty() {
-            tracing::info!("no available ingest files of type {file_type}");
-            return Ok(());
-        }
-
-        let infos_len = infos.len();
-        tracing::info!("processing {infos_len} ingest files of type {file_type}");
-        store
-            .source(stream::iter(infos).map(Ok).boxed())
-            .for_each_concurrent(STORE_WORKERS, |msg| async move {
-                match msg {
-                    Err(err) => tracing::warn!("skipping report of type {file_type} due to error {err:?}"),
-                    Ok(buf) => match self
-                        .handle_report(file_type, &buf)
-                        .await
-                    {
-                        Ok(()) => (),
-                        Err(err) => {
-                            tracing::warn!("error whilst handling incoming report of type: {file_type}, error: {err:?}")
-                        }
-                    },
-                }
-            })
-            .await;
-        tracing::info!("completed processing {infos_len} files of type {file_type}");
-        Ok(())
-    }
-
-    async fn handle_report(&self, file_type: FileType, buf: &[u8]) -> anyhow::Result<()> {
-        match file_type {
-            FileType::EntropyReport => {
-                let event = EntropyReportV1::decode(buf)?;
-                tracing::debug!("entropy report: {:?}", event);
-                let id = hash(&event.data).as_bytes().to_vec();
+        let mut transaction = self.pool.begin().await?;
+        file_info_stream
+            .into_stream(&mut transaction)
+            .await?
+            .map(anyhow::Ok)
+            .try_fold(transaction, |mut transaction, report| async move {
+                let id = hash(&report.data).as_bytes().to_vec();
                 Entropy::insert_into(
-                    &self.pool,
+                    &mut transaction,
                     &id,
-                    &event.data,
-                    &event.timestamp.to_timestamp()?,
-                    event.version as i32,
+                    &report.data,
+                    &report.timestamp,
+                    report.version as i32,
                 )
                 .await?;
                 metrics::increment_counter!("oracles_iot_verifier_loader_entropy");
-                Ok(())
-            }
-            _ => {
-                tracing::warn!("ignoring unexpected filetype: {file_type:?}");
-                Ok(())
-            }
-        }
+                Ok(transaction)
+            })
+            .await?
+            .commit()
+            .await?;
+        Ok(())
     }
 }

--- a/iot_verifier/src/loader.rs
+++ b/iot_verifier/src/loader.rs
@@ -60,7 +60,7 @@ impl Loader {
         let ingest_store = FileStore::from_settings(&settings.ingest).await?;
         let poll_time = settings.poc_loader_poll_time();
         let window_width = settings.poc_loader_window_width();
-        let max_lookback_age = settings.poc_loader_window_max_lookback_age();
+        let max_lookback_age = settings.loader_window_max_lookback_age();
         let deny_list = DenyList::new()?;
         Ok(Self {
             pool,

--- a/iot_verifier/src/poc_report.rs
+++ b/iot_verifier/src/poc_report.rs
@@ -358,7 +358,7 @@ impl Report {
 
     pub async fn get_stale_beacons<'c, E>(
         executor: E,
-        stale_period: i64,
+        stale_period: Duration,
     ) -> Result<Vec<Self>, ReportError>
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
@@ -371,7 +371,7 @@ impl Report {
         // if the entropy is not there the beacon will never be processed
         // Such beacons will eventually be handled by the purger and failed there
         // stale beacon reports, for this reason, are determined solely based on time
-        let stale_time = Utc::now() - Duration::seconds(stale_period);
+        let stale_time = Utc::now() - stale_period;
         Ok(sqlx::query_as::<_, Self>(
             r#"
             select * from poc_report
@@ -400,7 +400,7 @@ impl Report {
 
     pub async fn get_stale_witnesses<'c, E>(
         executor: E,
-        stale_period: i64,
+        stale_period: Duration,
     ) -> Result<Vec<Self>, ReportError>
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
@@ -412,7 +412,7 @@ impl Report {
         // as the verifier processes beacon reports and then pulls witness reports
         // linked to current beacon being processed
         // stale witness reports, for this reason, are determined solely based on time
-        let stale_time = Utc::now() - Duration::seconds(stale_period);
+        let stale_time = Utc::now() - stale_period;
         Ok(sqlx::query_as::<_, Self>(
             r#"
             select * from poc_report

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -57,8 +57,8 @@ pub struct Settings {
     pub poc_entropy_lifespan: i64,
     /// max window age for the poc report loader ( in seconds )
     /// the starting point of the window will never be older than now - max age
-    #[serde(default = "default_poc_loader_window_max_lookback_age")]
-    pub poc_loader_window_max_lookback_age: i64,
+    #[serde(default = "default_loader_window_max_lookback_age")]
+    pub loader_window_max_lookback_age: i64,
     /// File store poll interval for incoming entropy reports, in seconds
     #[serde(default = "default_entropy_interval")]
     pub entropy_interval: i64,
@@ -66,7 +66,7 @@ pub struct Settings {
 
 // Default: 60 minutes
 // this should be at least poc_loader_window_width * 2
-pub fn default_poc_loader_window_max_lookback_age() -> i64 {
+pub fn default_loader_window_max_lookback_age() -> i64 {
     60 * 60
 }
 
@@ -174,8 +174,8 @@ impl Settings {
         time::Duration::from_secs(self.poc_loader_poll_time)
     }
 
-    pub fn poc_loader_window_max_lookback_age(&self) -> Duration {
-        Duration::seconds(self.poc_loader_window_max_lookback_age)
+    pub fn loader_window_max_lookback_age(&self) -> Duration {
+        Duration::seconds(self.loader_window_max_lookback_age)
     }
 
     pub fn poc_entropy_lifespan(&self) -> Duration {

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -2,6 +2,7 @@ use chrono::Duration;
 use config::{Config, Environment, File};
 use serde::Deserialize;
 use std::path::Path;
+use tokio::time;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Settings {
@@ -42,6 +43,71 @@ pub struct Settings {
     /// Trigger interval for generating a transmit scaling map
     #[serde(default = "default_transmit_scale_interval")]
     pub transmit_scale_interval: i64,
+    /// window width for the poc report loader ( in seconds )
+    /// each poll the loader will load reports from start time to start time + window width
+    /// NOTE: the window width should be as a minimum equal to the ingestor roll up period
+    ///       any less and the verifier will potentially miss incoming
+    #[serde(default = "default_poc_loader_window_width")]
+    pub poc_loader_window_width: i64,
+    /// cadence for how often to look for poc reports from s3 buckets
+    #[serde(default = "default_poc_loader_poll_time")]
+    pub poc_loader_poll_time: u64,
+    /// cadence for how often to look for entropy reports from s3 buckets
+    #[serde(default = "default_poc_loader_entropy_poll_time")]
+    pub poc_loader_entropy_poll_time: u64,
+    /// window width for the entropy report loader ( in seconds )
+    /// each poll the loader will load reports from start time to start time + window width
+    #[serde(default = "default_poc_loader_entropy_window_width")]
+    pub poc_loader_entropy_window_width: i64,
+    /// the lifespan of a piece of entropy
+    #[serde(default = "default_poc_entropy_lifespan ")]
+    pub poc_entropy_lifespan: i64,
+    /// max window age for the entropy and poc report loader ( in seconds )
+    /// the starting point of the window will never be older than now - max age
+    #[serde(default = "default_poc_loader_window_max_lookback_age")]
+    pub poc_loader_window_max_lookback_age: i64,
+}
+
+// Default: 60 minutes
+// this should be at least poc_loader_window_width * 2
+pub fn default_poc_loader_window_max_lookback_age() -> i64 {
+    60 * 60
+}
+
+// Default: 3 minutes
+pub fn default_poc_entropy_lifespan() -> i64 {
+    3 * 60
+}
+
+// Default: 5 minutes
+pub fn default_poc_loader_entropy_window_width() -> i64 {
+    5 * 60
+}
+// Default: 5 minutes
+// in normal operational mode the poll time should be set same as that of the window width
+// however, if for example we are loading historic data, ie looking back 24hours, we will want
+// the loader to be catching up as quickly as possible and so we will want to poll more often
+// in order to iterate quickly over the historic data
+// the average time it takes to load the data available within with window width needs to be
+// considered here
+pub fn default_poc_loader_entropy_poll_time() -> u64 {
+    5 * 60
+}
+
+// Default: 5 minutes
+pub fn default_poc_loader_window_width() -> i64 {
+    5 * 60
+}
+
+// Default: 5 minutes
+// in normal operational mode the poll time should be set same as that of the window width
+// however, if for example we are loading historic data, ie looking back 24hours, we will want
+// the loader to be catching up as quickly as possible and so we will want to poll more often
+// in order to iterate quickly over the historic data
+// the average time it takes to load the data available within with window width needs to be
+// considered here
+pub fn default_poc_loader_poll_time() -> u64 {
+    5 * 60
 }
 
 // Default: 10 minutes
@@ -112,5 +178,33 @@ impl Settings {
 
     pub fn beacon_interval_tolerance(&self) -> Duration {
         Duration::seconds(self.beacon_interval_tolerance)
+    }
+
+    pub fn poc_loader_window_width(&self) -> Duration {
+        Duration::seconds(self.poc_loader_window_width)
+    }
+
+    pub fn poc_loader_poll_time(&self) -> time::Duration {
+        time::Duration::from_secs(self.poc_loader_poll_time)
+    }
+
+    pub fn poc_loader_window_max_lookback_age(&self) -> Duration {
+        Duration::seconds(self.poc_loader_window_max_lookback_age)
+    }
+
+    pub fn poc_entropy_lifespan(&self) -> Duration {
+        Duration::seconds(self.poc_entropy_lifespan)
+    }
+
+    pub fn poc_loader_entropy_window_width(&self) -> Duration {
+        Duration::seconds(self.poc_loader_entropy_window_width)
+    }
+
+    pub fn poc_loader_entropy_poll_time(&self) -> time::Duration {
+        time::Duration::from_secs(self.poc_loader_entropy_poll_time)
+    }
+
+    pub fn base_stale_period(&self) -> Duration {
+        Duration::seconds(self.base_stale_period)
     }
 }

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -52,20 +52,16 @@ pub struct Settings {
     /// cadence for how often to look for poc reports from s3 buckets
     #[serde(default = "default_poc_loader_poll_time")]
     pub poc_loader_poll_time: u64,
-    /// cadence for how often to look for entropy reports from s3 buckets
-    #[serde(default = "default_poc_loader_entropy_poll_time")]
-    pub poc_loader_entropy_poll_time: u64,
-    /// window width for the entropy report loader ( in seconds )
-    /// each poll the loader will load reports from start time to start time + window width
-    #[serde(default = "default_poc_loader_entropy_window_width")]
-    pub poc_loader_entropy_window_width: i64,
     /// the lifespan of a piece of entropy
     #[serde(default = "default_poc_entropy_lifespan ")]
     pub poc_entropy_lifespan: i64,
-    /// max window age for the entropy and poc report loader ( in seconds )
+    /// max window age for the poc report loader ( in seconds )
     /// the starting point of the window will never be older than now - max age
     #[serde(default = "default_poc_loader_window_max_lookback_age")]
     pub poc_loader_window_max_lookback_age: i64,
+    /// File store poll interval for incoming entropy reports, in seconds
+    #[serde(default = "default_entropy_interval")]
+    pub entropy_interval: i64,
 }
 
 // Default: 60 minutes
@@ -74,23 +70,13 @@ pub fn default_poc_loader_window_max_lookback_age() -> i64 {
     60 * 60
 }
 
-// Default: 3 minutes
-pub fn default_poc_entropy_lifespan() -> i64 {
-    3 * 60
+// Default: 5 minutes
+fn default_entropy_interval() -> i64 {
+    5 * 60
 }
 
 // Default: 5 minutes
-pub fn default_poc_loader_entropy_window_width() -> i64 {
-    5 * 60
-}
-// Default: 5 minutes
-// in normal operational mode the poll time should be set same as that of the window width
-// however, if for example we are loading historic data, ie looking back 24hours, we will want
-// the loader to be catching up as quickly as possible and so we will want to poll more often
-// in order to iterate quickly over the historic data
-// the average time it takes to load the data available within with window width needs to be
-// considered here
-pub fn default_poc_loader_entropy_poll_time() -> u64 {
+pub fn default_poc_entropy_lifespan() -> i64 {
     5 * 60
 }
 
@@ -196,15 +182,11 @@ impl Settings {
         Duration::seconds(self.poc_entropy_lifespan)
     }
 
-    pub fn poc_loader_entropy_window_width(&self) -> Duration {
-        Duration::seconds(self.poc_loader_entropy_window_width)
-    }
-
-    pub fn poc_loader_entropy_poll_time(&self) -> time::Duration {
-        time::Duration::from_secs(self.poc_loader_entropy_poll_time)
-    }
-
     pub fn base_stale_period(&self) -> Duration {
         Duration::seconds(self.base_stale_period)
+    }
+
+    pub fn entropy_interval(&self) -> Duration {
+        Duration::seconds(self.entropy_interval)
     }
 }

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -53,8 +53,8 @@ pub struct Settings {
     #[serde(default = "default_poc_loader_poll_time")]
     pub poc_loader_poll_time: u64,
     /// the lifespan of a piece of entropy
-    #[serde(default = "default_poc_entropy_lifespan ")]
-    pub poc_entropy_lifespan: i64,
+    #[serde(default = "default_entropy_lifespan ")]
+    pub entropy_lifespan: i64,
     /// max window age for the poc report loader ( in seconds )
     /// the starting point of the window will never be older than now - max age
     #[serde(default = "default_loader_window_max_lookback_age")]
@@ -76,7 +76,7 @@ fn default_entropy_interval() -> i64 {
 }
 
 // Default: 5 minutes
-pub fn default_poc_entropy_lifespan() -> i64 {
+pub fn default_entropy_lifespan() -> i64 {
     5 * 60
 }
 
@@ -178,8 +178,8 @@ impl Settings {
         Duration::seconds(self.loader_window_max_lookback_age)
     }
 
-    pub fn poc_entropy_lifespan(&self) -> Duration {
-        Duration::seconds(self.poc_entropy_lifespan)
+    pub fn entropy_lifespan(&self) -> Duration {
+        Duration::seconds(self.entropy_lifespan)
     }
 
     pub fn base_stale_period(&self) -> Duration {


### PR DESCRIPTION
Adds the ability to configure the poc loader window via settings, including the window width, max age and poll time.  The start point of the window can be configured by updating the meta db for keys `report` .  Through a combination of the newly added settings and the modification of the meta keys the loaders can be configured to load historic data, looking as far back in time into the S3 bucket as required.

The driver for this is the upcoming switch to solana, whereby the foundation has indicated it may be required to backfill 24hours worth of reports.  

Also includes a refactor of the entropy loader to use continious source. The poc loader cannot move to continuous source as its loading process is more involved.

Also removes the cloning of the full settings struct into various verifier processes.  Processes now only select the settings they require