### PR TITLE
Use seconds precision for entropy timestamp.  Use hotspot generated entropy inputs and outputs for beacon verification test

### DIFF
--- a/file_store/src/iot_beacon_report.rs
+++ b/file_store/src/iot_beacon_report.rs
@@ -153,7 +153,7 @@ impl IotBeaconReport {
         entropy_version: u32,
     ) -> Result<beacon::Beacon> {
         let remote_entropy = beacon::Entropy {
-            timestamp: entropy_start.timestamp_millis(),
+            timestamp: entropy_start.timestamp(),
             data: self.remote_entropy.clone(),
             version: entropy_version,
         };


### PR DESCRIPTION
This addresses a mismatch on the beacon generation on the verifier with that of the beacon generation on hotspots where the resultant generated data payload values did not match.

The root cause of the issue was that the verifier was passing in millisecs precision for its remote entropy timestamp value when generating the beacon to verify whereas the hotspots uses seconds precision.   
