### PR TITLE
fix erroneous decode route id direct to string

### DIFF
--- a/iot_config/src/org.rs
+++ b/iot_config/src/org.rs
@@ -184,7 +184,7 @@ pub async fn get_route_ids_by_route(
     .fetch_all(db)
     .await?
     .into_iter()
-    .map(|row| row.get::<String, &str>("id"))
+    .map(|row| row.get::<Uuid, &str>("id").to_string())
     .collect();
 
     Ok(route_ids)


### PR DESCRIPTION
This mistaken decode direct to a String type is causing a `Result.unwrap()` panic in a particular handler of the config service attempting to validate updates to the EUI pairs or DevAddr ranges submitted to the config service for routing