### PR TITLE
patch oracles for proto version changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#8815569df5b56cd93f4fcd0b4e0582de4ae71d92"
+source = "git+https://github.com/helium/proto?branch=master#c618b4aaf27df932cfc8bcab54e72ee612914e77"
 dependencies = [
  "bytes",
  "prost",

--- a/node_follower/src/gateway_resp.rs
+++ b/node_follower/src/gateway_resp.rs
@@ -53,6 +53,7 @@ impl TryFrom<GatewayInfo> for GatewayInfoProto {
             staking_mode: v.staking_mode as i32,
             gain: v.gain,
             region: v.region as i32,
+            region_params: None,
         })
     }
 }


### PR DESCRIPTION
the mismatch between the current proto version of the gateway_info_resp message and the one on main for oracles is preventing updates of other areas of the oracles project that require the latest proto changes; this shims the missing piece into line to allow the oracle to be updated for any other patches needed in the wake of off-chain activation