### PR TITLE
override channel to hold witness verification status

### DIFF
--- a/poc_iot_injector/src/receipt_txn.rs
+++ b/poc_iot_injector/src/receipt_txn.rs
@@ -150,7 +150,7 @@ fn construct_poc_witnesses(
             snr: witness_report.report.snr as f32 / SNR_MULTIPLIER,
             frequency: hz_to_mhz(witness_report.report.frequency),
             datarate: witness_report.report.datarate.to_string(),
-            channel: 0,
+            channel: witness_report.invalid_reason as i32,
             reward_shares,
         };
 


### PR DESCRIPTION
this is a hack to override the unused channel field of the witness_v1 proto with the enum value of the verifier assigned invalid reason.   ETL will then inspect this onchain data for any witness with 0 reward shares and use any non zero `channel` value as the reason why the witness is invalid.  Explorer can then depict the specific invalid reason on the UI

Linked core pr: https://github.com/helium/blockchain-core/pull/1525

NOTE: this is a known hack.  It is only meant to be temporary and will be dropped post current l1 transition ( along with the injector )