### PR TITLE
Add ability to hardcode aws creds but only when file-store/local feature is enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,6 +2323,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
+ "aws-types",
  "base64 0.21.0",
  "beacon",
  "blake3",

--- a/file_store/Cargo.toml
+++ b/file_store/Cargo.toml
@@ -31,6 +31,7 @@ csv = "*"
 http = {workspace = true}
 aws-config = "0.51"
 aws-sdk-s3 = "0.21"
+aws-types = { version = "0.51", features = ["hardcoded-credentials"], optional = true}
 strum = {version = "0", features = ["derive"]}
 strum_macros = "0"
 sha2 = {workspace = true}
@@ -49,3 +50,6 @@ retainer = {workspace = true}
 [dev-dependencies]
 hex-literal = "0"
 tempfile = "3"
+
+[features]
+local = ["aws-types"]

--- a/file_store/src/file_source.rs
+++ b/file_store/src/file_source.rs
@@ -65,7 +65,7 @@ mod test {
         // 2022-08-05 15:35:55     240363 cell_heartbeat.1658832527866.gz
         // 2022-08-05 15:36:08    6525274 cell_heartbeat.1658834120042.gz
         //
-        let file_store = FileStore::new(None, "us-east-1", "devnet-poc5g-rewards")
+        let file_store = FileStore::new(None, "us-east-1", "devnet-poc5g-rewards", None, None)
             .await
             .expect("file store");
         let stream = file_store.source(infos(&[

--- a/file_store/src/file_source.rs
+++ b/file_store/src/file_source.rs
@@ -46,7 +46,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{FileInfo, FileInfoStream, FileStore};
+    use crate::{FileInfo, FileInfoStream, FileStore, Settings};
     use std::str::FromStr;
 
     fn infos(names: &'static [&str]) -> FileInfoStream {
@@ -65,7 +65,16 @@ mod test {
         // 2022-08-05 15:35:55     240363 cell_heartbeat.1658832527866.gz
         // 2022-08-05 15:36:08    6525274 cell_heartbeat.1658834120042.gz
         //
-        let file_store = FileStore::new(None, "us-east-1", "devnet-poc5g-rewards", None, None)
+
+        let settings = Settings {
+            bucket: "devnet-poc5g-rewards".to_string(),
+            endpoint: None,
+            region: "us-east-1".to_string(),
+            access_key_id: None,
+            secret_access_key: None,
+        };
+
+        let file_store = FileStore::from_settings(&settings)
             .await
             .expect("file store");
         let stream = file_store.source(infos(&[

--- a/file_store/src/file_store.rs
+++ b/file_store/src/file_store.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::DecodeError, BytesMutStream, Error, FileInfo, FileInfoStream, FileType, Result, Settings,
 };
-use aws_config::meta::region::{ProvideRegion, RegionProviderChain};
+use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::{types::ByteStream, Client, Endpoint, Region};
 use chrono::{DateTime, Utc};
 use futures::FutureExt;
@@ -31,23 +31,6 @@ impl FileStore {
             _ => None,
         };
         let region = Region::new(settings.region.clone());
-        Self::new(
-            endpoint,
-            region,
-            &settings.bucket,
-            settings.access_key_id.clone(),
-            settings.secret_access_key.clone(),
-        )
-        .await
-    }
-
-    pub async fn new(
-        endpoint: Option<Endpoint>,
-        region: impl ProvideRegion + 'static,
-        bucket: impl Into<String>,
-        #[allow(unused_variables)] access_key_id: Option<String>,
-        #[allow(unused_variables)] secret_access_key: Option<String>,
-    ) -> Result<Self> {
         let region_provider = RegionProviderChain::first_try(region).or_default_provider();
 
         let mut config = aws_config::from_env().region(region_provider);
@@ -70,7 +53,7 @@ impl FileStore {
         let client = Client::new(&config);
         Ok(Self {
             client,
-            bucket: bucket.into(),
+            bucket: settings.bucket.clone(),
         })
     }
 

--- a/file_store/src/settings.rs
+++ b/file_store/src/settings.rs
@@ -12,6 +12,10 @@ pub struct Settings {
     /// Optional region for the endpoint. Default: us-west-2
     #[serde(default = "default_region")]
     pub region: String,
+
+    /// Should only be used for local testing
+    pub access_key_id: Option<String>,
+    pub secret_access_key: Option<String>,
 }
 
 fn default_region() -> String {


### PR DESCRIPTION
This should enable local testing to read from an AWS bucket and write to a local minio bucket.   The hardcoded credentials will only be used if the "file-store/local" feature is enabled.