### PR TITLE
verifier changes for helius integration

### DIFF
--- a/iot_verifier/src/gateway_cache.rs
+++ b/iot_verifier/src/gateway_cache.rs
@@ -1,41 +1,57 @@
-use crate::Settings;
+use crate::{helius, Settings};
+use futures::stream::TryStreamExt;
 use helium_crypto::PublicKeyBinary;
-use node_follower::{
-    follower_service::FollowerService,
-    gateway_resp::{GatewayInfo, GatewayInfoResolver},
-};
+use helius::GatewayInfo;
 use retainer::Cache;
+use sqlx::PgPool;
 use std::{sync::Arc, time::Duration};
 use tokio::task::JoinHandle;
 
-/// how long each cached items takes to expire ( 12 hours in seconds)
+// how long each cached items takes to expire ( 12 hours in seconds)
 const CACHE_TTL: Duration = Duration::from_secs(12 * (60 * 60));
 /// how often to evict expired items from the cache ( every 1 hour)
 const CACHE_EVICTION_FREQUENCY: Duration = Duration::from_secs(60 * 60);
 
+const HELIUS_DB_POOL_SIZE: usize = 100;
+
 pub struct GatewayCache {
-    pub follower_service: FollowerService,
+    pool: PgPool,
     pub cache: Arc<Cache<PublicKeyBinary, GatewayInfo>>,
     pub cache_monitor: JoinHandle<()>,
 }
+
+#[derive(thiserror::Error, Debug)]
+#[error("error creating gateway cache: {0}")]
+pub struct NewGatewayCacheError(#[from] db_store::Error);
 
 #[derive(thiserror::Error, Debug)]
 #[error("gateway not found: {0}")]
 pub struct GatewayNotFound(PublicKeyBinary);
 
 impl GatewayCache {
-    pub fn from_settings(settings: &Settings) -> Self {
-        let follower_service = FollowerService::from_settings(&settings.follower);
+    pub async fn from_settings(settings: &Settings) -> Result<Self, NewGatewayCacheError> {
+        let pool = settings.database.connect(HELIUS_DB_POOL_SIZE).await?;
         let cache = Arc::new(Cache::<PublicKeyBinary, GatewayInfo>::new());
         let clone = cache.clone();
         // monitor cache to handle evictions
         let cache_monitor =
             tokio::spawn(async move { clone.monitor(4, 0.25, CACHE_EVICTION_FREQUENCY).await });
-        Self {
-            follower_service,
+        Ok(Self {
+            pool,
             cache,
             cache_monitor,
+        })
+    }
+
+    pub async fn prewarm(&self) -> anyhow::Result<()> {
+        let sql = r#"SELECT address, location, elevation, gain, is_full_hotspot FROM gateways"#;
+        let mut rows = sqlx::query_as::<_, GatewayInfo>(sql).fetch(&self.pool);
+        while let Some(gateway) = rows.try_next().await? {
+            self.cache
+                .insert(gateway.address.clone(), gateway.clone(), CACHE_TTL)
+                .await;
         }
+        Ok(())
     }
 
     pub async fn resolve_gateway_info(
@@ -47,24 +63,16 @@ impl GatewayCache {
                 metrics::increment_counter!("oracles_iot_verifier_gateway_cache_hit");
                 Ok(hit.value().clone())
             }
-            _ => {
-                match self
-                    .follower_service
-                    .clone()
-                    .resolve_gateway_info(address)
-                    .await
-                {
-                    Ok(res) => {
-                        tracing::debug!("cache miss: {:?}", address);
-                        metrics::increment_counter!("oracles_iot_verifier_gateway_cache_miss");
-                        self.cache
-                            .insert(address.clone(), res.clone(), CACHE_TTL)
-                            .await;
-                        Ok(res)
-                    }
-                    _ => Err(GatewayNotFound(address.clone())),
+            _ => match GatewayInfo::resolve_gateway(&self.pool, address.as_ref()).await {
+                Ok(Some(res)) => {
+                    metrics::increment_counter!("oracles_iot_verifier_gateway_cache_miss");
+                    self.cache
+                        .insert(address.clone(), res.clone(), CACHE_TTL)
+                        .await;
+                    Ok(res)
                 }
-            }
+                _ => Err(GatewayNotFound(address.clone())),
+            },
         }
     }
 }

--- a/iot_verifier/src/helius.rs
+++ b/iot_verifier/src/helius.rs
@@ -1,0 +1,49 @@
+use helium_crypto::PublicKeyBinary;
+use sqlx::postgres::PgRow;
+use sqlx::{FromRow, Row};
+
+#[derive(Debug, Clone)]
+pub struct GatewayInfo {
+    pub address: PublicKeyBinary,
+    pub location: Option<u64>,
+    pub elevation: Option<i32>,
+    pub gain: i32,
+    pub is_full_hotspot: bool,
+}
+
+impl<'c> FromRow<'c, PgRow> for GatewayInfo {
+    fn from_row(row: &'c PgRow) -> Result<Self, sqlx::Error> {
+        Ok(GatewayInfo {
+            address: row.get(0),
+            //TODO: fix location, None value is not being handled here
+            location: Some(row.get::<i64, _>("location") as u64),
+            elevation: row.get(2),
+            gain: row.get(3),
+            is_full_hotspot: row.get(4),
+        })
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("report error: {0}")]
+pub struct SqlError(#[from] sqlx::Error);
+
+impl GatewayInfo {
+    pub async fn resolve_gateway<'c, E>(
+        executor: E,
+        id: &[u8],
+    ) -> Result<Option<GatewayInfo>, sqlx::Error>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
+        let result = sqlx::query_as::<_, Self>(
+            r#"
+            select address, location, elevation, gain, is_full_hotspot from gateways where address = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(executor)
+        .await?;
+        Ok(result)
+    }
+}

--- a/iot_verifier/src/lib.rs
+++ b/iot_verifier/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod entropy;
 pub mod entropy_loader;
 pub mod gateway_cache;
+pub mod helius;
 mod hex_density;
 pub mod last_beacon;
 pub mod loader;
@@ -9,6 +10,7 @@ pub mod metrics;
 pub mod poc;
 pub mod poc_report;
 pub mod purger;
+pub mod region_cache;
 pub mod reward_share;
 pub mod rewarder;
 pub mod runner;

--- a/iot_verifier/src/poc.rs
+++ b/iot_verifier/src/poc.rs
@@ -1,8 +1,10 @@
 use crate::{
     entropy::ENTROPY_LIFESPAN,
     gateway_cache::GatewayCache,
+    helius::GatewayInfo,
     hex_density::HexDensityMap,
     last_beacon::{LastBeacon, LastBeaconError},
+    region_cache::{RegionCache, RegionInfo},
 };
 use beacon;
 use chrono::{DateTime, Duration, Utc};
@@ -17,10 +19,9 @@ use h3ron::{to_geo::ToCoordinate, H3Cell, H3DirectedEdge, Index};
 use helium_crypto::PublicKeyBinary;
 use helium_proto::{
     services::poc_lora::{InvalidParticipantSide, InvalidReason, VerificationStatus},
-    BlockchainRegionParamV1, GatewayStakingMode, Region as ProtoRegion,
+    BlockchainRegionParamV1, Region as ProtoRegion,
 };
 use lazy_static::lazy_static;
-use node_follower::gateway_resp::GatewayInfo;
 use rust_decimal::Decimal;
 use sqlx::PgPool;
 use std::f64::consts::PI;
@@ -99,6 +100,7 @@ impl Poc {
         &mut self,
         hex_density_map: impl HexDensityMap,
         gateway_cache: &GatewayCache,
+        region_cache: &RegionCache,
         pool: &PgPool,
         beacon_interval: Duration,
         beacon_interval_tolerance: Duration,
@@ -113,6 +115,13 @@ impl Poc {
                 return Ok(VerifyBeaconResult::gateway_not_found());
             }
         };
+        let beaconer_region_info =
+            match get_gateway_region_info(region_cache, &beaconer_info.address).await {
+                Some(res) => res,
+                None => {
+                    return Ok(VerifyBeaconResult::gateway_not_found());
+                }
+            };
         // we have beaconer info, proceed to verifications
         let last_beacon = LastBeacon::get(pool, beaconer_pub_key.as_ref()).await?;
         match do_beacon_verifications(
@@ -122,6 +131,7 @@ impl Poc {
             last_beacon,
             &self.beacon_report,
             &beaconer_info,
+            &beaconer_region_info,
             beacon_interval,
             beacon_interval_tolerance,
         ) {
@@ -145,6 +155,7 @@ impl Poc {
         beacon_info: &GatewayInfo,
         hex_density_map: impl HexDensityMap,
         gateway_cache: &GatewayCache,
+        region_cache: &RegionCache,
     ) -> Result<VerifyWitnessesResult, VerificationError> {
         let mut verified_witnesses: Vec<IotVerifiedWitnessReport> = Vec::new();
         let mut failed_witnesses: Vec<IotWitnessIngestReport> = Vec::new();
@@ -161,6 +172,7 @@ impl Poc {
                         &witness_report,
                         beacon_info,
                         gateway_cache,
+                        region_cache,
                         &hex_density_map,
                     )
                     .await
@@ -196,6 +208,7 @@ impl Poc {
         witness_report: &IotWitnessIngestReport,
         beaconer_info: &GatewayInfo,
         gateway_cache: &GatewayCache,
+        region_cache: &RegionCache,
         hex_density_map: &impl HexDensityMap,
     ) -> Result<IotVerifiedWitnessReport, VerificationError> {
         let witness = &witness_report.report;
@@ -213,14 +226,43 @@ impl Poc {
                 ))
             }
         };
+        //get region data for beaconer and witness, required by verifications
+        let beaconer_region =
+            match get_gateway_region_info(region_cache, &beaconer_info.address).await {
+                Some(res) => res,
+                None => {
+                    return Ok(IotVerifiedWitnessReport::invalid(
+                        InvalidReason::GatewayNotFound,
+                        &witness_report.report,
+                        witness_report.received_timestamp,
+                        None,
+                        InvalidParticipantSide::Witness,
+                    ))
+                }
+            };
+        let witness_region = match get_gateway_region_info(region_cache, &witness_pub_key).await {
+            Some(res) => res,
+            None => {
+                return Ok(IotVerifiedWitnessReport::invalid(
+                    InvalidReason::GatewayNotFound,
+                    &witness_report.report,
+                    witness_report.received_timestamp,
+                    None,
+                    InvalidParticipantSide::Witness,
+                ))
+            }
+        };
+
         // run the witness verifications
         match do_witness_verifications(
             self.entropy_start,
             self.entropy_end,
             witness_report,
             &witness_info,
+            witness_region,
             &self.beacon_report,
             beaconer_info,
+            beaconer_region,
         ) {
             Ok(()) => {
                 // to avoid assuming beaconer location is set and to avoid unwrap
@@ -265,17 +307,18 @@ pub fn do_beacon_verifications(
     last_beacon: Option<LastBeacon>,
     beacon_report: &IotBeaconIngestReport,
     beaconer_info: &GatewayInfo,
+    beaconer_region_info: &RegionInfo,
     beacon_interval: Duration,
     beacon_interval_tolerance: Duration,
 ) -> GenericVerifyResult {
     tracing::debug!(
         "verifying beacon from beaconer: {:?}",
-        PublicKeyBinary::from(beaconer_info.address.clone())
+        beaconer_info.address.clone()
     );
     let beacon_received_ts = beacon_report.received_timestamp;
     verify_entropy(entropy_start, entropy_end, beacon_received_ts)?;
     verify_gw_location(beaconer_info.location)?;
-    verify_gw_capability(beaconer_info.staking_mode)?;
+    verify_gw_capability(beaconer_info.is_full_hotspot)?;
     verify_beacon_schedule(
         &last_beacon,
         beacon_received_ts,
@@ -284,30 +327,33 @@ pub fn do_beacon_verifications(
     )?;
     verify_beacon_payload(
         &beacon_report.report,
-        beaconer_info.region,
-        &beaconer_info.region_params,
+        beaconer_region_info.region,
+        &beaconer_region_info.region_params,
         beaconer_info.gain,
         entropy_start,
         entropy_version as u32,
     )?;
     tracing::debug!(
         "valid beacon from beaconer: {:?}",
-        PublicKeyBinary::from(beaconer_info.address.clone())
+        beaconer_info.address.clone()
     );
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn do_witness_verifications(
     entropy_start: DateTime<Utc>,
     entropy_end: DateTime<Utc>,
     witness_report: &IotWitnessIngestReport,
     witness_info: &GatewayInfo,
+    witness_region_info: RegionInfo,
     beacon_report: &IotBeaconIngestReport,
     beaconer_info: &GatewayInfo,
+    beaconer_region_info: RegionInfo,
 ) -> GenericVerifyResult {
     tracing::debug!(
         "verifying witness from gateway: {:?}",
-        PublicKeyBinary::from(witness_info.address.clone())
+        witness_info.address.clone()
     );
     let beacon_report = &beacon_report;
     verify_self_witness(
@@ -321,12 +367,12 @@ pub fn do_witness_verifications(
     )?;
     verify_witness_data(&beacon_report.report.data, &witness_report.report.data)?;
     verify_gw_location(witness_info.location)?;
-    verify_gw_capability(witness_info.staking_mode)?;
+    verify_gw_capability(witness_info.is_full_hotspot)?;
     verify_witness_freq(
         beacon_report.report.frequency,
         witness_report.report.frequency,
     )?;
-    verify_witness_region(beaconer_info.region, witness_info.region)?;
+    verify_witness_region(beaconer_region_info.region, witness_region_info.region)?;
     verify_witness_cell_distance(beaconer_info.location, witness_info.location)?;
     verify_witness_distance(beaconer_info.location, witness_info.location)?;
     verify_witness_rssi(
@@ -340,7 +386,7 @@ pub fn do_witness_verifications(
     )?;
     tracing::debug!(
         "valid witness from gateway: {:?}",
-        PublicKeyBinary::from(witness_info.address.clone())
+        witness_info.address.clone()
     );
     Ok(())
 }
@@ -466,19 +512,10 @@ fn verify_gw_location(gateway_loc: Option<u64>) -> GenericVerifyResult {
 }
 
 /// verify gateway is permitted to participate in POC
-fn verify_gw_capability(staking_mode: GatewayStakingMode) -> GenericVerifyResult {
-    match staking_mode {
-        GatewayStakingMode::Dataonly => {
-            tracing::debug!(
-                "witness verification failed, reason: {:?}. gateway staking mode: {:?}",
-                InvalidReason::InvalidCapability,
-                staking_mode
-            );
-            return Err(InvalidReason::InvalidCapability);
-        }
-        GatewayStakingMode::Full => (),
-        GatewayStakingMode::Light => (),
-    }
+fn verify_gw_capability(is_full_hotspot: bool) -> GenericVerifyResult {
+    if !is_full_hotspot {
+        return Err(InvalidReason::InvalidCapability);
+    };
     Ok(())
 }
 
@@ -517,8 +554,10 @@ fn verify_witness_region(
 ) -> GenericVerifyResult {
     if beacon_region != witness_region {
         tracing::debug!(
-            "witness verification failed, reason: {:?}. beaconer region: {beacon_region}, witness region: {witness_region}",
-            InvalidReason::InvalidRegion
+            "witness verification failed, reason: {:?}. beaconer region: {:?}, witness region: {:?}",
+            InvalidReason::InvalidRegion,
+            beacon_region,
+            witness_region,
         );
         return Err(InvalidReason::InvalidRegion);
     }
@@ -631,6 +670,16 @@ fn verify_witness_data(beacon_data: &Vec<u8>, witness_data: &Vec<u8>) -> Generic
         return Err(InvalidReason::InvalidPacket);
     }
     Ok(())
+}
+
+async fn get_gateway_region_info(
+    region_cache: &RegionCache,
+    address: &PublicKeyBinary,
+) -> Option<RegionInfo> {
+    match region_cache.resolve_region_info(address).await {
+        Ok(res) => Some(res),
+        Err(_e) => None,
+    }
 }
 
 fn calc_expected_rssi(

--- a/iot_verifier/src/region_cache.rs
+++ b/iot_verifier/src/region_cache.rs
@@ -1,0 +1,79 @@
+use crate::Settings;
+use helium_crypto::PublicKeyBinary;
+use helium_proto::{BlockchainRegionParamV1, Region};
+use node_follower::{follower_service::FollowerService, gateway_resp::GatewayInfoResolver};
+use retainer::Cache;
+use std::time::Duration;
+
+const CACHE_TTL: u64 = 86400;
+
+#[derive(Debug, Clone)]
+pub struct RegionInfo {
+    pub address: PublicKeyBinary,
+    pub region: Region,
+    pub region_params: Vec<BlockchainRegionParamV1>,
+}
+
+pub struct RegionCache {
+    pub follower_service: FollowerService,
+    pub cache: Cache<PublicKeyBinary, RegionInfo>,
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("error creating region cache: {0}")]
+pub struct NewGatewayCacheError(#[from] db_store::Error);
+
+#[derive(thiserror::Error, Debug)]
+#[error("gateway not found: {0}")]
+pub struct GatewayNotFound(PublicKeyBinary);
+
+impl RegionCache {
+    pub async fn from_settings(settings: &Settings) -> Result<Self, NewGatewayCacheError> {
+        let follower_service = FollowerService::from_settings(&settings.follower);
+        let cache = Cache::<PublicKeyBinary, RegionInfo>::new();
+        Ok(Self {
+            follower_service,
+            cache,
+        })
+    }
+
+    // temporarily pulls region from the node follower
+    // TODO: to be replaced with RPC to config service or to solana. TBC
+    pub async fn resolve_region_info(
+        &self,
+        address: &PublicKeyBinary,
+    ) -> Result<RegionInfo, GatewayNotFound> {
+        match self.cache.get(address).await {
+            Some(hit) => {
+                metrics::increment_counter!("oracles_iot_verifier_region_cache_hit");
+                Ok(hit.value().clone())
+            }
+            _ => {
+                match self
+                    .follower_service
+                    .clone()
+                    .resolve_gateway_info(address)
+                    .await
+                {
+                    Ok(res) => {
+                        metrics::increment_counter!("oracles_iot_verifier_region_cache_miss");
+                        let region_info = RegionInfo {
+                            address: res.address.clone().into(),
+                            region: res.region,
+                            region_params: res.region_params,
+                        };
+                        self.cache
+                            .insert(
+                                address.clone(),
+                                region_info.clone(),
+                                Duration::from_secs(CACHE_TTL),
+                            )
+                            .await;
+                        Ok(region_info)
+                    }
+                    _ => Err(GatewayNotFound(address.clone())),
+                }
+            }
+        }
+    }
+}

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -18,6 +18,7 @@ pub struct Settings {
     #[serde(default = "default_base_stale_period")]
     pub base_stale_period: i64,
     pub database: db_store::Settings,
+    pub helius: db_store::Settings,
     pub follower: node_follower::Settings,
     pub ingest: file_store::Settings,
     pub entropy: file_store::Settings,


### PR DESCRIPTION
WIP branch...

Initial requirements at replacing node follower usage in the IOT verifier

Region data continues to be pulled from node follower temporarily via RPC. This will be replaced with either a call to the config service or an RPC to helius ( tbd)  Previously the node data would have been returned from the follower as part of the gateway info and cached in the IOT verifier. Given the gateway info now originates from helius and that helius does not manage region data, deriving region data is now distinct from gateway info. Added a cache to store region data per gateway