### PR TITLE
Allow db url to be optional

### DIFF
--- a/db_store/src/settings.rs
+++ b/db_store/src/settings.rs
@@ -1,7 +1,9 @@
 use crate::Result;
-use http::Uri;
 use serde::Deserialize;
-use sqlx::{postgres::PgPoolOptions, Pool, Postgres};
+use sqlx::{
+    postgres::{PgConnectOptions, PgPoolOptions},
+    Pool, Postgres,
+};
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Settings {
@@ -9,19 +11,34 @@ pub struct Settings {
     /// by application code
     pub max_connections: Option<u32>,
     /// URL to access the postgres database. For example:
-    /// postgres://postgres:postgres@127.0.0.1:5432/mobile_index_db
-    #[serde(with = "http_serde::uri")]
-    pub url: Uri,
+    /// postgres://postgres:postgres@127.0.0.1:5432/mobile_index_db If the url
+    /// is not specified the following environment variables are used to pick up
+    /// the database settings:
+    ///
+    ///  * `PGHOST`
+    ///  * `PGPORT`
+    ///  * `PGUSER`
+    ///  * `PGPASSWORD`
+    ///  * `PGDATABASE`
+    ///  * `PGSSLROOTCERT`
+    ///  * `PGSSLMODE`
+    ///  * `PGAPPNAME`
+    pub url: Option<String>,
 }
 
 impl Settings {
     pub async fn connect(&self, default_max_connections: usize) -> Result<Pool<Postgres>> {
+        let connect_options = if let Some(url) = &self.url {
+            url.parse()?
+        } else {
+            PgConnectOptions::new()
+        };
         let pool = PgPoolOptions::new()
             .max_connections(
                 self.max_connections
                     .unwrap_or(default_max_connections as u32),
             )
-            .connect(&self.url.to_string())
+            .connect_with(connect_options)
             .await?;
         Ok(pool)
     }


### PR DESCRIPTION
When not specified the database connection settings are pulled from the following environment variables. Note that using this approach removes the ability to have multiple db connections sections in the same settings file.

* `PGHOST`
* `PGPORT`
* `PGUSER`
* `PGPASSWORD`
* `PGDATABASE`
* `PGSSLROOTCERT`
* `PGSSLMODE`
* `PGAPPNAME`