### PR TITLE
bugfix lora field from i32 conversion; more error logs

### DIFF
--- a/iot_config.Dockerfile
+++ b/iot_config.Dockerfile
@@ -1,5 +1,6 @@
-FROM rust:1.65 AS builder
+FROM rust:1.67 AS builder
 
+RUN apt-get update && apt-get install -y protobuf-compiler
 RUN rustup toolchain install nightly
 
 # Copy cargo file and workspace dependency crates to cache build
@@ -14,9 +15,9 @@ RUN mkdir ./iot_config/src \
  # Create a dummy project file to build deps around
  && echo "fn main() {}" > ./iot_config/src/main.rs \
  # Remove unused members of the workspace to avoid compile error on missing members
- && sed -i -e '/ingest/d'    -e '/mobile_rewards/d' -e '/mobile_verifier/d' \
-           -e '/poc_entropy/d'   -e '/iot_verifier/d'   -e '/poc_iot_injector/d' \
-           -e '/reward_index/d'   -e '/denylist/d' \
+ && sed -i -e '/ingest/d'       -e '/mobile_rewards/d' -e '/mobile_verifier/d' \
+           -e '/poc_entropy/d'  -e '/iot_verifier/d'   -e '/poc_iot_injector/d' \
+           -e '/reward_index/d' -e '/denylist/d'       -e '/iot_packet_verifier/d' \
            Cargo.toml \
  # Build on nightly cargo to use sparse-registry to avoid crates indexing infinite loop
  && cargo +nightly build --package iot-config --release -Z sparse-registry

--- a/iot_config.Dockerfile
+++ b/iot_config.Dockerfile
@@ -18,6 +18,7 @@ RUN mkdir ./iot_config/src \
  && sed -i -e '/ingest/d'       -e '/mobile_rewards/d' -e '/mobile_verifier/d' \
            -e '/poc_entropy/d'  -e '/iot_verifier/d'   -e '/poc_iot_injector/d' \
            -e '/reward_index/d' -e '/denylist/d'       -e '/iot_packet_verifier/d' \
+           -e '/price/d'
            Cargo.toml \
  # Build on nightly cargo to use sparse-registry to avoid crates indexing infinite loop
  && cargo +nightly build --package iot-config --release -Z sparse-registry

--- a/iot_config/src/admin.rs
+++ b/iot_config/src/admin.rs
@@ -138,6 +138,17 @@ impl AuthCache {
         .await
         .remove(key);
     }
+
+    pub async fn get_keys(&self, key_type: KeyType) -> Vec<PublicKey> {
+        match key_type {
+            KeyType::Administrator => self.admin_keys.read(),
+            KeyType::PacketRouter => self.router_keys.read(),
+        }
+        .await
+        .iter()
+        .cloned()
+        .collect::<Vec<PublicKey>>()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Serialize, sqlx::Type)]
@@ -152,7 +163,7 @@ pub enum AdminAuthError {
     #[error("unauthorized admin request signature")]
     UnauthorizedRequest,
     #[error("error deserializing pubkey: {0}")]
-    ConfigKey(#[from] helium_crypto::Error),
+    DecodeKey(#[from] helium_crypto::Error),
     #[error("error retrieving saved admin keys: {0}")]
     DbStore(#[from] sqlx::Error),
 }

--- a/iot_config/src/lora_field.rs
+++ b/iot_config/src/lora_field.rs
@@ -207,13 +207,13 @@ impl From<u32> for LoraField<8> {
 
 impl From<i32> for LoraField<6> {
     fn from(val: i32) -> Self {
-        LoraField::<6>(val as u64)
+        LoraField::<6>((val as u32) as u64)
     }
 }
 
 impl From<i32> for LoraField<8> {
     fn from(val: i32) -> Self {
-        LoraField::<8>(val as u64)
+        LoraField::<8>((val as u32) as u64)
     }
 }
 

--- a/iot_config/src/lora_field.rs
+++ b/iot_config/src/lora_field.rs
@@ -70,8 +70,12 @@ impl DevAddrConstraint {
         Ok(devaddr(end + 1))
     }
 
-    pub fn contains(&self, range: &DevAddrRange) -> bool {
+    pub fn contains_range(&self, range: &DevAddrRange) -> bool {
         self.start_addr <= range.start_addr && self.end_addr >= range.end_addr
+    }
+
+    pub fn contains_addr(&self, addr: DevAddrField) -> bool {
+        self.start_addr <= addr && self.end_addr >= addr
     }
 }
 

--- a/iot_config/src/org_service.rs
+++ b/iot_config/src/org_service.rs
@@ -85,7 +85,7 @@ impl iot_config::Org for OrgService {
         let org = org::get_with_constraints(request.oui, &self.pool)
             .await
             .map_err(|err| {
-                tracing::error!("get org failed {err:?}");
+                tracing::error!("get org {} request failed {err:?}", request.oui);
                 Status::internal("org get failed")
             })?;
         let net_id = org
@@ -129,16 +129,19 @@ impl iot_config::Org for OrgService {
                 self.verify_public_key(key)
                     .and_then(|pub_key| self.verify_network(pub_key))
                     .map_err(|err| {
+                        tracing::error!("failed pubkey validation: {err}");
                         Status::invalid_argument(format!("failed pubkey validation: {err}"))
                     })
             })
             .collect::<Result<Vec<PublicKey>, Status>>()?;
 
+        tracing::debug!("create helium org request: {request:?}");
+
         let requested_addrs = request.devaddrs;
         let devaddr_constraint = org::next_helium_devaddr(&self.pool)
             .await
             .map_err(|err| {
-                tracing::error!("failed to check next available helium network devaddr {err:?}");
+                tracing::error!("failed to retrieve next helium network devaddr {err:?}");
                 Status::failed_precondition("helium address unavailable")
             })?
             .to_range(requested_addrs);
@@ -196,6 +199,8 @@ impl iot_config::Org for OrgService {
             })
             .collect::<Result<Vec<PublicKey>, Status>>()?;
 
+        tracing::debug!("create roamer org request: {request:?}");
+
         let net_id = lora_field::net_id(request.net_id);
         let devaddr_range = net_id
             .full_range()
@@ -243,14 +248,17 @@ impl iot_config::Org for OrgService {
             org::toggle_locked(request.oui, &self.pool)
                 .await
                 .map_err(|err| {
-                    tracing::error!("failed to disable org {} with reason {err:?}", request.oui);
+                    tracing::error!(
+                        org = request.oui,
+                        "failed to disable org with reason {err:?}"
+                    );
                     Status::internal(format!("org disable failed for: {}", request.oui))
                 })?;
 
             let org_routes = list_routes(request.oui, &self.pool).await.map_err(|err| {
                 tracing::error!(
-                    "failed to list org {} routes for streaming disable update {err:?}",
-                    request.oui
+                    org = request.oui,
+                    "failed to list org routes for streaming disable update {err:?}"
                 );
                 Status::internal(format!(
                     "error retrieving routes for disabled org: {}",
@@ -269,11 +277,12 @@ impl iot_config::Org for OrgService {
                     .is_err()
                 {
                     tracing::info!(
-                        "all subscribers disconnected; route disable failed at route {route_id}"
+                        route_id = route_id,
+                        "all subscribers disconnected; route disable incomplete"
                     );
                     break;
                 };
-                tracing::debug!("updated packet routers with removed route: {route_id}");
+                tracing::debug!(route_id = route_id, "route disabled");
             }
         }
 
@@ -292,14 +301,17 @@ impl iot_config::Org for OrgService {
             org::toggle_locked(request.oui, &self.pool)
                 .await
                 .map_err(|err| {
-                    tracing::error!("failed to enable org {} with reason {err:?}", request.oui);
+                    tracing::error!(
+                        org = request.oui,
+                        "failed to enable org with reason {err:?}"
+                    );
                     Status::internal(format!("org enable failed for: {}", request.oui))
                 })?;
 
             let org_routes = list_routes(request.oui, &self.pool).await.map_err(|err| {
                 tracing::error!(
-                    "failed to list org {} routes for streaming enable update {err:?}",
-                    request.oui
+                    org = request.oui,
+                    "failed to list routes for streaming enable update {err:?}"
                 );
                 Status::internal(format!(
                     "error retrieving routes for enabled org: {}",
@@ -318,11 +330,12 @@ impl iot_config::Org for OrgService {
                     .is_err()
                 {
                     tracing::info!(
-                        "all subscribers disconnected; route enable failed at route {route_id}"
+                        route_id = route_id,
+                        "all subscribers disconnected; route enable incomplete"
                     );
                     break;
                 };
-                tracing::debug!("updated packet routers with recreated route: {route_id}");
+                tracing::debug!(route_id = route_id, "route enabled");
             }
         }
 

--- a/iot_config/src/route.rs
+++ b/iot_config/src/route.rs
@@ -515,16 +515,14 @@ pub async fn get_route(
     .fetch_one(db)
     .await;
 
-    tracing::info!("Result Route Row: {route_row:?}");
+    tracing::debug!("Result Route Row: {route_row:?}");
     let route = route_row?;
-    tracing::info!("The Server Protocol Json: {:?}", route.server_protocol_opts);
 
     let server = RouteServer::new(
         route.server_host,
         route.server_port as u32,
         serde_json::from_value(route.server_protocol_opts)?,
     );
-    tracing::info!("Successfully created new RouteServer");
 
     Ok(Route {
         id: route.id.to_string(),

--- a/iot_config/src/route_service.rs
+++ b/iot_config/src/route_service.rs
@@ -1,13 +1,14 @@
 use crate::{
     admin::{AuthCache, KeyType},
     lora_field::{DevAddrConstraint, DevAddrRange, EuiPair},
-    org::{self, get_org_pubkeys, get_org_pubkeys_by_route},
+    org::{self, DbOrgError},
     route::{self, Route, RouteStorageError},
     GrpcResult, GrpcStreamRequest, GrpcStreamResult,
 };
 use anyhow::Result;
 use file_store::traits::MsgVerify;
 use futures::stream::StreamExt;
+use helium_crypto::PublicKey;
 use helium_proto::services::iot_config::{
     self, route_stream_res_v1, ActionV1, DevaddrRangeV1, EuiPairV1, RouteCreateReqV1,
     RouteDeleteReqV1, RouteDevaddrRangesResV1, RouteEuisResV1, RouteGetDevaddrRangesReqV1,
@@ -18,6 +19,8 @@ use helium_proto::services::iot_config::{
 use sqlx::{Pool, Postgres};
 use tokio::sync::broadcast::{Receiver, Sender};
 use tonic::{Request, Response, Status};
+
+const UPDATE_BATCH_LIMIT: usize = 5_000;
 
 pub struct RouteService {
     auth_cache: AuthCache,
@@ -71,14 +74,17 @@ impl RouteService {
         }
 
         let org_keys = match id {
-            OrgId::Oui(oui) => get_org_pubkeys(oui, &self.pool).await,
-            OrgId::RouteId(route_id) => get_org_pubkeys_by_route(route_id, &self.pool).await,
+            OrgId::Oui(oui) => org::get_org_pubkeys(oui, &self.pool).await,
+            OrgId::RouteId(route_id) => org::get_org_pubkeys_by_route(route_id, &self.pool).await,
         }
         .map_err(|_| Status::internal("auth verification error"))?;
 
         for pubkey in org_keys.iter() {
             if request.verify(pubkey).is_ok() {
-                tracing::debug!("request authorized by delegate {pubkey}");
+                tracing::debug!(
+                    pubkey = pubkey.to_string(),
+                    "request authorized by delegate"
+                );
                 return Ok(());
             }
         }
@@ -108,6 +114,16 @@ impl RouteService {
         } else {
             Err(Status::permission_denied("unauthorized request signature"))
         }
+    }
+
+    async fn update_validator(
+        &self,
+        route_id: &str,
+        check_constraints: bool,
+    ) -> Result<DevAddrEuiValidator, DbOrgError> {
+        let admin_keys = self.auth_cache.get_keys(KeyType::Administrator).await;
+
+        DevAddrEuiValidator::new(route_id, admin_keys, &self.pool, check_constraints).await
     }
 }
 
@@ -368,40 +384,69 @@ impl iot_config::Route for RouteService {
 
         let mut to_add: Vec<EuiPair> = vec![];
         let mut to_remove: Vec<EuiPair> = vec![];
+        let mut pending_updates: usize = 0;
 
-        if let Ok(Some(first_update)) = request.message().await {
-            if let Some(eui_pair) = &first_update.eui_pair {
-                self.verify_request_signature(&first_update, OrgId::RouteId(&eui_pair.route_id))
-                    .await?;
-                match first_update.action() {
-                    ActionV1::Add => to_add.push(eui_pair.into()),
-                    ActionV1::Remove => to_remove.push(eui_pair.into()),
+        let mut validator: DevAddrEuiValidator =
+            if let Ok(Some(first_update)) = request.message().await {
+                if let Some(eui_pair) = &first_update.eui_pair {
+                    let mut validator = self
+                        .update_validator(&eui_pair.route_id, false)
+                        .await
+                        .map_err(|_| Status::internal("unable to verify updates"))?;
+                    validator.validate_update(&first_update)?;
+                    match first_update.action() {
+                        ActionV1::Add => to_add.push(eui_pair.into()),
+                        ActionV1::Remove => to_remove.push(eui_pair.into()),
+                    };
+                    pending_updates += 1;
+                    validator
+                } else {
+                    return Err(Status::invalid_argument("no valid route_id for update"));
                 }
-            }
-        } else {
-            return Err(Status::invalid_argument("no eui pair provided"));
-        }
+            } else {
+                return Err(Status::invalid_argument("no eui pair provided"));
+            };
 
         while let Ok(Some(update)) = request.message().await {
+            validator.validate_update(&update)?;
             match (update.action(), update.eui_pair) {
                 (ActionV1::Add, Some(eui_pair)) => to_add.push(eui_pair.into()),
                 (ActionV1::Remove, Some(eui_pair)) => to_remove.push(eui_pair.into()),
                 _ => return Err(Status::invalid_argument("no eui pair provided")),
+            };
+            pending_updates += 1;
+            if pending_updates >= UPDATE_BATCH_LIMIT {
+                tracing::debug!(
+                    adding = to_add.len(),
+                    removing = to_remove.len(),
+                    "updating eui pairs",
+                );
+                route::update_euis(&to_add, &to_remove, &self.pool, self.update_channel.clone())
+                    .await
+                    .map_err(|err| {
+                        tracing::error!("eui pair update failed: {err:?}");
+                        Status::internal("eui pair update failed")
+                    })?;
+                to_add = vec![];
+                to_remove = vec![];
+                pending_updates = 0;
             }
         }
-        tracing::debug!(
-            adding = to_add.len(),
-            removing = to_remove.len(),
-            "updating euis"
-        );
 
-        route::update_euis(&to_add, &to_remove, &self.pool, self.clone_update_channel())
-            .await
-            .map_err(|err| {
-                tracing::error!("eui update failed: {err:?}");
-                Status::internal("eui update failed")
-            })?;
+        if pending_updates > 0 {
+            tracing::debug!(
+                adding = to_add.len(),
+                removing = to_remove.len(),
+                "updating euis",
+            );
 
+            route::update_euis(&to_add, &to_remove, &self.pool, self.clone_update_channel())
+                .await
+                .map_err(|err| {
+                    tracing::error!("eui update failed: {err:?}");
+                    Status::internal("eui update failed")
+                })?;
+        }
         Ok(Response::new(RouteEuisResV1 {}))
     }
 
@@ -461,69 +506,237 @@ impl iot_config::Route for RouteService {
     ) -> GrpcResult<RouteDevaddrRangesResV1> {
         let mut request = request.into_inner();
 
-        let mut constraint_bounds = vec![];
         let mut to_add: Vec<DevAddrRange> = vec![];
         let mut to_remove: Vec<DevAddrRange> = vec![];
+        let mut pending_updates: usize = 0;
 
-        if let Ok(Some(first_update)) = request.message().await {
-            if let Some(devaddr) = &first_update.devaddr_range {
-                self.verify_request_signature(&first_update, OrgId::RouteId(&devaddr.route_id))
-                    .await?;
-                let mut constraints = org::get_constraints_by_route(&devaddr.route_id, &self.pool)
-                    .await
-                    .map_err(|_| Status::internal("no devaddr constraints for org"))?;
-                match first_update.action() {
-                    ActionV1::Add => {
-                        let add_range = devaddr.into();
-                        verify_range_in_bounds(&constraints, &add_range)
-                            .map(|_| to_add.push(add_range))?
-                    }
-                    ActionV1::Remove => to_remove.push(devaddr.into()),
-                };
-                constraint_bounds.append(&mut constraints)
-            }
-        } else {
-            return Err(Status::invalid_argument("no devaddr range provided"));
-        };
+        let mut validator: DevAddrEuiValidator =
+            if let Ok(Some(first_update)) = request.message().await {
+                if let Some(devaddr) = &first_update.devaddr_range {
+                    let mut validator = self
+                        .update_validator(&devaddr.route_id, true)
+                        .await
+                        .map_err(|_| Status::internal("unable to verify updates"))?;
+                    validator.validate_update(&first_update)?;
+                    match first_update.action() {
+                        ActionV1::Add => to_add.push(devaddr.into()),
+                        ActionV1::Remove => to_remove.push(devaddr.into()),
+                    };
+                    pending_updates += 1;
+                    validator
+                } else {
+                    return Err(Status::invalid_argument("no valid route_id for update"));
+                }
+            } else {
+                return Err(Status::invalid_argument("no devaddr range provided"));
+            };
 
         while let Ok(Some(update)) = request.message().await {
+            validator.validate_update(&update)?;
             match (update.action(), update.devaddr_range) {
-                (ActionV1::Add, Some(devaddr)) => {
-                    let add_range = devaddr.into();
-                    verify_range_in_bounds(&constraint_bounds, &add_range)
-                        .map(|_| to_add.push(add_range))?
-                }
+                (ActionV1::Add, Some(devaddr)) => to_add.push(devaddr.into()),
                 (ActionV1::Remove, Some(devaddr)) => to_remove.push(devaddr.into()),
                 _ => return Err(Status::invalid_argument("no devaddr range provided")),
+            };
+            pending_updates += 1;
+            if pending_updates >= UPDATE_BATCH_LIMIT {
+                tracing::debug!(
+                    adding = to_add.len(),
+                    removing = to_remove.len(),
+                    "updating devaddr ranges"
+                );
+                route::update_devaddr_ranges(
+                    &to_add,
+                    &to_remove,
+                    &self.pool,
+                    self.update_channel.clone(),
+                )
+                .await
+                .map_err(|err| {
+                    tracing::error!("devaddr range update failed: {err:?}");
+                    Status::internal("devaddr range update failed")
+                })?;
+                to_add = vec![];
+                to_remove = vec![];
+                pending_updates = 0;
             }
         }
-        tracing::debug!(
-            adding = to_add.len(),
-            removing = to_remove.len(),
-            "updating devaddr ranges"
-        );
 
-        route::update_devaddr_ranges(&to_add, &to_remove, &self.pool, self.update_channel.clone())
+        if pending_updates > 0 {
+            tracing::debug!(
+                adding = to_add.len(),
+                removing = to_remove.len(),
+                "updating devaddr ranges"
+            );
+
+            route::update_devaddr_ranges(
+                &to_add,
+                &to_remove,
+                &self.pool,
+                self.update_channel.clone(),
+            )
             .await
             .map_err(|err| {
                 tracing::error!("devaddr range update failed: {err:?}");
                 Status::internal("devaddr range update failed")
             })?;
+        }
         Ok(Response::new(RouteDevaddrRangesResV1 {}))
     }
 }
 
-fn verify_range_in_bounds(
-    constraints: &[DevAddrConstraint],
-    range: &DevAddrRange,
-) -> Result<(), Status> {
-    for constraint in constraints {
-        if constraint.contains(range) {
-            return Ok(());
+struct DevAddrEuiValidator {
+    route_ids: Vec<String>,
+    constraints: Option<Vec<DevAddrConstraint>>,
+    signing_keys: Vec<PublicKey>,
+}
+
+#[derive(thiserror::Error, Debug)]
+enum DevAddrEuiValidationError {
+    #[error("devaddr range outside of constraint bounds {0}")]
+    RangeOutOfBounds(String),
+    #[error("no route for update {0}")]
+    NoRouteId(String),
+    #[error("unauthorized signature {0}")]
+    UnauthorizedSignature(String),
+    #[error("invalid update {0}")]
+    InvalidUpdate(String),
+}
+
+impl DevAddrEuiValidator {
+    async fn new(
+        route_id: &str,
+        mut admin_keys: Vec<PublicKey>,
+        db: impl sqlx::PgExecutor<'_> + Copy,
+        check_constraints: bool,
+    ) -> Result<Self, DbOrgError> {
+        let constraints = if check_constraints {
+            Some(org::get_constraints_by_route(route_id, db).await?)
+        } else {
+            None
+        };
+
+        let mut org_keys = org::get_org_pubkeys_by_route(route_id, db).await?;
+        org_keys.append(&mut admin_keys);
+
+        Ok(Self {
+            route_ids: org::get_route_ids_by_route(route_id, db).await?,
+            constraints,
+            signing_keys: org_keys,
+        })
+    }
+
+    fn validate_update<'a, R>(&'a mut self, request: &'a R) -> Result<(), Status>
+    where
+        R: MsgVerify + ValidateRouteComponent<'a> + std::fmt::Debug,
+    {
+        validate_owned_route(request, &self.route_ids)
+            .and_then(|update| validate_range_bounds(update, self.constraints.as_ref()))
+            .and_then(|update| validate_signature(update, &mut self.signing_keys))
+            .map_err(|err| Status::invalid_argument(format!("{err:?}")))?;
+        Ok(())
+    }
+}
+
+trait ValidateRouteComponent<'a> {
+    type Error;
+    fn route_id(&'a self) -> Result<&'a String, Self::Error>;
+    fn range(&self) -> Result<Option<DevAddrRange>, Self::Error>;
+}
+
+impl<'a> ValidateRouteComponent<'a> for RouteUpdateDevaddrRangesReqV1 {
+    type Error = &'a str;
+
+    fn route_id(&'a self) -> Result<&'a String, Self::Error> {
+        if let Some(ref devaddr) = self.devaddr_range {
+            Ok(&devaddr.route_id)
+        } else {
+            Err("missing devaddr range update")
         }
     }
-    tracing::error!("range {range:?} does not fall within constraints {constraints:?}");
-    Err(Status::invalid_argument(
-        "devaddr range outside of org constraints",
-    ))
+    fn range(&self) -> Result<Option<DevAddrRange>, Self::Error> {
+        if let Some(ref devaddr) = self.devaddr_range {
+            Ok(Some(devaddr.into()))
+        } else {
+            Err("missing devaddr range update")
+        }
+    }
+}
+
+impl<'a> ValidateRouteComponent<'a> for RouteUpdateEuisReqV1 {
+    type Error = &'a str;
+
+    fn route_id(&'a self) -> Result<&'a String, Self::Error> {
+        if let Some(ref eui_pair) = self.eui_pair {
+            Ok(&eui_pair.route_id)
+        } else {
+            Err("missing eui pair update")
+        }
+    }
+    fn range(&self) -> Result<Option<DevAddrRange>, Self::Error> {
+        Ok(None)
+    }
+}
+
+fn validate_owned_route<'a, T>(
+    update: &'a T,
+    route_ids: &'a [String],
+) -> Result<&'a T, DevAddrEuiValidationError>
+where
+    T: ValidateRouteComponent<'a> + std::fmt::Debug,
+{
+    let update_id = update
+        .route_id()
+        .map_err(|_| DevAddrEuiValidationError::InvalidUpdate(format!("{update:?}")))?;
+    if !route_ids.contains(update_id) {
+        return Err(DevAddrEuiValidationError::NoRouteId(format!("{update:?}")));
+    }
+    Ok(update)
+}
+
+fn validate_range_bounds<'a, T>(
+    update: &'a T,
+    constraints: Option<&Vec<DevAddrConstraint>>,
+) -> Result<&'a T, DevAddrEuiValidationError>
+where
+    T: ValidateRouteComponent<'a> + std::fmt::Debug,
+{
+    if let Some(constraints) = constraints {
+        match update.range() {
+            Ok(Some(range)) => {
+                for constraint in constraints {
+                    if constraint.contains_range(&range) {
+                        return Ok(update);
+                    }
+                }
+                Err(DevAddrEuiValidationError::RangeOutOfBounds(format!(
+                    "{update:?}"
+                )))
+            }
+            Ok(None) => Ok(update),
+            _ => Err(DevAddrEuiValidationError::InvalidUpdate(format!(
+                "{update:?}"
+            ))),
+        }
+    } else {
+        Ok(update)
+    }
+}
+
+fn validate_signature<'a, R>(
+    request: &'a R,
+    signing_keys: &mut [PublicKey],
+) -> Result<&'a R, DevAddrEuiValidationError>
+where
+    R: MsgVerify + ValidateRouteComponent<'a> + std::fmt::Debug,
+{
+    for (idx, pubkey) in signing_keys.iter().enumerate() {
+        if request.verify(pubkey).is_ok() {
+            signing_keys.swap(idx, 0);
+            return Ok(request);
+        }
+    }
+    Err(DevAddrEuiValidationError::UnauthorizedSignature(format!(
+        "{request:?}"
+    )))
 }

--- a/iot_config/src/session_key_service.rs
+++ b/iot_config/src/session_key_service.rs
@@ -1,12 +1,14 @@
 use crate::{
     admin::{AuthCache, KeyType},
-    org::get_org_pubkeys,
+    lora_field::DevAddrConstraint,
+    org::{self, DbOrgError},
     session_key::{self, SessionKeyFilter},
     GrpcResult, GrpcStreamRequest, GrpcStreamResult,
 };
 use anyhow::Result;
 use file_store::traits::MsgVerify;
 use futures::stream::StreamExt;
+use helium_crypto::PublicKey;
 use helium_proto::services::iot_config::{
     self, ActionV1, SessionKeyFilterGetReqV1, SessionKeyFilterListReqV1,
     SessionKeyFilterStreamReqV1, SessionKeyFilterStreamResV1, SessionKeyFilterUpdateReqV1,
@@ -15,6 +17,8 @@ use helium_proto::services::iot_config::{
 use sqlx::{Pool, Postgres};
 use tokio::sync::broadcast::{Receiver, Sender};
 use tonic::{Request, Response, Status};
+
+const UPDATE_BATCH_LIMIT: usize = 5_000;
 
 pub struct SessionKeyFilterService {
     auth_cache: AuthCache,
@@ -56,7 +60,7 @@ impl SessionKeyFilterService {
             return Ok(());
         }
 
-        let org_keys = get_org_pubkeys(id, &self.pool)
+        let org_keys = org::get_org_pubkeys(id, &self.pool)
             .await
             .map_err(|_| Status::internal("auth verification error"))?;
 
@@ -92,6 +96,12 @@ impl SessionKeyFilterService {
         } else {
             Err(Status::permission_denied("unauthorized request signature"))
         }
+    }
+
+    async fn update_validator(&self, oui: u64) -> Result<SkfValidator, DbOrgError> {
+        let admin_keys = self.auth_cache.get_keys(KeyType::Administrator).await;
+
+        SkfValidator::new(oui, admin_keys, &self.pool).await
     }
 }
 
@@ -167,45 +177,80 @@ impl iot_config::SessionKeyFilter for SessionKeyFilterService {
 
         let mut to_add: Vec<SessionKeyFilter> = vec![];
         let mut to_remove: Vec<SessionKeyFilter> = vec![];
+        let mut pending_updates: usize = 0;
 
-        if let Ok(Some(first_update)) = request.message().await {
+        let mut validator: SkfValidator = if let Ok(Some(first_update)) = request.message().await {
             if let Some(filter) = &first_update.filter {
-                self.verify_request_signature(&first_update, filter.oui)
-                    .await?;
+                let mut validator = self
+                    .update_validator(filter.oui)
+                    .await
+                    .map_err(|_| Status::internal("unable to verify updates"))?;
+                validator.validate_update(&first_update)?;
                 match first_update.action() {
                     ActionV1::Add => to_add.push(filter.into()),
                     ActionV1::Remove => to_remove.push(filter.into()),
-                }
+                };
+                pending_updates += 1;
+                validator
+            } else {
+                return Err(Status::invalid_argument(
+                    "no valid session key filter for update",
+                ));
             }
         } else {
             return Err(Status::invalid_argument("no session key filter provided"));
-        }
+        };
 
         while let Ok(Some(update)) = request.message().await {
+            validator.validate_update(&update)?;
             match (update.action(), update.filter) {
                 (ActionV1::Add, Some(filter)) => to_add.push(filter.into()),
                 (ActionV1::Remove, Some(filter)) => to_remove.push(filter.into()),
                 _ => return Err(Status::invalid_argument("no filter provided")),
+            };
+            pending_updates += 1;
+            if pending_updates >= UPDATE_BATCH_LIMIT {
+                tracing::debug!(
+                    adding = to_add.len(),
+                    removing = to_remove.len(),
+                    "update session key filters",
+                );
+                session_key::update_session_keys(
+                    &to_add,
+                    &to_remove,
+                    &self.pool,
+                    self.clone_update_channel(),
+                )
+                .await
+                .map_err(|err| {
+                    tracing::error!("session key update failed: {err:?}");
+                    Status::internal("session key update failed")
+                })?;
+                to_add = vec![];
+                to_remove = vec![];
+                pending_updates = 0;
             }
         }
-        tracing::debug!(
-            adding = to_add.len(),
-            removing = to_remove.len(),
-            "updating session key filters",
-        );
 
-        session_key::update_session_keys(
-            &to_add,
-            &to_remove,
-            &self.pool,
-            self.clone_update_channel(),
-        )
-        .await
-        .map_err(|err| {
-            tracing::error!("session key update failed: {err:?}");
-            Status::internal("session key update failed")
-        })?;
+        if pending_updates > 0 {
+            tracing::debug!(
+                adding = to_add.len(),
+                removing = to_remove.len(),
+                "updating session key filters",
+            );
 
+            session_key::update_session_keys(
+                &to_add,
+                &to_remove,
+                &self.pool,
+                self.clone_update_channel(),
+            )
+            .await
+            .map_err(|err| {
+                tracing::error!("session key update failed: {err:?}");
+                Status::internal("session key update failed")
+            })?;
+        }
         Ok(Response::new(SessionKeyFilterUpdateResV1 {}))
     }
 
@@ -255,4 +300,106 @@ impl iot_config::SessionKeyFilter for SessionKeyFilterService {
 
         Ok(Response::new(GrpcStreamResult::new(rx)))
     }
+}
+
+struct SkfValidator {
+    oui: u64,
+    constraints: Vec<DevAddrConstraint>,
+    signing_keys: Vec<PublicKey>,
+}
+
+#[derive(thiserror::Error, Debug)]
+enum SkfValidatorError {
+    #[error("devaddr outside of constraint bounds {0}")]
+    AddrOutOfBounds(String),
+    #[error("wrong oui for session key filter {0}")]
+    WrongOui(String),
+    #[error("unauthorized signature {0}")]
+    UnauthorizedSignature(String),
+    #[error("invalid update {0}")]
+    InvalidUpdate(String),
+}
+
+impl SkfValidator {
+    async fn new(
+        oui: u64,
+        mut admin_keys: Vec<PublicKey>,
+        db: impl sqlx::PgExecutor<'_> + Copy,
+    ) -> Result<SkfValidator, DbOrgError> {
+        let org = org::get_with_constraints(oui, db).await?;
+        let mut org_keys = org::get_org_pubkeys(oui, db).await?;
+        org_keys.append(&mut admin_keys);
+
+        Ok(Self {
+            oui,
+            constraints: org.constraints,
+            signing_keys: org_keys,
+        })
+    }
+
+    fn validate_update<'a>(
+        &'a mut self,
+        request: &'a SessionKeyFilterUpdateReqV1,
+    ) -> Result<(), Status> {
+        validate_oui(request, self.oui)
+            .and_then(|update| validate_constraint_bounds(update, self.constraints.as_ref()))
+            .and_then(|update| validate_signature(update, &mut self.signing_keys))
+            .map_err(|err| Status::invalid_argument(format!("{err:?}")))?;
+        Ok(())
+    }
+}
+
+fn validate_oui(
+    update: &SessionKeyFilterUpdateReqV1,
+    oui: u64,
+) -> Result<&SessionKeyFilterUpdateReqV1, SkfValidatorError> {
+    let filter_oui = if let Some(ref filter) = update.filter {
+        filter.oui
+    } else {
+        return Err(SkfValidatorError::InvalidUpdate(format!("{update:?}")));
+    };
+
+    if oui == filter_oui {
+        Ok(update)
+    } else {
+        Err(SkfValidatorError::WrongOui(format!(
+            "authorized oui: {oui}, update: {filter_oui}"
+        )))
+    }
+}
+
+fn validate_constraint_bounds<'a>(
+    update: &'a SessionKeyFilterUpdateReqV1,
+    constraints: &'a Vec<DevAddrConstraint>,
+) -> Result<&'a SessionKeyFilterUpdateReqV1, SkfValidatorError> {
+    let filter_addr = if let Some(ref filter) = update.filter {
+        filter.devaddr
+    } else {
+        return Err(SkfValidatorError::InvalidUpdate(format!("{update:?}")));
+    };
+
+    for constraint in constraints {
+        if constraint.contains_addr(filter_addr.into()) {
+            return Ok(update);
+        }
+    }
+    Err(SkfValidatorError::AddrOutOfBounds(format!("{update:?}")))
+}
+
+fn validate_signature<'a, R>(
+    request: &'a R,
+    signing_keys: &mut [PublicKey],
+) -> Result<&'a R, SkfValidatorError>
+where
+    R: MsgVerify + std::fmt::Debug,
+{
+    for (idx, pubkey) in signing_keys.iter().enumerate() {
+        if request.verify(pubkey).is_ok() {
+            signing_keys.swap(idx, 0);
+            return Ok(request);
+        }
+    }
+    Err(SkfValidatorError::UnauthorizedSignature(format!(
+        "{request:?}"
+    )))
 }


### PR DESCRIPTION
adds additional logging to the iot-config service for error debugging and resolves a bug converting (database persisted) devaddr records, stored in postgres as i32 but otherwise handled as u32 into the u64 DevAddrConstraint struct when retrieved from the database for comparison against requested DevAddrRange records.

the bugfix converts the stored record to the correct unsigned format before casting up to a u64