### PR TITLE
widen witness loaded window to be > ingestor roll up time

### DIFF
--- a/iot_verifier/src/loader.rs
+++ b/iot_verifier/src/loader.rs
@@ -209,8 +209,8 @@ impl Loader {
                 FileType::IotWitnessIngestReport,
                 &self.ingest_store,
                 gateway_cache,
-                after - ChronoDuration::seconds(60 * 6),
-                before + ChronoDuration::seconds(60 * 6),
+                after - ChronoDuration::minutes(6),
+                before + ChronoDuration::minutes(6),
                 None,
                 Some(&filter),
             )

--- a/iot_verifier/src/loader.rs
+++ b/iot_verifier/src/loader.rs
@@ -26,8 +26,8 @@ use twox_hash::XxHash64;
 use xorf::{Filter as XorFilter, Xor16};
 
 const REPORTS_META_NAME: &str = "report";
-/// cadence for how often to look for  reports from s3 buckets
-const REPORTS_POLL_TIME: u64 = 60 * 5;
+/// cadence for how often to look for  reports from s3 buckets in minutes
+const REPORTS_POLL_TIME: i64 = 5;
 
 const STORE_WORKERS: usize = 100;
 // DB pool size if the store worker count multiplied by the number of file types
@@ -79,7 +79,8 @@ impl Loader {
         gateway_cache: &GatewayCache,
     ) -> anyhow::Result<()> {
         tracing::info!("started verifier loader");
-        let mut report_timer = time::interval(time::Duration::from_secs(REPORTS_POLL_TIME));
+        let mut report_timer =
+            time::interval(time::Duration::from_secs(REPORTS_POLL_TIME as u64 * 60));
         report_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
         let mut denylist_timer = time::interval(self.deny_list_trigger_interval);
         denylist_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -135,18 +136,18 @@ impl Loader {
         // as such data being loaded is always stale by a time equal to REPORTS_POLL_TIME
 
         // if there is NO last timestamp in the DB, we will start our sliding window from this point
-        let window_default_lookback = now - ChronoDuration::seconds(REPORTS_POLL_TIME as i64 * 3);
+        let window_default_lookback = now - ChronoDuration::minutes(REPORTS_POLL_TIME * 4);
         // NOTE: Atm we never look back more than window_default_lookback
         // The experience has been that once we start processing a window longer than default
         // we never recover the time and end up stuck on a window of the extended size
         // The option is here however to extend the window size should it be needed
-        let window_max_lookback = now - ChronoDuration::seconds(REPORTS_POLL_TIME as i64 * 3);
+        let window_max_lookback = now - ChronoDuration::minutes(REPORTS_POLL_TIME * 4);
         let after = Meta::last_timestamp(&self.pool, REPORTS_META_NAME)
             .await?
             .unwrap_or(window_default_lookback)
             .max(window_max_lookback);
 
-        let before = now - ChronoDuration::seconds(REPORTS_POLL_TIME as i64 * 2);
+        let before = now - ChronoDuration::minutes(REPORTS_POLL_TIME * 3);
         let window_width = (before - after).num_minutes() as u64;
         tracing::info!("sliding window, after: {after}, before: {before}, width: {window_width}");
         self.process_window(gateway_cache, after, before).await?;
@@ -209,8 +210,8 @@ impl Loader {
                 FileType::IotWitnessIngestReport,
                 &self.ingest_store,
                 gateway_cache,
-                after - ChronoDuration::minutes(6),
-                before + ChronoDuration::minutes(6),
+                after - ChronoDuration::minutes(REPORTS_POLL_TIME),
+                before + ChronoDuration::minutes(REPORTS_POLL_TIME),
                 None,
                 Some(&filter),
             )

--- a/iot_verifier/src/loader.rs
+++ b/iot_verifier/src/loader.rs
@@ -201,14 +201,16 @@ impl Loader {
         // widen the window for these over that used for the beacons
         // this is to allow for a witness being in a rolled up file
         // from just before or after the beacon files
+        // the width extention needs to be at least equal to that
+        // of the ingestor roll up time
         // for witnesses we do need the filter but not the arc
         match self
             .process_events(
                 FileType::IotWitnessIngestReport,
                 &self.ingest_store,
                 gateway_cache,
-                after - ChronoDuration::seconds(60 * 2),
-                before + ChronoDuration::seconds(60 * 2),
+                after - ChronoDuration::seconds(60 * 6),
+                before + ChronoDuration::seconds(60 * 6),
                 None,
                 Some(&filter),
             )


### PR DESCRIPTION
When loading witnesses the loader will take the beaon's window start/end times and widen it so that we load the roll up files not just for the same period as the beacons but those rolls up to the left and right of the beacons.
This is to ensure we do not miss witnesses which were included in a roll up just prior or after that of the beaconers.

The period of time the witness window should be widened by should be at least equal to that of the ingestor roll up time.  This was not the case with the current settings.  The ingestor roll up time is 5 mins, whilst the verifier was only widening the witness window by 2 mins on each side.

This fixes that by adding widening the witness window on both ends by the ingestor roll up time ( currently 5 mins )

A side effect of this change is that it would push the witness's window into the danger zone of being less that 2x that of the ingestor roll up time and thus susceptible to missing a file from one of the ingestors which has not yet made it to S3.
To accomodate this I have had to push the beaconers window start time back by another 1x the ingestor roll up time.  It now moves from 3x to 4x.

**NOTE: when deploying this on mainnet we will need to wipe the meta DB timestamp for `report` in order to permit the lookback to stretch to 4x.  Without changing that the loader's start point will be incorrect and thus push the witness endpoint into the danger zone again**