### PR TITLE
make idz file non-optional for proto3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,7 +1947,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#8f6218e04cce79cd9cc012147e638b4ba1a6b27e"
+source = "git+https://github.com/helium/proto?branch=master#41c03318556157a7014ffd75d3fa6bb5ed7d3de5"
 dependencies = [
  "bytes",
  "prost",

--- a/file_store/src/traits/msg_verify.rs
+++ b/file_store/src/traits/msg_verify.rs
@@ -2,11 +2,11 @@ use crate::{Error, Result};
 use helium_crypto::{PublicKey, Verify};
 use helium_proto::services::{
     iot_config::{
-        GatewayRegionParamsReqV1, LoadRegionReqV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1,
-        OrgDisableReqV1, OrgEnableReqV1, RouteCreateReqV1, RouteDeleteDevaddrRangesReqV1,
-        RouteDeleteEuisReqV1, RouteDeleteReqV1, RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1,
-        RouteGetReqV1, RouteListReqV1, RouteStreamReqV1, RouteUpdateDevaddrRangesReqV1,
-        RouteUpdateEuisReqV1, RouteUpdateReqV1,
+        GatewayLoadRegionReqV1, GatewayRegionParamsReqV1, OrgCreateHeliumReqV1,
+        OrgCreateRoamerReqV1, OrgDisableReqV1, OrgEnableReqV1, RouteCreateReqV1,
+        RouteDeleteDevaddrRangesReqV1, RouteDeleteEuisReqV1, RouteDeleteReqV1,
+        RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1, RouteGetReqV1, RouteListReqV1,
+        RouteStreamReqV1, RouteUpdateDevaddrRangesReqV1, RouteUpdateEuisReqV1, RouteUpdateReqV1,
     },
     poc_lora::{LoraBeaconReportReqV1, LoraWitnessReportReqV1},
 };
@@ -55,7 +55,7 @@ impl_msg_verify!(RouteGetDevaddrRangesReqV1, signature);
 impl_msg_verify!(RouteUpdateDevaddrRangesReqV1, signature);
 impl_msg_verify!(RouteDeleteDevaddrRangesReqV1, signature);
 impl_msg_verify!(GatewayRegionParamsReqV1, signature);
-impl_msg_verify!(LoadRegionReqV1, signature);
+impl_msg_verify!(GatewayLoadRegionReqV1, signature);
 
 #[cfg(test)]
 mod test {

--- a/iot_config/migrations/3_routes.sql
+++ b/iot_config/migrations/3_routes.sql
@@ -20,6 +20,7 @@ create table route_eui_pairs (
     route_id uuid not null references routes(id) on delete cascade,
     app_eui bigint not null,
     dev_eui bigint not null,
+    primary key (route_id, app_eui, dev_eui),
 
     inserted_at timestamptz not null default now(),
     updated_at timestamptz not null default now()
@@ -33,6 +34,7 @@ create table route_devaddr_ranges (
     route_id uuid not null references routes(id) on delete cascade,
     start_addr int not null,
     end_addr int not null,
+    primary key (route_id, start_addr, end_addr),
 
     inserted_at timestamptz not null default now(),
     updated_at timestamptz not null default now()

--- a/iot_config/src/lora_field.rs
+++ b/iot_config/src/lora_field.rs
@@ -35,7 +35,9 @@ impl DevAddrRange {
 impl FromRow<'_, PgRow> for DevAddrRange {
     fn from_row(row: &PgRow) -> sqlx::Result<Self> {
         Ok(Self {
-            route_id: row.try_get::<String, &str>("route_id")?,
+            route_id: row
+                .try_get::<sqlx::types::Uuid, &str>("route_id")?
+                .to_string(),
             start_addr: row.try_get::<i64, &str>("start_addr")?.into(),
             end_addr: row.try_get::<i64, &str>("end_addr")?.into(),
         })
@@ -93,7 +95,9 @@ impl EuiPair {
 impl FromRow<'_, PgRow> for EuiPair {
     fn from_row(row: &PgRow) -> sqlx::Result<Self> {
         Ok(Self {
-            route_id: row.try_get::<String, &str>("route_id")?,
+            route_id: row
+                .try_get::<sqlx::types::Uuid, &str>("route_id")?
+                .to_string(),
             app_eui: row.try_get::<i64, &str>("app_eui")?.into(),
             dev_eui: row.try_get::<i64, &str>("dev_eui")?.into(),
         })

--- a/iot_config/src/route.rs
+++ b/iot_config/src/route.rs
@@ -205,12 +205,15 @@ async fn insert_euis(
         ));
     }
 
-    const EUI_INSERT_SQL: &str = " insert into route_eui_pairs (route_id, app_eui, dev_eui) ";
+    const EUI_INSERT_VALS: &str = " insert into route_eui_pairs (route_id, app_eui, dev_eui) ";
+    const EUI_INSERT_ON_CONF: &str = " on conflict (route_id, app_eui, dev_eui) do nothing ";
     let mut query_builder: sqlx::QueryBuilder<sqlx::Postgres> =
-        sqlx::QueryBuilder::new(EUI_INSERT_SQL);
-    query_builder.push_values(eui_values, |mut builder, (id, app_eui, dev_eui)| {
-        builder.push_bind(id).push_bind(app_eui).push_bind(dev_eui);
-    });
+        sqlx::QueryBuilder::new(EUI_INSERT_VALS);
+    query_builder
+        .push_values(eui_values, |mut builder, (id, app_eui, dev_eui)| {
+            builder.push_bind(id).push_bind(app_eui).push_bind(dev_eui);
+        })
+        .push(EUI_INSERT_ON_CONF);
 
     query_builder.build().execute(db).await.map(|_| ())?;
 
@@ -323,13 +326,17 @@ async fn insert_devaddr_ranges(
         ));
     }
 
-    const DEVADDR_RANGE_INSERT_SQL: &str =
-        "insert into route_devaddr_ranges (route_id, start_addr, end_addr) ";
+    const DEVADDR_RANGE_INSERT_VALS: &str =
+        " insert into route_devaddr_ranges (route_id, start_addr, end_addr) ";
+    const DEVADDR_RANGE_INSERT_ON_CONF: &str =
+        " on conflict (route_id, start_addr, end_addr) do nothing ";
     let mut query_builder: sqlx::QueryBuilder<sqlx::Postgres> =
-        sqlx::QueryBuilder::new(DEVADDR_RANGE_INSERT_SQL);
-    query_builder.push_values(devaddr_values, |mut builder, (id, start, end)| {
-        builder.push_bind(id).push_bind(start).push_bind(end);
-    });
+        sqlx::QueryBuilder::new(DEVADDR_RANGE_INSERT_VALS);
+    query_builder
+        .push_values(devaddr_values, |mut builder, (id, start, end)| {
+            builder.push_bind(id).push_bind(start).push_bind(end);
+        })
+        .push(DEVADDR_RANGE_INSERT_ON_CONF);
 
     query_builder.build().execute(db).await.map(|_| ())?;
 


### PR DESCRIPTION
Requires merging https://github.com/helium/proto/pull/284 first.
Renames the load region params req/res to conform to the convention used by the other iot_config rpc messages by prepending each message with the name of the service it corresponds with.
This makes the proto encoding of the `hex_indexes` field in the region loading rpc non-optional from the perspective of proto3 but still allows it to be an optional argument by the config service operator.
- [x] merge https://github.com/helium/proto/pull/284
- [x] update Cargo.toml to proto master branch again