### PR TITLE
Config Service bugfixes, Admin API and Gateway Location RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/gateway-rs.git?branch=jg/config-admin-svc#4ef554fe206dec7f6dff74adc6deda8b3fb2d195"
+source = "git+https://github.com/helium/gateway-rs.git?branch=main#a8987fe422af9416b7419fb68151f79c087c5dac"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -689,7 +689,7 @@ dependencies = [
  "rand_chacha",
  "rust_decimal",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "thiserror",
 ]
 
@@ -1332,7 +1332,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "structopt",
  "thiserror",
  "tracing",
@@ -1559,7 +1559,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "strum",
  "strum_macros",
@@ -1982,7 +1982,7 @@ dependencies = [
  "p256",
  "rand_core",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "signature",
  "sqlx",
  "thiserror",
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=jg/config-admin-svc#89b493096d25504180a737e8304ff011a8ce50cb"
+source = "git+https://github.com/helium/proto?branch=master#e1f810224509ce1c141ae78c8589ab3740231ee1"
 dependencies = [
  "bytes",
  "prost",
@@ -2240,7 +2240,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "thiserror",
  "tokio",
  "tonic",
@@ -2330,7 +2330,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -2716,7 +2716,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -2756,7 +2756,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -3121,7 +3121,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -3517,7 +3517,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/gateway-rs.git?branch=main#a8987fe422af9416b7419fb68151f79c087c5dac"
+source = "git+https://github.com/helium/gateway-rs.git?branch=jg/config-admin-svc#4ef554fe206dec7f6dff74adc6deda8b3fb2d195"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#e19a45c84a3dae2e1ea42b50515317a0e935903b"
+source = "git+https://github.com/helium/proto?branch=jg/config-admin-svc#89b493096d25504180a737e8304ff011a8ce50cb"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,10 @@ sqlx = {version = "0", features = [
 ]}
 
 helium-crypto = {version = "0.6.3", features=["sqlx-postgres", "multisig"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "jg/config-admin-svc", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
 hextree = "*"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
-beacon = {git = "https://github.com/helium/gateway-rs.git", branch = "jg/config-admin-svc"}
+beacon = {git = "https://github.com/helium/gateway-rs.git", branch = "main"}
 humantime = "2"
 metrics = "0"
 metrics-exporter-prometheus = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,10 @@ sqlx = {version = "0", features = [
 ]}
 
 helium-crypto = {version = "0.6.3", features=["sqlx-postgres", "multisig"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "jg/config-admin-svc", features = ["services"]}
 hextree = "*"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
-beacon = {git = "https://github.com/helium/gateway-rs.git", branch = "main"}
+beacon = {git = "https://github.com/helium/gateway-rs.git", branch = "jg/config-admin-svc"}
 humantime = "2"
 metrics = "0"
 metrics-exporter-prometheus = "0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,18 +8,28 @@ services:
       dockerfile: iot_config.Dockerfile
     depends_on:
       - postgres
+      - node
     ports:
       - "8080:8080"
     environment:
       CFG_DATABASE_URL: postgres://postgres:postgres@postgres:5432/config_db
       CFG_LISTEN: 0.0.0.0:8080
       CFG_METRICS_ENDPOINT: 0.0.0.0:19000
+      CFG_FOLLOWER_URL: "http://node:8090"
       CFG_NETWORK: mainnet
       CFG_ADMIN: ${CONFIG_ADMIN_PUBKEY}
       CFG_KEYPAIR: /config-signing-key.bin
       CFG_LOG: info
     volumes:
       - ${CONFIG_SIGNING_KEY}:/config-signing-key.bin:ro
+
+  node:
+    image: jeffgrunewald/helium-mock-follower:latest
+    environment:
+      FLW_GATEWAYS: /demo_gateways.csv
+      FLW_LISTEN: 0.0.0.0:8090
+    ports:
+      - "8090:8090"
 
   postgres:
     image: postgres:latest

--- a/file_store/src/traits/msg_verify.rs
+++ b/file_store/src/traits/msg_verify.rs
@@ -2,11 +2,12 @@ use crate::{Error, Result};
 use helium_crypto::{PublicKey, Verify};
 use helium_proto::services::{
     iot_config::{
-        GatewayLoadRegionReqV1, GatewayRegionParamsReqV1, OrgCreateHeliumReqV1,
-        OrgCreateRoamerReqV1, OrgDisableReqV1, OrgEnableReqV1, RouteCreateReqV1,
-        RouteDeleteDevaddrRangesReqV1, RouteDeleteEuisReqV1, RouteDeleteReqV1,
-        RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1, RouteGetReqV1, RouteListReqV1,
-        RouteStreamReqV1, RouteUpdateDevaddrRangesReqV1, RouteUpdateEuisReqV1, RouteUpdateReqV1,
+        AdminAddKeyReqV1, AdminLoadRegionReqV1, AdminRemoveKeyReqV1, GatewayLocationReqV1,
+        GatewayRegionParamsReqV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgDisableReqV1,
+        OrgEnableReqV1, RouteCreateReqV1, RouteDeleteDevaddrRangesReqV1, RouteDeleteEuisReqV1,
+        RouteDeleteReqV1, RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1, RouteGetReqV1,
+        RouteListReqV1, RouteStreamReqV1, RouteUpdateDevaddrRangesReqV1, RouteUpdateEuisReqV1,
+        RouteUpdateReqV1,
     },
     poc_lora::{LoraBeaconReportReqV1, LoraWitnessReportReqV1},
 };
@@ -54,8 +55,11 @@ impl_msg_verify!(RouteUpdateEuisReqV1, signature);
 impl_msg_verify!(RouteGetDevaddrRangesReqV1, signature);
 impl_msg_verify!(RouteUpdateDevaddrRangesReqV1, signature);
 impl_msg_verify!(RouteDeleteDevaddrRangesReqV1, signature);
+impl_msg_verify!(GatewayLocationReqV1, signature);
 impl_msg_verify!(GatewayRegionParamsReqV1, signature);
-impl_msg_verify!(GatewayLoadRegionReqV1, signature);
+impl_msg_verify!(AdminAddKeyReqV1, signature);
+impl_msg_verify!(AdminLoadRegionReqV1, signature);
+impl_msg_verify!(AdminRemoveKeyReqV1, signature);
 
 #[cfg(test)]
 mod test {

--- a/file_store/src/traits/msg_verify.rs
+++ b/file_store/src/traits/msg_verify.rs
@@ -4,10 +4,9 @@ use helium_proto::services::{
     iot_config::{
         AdminAddKeyReqV1, AdminLoadRegionReqV1, AdminRemoveKeyReqV1, GatewayLocationReqV1,
         GatewayRegionParamsReqV1, OrgCreateHeliumReqV1, OrgCreateRoamerReqV1, OrgDisableReqV1,
-        OrgEnableReqV1, RouteCreateReqV1, RouteDeleteDevaddrRangesReqV1, RouteDeleteEuisReqV1,
-        RouteDeleteReqV1, RouteGetDevaddrRangesReqV1, RouteGetEuisReqV1, RouteGetReqV1,
-        RouteListReqV1, RouteStreamReqV1, RouteUpdateDevaddrRangesReqV1, RouteUpdateEuisReqV1,
-        RouteUpdateReqV1,
+        OrgEnableReqV1, RouteCreateReqV1, RouteDeleteReqV1, RouteGetDevaddrRangesReqV1,
+        RouteGetEuisReqV1, RouteGetReqV1, RouteListReqV1, RouteStreamReqV1,
+        RouteUpdateDevaddrRangesReqV1, RouteUpdateEuisReqV1, RouteUpdateReqV1,
     },
     poc_lora::{LoraBeaconReportReqV1, LoraWitnessReportReqV1},
 };
@@ -50,11 +49,9 @@ impl_msg_verify!(RouteCreateReqV1, signature);
 impl_msg_verify!(RouteUpdateReqV1, signature);
 impl_msg_verify!(RouteDeleteReqV1, signature);
 impl_msg_verify!(RouteGetEuisReqV1, signature);
-impl_msg_verify!(RouteDeleteEuisReqV1, signature);
 impl_msg_verify!(RouteUpdateEuisReqV1, signature);
 impl_msg_verify!(RouteGetDevaddrRangesReqV1, signature);
 impl_msg_verify!(RouteUpdateDevaddrRangesReqV1, signature);
-impl_msg_verify!(RouteDeleteDevaddrRangesReqV1, signature);
 impl_msg_verify!(GatewayLocationReqV1, signature);
 impl_msg_verify!(GatewayRegionParamsReqV1, signature);
 impl_msg_verify!(AdminAddKeyReqV1, signature);

--- a/iot_config/migrations/5_admin_keys.sql
+++ b/iot_config/migrations/5_admin_keys.sql
@@ -1,0 +1,14 @@
+create type key_type as enum (
+    'administrator',
+    'packet_router'
+);
+
+create table admin_keys (
+    pubkey text not null unique,
+    key_type key_type not null,
+    
+    inserted_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+select trigger_updated_at('admin_keys');

--- a/iot_config/migrations/5_hpr_keys.sql
+++ b/iot_config/migrations/5_hpr_keys.sql
@@ -1,8 +1,0 @@
-create table hpr_keys (
-    pubkey text not null unique,
-    
-    inserted_at timestamptz not null default now(),
-    updated_at timestamptz not null default now()
-);
-
-select trigger_updated_at('hpr_keys');

--- a/iot_config/src/admin.rs
+++ b/iot_config/src/admin.rs
@@ -1,0 +1,72 @@
+use helium_crypto::PublicKey;
+use helium_proto::services::iot_config::admin_add_key_req_v1::KeyTypeV1 as ProtoKeyType;
+use serde::Serialize;
+
+pub async fn get_admin_keys(
+    key_type: KeyType,
+    db: impl sqlx::PgExecutor<'_>,
+) -> Result<Vec<PublicKey>, AdminKeysError> {
+    Ok(
+        sqlx::query_scalar::<_, PublicKey>(
+            r#" select pubkey from admin_keys where key_type = $1 "#,
+        )
+        .bind(key_type)
+        .fetch_all(db)
+        .await?
+        .into_iter()
+        .map(PublicKey::try_from)
+        .filter_map(|key| key.ok())
+        .collect(),
+    )
+}
+
+#[derive(Clone, Debug, Serialize, sqlx::Type)]
+#[sqlx(type_name = "key_type", rename_all = "snake_case")]
+pub enum KeyType {
+    Administrator,
+    PacketRouter,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum AdminKeysError {
+    #[error("error retrieving saved admin keys: {0}")]
+    DbError(#[from] sqlx::Error),
+    #[error("unable to deserialize pubkey: {0}")]
+    DecodeError(#[from] helium_crypto::Error),
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("unsupported key type {0}")]
+pub struct UnsupportedKeyTypeError(i32);
+
+impl KeyType {
+    pub fn from_i32(v: i32) -> Result<Self, UnsupportedKeyTypeError> {
+        ProtoKeyType::from_i32(v)
+            .map(|kt| kt.into())
+            .ok_or(UnsupportedKeyTypeError(v))
+    }
+}
+
+impl From<KeyType> for ProtoKeyType {
+    fn from(key_type: KeyType) -> Self {
+        ProtoKeyType::from(&key_type)
+    }
+}
+
+impl From<&KeyType> for ProtoKeyType {
+    fn from(skt: &KeyType) -> Self {
+        match skt {
+            KeyType::Administrator => ProtoKeyType::Administrator,
+            KeyType::PacketRouter => ProtoKeyType::PacketRouter,
+        }
+    }
+}
+
+impl From<ProtoKeyType> for KeyType {
+    fn from(kt: ProtoKeyType) -> Self {
+        match kt {
+            ProtoKeyType::Administrator => KeyType::Administrator,
+            ProtoKeyType::PacketRouter => KeyType::PacketRouter,
+        }
+    }
+}

--- a/iot_config/src/admin.rs
+++ b/iot_config/src/admin.rs
@@ -1,11 +1,16 @@
-use helium_crypto::PublicKey;
+use crate::settings::Settings;
+use file_store::traits::MsgVerify;
+use helium_crypto::{PublicKey, PublicKeyBinary};
 use helium_proto::services::iot_config::admin_add_key_req_v1::KeyTypeV1 as ProtoKeyType;
 use serde::Serialize;
+use sqlx::Row;
+use std::{collections::HashSet, sync::Arc};
+use tokio::sync::RwLock;
 
 pub async fn get_admin_keys(
-    key_type: KeyType,
+    key_type: &KeyType,
     db: impl sqlx::PgExecutor<'_>,
-) -> Result<Vec<PublicKey>, AdminKeysError> {
+) -> Result<Vec<PublicKey>, AdminAuthError> {
     Ok(
         sqlx::query_scalar::<_, PublicKey>(
             r#" select pubkey from admin_keys where key_type = $1 "#,
@@ -20,7 +25,122 @@ pub async fn get_admin_keys(
     )
 }
 
-#[derive(Clone, Debug, Serialize, sqlx::Type)]
+pub async fn insert_key(
+    pubkey: PublicKeyBinary,
+    key_type: KeyType,
+    db: impl sqlx::PgExecutor<'_>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(r#" insert into admin_keys (pubkey, key_type) values ($1, $2) "#)
+        .bind(pubkey)
+        .bind(key_type)
+        .execute(db)
+        .await
+        .map(|_| ())
+}
+
+pub async fn remove_key(
+    pubkey: PublicKeyBinary,
+    db: impl sqlx::PgExecutor<'_>,
+) -> Result<Option<(PublicKey, KeyType)>, sqlx::Error> {
+    let result = sqlx::query(
+        r#"
+        delete from admin_keys
+        where pubkey = $1
+        returning (pubkey, key_type)
+        "#,
+    )
+    .bind(pubkey)
+    .fetch_optional(db)
+    .await?
+    .map(|row| {
+        (
+            row.get::<PublicKey, &str>("pubkey"),
+            row.get::<KeyType, &str>("key_type"),
+        )
+    });
+
+    Ok(result)
+}
+
+#[derive(Clone, Debug)]
+pub struct AuthCache {
+    admin_keys: Arc<RwLock<HashSet<PublicKey>>>,
+    router_keys: Arc<RwLock<HashSet<PublicKey>>>,
+}
+
+impl AuthCache {
+    pub async fn new(
+        settings: &Settings,
+        db: impl sqlx::PgExecutor<'_> + Copy,
+    ) -> Result<Self, AdminAuthError> {
+        let config_admin = settings.admin_pubkey()?;
+
+        let mut admin_keys = get_admin_keys(&KeyType::Administrator, db)
+            .await?
+            .into_iter()
+            .collect::<HashSet<PublicKey>>();
+        _ = admin_keys.insert(config_admin);
+
+        let router_keys = get_admin_keys(&KeyType::PacketRouter, db)
+            .await?
+            .into_iter()
+            .collect::<HashSet<PublicKey>>();
+
+        Ok(Self {
+            admin_keys: Arc::new(RwLock::new(admin_keys)),
+            router_keys: Arc::new(RwLock::new(router_keys)),
+        })
+    }
+
+    pub async fn verify_signature<R>(
+        &self,
+        key_type: KeyType,
+        request: &R,
+    ) -> Result<(), AdminAuthError>
+    where
+        R: MsgVerify,
+    {
+        match key_type {
+            KeyType::Administrator => {
+                for key in self.admin_keys.read().await.iter() {
+                    if request.verify(key).is_ok() {
+                        tracing::debug!("request authorized by admin");
+                        return Ok(());
+                    }
+                }
+            }
+            KeyType::PacketRouter => {
+                for key in self.router_keys.read().await.iter() {
+                    if request.verify(key).is_ok() {
+                        tracing::debug!("request authorized by packet router {key}");
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        Err(AdminAuthError::UnauthorizedRequest)
+    }
+
+    pub async fn insert_key(&self, key_type: KeyType, key: PublicKey) {
+        match key_type {
+            KeyType::Administrator => self.admin_keys.write(),
+            KeyType::PacketRouter => self.router_keys.write(),
+        }
+        .await
+        .insert(key);
+    }
+
+    pub async fn remove_key(&self, key_type: KeyType, key: &PublicKey) {
+        match key_type {
+            KeyType::Administrator => self.admin_keys.write(),
+            KeyType::PacketRouter => self.router_keys.write(),
+        }
+        .await
+        .remove(key);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, sqlx::Type)]
 #[sqlx(type_name = "key_type", rename_all = "snake_case")]
 pub enum KeyType {
     Administrator,
@@ -28,11 +148,13 @@ pub enum KeyType {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum AdminKeysError {
+pub enum AdminAuthError {
+    #[error("unauthorized admin request signature")]
+    UnauthorizedRequest,
+    #[error("error deserializing pubkey: {0}")]
+    ConfigKey(#[from] helium_crypto::Error),
     #[error("error retrieving saved admin keys: {0}")]
-    DbError(#[from] sqlx::Error),
-    #[error("unable to deserialize pubkey: {0}")]
-    DecodeError(#[from] helium_crypto::Error),
+    DbStore(#[from] sqlx::Error),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/iot_config/src/admin_service.rs
+++ b/iot_config/src/admin_service.rs
@@ -1,0 +1,90 @@
+use crate::{
+    region_map::{self, RegionMap},
+    GrpcResult, Settings,
+};
+use anyhow::Result;
+use file_store::traits::MsgVerify;
+use helium_crypto::PublicKey;
+use helium_proto::{
+    services::iot_config::{
+        self, AdminAddKeyReqV1, AdminKeyResV1, AdminLoadRegionReqV1, AdminLoadRegionResV1,
+        AdminRemoveKeyReqV1,
+    },
+    Region,
+};
+use sqlx::{Pool, Postgres};
+use tonic::{Request, Response, Status};
+
+pub struct AdminService {
+    admin_pubkey: PublicKey,
+    pool: Pool<Postgres>,
+    region_map: RegionMap,
+}
+
+impl AdminService {
+    pub fn new(settings: &Settings, pool: Pool<Postgres>, region_map: RegionMap) -> Result<Self> {
+        Ok(Self {
+            admin_pubkey: settings.admin_pubkey()?,
+            pool,
+            region_map,
+        })
+    }
+
+    fn verify_admin_signature<R>(&self, request: R) -> Result<R, Status>
+    where
+        R: MsgVerify,
+    {
+        request
+            .verify(&self.admin_pubkey)
+            .map_err(|_| Status::permission_denied("invalid admin signature"))?;
+        Ok(request)
+    }
+}
+
+#[tonic::async_trait]
+impl iot_config::Admin for AdminService {
+    async fn add_key(&self, _request: Request<AdminAddKeyReqV1>) -> GrpcResult<AdminKeyResV1> {
+        unimplemented!();
+    }
+
+    async fn remove_key(
+        &self,
+        _request: Request<AdminRemoveKeyReqV1>,
+    ) -> GrpcResult<AdminKeyResV1> {
+        unimplemented!();
+    }
+
+    async fn load_region(
+        &self,
+        request: Request<AdminLoadRegionReqV1>,
+    ) -> GrpcResult<AdminLoadRegionResV1> {
+        let request = request.into_inner();
+        let req = self.verify_admin_signature(request)?;
+
+        let region = Region::from_i32(req.region)
+            .ok_or_else(|| Status::invalid_argument("invalid region"))?;
+
+        let params = match req.params {
+            Some(params) => params,
+            None => return Err(Status::invalid_argument("missing region")),
+        };
+
+        let idz = if !req.hex_indexes.is_empty() {
+            Some(req.hex_indexes.as_ref())
+        } else {
+            None
+        };
+
+        let updated_region = region_map::update_region(region, &params, idz, &self.pool)
+            .await
+            .map_err(|_| Status::internal("region update failed"))?;
+
+        self.region_map.insert_params(region, params).await;
+        if let Some(region_tree) = updated_region {
+            tracing::debug!("New compacted region map with {} cells", region_tree.len());
+            self.region_map.replace_tree(region_tree).await;
+        }
+
+        Ok(Response::new(AdminLoadRegionResV1 {}))
+    }
+}

--- a/iot_config/src/gateway_service.rs
+++ b/iot_config/src/gateway_service.rs
@@ -39,6 +39,9 @@ impl iot_config::Gateway for GatewayService {
         &self,
         request: Request<GatewayLocationReqV1>,
     ) -> GrpcResult<GatewayLocationResV1> {
+        // Should this rpc be admin-authorized only or should a requesting pubkey
+        // field be added to the request to do basic signature verification, allowing
+        // open access but discourage endpoint abuse?
         let request = request.into_inner();
 
         let location = self

--- a/iot_config/src/gateway_service.rs
+++ b/iot_config/src/gateway_service.rs
@@ -1,14 +1,11 @@
-use crate::{
-    region_map::{self, RegionMap},
-    GrpcResult, Settings,
-};
+use crate::{region_map::RegionMap, GrpcResult, Settings};
 use anyhow::Result;
 use file_store::traits::MsgVerify;
 use helium_crypto::{Keypair, PublicKey, Sign};
 use helium_proto::{
     services::iot_config::{
-        self, GatewayLoadRegionReqV1, GatewayLoadRegionResV1, GatewayLocationReqV1,
-        GatewayLocationResV1, GatewayRegionParamsReqV1, GatewayRegionParamsResV1,
+        self, GatewayLocationReqV1, GatewayLocationResV1, GatewayRegionParamsReqV1,
+        GatewayRegionParamsResV1,
     },
     Message, Region,
 };
@@ -17,38 +14,21 @@ use node_follower::{
     follower_service::FollowerService,
     gateway_resp::{GatewayInfo, GatewayInfoResolver},
 };
-use sqlx::{Pool, Postgres};
 use tonic::{Request, Response, Status};
 
 pub struct GatewayService {
-    admin_pubkey: PublicKey,
     follower_service: FollowerService,
-    pool: Pool<Postgres>,
     region_map: RegionMap,
     signing_key: Keypair,
 }
 
 impl GatewayService {
-    pub async fn new(settings: &Settings) -> Result<Self> {
-        let pool = settings.database.connect(10).await?;
-        let region_map = RegionMap::new(&pool).await?;
+    pub fn new(settings: &Settings, region_map: RegionMap) -> Result<Self> {
         Ok(Self {
-            admin_pubkey: settings.admin_pubkey()?,
             follower_service: FollowerService::from_settings(&settings.follower),
-            pool,
             region_map,
             signing_key: settings.signing_keypair()?,
         })
-    }
-
-    fn verify_admin_signature<R>(&self, request: R) -> Result<R, Status>
-    where
-        R: MsgVerify,
-    {
-        request
-            .verify(&self.admin_pubkey)
-            .map_err(|_| Status::permission_denied("invalid admin signature"))?;
-        Ok(request)
     }
 }
 
@@ -107,39 +87,5 @@ impl iot_config::Gateway for GatewayService {
             .sign(&resp.encode_to_vec())
             .map_err(|_| Status::internal("resp signing error"))?;
         Ok(Response::new(resp))
-    }
-
-    async fn load_region(
-        &self,
-        request: Request<GatewayLoadRegionReqV1>,
-    ) -> GrpcResult<GatewayLoadRegionResV1> {
-        let request = request.into_inner();
-        let req = self.verify_admin_signature(request)?;
-
-        let region = Region::from_i32(req.region)
-            .ok_or_else(|| Status::invalid_argument("invalid region"))?;
-
-        let params = match req.params {
-            Some(params) => params,
-            None => return Err(Status::invalid_argument("missing region")),
-        };
-
-        let idz = if !req.hex_indexes.is_empty() {
-            Some(req.hex_indexes.as_ref())
-        } else {
-            None
-        };
-
-        let updated_region = region_map::update_region(region, &params, idz, &self.pool)
-            .await
-            .map_err(|_| Status::internal("region update failed"))?;
-
-        self.region_map.insert_params(region, params).await;
-        if let Some(region_tree) = updated_region {
-            tracing::debug!("New compacted region map with {} cells", region_tree.len());
-            self.region_map.replace_tree(region_tree).await;
-        }
-
-        Ok(Response::new(GatewayLoadRegionResV1 {}))
     }
 }

--- a/iot_config/src/lib.rs
+++ b/iot_config/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod admin;
+pub mod admin_service;
 pub mod gateway_service;
 pub mod lora_field;
 pub mod org;
@@ -8,6 +10,7 @@ pub mod route_service;
 pub mod session_key_service;
 pub mod settings;
 
+pub use admin_service::AdminService;
 pub use gateway_service::GatewayService;
 use lora_field::{LoraField, NetIdField};
 pub use org_service::OrgService;
@@ -22,4 +25,4 @@ pub type GrpcResult<T> = Result<Response<T>, Status>;
 pub type GrpcStreamResult<T> = ReceiverStream<Result<T, Status>>;
 pub type GrpcStreamRequest<T> = tonic::Request<tonic::Streaming<T>>;
 
-pub const HELIUM_NET_ID: NetIdField = LoraField(0xc00053);
+pub const HELIUM_NET_ID: NetIdField = LoraField(0x000024);

--- a/iot_config/src/lora_field.rs
+++ b/iot_config/src/lora_field.rs
@@ -38,8 +38,8 @@ impl FromRow<'_, PgRow> for DevAddrRange {
             route_id: row
                 .try_get::<sqlx::types::Uuid, &str>("route_id")?
                 .to_string(),
-            start_addr: row.try_get::<i64, &str>("start_addr")?.into(),
-            end_addr: row.try_get::<i64, &str>("end_addr")?.into(),
+            start_addr: row.try_get::<i32, &str>("start_addr")?.into(),
+            end_addr: row.try_get::<i32, &str>("end_addr")?.into(),
         })
     }
 }
@@ -463,6 +463,16 @@ impl From<proto::DevaddrRangeV1> for DevAddrRange {
     fn from(range: proto::DevaddrRangeV1) -> Self {
         Self {
             route_id: range.route_id,
+            start_addr: range.start_addr.into(),
+            end_addr: range.end_addr.into(),
+        }
+    }
+}
+
+impl From<&proto::DevaddrRangeV1> for DevAddrRange {
+    fn from(range: &proto::DevaddrRangeV1) -> Self {
+        Self {
+            route_id: range.route_id.clone(),
             start_addr: range.start_addr.into(),
             end_addr: range.end_addr.into(),
         }

--- a/iot_config/src/lora_field.rs
+++ b/iot_config/src/lora_field.rs
@@ -70,7 +70,7 @@ impl DevAddrConstraint {
         Ok(devaddr(end + 1))
     }
 
-    pub fn contains(&self, range: &Self) -> bool {
+    pub fn contains(&self, range: &DevAddrRange) -> bool {
         self.start_addr <= range.start_addr && self.end_addr >= range.end_addr
     }
 }

--- a/iot_config/src/main.rs
+++ b/iot_config/src/main.rs
@@ -5,9 +5,9 @@ use helium_proto::services::iot_config::{
     AdminServer, GatewayServer, OrgServer, RouteServer, SessionKeyFilterServer,
 };
 use iot_config::{
-    gateway_service::GatewayService, org_service::OrgService, region_map::RegionMap,
-    route_service::RouteService, session_key_service::SessionKeyFilterService, settings::Settings,
-    AdminService,
+    admin::AuthCache, gateway_service::GatewayService, org_service::OrgService,
+    region_map::RegionMap, route_service::RouteService,
+    session_key_service::SessionKeyFilterService, settings::Settings, AdminService,
 };
 use std::{path::PathBuf, time::Duration};
 use tokio::signal;
@@ -62,7 +62,7 @@ impl Daemon {
         poc_metrics::start_metrics(&settings.metrics)?;
 
         // Create database pool
-        let pool = settings.database.connect(10).await?;
+        let pool = settings.database.connect(50).await?;
         sqlx::migrate!().run(&pool).await?;
 
         // Configure shutdown trigger
@@ -74,12 +74,24 @@ impl Daemon {
 
         let listen_addr = settings.listen_addr()?;
 
+        let auth_cache = AuthCache::new(settings, &pool).await?;
         let region_map = RegionMap::new(&pool).await?;
 
         let gateway_svc = GatewayService::new(settings, region_map.clone())?;
-        let route_svc = RouteService::new(settings, shutdown_listener.clone()).await?;
-        let org_svc = OrgService::new(settings, route_svc.clone_update_channel()).await?;
-        let admin_svc = AdminService::new(settings, pool.clone(), region_map.clone())?;
+        let route_svc =
+            RouteService::new(auth_cache.clone(), pool.clone(), shutdown_listener.clone());
+        let org_svc = OrgService::new(
+            auth_cache.clone(),
+            pool.clone(),
+            settings.network,
+            route_svc.clone_update_channel(),
+        );
+        let admin_svc = AdminService::new(
+            auth_cache.clone(),
+            pool.clone(),
+            region_map.clone(),
+            settings.network,
+        );
         let session_key_filter_svc = SessionKeyFilterService {};
 
         transport::Server::builder()

--- a/iot_config/src/org.rs
+++ b/iot_config/src/org.rs
@@ -32,7 +32,7 @@ pub struct OrgList {
 #[derive(Debug)]
 pub struct OrgWithConstraints {
     pub org: Org,
-    pub constraints: DevAddrConstraint,
+    pub constraints: Vec<DevAddrConstraint>,
 }
 
 pub async fn create_org(
@@ -108,9 +108,9 @@ pub async fn get_with_constraints(
 ) -> Result<OrgWithConstraints, sqlx::Error> {
     let row = sqlx::query(
         r#"
-        select org.owner_pubkey, org.payer_pubkey, org.delegate_keys, org.locked, org_const.start_addr, org_const.end_addr
-        from organizations org join organization_devaddr_constraints org_const
-        on org.oui = org_const.oui
+        select org.owner_pubkey, org.payer_pubkey, org.delegate_keys, org.locked,
+            array(select (start_addr, end_addr) from organization_devaddr_constraints org_const where org_const.oui = org.oui) as constraints
+        from organizations org
         where org.oui = $1
         "#,
     )
@@ -118,8 +118,14 @@ pub async fn get_with_constraints(
     .fetch_one(db)
     .await?;
 
-    let start_addr = row.get::<i32, &str>("start_addr");
-    let end_addr = row.get::<i32, &str>("end_addr");
+    let constraints = row
+        .get::<Vec<(i32, i32)>, &str>("constraints")
+        .into_iter()
+        .map(|(start, end)| DevAddrConstraint {
+            start_addr: start.into(),
+            end_addr: end.into(),
+        })
+        .collect();
 
     Ok(OrgWithConstraints {
         org: Org {
@@ -129,11 +135,34 @@ pub async fn get_with_constraints(
             delegate_keys: row.get("delegate_keys"),
             locked: row.get("locked"),
         },
-        constraints: DevAddrConstraint {
-            start_addr: start_addr.into(),
-            end_addr: end_addr.into(),
-        },
+        constraints,
     })
+}
+
+pub async fn get_constraints_by_route(
+    route_id: &str,
+    db: impl sqlx::PgExecutor<'_>,
+) -> Result<Vec<DevAddrConstraint>, DbOrgError> {
+    let uuid = Uuid::try_parse(route_id)?;
+
+    let constraints = sqlx::query(
+        r#"
+        select consts.start_addr, consts.end_addr from organization_devaddr_constraints consts
+        join routes.oui on consts.oui
+        where routes.id = $1
+        "#,
+    )
+    .bind(uuid)
+    .fetch_all(db)
+    .await?
+    .into_iter()
+    .map(|row| DevAddrConstraint {
+        start_addr: row.get::<i32, &str>("start_addr").into(),
+        end_addr: row.get::<i32, &str>("end_addr").into(),
+    })
+    .collect();
+
+    Ok(constraints)
 }
 
 pub async fn is_locked(oui: u64, db: impl sqlx::PgExecutor<'_>) -> Result<bool, sqlx::Error> {
@@ -163,11 +192,11 @@ pub async fn toggle_locked(oui: u64, db: impl sqlx::PgExecutor<'_>) -> Result<()
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum DbPubkeysError {
-    #[error("error retrieving saved org keys: {0}")]
-    DbError(#[from] sqlx::Error),
+pub enum DbOrgError {
+    #[error("error retrieving saved org row: {0}")]
+    Fetch(#[from] sqlx::Error),
     #[error("unable to deserialize pubkey: {0}")]
-    DecodeError(#[from] helium_crypto::Error),
+    Decode(#[from] helium_crypto::Error),
     #[error("Route Id parse error: {0}")]
     RouteIdParse(#[from] sqlx::types::uuid::Error),
 }
@@ -175,7 +204,7 @@ pub enum DbPubkeysError {
 pub async fn get_org_pubkeys(
     oui: u64,
     db: impl sqlx::PgExecutor<'_>,
-) -> Result<Vec<PublicKey>, DbPubkeysError> {
+) -> Result<Vec<PublicKey>, DbOrgError> {
     let org = get(oui, db).await?;
 
     let mut pubkeys: Vec<PublicKey> = vec![PublicKey::try_from(org.owner)?];
@@ -194,7 +223,7 @@ pub async fn get_org_pubkeys(
 pub async fn get_org_pubkeys_by_route(
     route_id: &str,
     db: impl sqlx::PgExecutor<'_>,
-) -> Result<Vec<PublicKey>, DbPubkeysError> {
+) -> Result<Vec<PublicKey>, DbOrgError> {
     let uuid = Uuid::try_parse(route_id)?;
 
     let org = sqlx::query_as::<_, Org>(

--- a/iot_config/src/org_service.rs
+++ b/iot_config/src/org_service.rs
@@ -1,4 +1,9 @@
-use crate::{lora_field, org, route::list_routes, GrpcResult, Settings, HELIUM_NET_ID};
+use crate::{
+    admin::{AuthCache, KeyType},
+    lora_field, org,
+    route::list_routes,
+    GrpcResult, HELIUM_NET_ID,
+};
 use anyhow::Result;
 use file_store::traits::MsgVerify;
 use helium_crypto::{Network, PublicKey};
@@ -12,23 +17,25 @@ use tokio::sync::broadcast::Sender;
 use tonic::{Request, Response, Status};
 
 pub struct OrgService {
-    admin_pubkey: PublicKey,
+    auth_cache: AuthCache,
     pool: Pool<Postgres>,
     required_network: Network,
     route_update_tx: Sender<RouteStreamResV1>,
 }
 
 impl OrgService {
-    pub async fn new(
-        settings: &Settings,
+    pub fn new(
+        auth_cache: AuthCache,
+        pool: Pool<Postgres>,
+        required_network: Network,
         route_update_tx: Sender<RouteStreamResV1>,
-    ) -> Result<Self> {
-        Ok(Self {
-            admin_pubkey: settings.admin_pubkey()?,
-            pool: settings.database.connect(10).await?,
-            required_network: settings.network,
+    ) -> Self {
+        Self {
+            auth_cache,
+            pool,
+            required_network,
             route_update_tx,
-        })
+        }
     }
 
     fn verify_network(&self, public_key: PublicKey) -> Result<PublicKey, Status> {
@@ -47,14 +54,15 @@ impl OrgService {
             .map_err(|_| Status::invalid_argument(format!("invalid public key: {bytes:?}")))
     }
 
-    fn verify_admin_signature<R>(&self, request: R) -> Result<R, Status>
+    async fn verify_request_signature<R>(&self, request: &R) -> Result<(), Status>
     where
         R: MsgVerify,
     {
-        request
-            .verify(&self.admin_pubkey)
+        self.auth_cache
+            .verify_signature(KeyType::Administrator, request)
+            .await
             .map_err(|_| Status::permission_denied("invalid admin signature"))?;
-        Ok(request)
+        Ok(())
     }
 }
 
@@ -93,11 +101,14 @@ impl iot_config::Org for OrgService {
     async fn create_helium(&self, request: Request<OrgCreateHeliumReqV1>) -> GrpcResult<OrgResV1> {
         let request = request.into_inner();
 
-        let req = self.verify_admin_signature(request)?;
+        self.verify_request_signature(&request).await?;
 
-        let mut verify_keys: Vec<&[u8]> = vec![req.owner.as_ref(), req.payer.as_ref()];
-        let mut verify_delegates: Vec<&[u8]> =
-            req.delegate_keys.iter().map(|key| key.as_slice()).collect();
+        let mut verify_keys: Vec<&[u8]> = vec![request.owner.as_ref(), request.payer.as_ref()];
+        let mut verify_delegates: Vec<&[u8]> = request
+            .delegate_keys
+            .iter()
+            .map(|key| key.as_slice())
+            .collect();
         verify_keys.append(&mut verify_delegates);
         _ = verify_keys
             .iter()
@@ -110,16 +121,17 @@ impl iot_config::Org for OrgService {
             })
             .collect::<Result<Vec<PublicKey>, Status>>()?;
 
-        let requested_addrs = req.devaddrs;
+        let requested_addrs = request.devaddrs;
         let devaddr_constraint = org::next_helium_devaddr(&self.pool)
             .await
             .map_err(|_| Status::failed_precondition("helium address unavailable"))?
             .to_range(requested_addrs);
 
         let org = org::create_org(
-            req.owner.into(),
-            req.payer.into(),
-            req.delegate_keys
+            request.owner.into(),
+            request.payer.into(),
+            request
+                .delegate_keys
                 .into_iter()
                 .map(|key| key.into())
                 .collect(),
@@ -148,11 +160,14 @@ impl iot_config::Org for OrgService {
     async fn create_roamer(&self, request: Request<OrgCreateRoamerReqV1>) -> GrpcResult<OrgResV1> {
         let request = request.into_inner();
 
-        let req = self.verify_admin_signature(request)?;
+        self.verify_request_signature(&request).await?;
 
-        let mut verify_keys: Vec<&[u8]> = vec![req.owner.as_ref(), req.payer.as_ref()];
-        let mut verify_delegates: Vec<&[u8]> =
-            req.delegate_keys.iter().map(|key| key.as_slice()).collect();
+        let mut verify_keys: Vec<&[u8]> = vec![request.owner.as_ref(), request.payer.as_ref()];
+        let mut verify_delegates: Vec<&[u8]> = request
+            .delegate_keys
+            .iter()
+            .map(|key| key.as_slice())
+            .collect();
         verify_keys.append(&mut verify_delegates);
         _ = verify_keys
             .iter()
@@ -165,15 +180,16 @@ impl iot_config::Org for OrgService {
             })
             .collect::<Result<Vec<PublicKey>, Status>>()?;
 
-        let net_id = lora_field::net_id(req.net_id);
+        let net_id = lora_field::net_id(request.net_id);
         let devaddr_range = net_id
             .full_range()
             .map_err(|_| Status::invalid_argument("invalid net_id"))?;
 
         let org = org::create_org(
-            req.owner.into(),
-            req.payer.into(),
-            req.delegate_keys
+            request.owner.into(),
+            request.payer.into(),
+            request
+                .delegate_keys
                 .into_iter()
                 .map(|key| key.into())
                 .collect(),
@@ -196,20 +212,22 @@ impl iot_config::Org for OrgService {
     async fn disable(&self, request: Request<OrgDisableReqV1>) -> GrpcResult<OrgDisableResV1> {
         let request = request.into_inner();
 
-        let req = self.verify_admin_signature(request)?;
+        self.verify_request_signature(&request).await?;
 
-        if !org::is_locked(req.oui, &self.pool)
+        if !org::is_locked(request.oui, &self.pool)
             .await
             .map_err(|_| Status::internal("error retrieving current status"))?
         {
-            org::toggle_locked(req.oui, &self.pool)
+            org::toggle_locked(request.oui, &self.pool)
                 .await
-                .map_err(|_| Status::internal(format!("org disable failed for: {}", req.oui)))?;
+                .map_err(|_| {
+                    Status::internal(format!("org disable failed for: {}", request.oui))
+                })?;
 
-            let org_routes = list_routes(req.oui, &self.pool).await.map_err(|_| {
+            let org_routes = list_routes(request.oui, &self.pool).await.map_err(|_| {
                 Status::internal(format!(
                     "error retrieving routes for disabled org: {}",
-                    req.oui
+                    request.oui
                 ))
             })?;
 
@@ -232,26 +250,26 @@ impl iot_config::Org for OrgService {
             }
         }
 
-        Ok(Response::new(OrgDisableResV1 { oui: req.oui }))
+        Ok(Response::new(OrgDisableResV1 { oui: request.oui }))
     }
 
     async fn enable(&self, request: Request<OrgEnableReqV1>) -> GrpcResult<OrgEnableResV1> {
         let request = request.into_inner();
 
-        let req = self.verify_admin_signature(request)?;
+        self.verify_request_signature(&request).await?;
 
-        if org::is_locked(req.oui, &self.pool)
+        if org::is_locked(request.oui, &self.pool)
             .await
             .map_err(|_| Status::internal("error retrieving current status"))?
         {
-            org::toggle_locked(req.oui, &self.pool)
+            org::toggle_locked(request.oui, &self.pool)
                 .await
-                .map_err(|_| Status::internal(format!("org enable failed for: {}", req.oui)))?;
+                .map_err(|_| Status::internal(format!("org enable failed for: {}", request.oui)))?;
 
-            let org_routes = list_routes(req.oui, &self.pool).await.map_err(|_| {
+            let org_routes = list_routes(request.oui, &self.pool).await.map_err(|_| {
                 Status::internal(format!(
                     "error retrieving routes for enabled org: {}",
-                    req.oui
+                    request.oui
                 ))
             })?;
 
@@ -274,6 +292,6 @@ impl iot_config::Org for OrgService {
             }
         }
 
-        Ok(Response::new(OrgEnableResV1 { oui: req.oui }))
+        Ok(Response::new(OrgEnableResV1 { oui: request.oui }))
     }
 }

--- a/iot_config/src/org_service.rs
+++ b/iot_config/src/org_service.rs
@@ -246,7 +246,7 @@ impl iot_config::Org for OrgService {
                 if self
                     .route_update_tx
                     .send(RouteStreamResV1 {
-                        action: ActionV1::Remove.into(),
+                        action: ActionV1::Add.into(),
                         data: Some(route_stream_res_v1::Data::Route(route.into())),
                     })
                     .is_err()

--- a/iot_config/src/region_map.rs
+++ b/iot_config/src/region_map.rs
@@ -5,6 +5,7 @@ use libflate::gzip::Decoder;
 use std::{collections::HashMap, io::Read, str::FromStr, sync::Arc};
 use tokio::sync::RwLock;
 
+#[derive(Clone, Debug)]
 pub struct RegionMap {
     region_hextree: Arc<RwLock<HexTreeMap<Region, EqCompactor>>>,
     params_hashmap: Arc<RwLock<HashMap<Region, BlockchainRegionParamsV1>>>,

--- a/iot_config/src/route.rs
+++ b/iot_config/src/route.rs
@@ -534,6 +534,34 @@ pub async fn active_route_stream<'a>(
     .filter_map(|route| async move { route.ok() })
 }
 
+pub async fn eui_stream<'a>(
+    db: impl sqlx::PgExecutor<'a> + 'a + Copy,
+) -> impl Stream<Item = EuiPair> + 'a {
+    sqlx::query_as::<_, EuiPair>(
+        r#"
+        select eui.route_id, eui.app_eui, eui.dev_eui
+        from route_eui_pairs eui
+        "#,
+    )
+    .fetch(db)
+    .map_err(sqlx::Error::from)
+    .filter_map(|eui| async move { eui.ok() })
+}
+
+pub async fn devaddr_range_stream<'a>(
+    db: impl sqlx::PgExecutor<'a> + 'a + Copy,
+) -> impl Stream<Item = DevAddrRange> + 'a {
+    sqlx::query_as::<_, DevAddrRange>(
+        r#"
+        select devaddr.route_id, devaddr.start_addr, devaddr.end_addr
+        from route_devaddr_ranges devaddr
+        "#,
+    )
+    .fetch(db)
+    .map_err(sqlx::Error::from)
+    .filter_map(|devaddr| async move { devaddr.ok() })
+}
+
 pub async fn get_route(
     id: &str,
     db: impl sqlx::PgExecutor<'_>,


### PR DESCRIPTION
! Depends on https://github.com/helium/proto/pull/288

This doozy introduces several bug fixes in the implementation of the streaming RPCs, retrieving records from the DB and decoding their types, integer size changes in the upstream proto dependency, and devaddr constraints records

- Introduces devaddr constraint bounds checking when attempting to add new devaddr ranges to routers
- Implements the Gateway service's Location rpc
- Implements the Admin service's rpcs and an AuthCache shared between all the services for efficient validation of administrative requests
- Restructures the region_params management rpc underneath the Admin service (formerly under the Gateway service)
- Extends the docker-compose stack to include a mock node-follower service for easier testing