### PR TITLE
convert session keys from binary to hex strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,7 +1150,7 @@ checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/gateway-rs.git?branch=main#4e838655c7087a10cb4725f002bb5c572542a247"
+source = "git+https://github.com/helium/gateway-rs.git?branch=main#c9c23de5be80ed1712cfd4a8c71e87c5cf692c41"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -2979,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#ef1c152fe33993c6da598af9c1a6100d952f4f03"
+source = "git+https://github.com/helium/proto?branch=master#4afcaaea25bde4e333f1e57fc32f163910e8ca0a"
 dependencies = [
  "bytes",
  "prost",

--- a/iot_config/migrations/6_session_key_filters.sql
+++ b/iot_config/migrations/6_session_key_filters.sql
@@ -1,7 +1,7 @@
 create table session_key_filters (
     oui bigint not null references organizations(oui) on delete cascade,
     devaddr int not null,
-    session_key bytea not null,
+    session_key text not null,
 
     inserted_at timestamptz not null default now(),
     updated_at timestamptz not null default now(),

--- a/iot_config/src/session_key.rs
+++ b/iot_config/src/session_key.rs
@@ -10,7 +10,7 @@ use tokio::sync::broadcast::Sender;
 pub struct SessionKeyFilter {
     pub oui: u64,
     pub devaddr: DevAddrField,
-    pub session_key: Vec<u8>,
+    pub session_key: String,
 }
 
 impl FromRow<'_, PgRow> for SessionKeyFilter {
@@ -18,7 +18,7 @@ impl FromRow<'_, PgRow> for SessionKeyFilter {
         Ok(Self {
             oui: row.get::<i64, &str>("oui") as u64,
             devaddr: row.get::<i32, &str>("devaddr").into(),
-            session_key: row.get::<Vec<u8>, &str>("session_key"),
+            session_key: row.get::<String, &str>("session_key"),
         })
     }
 }

--- a/iot_config/src/session_key_service.rs
+++ b/iot_config/src/session_key_service.rs
@@ -126,8 +126,7 @@ impl iot_config::SessionKeyFilter for SessionKeyFilterService {
                 let message = match filter {
                     Ok(filter) => Ok(filter.into()),
                     Err(bad_filter) => Err(Status::internal(format!(
-                        "invalid session key filter {:?}",
-                        bad_filter
+                        "invalid session key filter {bad_filter:?}"
                     ))),
                 };
                 if tx.send(message).await.is_err() {
@@ -156,8 +155,7 @@ impl iot_config::SessionKeyFilter for SessionKeyFilterService {
                 let message = match filter {
                     Ok(filter) => Ok(filter.into()),
                     Err(bad_filter) => Err(Status::internal(format!(
-                        "invalid session key filter {:?}",
-                        bad_filter
+                        "invalid session key filter {bad_filter:?}"
                     ))),
                 };
                 if tx.send(message).await.is_err() {


### PR DESCRIPTION
raw binary session keys are proving unwieldy on the routing infrastructure; to manage them better we're converting them to hex-encoded strings on the proto side as well as in the config service, which doesn't really care what format they're in.

this will have the beneficial side effect of making them easier to debug/inspect on if needed