### PR TITLE
constrain aws-config + deconstrain aws-sdk-s3

### DIFF
--- a/file_store/Cargo.toml
+++ b/file_store/Cargo.toml
@@ -29,8 +29,8 @@ helium-proto = {workspace = true}
 helium-crypto = {workspace = true}
 csv = "*"
 http = {workspace = true}
-aws-config = "0"
-aws-sdk-s3 = "0.21.0"
+aws-config = "0.51"
+aws-sdk-s3 = "0.21"
 strum = {version = "0", features = ["derive"]}
 strum_macros = "0"
 sha2 = {workspace = true}


### PR DESCRIPTION
When using file-store as a crate the latest versions don't compile. This constrains aws-config to match what is in the cargo.lock 