### PR TITLE
attempting to cache dependencies in the rust build to speed up ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,13 @@ on:
     branches: [main]
     tags: ["*"]
 
+env:
+  CARGO_INCREMENTAL: 0 # this setting is automatically applied by rust-cache but documented here for explicitness
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTFLAGS: "-D warnings"
+  RUSTUP_MAX_RETRIES: 10
+
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -19,6 +26,9 @@ jobs:
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
+
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/iot_config/README.md
+++ b/iot_config/README.md
@@ -29,4 +29,11 @@ data associated with usage of the network
 ## `gateway`
 
 configuration data provided to LoRaWAN gateways serving the network, including
-the current region parameters for the region in which the gateway is asserted
+the current region parameters for the region in which the gateway is asserted and
+metadata info about gateways primarily stored on-chain but fed through the config service
+to other oracles
+
+## `admin`
+
+administrative apis for managing auth keys, region params binaries, and other service-wide
+settings


### PR DESCRIPTION
Cache the dependencies of the oracles project now that they've grown significantly to get CI build times back down to manageable levels.

This is particularly desirable in the event of a hotfix that needs to be deployed but is held up by a build/release process that takes longer than implementing the actual solution.