### PR TITLE
handle enable and disable org rpcs

### DIFF
--- a/file_store/src/traits/msg_verify.rs
+++ b/file_store/src/traits/msg_verify.rs
@@ -3,7 +3,7 @@ use helium_crypto::{PublicKey, Verify};
 use helium_proto::services::{
     iot_config::{
         GatewayRegionParamsReqV1, LoadRegionReqV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1,
-        OrgDisableReqV1, RouteCreateReqV1, RouteDeleteDevaddrRangesReqV1, RouteDeleteEuisReqV1,
+        OrgDisableReqV1, OrgEnableReqV1, RouteCreateReqV1, RouteDeleteDevaddrRangesReqV1, RouteDeleteEuisReqV1,
         RouteDeleteReqV1, RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1, RouteGetReqV1,
         RouteListReqV1, RouteStreamReqV1, RouteUpdateDevaddrRangesReqV1, RouteUpdateEuisReqV1,
         RouteUpdateReqV1,
@@ -41,6 +41,7 @@ impl_msg_verify!(DataTransferSessionReqV1, signature);
 impl_msg_verify!(OrgCreateHeliumReqV1, signature);
 impl_msg_verify!(OrgCreateRoamerReqV1, signature);
 impl_msg_verify!(OrgDisableReqV1, signature);
+impl_msg_verify!(OrgEnableReqV1, signature);
 impl_msg_verify!(RouteStreamReqV1, signature);
 impl_msg_verify!(RouteListReqV1, signature);
 impl_msg_verify!(RouteGetReqV1, signature);

--- a/file_store/src/traits/msg_verify.rs
+++ b/file_store/src/traits/msg_verify.rs
@@ -3,10 +3,10 @@ use helium_crypto::{PublicKey, Verify};
 use helium_proto::services::{
     iot_config::{
         GatewayRegionParamsReqV1, LoadRegionReqV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1,
-        OrgDisableReqV1, OrgEnableReqV1, RouteCreateReqV1, RouteDeleteDevaddrRangesReqV1, RouteDeleteEuisReqV1,
-        RouteDeleteReqV1, RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1, RouteGetReqV1,
-        RouteListReqV1, RouteStreamReqV1, RouteUpdateDevaddrRangesReqV1, RouteUpdateEuisReqV1,
-        RouteUpdateReqV1,
+        OrgDisableReqV1, OrgEnableReqV1, RouteCreateReqV1, RouteDeleteDevaddrRangesReqV1,
+        RouteDeleteEuisReqV1, RouteDeleteReqV1, RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1,
+        RouteGetReqV1, RouteListReqV1, RouteStreamReqV1, RouteUpdateDevaddrRangesReqV1,
+        RouteUpdateEuisReqV1, RouteUpdateReqV1,
     },
     poc_lora::{LoraBeaconReportReqV1, LoraWitnessReportReqV1},
 };

--- a/iot_config/src/main.rs
+++ b/iot_config/src/main.rs
@@ -74,8 +74,8 @@ impl Daemon {
         let listen_addr = settings.listen_addr()?;
 
         let gateway_svc = GatewayService::new(settings).await?;
-        let org_svc = OrgService::new(settings).await?;
         let route_svc = RouteService::new(settings).await?;
+        let org_svc = OrgService::new(settings, route_svc.clone_update_channel()).await?;
         let session_key_filter_svc = SessionKeyFilterService {};
 
         transport::Server::builder()

--- a/iot_config/src/org.rs
+++ b/iot_config/src/org.rs
@@ -12,7 +12,7 @@ pub mod proto {
     pub use helium_proto::services::iot_config::{OrgResV1, OrgV1};
 }
 
-#[derive(Clone, Debug, Serialize, sqlx::Type)]
+#[derive(Clone, Debug, PartialEq, Serialize, sqlx::Type)]
 #[sqlx(type_name = "org_status", rename_all = "snake_case")]
 pub enum OrgStatus {
     Enabled,
@@ -140,6 +140,17 @@ pub async fn get_with_constraints(
             end_addr: end_addr.into(),
         },
     })
+}
+
+pub async fn get_status(oui: u64, db: impl sqlx::PgExecutor<'_>) -> Result<OrgStatus, sqlx::Error> {
+    sqlx::query_scalar::<_, OrgStatus>(
+        r#"
+        select status from organizations where oui = $1
+        "#,
+    )
+    .bind(oui as i64)
+    .fetch_one(db)
+    .await
 }
 
 pub async fn toggle_status(

--- a/iot_config/src/org.rs
+++ b/iot_config/src/org.rs
@@ -142,6 +142,26 @@ pub async fn get_with_constraints(
     })
 }
 
+pub async fn toggle_status(
+    oui: u64,
+    status: OrgStatus,
+    db: impl sqlx::PgExecutor<'_>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        update organizations
+        set status = $1
+        where oui = $2
+        "#,
+    )
+    .bind(status)
+    .bind(oui as i64)
+    .execute(db)
+    .await?;
+
+    Ok(())
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum OrgPubkeysError {
     #[error("error retrieving saved org keys: {0}")]

--- a/iot_config/src/org_service.rs
+++ b/iot_config/src/org_service.rs
@@ -1,26 +1,38 @@
-use crate::{lora_field, org, GrpcResult, Settings, HELIUM_NET_ID};
+use crate::{
+    lora_field,
+    org::{self, OrgStatus},
+    route::list_routes,
+    GrpcResult, Settings, HELIUM_NET_ID,
+};
 use anyhow::Result;
 use file_store::traits::MsgVerify;
 use helium_crypto::{Network, PublicKey};
 use helium_proto::services::iot_config::{
-    self, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgDisableReqV1, OrgDisableResV1,
+    self, ActionV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgDisableReqV1, OrgDisableResV1,
     OrgEnableReqV1, OrgEnableResV1, OrgGetReqV1, OrgListReqV1, OrgListResV1, OrgResV1, OrgV1,
+    RouteStreamResV1,
 };
 use sqlx::{Pool, Postgres};
+use tokio::sync::broadcast::Sender;
 use tonic::{Request, Response, Status};
 
 pub struct OrgService {
     admin_pubkey: PublicKey,
     pool: Pool<Postgres>,
     required_network: Network,
+    route_update_tx: Sender<RouteStreamResV1>,
 }
 
 impl OrgService {
-    pub async fn new(settings: &Settings) -> Result<Self> {
+    pub async fn new(
+        settings: &Settings,
+        route_update_tx: Sender<RouteStreamResV1>,
+    ) -> Result<Self> {
         Ok(Self {
             admin_pubkey: settings.admin_pubkey()?,
             pool: settings.database.connect(10).await?,
             required_network: settings.network,
+            route_update_tx,
         })
     }
 
@@ -164,11 +176,71 @@ impl iot_config::Org for OrgService {
         }))
     }
 
-    async fn disable(&self, _request: Request<OrgDisableReqV1>) -> GrpcResult<OrgDisableResV1> {
-        unimplemented!()
+    async fn disable(&self, request: Request<OrgDisableReqV1>) -> GrpcResult<OrgDisableResV1> {
+        let request = request.into_inner();
+
+        let req = self.verify_admin_signature(request)?;
+
+        org::toggle_status(req.oui, OrgStatus::Disabled, &self.pool)
+            .await
+            .map_err(|_| Status::internal(format!("org disable failed for: {}", req.oui)))?;
+
+        let org_routes = list_routes(req.oui, &self.pool).await.map_err(|_| {
+            Status::internal(format!(
+                "error retrieving routes for disabled org: {}",
+                req.oui
+            ))
+        })?;
+
+        for route in org_routes {
+            let route_id = route.id.clone();
+            self.route_update_tx
+                .send(RouteStreamResV1 {
+                    action: ActionV1::Delete.into(),
+                    route: Some(route.into()),
+                })
+                .map_err(|_| {
+                    Status::internal(format!(
+                        "failed updating routers with deleted route: {route_id}"
+                    ))
+                })?;
+            tracing::debug!("updated packet routers with removed route: {route_id}");
+        }
+
+        Ok(Response::new(OrgDisableResV1 { oui: req.oui }))
     }
 
-    async fn enable(&self, _request: Request<OrgEnableReqV1>) -> GrpcResult<OrgEnableResV1> {
-        unimplemented!()
+    async fn enable(&self, request: Request<OrgEnableReqV1>) -> GrpcResult<OrgEnableResV1> {
+        let request = request.into_inner();
+
+        let req = self.verify_admin_signature(request)?;
+
+        org::toggle_status(req.oui, OrgStatus::Enabled, &self.pool)
+            .await
+            .map_err(|_| Status::internal(format!("org enable failed for: {}", req.oui)))?;
+
+        let org_routes = list_routes(req.oui, &self.pool).await.map_err(|_| {
+            Status::internal(format!(
+                "error retrieving routes for enabled org: {}",
+                req.oui
+            ))
+        })?;
+
+        for route in org_routes {
+            let route_id = route.id.clone();
+            self.route_update_tx
+                .send(RouteStreamResV1 {
+                    action: ActionV1::Create.into(),
+                    route: Some(route.into()),
+                })
+                .map_err(|_| {
+                    Status::internal(format!(
+                        "failed updating routers with created route: {route_id}"
+                    ))
+                })?;
+            tracing::debug!("updated packet routers with recreated route: {route_id}");
+        }
+
+        Ok(Response::new(OrgEnableResV1 { oui: req.oui }))
     }
 }

--- a/iot_config/src/route.rs
+++ b/iot_config/src/route.rs
@@ -6,7 +6,7 @@ use futures::stream::{Stream, StreamExt, TryStreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::{types::Uuid, Row};
-use std::{collections::BTreeMap, sync::Arc};
+use std::collections::BTreeMap;
 use tokio::sync::broadcast::{self, Sender};
 
 pub mod proto {
@@ -81,7 +81,7 @@ pub enum RouteStorageError {
 pub async fn create_route(
     route: Route,
     db: impl sqlx::PgExecutor<'_> + sqlx::Acquire<'_, Database = sqlx::Postgres> + Copy,
-    update_tx: Arc<Sender<proto::RouteStreamResV1>>,
+    update_tx: Sender<proto::RouteStreamResV1>,
 ) -> Result<Route, RouteStorageError> {
     let net_id: i64 = route.net_id.into();
     let protocol_opts = route
@@ -128,7 +128,7 @@ pub async fn create_route(
 pub async fn update_route(
     route: Route,
     db: impl sqlx::PgExecutor<'_> + sqlx::Acquire<'_, Database = sqlx::Postgres> + Copy,
-    update_tx: Arc<Sender<proto::RouteStreamResV1>>,
+    update_tx: Sender<proto::RouteStreamResV1>,
 ) -> Result<Route, RouteStorageError> {
     let protocol_opts = route
         .server
@@ -227,7 +227,7 @@ pub async fn update_euis(
     to_add: &[EuiPair],
     to_remove: &[EuiPair],
     db: impl sqlx::PgExecutor<'_> + sqlx::Acquire<'_, Database = sqlx::Postgres> + Copy,
-    update_tx: Arc<Sender<proto::RouteStreamResV1>>,
+    update_tx: Sender<proto::RouteStreamResV1>,
 ) -> Result<(), RouteStorageError> {
     let mut transaction = db.begin().await?;
 
@@ -347,7 +347,7 @@ pub async fn update_devaddr_ranges(
     to_add: &[DevAddrRange],
     to_remove: &[DevAddrRange],
     db: impl sqlx::PgExecutor<'_> + sqlx::Acquire<'_, Database = sqlx::Postgres> + Copy,
-    update_tx: Arc<Sender<proto::RouteStreamResV1>>,
+    update_tx: Sender<proto::RouteStreamResV1>,
 ) -> Result<(), RouteStorageError> {
     let mut transaction = db.begin().await?;
 
@@ -543,7 +543,7 @@ pub async fn get_route(
 pub async fn delete_route(
     id: &str,
     db: impl sqlx::PgExecutor<'_> + sqlx::Acquire<'_, Database = sqlx::Postgres> + Copy,
-    update_tx: Arc<Sender<proto::RouteStreamResV1>>,
+    update_tx: Sender<proto::RouteStreamResV1>,
 ) -> Result<(), RouteStorageError> {
     let uuid = Uuid::try_parse(id)?;
     let mut transaction = db.begin().await?;

--- a/iot_config/src/route.rs
+++ b/iot_config/src/route.rs
@@ -267,7 +267,7 @@ pub async fn update_euis(
 pub async fn delete_euis(
     id: &str,
     db: impl sqlx::PgExecutor<'_> + Copy,
-    update_tx: Arc<Sender<proto::RouteStreamResV1>>,
+    update_tx: Sender<proto::RouteStreamResV1>,
 ) -> Result<(), RouteStorageError> {
     let euis = list_euis_for_route(id, db).await?;
     let id = Uuid::try_parse(id)?;
@@ -389,7 +389,7 @@ pub async fn update_devaddr_ranges(
 pub async fn delete_devaddr_ranges(
     id: &str,
     db: impl sqlx::PgExecutor<'_> + Copy,
-    update_tx: Arc<Sender<proto::RouteStreamResV1>>,
+    update_tx: Sender<proto::RouteStreamResV1>,
 ) -> Result<(), RouteStorageError> {
     let devaddr_ranges = list_devaddr_ranges_for_route(id, db).await?;
     let id = Uuid::try_parse(id)?;


### PR DESCRIPTION
Implement the config service's `enable` and `disable` org RPCs to allow the packet verifier to disable orgs and have their routes cascade-removed from the downstream helium packet routers when they run out of DC to pay for routing and allow re-enabling the orgs to cascade-recreate their routes when funds are replenished.

This change necessitates cloning the router service's ~~Arc-wrapped~~ broadcast channel transmitter to allow it to broadcast to subscribed packet routers when an org's status changes, thereby deleting or creating the routes registered to those orgs from the routing infrastructure