### PR TITLE
Add submission_offset setting for receipt submission

### DIFF
--- a/poc_iot_injector/pkg/settings-template.toml
+++ b/poc_iot_injector/pkg/settings-template.toml
@@ -11,6 +11,10 @@ keypair = "/path/to/key_pair"
 #
 # trigger = 1800
 
+# Submission offset in seconds. (Default is 600; 5 minutes)
+#
+# submission_offset = 600
+
 # Last PoC submission timestamp in seconds since unix epoch. (Default is unix epoch)
 #
 # last_poc_submission = 0

--- a/poc_iot_injector/src/settings.rs
+++ b/poc_iot_injector/src/settings.rs
@@ -26,6 +26,11 @@ pub struct Settings {
     pub metrics: poc_metrics::Settings,
     #[serde(default = "default_max_witnesses_per_receipt")]
     pub max_witnesses_per_receipt: u64,
+    /// Offset receipt submission to wait for S3 files being written (secs)
+    /// Receipts would be submitted at trigger_interval + submission_offset
+    /// Default = 5 mins
+    #[serde(default = "default_submission_offset")]
+    pub submission_offset: u64,
 }
 
 pub fn default_log() -> String {
@@ -42,6 +47,10 @@ pub fn default_do_submission() -> bool {
 
 fn default_trigger_interval() -> u64 {
     1800
+}
+
+fn default_submission_offset() -> u64 {
+    5 * 60
 }
 
 pub fn default_max_witnesses_per_receipt() -> u64 {
@@ -78,5 +87,9 @@ impl Settings {
 
     pub fn trigger_interval(&self) -> Duration {
         Duration::from_secs(self.trigger)
+    }
+
+    pub fn submission_offset(&self) -> Duration {
+        Duration::from_secs(self.submission_offset)
     }
 }

--- a/poc_iot_injector/src/settings.rs
+++ b/poc_iot_injector/src/settings.rs
@@ -1,3 +1,4 @@
+use chrono::Duration as ChronoDuration;
 use config::{Config, Environment, File};
 use serde::Deserialize;
 use std::{path::Path, time::Duration};
@@ -27,10 +28,10 @@ pub struct Settings {
     #[serde(default = "default_max_witnesses_per_receipt")]
     pub max_witnesses_per_receipt: u64,
     /// Offset receipt submission to wait for S3 files being written (secs)
-    /// Receipts would be submitted at trigger_interval + submission_offset
+    /// Receipts would be submitted from last_poc_submission_ts to utc::now - submission_offset
     /// Default = 5 mins
     #[serde(default = "default_submission_offset")]
-    pub submission_offset: u64,
+    pub submission_offset: i64,
 }
 
 pub fn default_log() -> String {
@@ -49,7 +50,7 @@ fn default_trigger_interval() -> u64 {
     1800
 }
 
-fn default_submission_offset() -> u64 {
+fn default_submission_offset() -> i64 {
     5 * 60
 }
 
@@ -89,7 +90,7 @@ impl Settings {
         Duration::from_secs(self.trigger)
     }
 
-    pub fn submission_offset(&self) -> Duration {
-        Duration::from_secs(self.submission_offset)
+    pub fn submission_offset(&self) -> ChronoDuration {
+        ChronoDuration::seconds(self.submission_offset)
     }
 }


### PR DESCRIPTION
This adds a `submission_offset` (secs) setting to injector to offset receipt submission interval. This should ensure that we capture all the files written to S3, previously we would potentially skip S3 files which were still being written to. 