### PR TITLE
add max file age for injector loading

### DIFF
--- a/poc_iot_injector/pkg/settings-template.toml
+++ b/poc_iot_injector/pkg/settings-template.toml
@@ -1,6 +1,6 @@
 
 # log settings for the application (RUST_LOG format). Default below
-# 
+#
 # log = "poc-iot-injector=debug,poc_store=info"
 
 #file to load keypair from
@@ -26,6 +26,10 @@ do_submission = true
 # Number of witnesses allowed per receipt
 #
 # max_witnesses_per_receipt = 14
+
+# max lookback age for the injector when loading files from s3 ( in seconds )
+#
+max_lookback_age = 3600
 
 [database]
 

--- a/poc_iot_injector/src/server.rs
+++ b/poc_iot_injector/src/server.rs
@@ -94,7 +94,7 @@ impl Server {
 
     async fn handle_poc_tick(&mut self) -> anyhow::Result<()> {
         let now = Utc::now();
-        let max_lookback_time = now - self.max_lookback_age;
+        let max_lookback_time = now.checked_sub_signed(self.max_lookback_age).unwrap_or(now);
         let after_utc = Utc
             .from_utc_datetime(&NaiveDateTime::from_timestamp(
                 *self.last_poc_submission_ts.value(),

--- a/poc_iot_injector/src/settings.rs
+++ b/poc_iot_injector/src/settings.rs
@@ -32,6 +32,9 @@ pub struct Settings {
     /// Default = 5 mins
     #[serde(default = "default_submission_offset")]
     pub submission_offset: i64,
+    /// max lookback age for the injector when loading files from s3 ( in seconds )
+    #[serde(default = "default_max_lookback_age")]
+    pub max_lookback_age: i64,
 }
 
 pub fn default_log() -> String {
@@ -56,6 +59,11 @@ fn default_submission_offset() -> i64 {
 
 pub fn default_max_witnesses_per_receipt() -> u64 {
     14
+}
+
+// Default: 60 minutes ( in seconds )
+pub fn default_max_lookback_age() -> i64 {
+    60 * 60
 }
 
 impl Settings {
@@ -92,5 +100,9 @@ impl Settings {
 
     pub fn submission_offset(&self) -> ChronoDuration {
         ChronoDuration::seconds(self.submission_offset)
+    }
+
+    pub fn max_lookback_age(&self) -> ChronoDuration {
+        ChronoDuration::seconds(self.max_lookback_age)
     }
 }


### PR DESCRIPTION
This adds a max age at which the injector can look back for files from S3. 