### PR TITLE
Implement rate limit for poc receipt txns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,6 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "node-follower",
- "nonzero_ext",
  "poc-metrics",
  "prost",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,6 +1235,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.12.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.4",
+]
+
+[[package]]
 name = "db-store"
 version = "0.1.0"
 dependencies = [
@@ -1285,7 +1298,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "structopt",
  "thiserror",
  "tracing",
@@ -1478,7 +1491,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "strum",
  "strum_macros",
  "tempfile",
@@ -1720,6 +1733,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "governor"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c390a940a5d157878dd057c78680a33ce3415bcd05b4799509ea44210914b4d5"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot 0.12.1",
+ "quanta 0.9.3",
+ "rand",
+ "smallvec",
+]
+
+[[package]]
 name = "group"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,7 +1913,7 @@ dependencies = [
  "p256",
  "rand_core",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "signature",
  "sqlx",
  "thiserror",
@@ -2126,7 +2157,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "thiserror",
  "tokio",
  "tonic",
@@ -2213,7 +2244,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -2474,7 +2505,7 @@ dependencies = [
  "metrics-util",
  "parking_lot 0.12.1",
  "portable-atomic",
- "quanta",
+ "quanta 0.10.1",
  "thiserror",
  "tokio",
  "tracing",
@@ -2504,7 +2535,7 @@ dependencies = [
  "num_cpus",
  "parking_lot 0.12.1",
  "portable-atomic",
- "quanta",
+ "quanta 0.10.1",
  "sketches-ddsketch",
 ]
 
@@ -2579,7 +2610,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -2619,7 +2650,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -2682,6 +2713,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "node-follower"
 version = "0.1.0"
 dependencies = [
@@ -2707,6 +2744,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "num-bigint"
@@ -2933,7 +2976,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "thiserror",
  "tokio",
  "tonic",
@@ -2957,12 +3000,14 @@ dependencies = [
  "file-store",
  "futures",
  "futures-util",
+ "governor",
  "helium-crypto",
  "helium-proto",
  "http-serde",
  "metrics",
  "metrics-exporter-prometheus",
  "node-follower",
+ "nonzero_ext",
  "poc-metrics",
  "prost",
  "rand",
@@ -2970,7 +3015,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -3193,6 +3238,22 @@ dependencies = [
 
 [[package]]
 name = "quanta"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "quanta"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e31331286705f455e56cca62e0e717158474ff02b7936c1fa596d983f4ae27"
@@ -3400,7 +3461,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",

--- a/mobile_rewards/src/server.rs
+++ b/mobile_rewards/src/server.rs
@@ -428,7 +428,7 @@ pub fn construct_txn(
 fn hash_txn_b64_url(txn: &BlockchainTxnSubnetworkRewardsV1) -> String {
     let mut txn = txn.clone();
     txn.reward_server_signature = vec![];
-    let digest = Sha256::digest(&txn.encode_to_vec()).to_vec();
+    let digest = Sha256::digest(txn.encode_to_vec()).to_vec();
     base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
 }
 

--- a/poc_iot_injector/Cargo.toml
+++ b/poc_iot_injector/Cargo.toml
@@ -39,4 +39,3 @@ db-store = {path = "../db_store"}
 node-follower = {path = "../node_follower"}
 density-scaler = {path = "../density_scaler"}
 governor = "0.5.1"
-nonzero_ext = "0.3.0"

--- a/poc_iot_injector/Cargo.toml
+++ b/poc_iot_injector/Cargo.toml
@@ -38,3 +38,5 @@ file-store = {path = "../file_store"}
 db-store = {path = "../db_store"}
 node-follower = {path = "../node_follower"}
 density-scaler = {path = "../density_scaler"}
+governor = "0.5.1"
+nonzero_ext = "0.3.0"

--- a/poc_iot_injector/pkg/settings-template.toml
+++ b/poc_iot_injector/pkg/settings-template.toml
@@ -31,6 +31,10 @@ do_submission = true
 #
 max_lookback_age = 3600
 
+# max txns to submit per minute
+#
+max_txns_per_min = 2000
+
 [database]
 
 # Url for database to write indexed rewards to

--- a/poc_iot_injector/src/receipt_txn.rs
+++ b/poc_iot_injector/src/receipt_txn.rs
@@ -197,7 +197,7 @@ fn construct_poc_receipt(beacon_report: IotValidBeaconReport) -> (BlockchainPocR
 fn hash_txn(txn: &BlockchainTxnPocReceiptsV2) -> (Vec<u8>, String) {
     let mut txn = txn.clone();
     txn.signature = vec![];
-    let digest = Sha256::digest(&txn.encode_to_vec()).to_vec();
+    let digest = Sha256::digest(txn.encode_to_vec()).to_vec();
     (
         digest.clone(),
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&digest),

--- a/poc_iot_injector/src/server.rs
+++ b/poc_iot_injector/src/server.rs
@@ -9,13 +9,11 @@ use futures::stream::{self, StreamExt};
 use governor::{Jitter, Quota, RateLimiter};
 use helium_crypto::Keypair;
 use node_follower::txn_service::TransactionService;
-use nonzero_ext::nonzero;
 use prost::bytes::BytesMut;
 use sqlx::{Pool, Postgres};
 use std::{num::NonZeroU32, sync::Arc, time::Duration as StdDuration};
 use tokio::{task::JoinSet, time};
 
-const MAX_TXNS_PER_MIN: u32 = 2000;
 const MAX_CONCURRENT_SUBMISSIONS: usize = 16;
 
 pub struct Server {
@@ -38,6 +36,12 @@ pub enum NewServerError {
     KeypairError(#[from] Box<helium_crypto::Error>),
     #[error("file store error: {0}")]
     FileStoreError(#[from] file_store::Error),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum SubmissionError {
+    #[error("rate limit not set")]
+    RateLimitNotSet,
 }
 
 impl Server {
@@ -154,7 +158,7 @@ async fn submit_txns(
         store.source_unordered(LOADER_WORKERS, stream::iter(file_list).map(Ok).boxed());
 
     let max_txns_per_min =
-        NonZeroU32::new(settings.max_txns_per_min).unwrap_or(nonzero!(MAX_TXNS_PER_MIN));
+        NonZeroU32::new(settings.max_txns_per_min).ok_or(SubmissionError::RateLimitNotSet)?;
     let bucket = Arc::new(RateLimiter::direct(Quota::per_minute(max_txns_per_min)));
 
     // To ensure that multiple tasks don't wake up at the exact same time
@@ -163,7 +167,7 @@ async fn submit_txns(
     let mut set = JoinSet::new();
 
     while let Some(msg) = stream.next().await {
-        let bucket = Arc::clone(&bucket);
+        let bucket = bucket.clone();
 
         match msg {
             Err(err) => tracing::warn!("skipping entry in stream: {err:?}"),

--- a/poc_iot_injector/src/settings.rs
+++ b/poc_iot_injector/src/settings.rs
@@ -35,6 +35,13 @@ pub struct Settings {
     /// max lookback age for the injector when loading files from s3 ( in seconds )
     #[serde(default = "default_max_lookback_age")]
     pub max_lookback_age: i64,
+    /// max txns to submit per min (default = 2000)
+    #[serde(default = "default_max_txns_per_min")]
+    pub max_txns_per_min: u32,
+}
+
+pub fn default_max_txns_per_min() -> u32 {
+    2000
 }
 
 pub fn default_log() -> String {


### PR DESCRIPTION
Summary
----
- Rate limit submission of poc receipt txns from the injector to chain.
- This is done using the [governor](https://crates.io/crates/governor) crate.
- The `max_txns_per_min` is configurable via settings (default = 2000)

TODO:
- [ ] Testing whether it actually works.