### PR TITLE
invalidate dup witness reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,7 +2017,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#6fe732f2ce26ccafbb5a6b4382ebf37d3078bb69"
+source = "git+https://github.com/helium/proto?branch=master#e26cab8368ba6c901b5a9efe552fe6cd3eaf6218"
 dependencies = [
  "bytes",
  "prost",

--- a/file_store/src/iot_valid_poc.rs
+++ b/file_store/src/iot_valid_poc.rs
@@ -214,3 +214,45 @@ impl From<IotVerifiedWitnessReport> for LoraVerifiedWitnessReportV1 {
         }
     }
 }
+
+impl IotVerifiedWitnessReport {
+    pub fn valid(
+        report: &IotWitnessReport,
+        received_timestamp: DateTime<Utc>,
+        location: Option<u64>,
+        hex_scale: Decimal,
+    ) -> IotVerifiedWitnessReport {
+        Self {
+            received_timestamp,
+            status: VerificationStatus::Valid,
+            invalid_reason: InvalidReason::ReasonNone,
+            report: report.clone(),
+            location,
+            hex_scale,
+            // default reward units to zero until we've got the full count of
+            // valid, non-failed witnesses for the final validated poc report
+            reward_unit: Decimal::ZERO,
+            participant_side: InvalidParticipantSide::SideNone,
+        }
+    }
+    pub fn invalid(
+        invalid_reason: InvalidReason,
+        report: &IotWitnessReport,
+        received_timestamp: DateTime<Utc>,
+        location: Option<u64>,
+        participant_side: InvalidParticipantSide,
+    ) -> IotVerifiedWitnessReport {
+        Self {
+            received_timestamp,
+            status: VerificationStatus::Invalid,
+            invalid_reason,
+            report: report.clone(),
+            location,
+            hex_scale: Decimal::ZERO,
+            // default reward units to zero until we've got the full count of
+            // valid, non-failed witnesses for the final validated poc report
+            reward_unit: Decimal::ZERO,
+            participant_side,
+        }
+    }
+}

--- a/iot_verifier/src/poc.rs
+++ b/iot_verifier/src/poc.rs
@@ -164,7 +164,7 @@ impl Poc {
             } else {
                 // the report is a dup
                 let dup_witness = IotVerifiedWitnessReport::invalid(
-                    InvalidReason::InvalidCapability, //TODO change 'Duplicate' reason after proto is merged
+                    InvalidReason::Duplicate,
                     &witness_report.report,
                     witness_report.received_timestamp,
                     None,

--- a/iot_verifier/src/poc_report.rs
+++ b/iot_verifier/src/poc_report.rs
@@ -274,6 +274,7 @@ impl Report {
             where packet_data = $1
             and report_type = 'witness'
             and attempts < $2
+            order by report_timestamp asc
             "#,
         )
         .bind(packet_data)

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -628,24 +628,37 @@ mod tests {
 
         let witness3 = IotVerifiedWitnessReport {
             received_timestamp: Utc::now(),
-            report,
+            report: report.clone(),
             location: Some(631252734740306943),
             hex_scale: Decimal::ZERO,
             reward_unit: Decimal::ZERO,
-            status: VerificationStatus::Valid,
+            status: VerificationStatus::Invalid,
             invalid_reason: InvalidReason::Stale,
             participant_side: InvalidParticipantSide::Witness,
         };
 
-        // vec of 3 witnesses
-        let witnesses = vec![witness1, witness2, witness3];
-        let (excluded_witnesses, included_witnesses) = filter_witnesses(witnesses);
+        let witness4 = IotVerifiedWitnessReport {
+            received_timestamp: Utc::now(),
+            report,
+            location: Some(631252734740306943),
+            hex_scale: Decimal::ZERO,
+            reward_unit: Decimal::ZERO,
+            status: VerificationStatus::Invalid,
+            invalid_reason: InvalidReason::Duplicate,
+            participant_side: InvalidParticipantSide::Witness,
+        };
 
-        assert_eq!(1, excluded_witnesses.len());
+        let witnesses = vec![witness1, witness2, witness3, witness4];
+        let (excluded_witnesses, included_witnesses) = filter_witnesses(witnesses);
+        assert_eq!(2, excluded_witnesses.len());
         assert_eq!(1, included_witnesses.len());
         assert_eq!(
             InvalidReason::Stale,
-            excluded_witnesses.first().unwrap().invalid_reason
+            excluded_witnesses.get(0).unwrap().invalid_reason
+        );
+        assert_eq!(
+            InvalidReason::Duplicate,
+            excluded_witnesses.get(1).unwrap().invalid_reason
         );
         assert_eq!(
             InvalidReason::ReasonNone,


### PR DESCRIPTION
Address duplicate witness reports received for any one individual beacon and includes a slight refactor of witness verification flow.

The first witness report from any one gateway is accepted.  Any subsequent report from the same gateway for the same beacon will be rendered invalid with reason 'duplicate'.  Verifications will not be run on duplicates.

Reports marked as duplicate will be excluded from the last 14 and will make it to S3 as part of the `unselected` list.


There are multiple ways to handle duplications but the key considerations are:

1.  Do we require a report to make it to S3 for any witness rendered a dup ?
2.  In the scenario whereby we have both a valid and N invalids report from the same gateway....which one is deduped ?  How do we decide on that ?  
3. In the scenario whereby we have dups that include 1 valid and one or more invalids ( invalid in the sense they would fail verifications ) do we allow for the possibility that the last 14 could consist of both a valid and an invalid report from the same gateway ?
4.  Can a report marked as a dup be selected for the last 14 ?

This PR deals with each of the above via:

1. Dup reports make it to S3, they are not dropped to the floor
2. Witnesses are sorted based on received timestamp ( time they hit the ingestor ).  The first received report is accepted, any subsequent report is rejected and marked as a dup
3.  Only the first witness report has the potential to make it to the last 14.  A gateway cannot have more that 1 report in the last 14 
4.  Reports marked as dups cannot make it to the last 14 list
