### PR TITLE
write out metrics for invalid witnesses directly from runner

### DIFF
--- a/iot_verifier/src/metrics.rs
+++ b/iot_verifier/src/metrics.rs
@@ -6,6 +6,8 @@ const LOADER_DROPPED_BEACON_COUNTER: &str = concat!(env!("CARGO_PKG_NAME"), "_",
 const LOADER_DROPPED_WITNESS_COUNTER: &str =
     concat!(env!("CARGO_PKG_NAME"), "_", "dropped_witness");
 const BEACON_GUAGE: &str = concat!(env!("CARGO_PKG_NAME"), "_", "num_beacons");
+const INVALID_WITNESS_COUNTER: &str =
+    concat!(env!("CARGO_PKG_NAME"), "_", "invalid_witness_report");
 
 pub struct Metrics;
 
@@ -36,6 +38,9 @@ impl Metrics {
 
     pub fn decrement_num_beacons() {
         metrics::decrement_gauge!(BEACON_GUAGE, 1.0)
+    }
+    pub fn increment_invalid_witnesses(labels: &[(&'static str, &'static str)]) {
+        metrics::increment_counter!(INVALID_WITNESS_COUNTER, labels);
     }
 }
 


### PR DESCRIPTION
When we switched to the iot verifier performing the final 14 witness selection we broke the metrics for invalid witnesses.

Prior to this change, invalid witnesses were all written directly to S3 via their own invalid_witness proto.  The write function of the filestore took care of firing a metric for each file written to the sink.  

Post the above change however invalid witnesses form part of the `poc` proto, where invalid and valids make up the `poc` proto's `selected` and `unselected` lists.  This means the invalids now bypass the existing filestore metric generation.

This PR fixes the issue by firing the same metric as previously but from outside of the filestore and from the runner directly.  The filestore metric remains in place as there are other uses cases for it including the purger which writes out stales witnesses as invalid_witnesses.
