### PR TITLE
Scale up reward_share_multiple by 100x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,6 +3046,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "node-follower",
+ "once_cell",
  "poc-metrics",
  "prost",
  "rand",

--- a/poc_iot_injector/Cargo.toml
+++ b/poc_iot_injector/Cargo.toml
@@ -33,6 +33,7 @@ metrics = {workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 helium-crypto = { workspace = true }
 helium-proto = { workspace = true }
+once_cell = {workspace = true}
 poc-metrics = { path = "../metrics" }
 file-store = {path = "../file_store"}
 db-store = {path = "../db_store"}


### PR DESCRIPTION
We've noticed that `reward_shares` sometimes are incorrectly getting zero-ed out because of very low hex_scale values coming from the verifier.

This scales up the `REWARD_SHARE_MULTIPLIER` to `10000` to ensure that unless either hex_scale or reward_unit is very very low (0.0009 for example), the hotspots would still get some rewards.

The blockchain itself does not care what the multiplier is because its unit independent but we have to be careful when deploying this to ensure that we don't get blocks with mixed reward_share scales.