### PR TITLE
New module to stream FileInfoStream from s3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,6 +1269,39 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.4",
+=======
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1337,6 +1370,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
  "const-oid",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -1490,6 +1554,7 @@ name = "file-store"
 version = "0.1.0"
 dependencies = [
  "async-compression",
+ "async-trait",
  "aws-config",
  "aws-sdk-s3",
  "base64 0.21.0",
@@ -1501,6 +1566,7 @@ dependencies = [
  "config",
  "csv",
  "density-scaler",
+ "derive_builder",
  "futures",
  "futures-util",
  "helium-crypto",
@@ -1517,6 +1583,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.6",
+ "sqlx",
  "strum",
  "strum_macros",
  "tempfile",
@@ -2150,6 +2217,12 @@ dependencies = [
  "cxx",
  "cxx-build",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,17 +1259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
-dependencies = [
- "cfg-if",
- "hashbrown 0.12.3",
- "lock_api",
- "once_cell",
- "parking_lot_core 0.9.4",
-=======
 name = "darling"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1291,19 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.12.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,7 @@ dependencies = [
  "poc-metrics",
  "prost",
  "regex",
+ "retainer",
  "rust_decimal",
  "rust_decimal_macros",
  "serde",

--- a/file_store/Cargo.toml
+++ b/file_store/Cargo.toml
@@ -45,6 +45,7 @@ beacon = {workspace = true}
 sqlx = {workspace = true}
 async-trait = {workspace = true}
 derive_builder = "0"
+retainer = {workspace = true}
 
 [dev-dependencies]
 hex-literal = "0"

--- a/file_store/Cargo.toml
+++ b/file_store/Cargo.toml
@@ -42,6 +42,9 @@ rust_decimal_macros = {workspace = true}
 density-scaler = {path = "../density_scaler"}
 base64 = {workspace = true}
 beacon = {workspace = true}
+sqlx = {workspace = true}
+async-trait = {workspace = true}
+derive_builder = "0"
 
 [dev-dependencies]
 hex-literal = "0"

--- a/file_store/src/error.rs
+++ b/file_store/src/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     Channel,
     #[error("no manifest")]
     NoManifest,
+    #[error("db error")]
+    DbError(#[from] sqlx::Error),
 }
 
 #[derive(Error, Debug)]

--- a/file_store/src/file_info_poller.rs
+++ b/file_store/src/file_info_poller.rs
@@ -66,13 +66,6 @@ where
         Ok((receiver, join_handle))
     }
 
-    fn after(&self, latest: DateTime<Utc>) -> DateTime<Utc> {
-        self.max_lookback
-            .map(|max_lookback| Utc::now() - max_lookback)
-            .map(|max_ts| max_ts.max(latest))
-            .unwrap_or(latest)
-    }
-
     async fn run(self, shutdown: triggered::Listener, sender: Sender<FileInfoStream<T>>) -> Result {
         let cache = create_cache();
         let mut poll_trigger = tokio::time::interval(self.poll_duration());
@@ -101,6 +94,13 @@ where
             }
         }
         Ok(())
+    }
+
+    fn after(&self, latest: DateTime<Utc>) -> DateTime<Utc> {
+        self.max_lookback
+            .map(|max_lookback| Utc::now() - max_lookback)
+            .map(|max_ts| max_ts.max(latest))
+            .unwrap_or(latest)
     }
 
     async fn clean(&self, cache: &MemoryFileCache) -> Result {
@@ -244,8 +244,8 @@ mod tests {
     use chrono::TimeZone;
     use sqlx::postgres::PgPoolOptions;
 
-    use crate::iot_beacon_report::IotBeaconIngestReport;
     use crate::file_source::continuous_source;
+    use crate::iot_beacon_report::IotBeaconIngestReport;
 
     use super::*;
 

--- a/file_store/src/file_info_poller.rs
+++ b/file_store/src/file_info_poller.rs
@@ -52,6 +52,8 @@ pub struct FileInfoPoller<T> {
     lookback: LookbackBehavior,
     #[builder(default = "Duration::minutes(10)")]
     offset: Duration,
+    #[builder(default = "4")]
+    queue_size: usize,
     #[builder(setter(skip))]
     p: PhantomData<T>,
 }
@@ -64,7 +66,7 @@ where
         self,
         shutdown: triggered::Listener,
     ) -> Result<(Receiver<FileInfoStream<T>>, JoinHandle<Result>)> {
-        let (sender, receiver) = tokio::sync::mpsc::channel(4);
+        let (sender, receiver) = tokio::sync::mpsc::channel(self.queue_size);
         let join_handle = tokio::spawn(async move { self.run(shutdown, sender).await });
 
         Ok((receiver, join_handle))

--- a/file_store/src/file_source.rs
+++ b/file_store/src/file_source.rs
@@ -10,7 +10,7 @@ use tokio_util::codec::{length_delimited::LengthDelimitedCodec, FramedRead};
 
 pub fn continuous_source<T>() -> FileInfoPollerBuilder<T>
 where
-    T: Clone
+    T: Clone,
 {
     FileInfoPollerBuilder::<T>::default()
 }

--- a/file_store/src/file_source.rs
+++ b/file_store/src/file_source.rs
@@ -1,4 +1,4 @@
-use crate::{file_sink, BytesMutStream, Error};
+use crate::{file_info_poller::FileInfoPollerBuilder, file_sink, BytesMutStream, Error};
 use async_compression::tokio::bufread::GzipDecoder;
 use futures::{
     stream::{self},
@@ -7,6 +7,13 @@ use futures::{
 use std::path::{Path, PathBuf};
 use tokio::{fs::File, io::BufReader};
 use tokio_util::codec::{length_delimited::LengthDelimitedCodec, FramedRead};
+
+pub fn continuous_source<T>() -> FileInfoPollerBuilder<T>
+where
+    T: Clone
+{
+    FileInfoPollerBuilder::<T>::default()
+}
 
 pub fn source<I, P>(paths: I) -> BytesMutStream
 where

--- a/file_store/src/incoming_data.rs
+++ b/file_store/src/incoming_data.rs
@@ -1,0 +1,259 @@
+use std::marker::PhantomData;
+
+use crate::{traits::MsgDecode, Error, FileInfo, FileStore, FileType, Result};
+use chrono::{DateTime, Duration, Utc};
+use derive_builder::Builder;
+use futures::{stream::BoxStream, StreamExt};
+use tokio::{
+    sync::mpsc::{Receiver, Sender},
+    task::JoinHandle,
+};
+
+const DEFAULT_POLL_DURATION_SECS: i64 = 30;
+const CLEAN_DURATION_SECS: u64 = 12 * 60 * 60;
+
+pub struct IncomingDataStream<T> {
+    pub file_info: FileInfo,
+    pub stream: BoxStream<'static, T>,
+    sender: tokio::sync::oneshot::Sender<bool>,
+}
+
+#[derive(Debug, Clone, Builder)]
+pub struct IncomingDataPoller<T> {
+    #[builder(default = "Duration::seconds(DEFAULT_POLL_DURATION_SECS)")]
+    poll_duration: Duration,
+    db: sqlx::Pool<sqlx::Postgres>,
+    store: FileStore,
+    file_type: FileType,
+    start_after: DateTime<Utc>,
+    #[builder(default = "Duration::minutes(10)")]
+    offset: Duration,
+    #[builder(setter(skip))]
+    p: PhantomData<T>,
+}
+
+impl<T: MsgDecode + TryFrom<T::Msg, Error = Error> + Send + Sync + 'static> IncomingDataPoller<T> {
+    pub async fn start(
+        self,
+        shutdown: triggered::Listener,
+    ) -> Result<(Receiver<IncomingDataStream<T>>, JoinHandle<Result>)> {
+        let (sender, receiver) = tokio::sync::mpsc::channel(50);
+        let join_handle = tokio::spawn(async move { self.run(shutdown, sender).await });
+
+        Ok((receiver, join_handle))
+    }
+
+    async fn run(
+        self,
+        shutdown: triggered::Listener,
+        sender: Sender<IncomingDataStream<T>>,
+    ) -> Result {
+        let duration = self
+            .poll_duration
+            .to_std()
+            .unwrap_or_else(|_| std::time::Duration::from_secs(DEFAULT_POLL_DURATION_SECS as u64));
+
+        let mut trigger = tokio::time::interval(duration);
+        let mut cleanup_trigger =
+            tokio::time::interval(std::time::Duration::from_secs(CLEAN_DURATION_SECS));
+
+        let mut latest_ts = db_latest_ts(&self.db, self.start_after, self.file_type).await?;
+        println!("Latest_ts: {latest_ts:?}");
+
+        loop {
+            let after = latest_ts - self.offset;
+            let before = Utc::now();
+            let shutdown = shutdown.clone();
+
+            tokio::select! {
+                _ = shutdown => break,
+                _ = cleanup_trigger.tick() => db_clean(&self.db, &self.file_type).await?,
+                _ = trigger.tick() => {
+                    let files = self.store.list_all(self.file_type, after, before).await?;
+                    for file in files {
+                        if !db_exists(&self.db, &file).await? {
+                            latest_ts = file.timestamp;
+                            send_stream(&sender, &self.store, file).await?;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<T> IncomingDataStream<T> {
+    pub async fn mark_done(
+        self,
+        transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    ) -> Result {
+        db_insert(transaction, self.file_info).await?;
+        let _ = self.sender.send(true);
+        Ok(())
+    }
+}
+
+async fn send_stream<T>(
+    sender: &Sender<IncomingDataStream<T>>,
+    store: &FileStore,
+    file: FileInfo,
+) -> Result
+where
+    T: MsgDecode + TryFrom<T::Msg, Error = Error> + Send + Sync + 'static,
+{
+    let (os_sender, os_receiver) = tokio::sync::oneshot::channel();
+    let stream = store
+        .stream_file(file.clone())
+        .await?
+        .filter_map(|msg| async {
+            msg.map_err(|err| {
+                tracing::error!("Error in processing binary");
+                err
+            })
+            .ok()
+        })
+        .filter_map(|msg| async {
+            <T as MsgDecode>::decode(msg)
+                .map_err(|err| {
+                    tracing::error!("Error in decoding message");
+                    err
+                })
+                .ok()
+        })
+        .boxed();
+
+    let incoming_data_stream = IncomingDataStream {
+        file_info: file,
+        stream,
+        sender: os_sender,
+    };
+
+    let _ = sender.send(incoming_data_stream).await;
+    let _ = os_receiver.await;
+    Ok(())
+}
+
+async fn db_latest_ts(
+    db: impl sqlx::PgExecutor<'_>,
+    start_after: DateTime<Utc>,
+    file_type: FileType,
+) -> Result<DateTime<Utc>> {
+    Ok(sqlx::query_scalar::<_, DateTime<Utc>>(
+        r#"
+        SELECT COALESCE(MAX(file_timestamp), $1) FROM incoming_files where file_type = $2
+        "#,
+    )
+    .bind(start_after)
+    .bind(file_type.to_str())
+    .fetch_one(db)
+    .await?)
+}
+
+async fn db_exists(db: impl sqlx::PgExecutor<'_>, file_info: &FileInfo) -> Result<bool> {
+    Ok(sqlx::query_scalar::<_, bool>(
+        r#"
+        SELECT EXISTS(SELECT 1 from incoming_files where file_name = $1)
+        "#,
+    )
+    .bind(file_info.key.clone())
+    .fetch_one(db)
+    .await?)
+}
+
+async fn db_insert(tx: &mut sqlx::Transaction<'_, sqlx::Postgres>, file_info: FileInfo) -> Result {
+    sqlx::query(r#"
+        INSERT INTO incoming_files(file_name, file_type, file_timestamp, processed_at) VALUES($1, $2, $3, $4)
+        "#)
+    .bind(file_info.key)
+    .bind(file_info.file_type.to_str())
+    .bind(file_info.timestamp)
+    .bind(Utc::now())
+    .execute(tx)
+    .await?;
+
+    Ok(())
+}
+
+async fn db_clean(db: impl sqlx::PgExecutor<'_>, file_type: &FileType) -> Result {
+    sqlx::query(
+        r#"
+        DELETE FROM incoming_files where file_name in (
+            SELECT file_name
+            FROM incoming_files
+            WHERE file_type = $1
+            ORDER BY file_timestamp DESC
+            OFFSET 3 
+        )
+        "#,
+    )
+    .bind(file_type.to_str())
+    .execute(db)
+    .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use sqlx::postgres::PgPoolOptions;
+
+    use crate::iot_beacon_report::IotBeaconIngestReport;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test() {
+        let (shutdown_trigger, shutdown_listener) = triggered::trigger();
+        let pool = PgPoolOptions::new()
+            .connect("psql://postgres:password@localhost/iot_packet_verifier")
+            .await
+            .expect("db connection");
+
+        let settings = crate::Settings {
+            bucket: "devnet-iot-ingest".to_string(),
+            endpoint: None,
+            region: "us-east-1".to_string(),
+        };
+
+        let file_store = FileStore::from_settings(&settings)
+            .await
+            .expect("File Store");
+
+        let poller = IncomingDataPollerBuilder::<IotBeaconIngestReport>::default()
+            .db(pool.clone())
+            .store(file_store)
+            .file_type(FileType::IotBeaconIngestReport)
+            .start_after(Utc.timestamp_millis(1675299181384))
+            .poll_duration(Duration::seconds(1))
+            .build()
+            .expect("Poller");
+
+        let (mut receiver, join_handle) =
+            poller.start(shutdown_listener).await.expect("start poller");
+
+        let mut tx = pool.begin().await.expect("TX BEGIN");
+
+        tokio::select! {
+            msg = receiver.recv() => match msg {
+                Some(mut msg) => {
+                    println!("{:?}", &msg.file_info);
+                    let x = msg.stream.next().await;
+                    dbg!(x);
+                    msg.mark_done(&mut tx).await.expect("MARK DONE");
+                }
+                None => println!("WTF"),
+            }
+        }
+
+        tx.commit().await.expect("TX COMMIT");
+
+        shutdown_trigger.trigger();
+
+        // let x = join_handle.await;
+        // dbg!(x);
+
+        assert!(false);
+    }
+}

--- a/file_store/src/lib.rs
+++ b/file_store/src/lib.rs
@@ -6,6 +6,7 @@ pub mod file_source;
 pub mod file_store;
 pub mod file_upload;
 pub mod heartbeat;
+pub mod incoming_data;
 pub mod iot_beacon_report;
 pub mod iot_invalid_poc;
 pub mod iot_valid_poc;

--- a/file_store/src/lib.rs
+++ b/file_store/src/lib.rs
@@ -1,12 +1,12 @@
 pub mod cli;
 mod error;
 mod file_info;
+pub mod file_info_poller;
 pub mod file_sink;
 pub mod file_source;
 pub mod file_store;
 pub mod file_upload;
 pub mod heartbeat;
-pub mod incoming_data;
 pub mod iot_beacon_report;
 pub mod iot_invalid_poc;
 pub mod iot_valid_poc;


### PR DESCRIPTION
This will poll s3 for new files on a short duration , but keep track of each individual file so it can handle files coming out of order.  The service will receive an already decoded stream over a channel when a new file is seen in s3.

The benefit of this is we will not have to make sure to have certain offsets configured based on the previous service's roll time on its output files.

Table definition
```
create table files_processed (
	file_name varchar primary key,
	file_type varchar,
	file_timestamp timestamp,
	processed_at timestamp
)
```

Configuration:
`start_after` --> the start point when querying into s3.  Will only be used when no records are found in the db.
`max_lookback` --> the max it will look back from now when querying s3.

Having both set doesn't really make sense, do we need both? should be an enum?

Another design choice that comes off little weird, but couldn't come up with anything better is that calling `FileInfoStream::into_stream` consumes the struct and inserts the record into the db within the provided transaction.  It feels odd to insert the db record before reading the stream but the thought was it shouldn't matter as long as the transaction is committed after processing stream.  Welcome to other ideas.