### PR TITLE
Change last_poc_submission_ts to milliseconds

### DIFF
--- a/poc_iot_injector/src/server.rs
+++ b/poc_iot_injector/src/server.rs
@@ -2,9 +2,9 @@ use crate::{
     receipt_txn::{handle_report_msg, TxnDetails},
     Settings, LOADER_WORKERS,
 };
-use chrono::{DateTime, Duration as ChronoDuration, NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use db_store::MetaValue;
-use file_store::{FileStore, FileType};
+use file_store::{traits::TimestampDecode, FileStore, FileType};
 use futures::stream::{self, StreamExt};
 use helium_crypto::Keypair;
 use node_follower::txn_service::TransactionService;
@@ -91,10 +91,7 @@ impl Server {
     }
 
     async fn handle_poc_tick(&mut self) -> anyhow::Result<()> {
-        let after_utc = Utc.from_utc_datetime(&NaiveDateTime::from_timestamp(
-            *self.last_poc_submission_ts.value(),
-            0,
-        ));
+        let after_utc = (*self.last_poc_submission_ts.value() as u64).to_timestamp_millis()?;
 
         let now = Utc::now();
         let before_utc = now

--- a/poc_iot_injector/src/server.rs
+++ b/poc_iot_injector/src/server.rs
@@ -46,7 +46,7 @@ impl Server {
 
         // Check meta for last_poc_submission_ts, if not found, use the env var and insert it
         let last_poc_submission_ts =
-            MetaValue::<i64>::fetch_or_insert_with(&pool, "last_reward_end_time", || {
+            MetaValue::<i64>::fetch_or_insert_with(&pool, "last_poc_submission_ts", || {
                 settings.last_poc_submission
             })
             .await?;
@@ -124,7 +124,7 @@ impl Server {
         // at least submitted all the receipts we could for that time period and will look at the
         // next incoming reports in the next poc_iot_timer tick.
         self.last_poc_submission_ts
-            .update(&self.pool, before_utc.timestamp())
+            .update(&self.pool, before_utc.timestamp_millis())
             .await?;
 
         Ok(())

--- a/poc_iot_injector/src/settings.rs
+++ b/poc_iot_injector/src/settings.rs
@@ -15,7 +15,7 @@ pub struct Settings {
     #[serde(default = "default_trigger_interval")]
     pub trigger: u64,
     /// Last PoC submission timestamp in seconds since unix epoch. (Default is
-    /// unix epoch)
+    /// unix epoch) (in ms)
     #[serde(default = "default_last_poc_submission")]
     pub last_poc_submission: i64,
     #[serde(default = "default_do_submission")]


### PR DESCRIPTION
Two changes here:
- We were incorrectly storing the key for the meta table as `last_reward_end_time`, I've updated it to `last_poc_submission_ts`. We'd need to change it in the DB by hand.
- Changed the unit of `last_poc_submission_ts` to be milliseconds instead of seconds.