### PR TITLE
Add denylist check cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,10 +1348,12 @@ dependencies = [
 name = "denylist"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "base64 0.21.0",
  "bincode",
  "bytes",
  "chrono",
+ "clap 3.2.23",
  "config",
  "helium-crypto",
  "reqwest",
@@ -1360,6 +1362,7 @@ dependencies = [
  "sha2 0.10.6",
  "structopt",
  "thiserror",
+ "tokio",
  "tracing",
  "twox-hash",
  "xorf",

--- a/denylist/Cargo.toml
+++ b/denylist/Cargo.toml
@@ -23,3 +23,6 @@ serde = {workspace = true}
 serde_json = {workspace = true}
 config = {workspace = true}
 chrono = { workspace = true }
+clap = {workspace = true}
+anyhow = {workspace = true}
+tokio = { workspace = true }

--- a/denylist/src/cli/check.rs
+++ b/denylist/src/cli/check.rs
@@ -1,0 +1,24 @@
+use crate::{DenyList, Settings};
+use helium_crypto::PublicKey;
+use std::{path::PathBuf, str::FromStr};
+
+/// Check if pubkey b58 is in denylist
+#[derive(Debug, clap::Args)]
+pub struct Cmd {
+    /// Required pubkey in b58 form
+    #[clap(long)]
+    key: String,
+    /// Required path to local_filter_bin
+    #[clap(long)]
+    filter_path: PathBuf,
+}
+
+impl Cmd {
+    pub async fn run(&self, _settings: &Settings) -> anyhow::Result<bool> {
+        let pubkey = PublicKey::from_str(&self.key)?;
+        let pubkey_bin = pubkey.to_vec();
+        let dl = DenyList::from_filter(self.filter_path.as_path())?;
+        let res = dl.check_key(&pubkey_bin).await;
+        Ok(res)
+    }
+}

--- a/denylist/src/cli/mod.rs
+++ b/denylist/src/cli/mod.rs
@@ -1,0 +1,1 @@
+pub mod check;

--- a/denylist/src/denylist.rs
+++ b/denylist/src/denylist.rs
@@ -45,17 +45,10 @@ impl DenyList {
             );
             Vec::new()
         });
-        let filter = filter_from_bin(&bin).unwrap_or_else(|_| Xor32::from(Vec::new()));
-        let client = DenyListClient::new()?;
-        Ok(Self {
-            // default tag to 0, proper tag name will be set on first
-            // call to update_to_latest
-            tag_name: 0,
-            client,
-            filter,
-        })
+        Self::construct(bin)
     }
 
+    /// Construct Denylist using a local filter_path
     pub fn from_filter<P: AsRef<Path>>(filter_path: P) -> Result<Self> {
         let bin: Vec<u8> = fs::read(filter_path).unwrap_or_else(|_| {
             tracing::warn!(
@@ -63,7 +56,11 @@ impl DenyList {
             );
             Vec::new()
         });
-        let filter = filter_from_bin(&bin).unwrap_or_else(|_| Xor32::from(Vec::new()));
+        Self::construct(bin)
+    }
+
+    fn construct(filter_bin: Vec<u8>) -> Result<Self> {
+        let filter = filter_from_bin(&filter_bin).unwrap_or_else(|_| Xor32::from(Vec::new()));
         let client = DenyListClient::new()?;
         Ok(Self {
             // default tag to 0, proper tag name will be set on first

--- a/denylist/src/lib.rs
+++ b/denylist/src/lib.rs
@@ -1,5 +1,6 @@
 mod error;
 pub use error::{Error, Result};
+pub mod cli;
 pub mod client;
 pub mod denylist;
 pub mod models;

--- a/denylist/src/main.rs
+++ b/denylist/src/main.rs
@@ -1,0 +1,48 @@
+use std::path;
+
+use clap::Parser;
+use denylist::{cli::check, Settings};
+
+#[derive(Debug, clap::Subcommand)]
+pub enum Cmd {
+    Check(check::Cmd),
+}
+
+impl Cmd {
+    pub async fn run(self, settings: Settings) -> anyhow::Result<()> {
+        match self {
+            Self::Check(cmd) => {
+                let res = cmd.run(&settings).await?;
+                println!("{:?}", res);
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Debug, clap::Parser)]
+#[clap(version = env!("CARGO_PKG_VERSION"))]
+#[clap(about = "Helium Denylist Checker")]
+pub struct Cli {
+    /// Optional configuration file to use. If present the toml file at the
+    /// given path will be loaded. Environemnt variables can override the
+    /// settins in the given file.
+    #[clap(short = 'c')]
+    config: Option<path::PathBuf>,
+
+    #[clap(subcommand)]
+    cmd: Cmd,
+}
+
+impl Cli {
+    pub async fn run(self) -> anyhow::Result<()> {
+        let settings = Settings::new(self.config)?;
+        self.cmd.run(settings).await
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    cli.run().await
+}


### PR DESCRIPTION
Summary
----
This PR adds a check cli to the denylist crate. This is useful to check whether a given hotspot b58 address is on the denylist or not.

Usage:
```
./target/release/denylist check --key <b58_key> --filter-path <local_filter_path.bin>
```