### PR TITLE
Refactor price service and enable stale price lifetime

### DIFF
--- a/price/src/error.rs
+++ b/price/src/error.rs
@@ -1,9 +1,0 @@
-#[derive(thiserror::Error, Debug)]
-pub enum PriceError {
-    #[error("unsupported token type: {0}")]
-    UnsupportedTokenType(i32),
-    #[error("unable to fetch price")]
-    UnableToFetch,
-    #[error("unknown price account key, token_type: {0}")]
-    UnknownKey(String),
-}

--- a/price/src/lib.rs
+++ b/price/src/lib.rs
@@ -1,10 +1,8 @@
-pub mod error;
 pub mod metrics;
 pub mod price_generator;
 pub mod price_tracker;
 pub mod settings;
 
-pub use error::PriceError;
 pub use price_generator::PriceGenerator;
 pub use price_tracker::PriceTracker;
 pub use settings::Settings;

--- a/price/src/main.rs
+++ b/price/src/main.rs
@@ -94,16 +94,16 @@ impl Server {
 
         tokio::try_join!(
             hnt_price_generator
-                .run(price_sink.clone(), &shutdown, BlockchainTokenTypeV1::Hnt)
+                .run(price_sink.clone(), &shutdown)
                 .map_err(Error::from),
             mobile_price_generator
-                .run(price_sink.clone(), &shutdown, BlockchainTokenTypeV1::Mobile)
+                .run(price_sink.clone(), &shutdown)
                 .map_err(Error::from),
             iot_price_generator
-                .run(price_sink.clone(), &shutdown, BlockchainTokenTypeV1::Iot)
+                .run(price_sink.clone(), &shutdown)
                 .map_err(Error::from),
             hst_price_generator
-                .run(price_sink, &shutdown, BlockchainTokenTypeV1::Hst)
+                .run(price_sink, &shutdown)
                 .map_err(Error::from),
             price_sink_server.run(&shutdown).map_err(Error::from),
             file_upload.run(&shutdown).map_err(Error::from),

--- a/price/src/price_generator.rs
+++ b/price/src/price_generator.rs
@@ -172,7 +172,7 @@ impl PriceGenerator {
             }
             Err(err) => {
                 tracing::error!(
-                    "error is retrieving new price for {:?}: {err:?}",
+                    "error in retrieving new price for {:?}: {err:?}",
                     self.token_type
                 );
 

--- a/price/src/price_generator.rs
+++ b/price/src/price_generator.rs
@@ -1,6 +1,6 @@
-use crate::{metrics::Metrics, PriceError, Settings};
-use anyhow::Result;
-use chrono::Utc;
+use crate::{metrics::Metrics, Settings};
+use anyhow::{anyhow, Error, Result};
+use chrono::{DateTime, Duration, TimeZone, Utc};
 use file_store::file_sink;
 use helium_proto::{BlockchainTokenTypeV1, PriceReportV1};
 use pyth_sdk_solana::load_price_feed_from_account;
@@ -11,13 +11,13 @@ use tokio::time;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Price {
-    pub timestamp: i64,
+    pub timestamp: DateTime<Utc>,
     pub price: u64,
     pub token_type: BlockchainTokenTypeV1,
 }
 
 impl Price {
-    pub fn new(timestamp: i64, price: u64, token_type: BlockchainTokenTypeV1) -> Self {
+    pub fn new(timestamp: DateTime<Utc>, price: u64, token_type: BlockchainTokenTypeV1) -> Self {
         Self {
             timestamp,
             price,
@@ -27,15 +27,20 @@ impl Price {
 }
 
 pub struct PriceGenerator {
-    settings: Settings,
+    token_type: BlockchainTokenTypeV1,
+    age: u64,
     client: RpcClient,
-    price: Option<Price>,
+    interval_duration: std::time::Duration,
+    last_price_opt: Option<Price>,
+    key: Option<SolPubkey>,
+    default_price: Option<u64>,
+    stale_price_duration: Duration,
 }
 
 impl From<Price> for PriceReportV1 {
     fn from(value: Price) -> Self {
         Self {
-            timestamp: value.timestamp as u64,
+            timestamp: value.timestamp.timestamp() as u64,
             price: value.price,
             token_type: value.token_type.into(),
         }
@@ -43,13 +48,16 @@ impl From<Price> for PriceReportV1 {
 }
 
 impl TryFrom<PriceReportV1> for Price {
-    type Error = PriceError;
+    type Error = Error;
 
     fn try_from(value: PriceReportV1) -> Result<Self, Self::Error> {
         let tt: BlockchainTokenTypeV1 = BlockchainTokenTypeV1::from_i32(value.token_type)
-            .ok_or(PriceError::UnsupportedTokenType(value.token_type))?;
+            .ok_or(anyhow!("unsupported token type: {:?}", value.token_type))?;
         Ok(Self {
-            timestamp: value.timestamp as i64,
+            timestamp: Utc
+                .timestamp_opt(value.timestamp as i64, 0)
+                .single()
+                .ok_or_else(|| anyhow!("invalid timestamp"))?,
             price: value.price,
             token_type: tt,
         })
@@ -59,29 +67,15 @@ impl TryFrom<PriceReportV1> for Price {
 impl PriceGenerator {
     pub async fn new(settings: &Settings, token_type: BlockchainTokenTypeV1) -> Result<Self> {
         let client = RpcClient::new(&settings.source);
-        let price = match settings.price_key(token_type) {
-            None => {
-                let timestamp = Utc::now().timestamp();
-                match settings.default_price(token_type) {
-                    None => {
-                        tracing::warn!(
-                            "no price_key and no default_price in settings for {:?}",
-                            token_type
-                        );
-                        None
-                    }
-                    Some(p) => Some(Price::new(timestamp, p, token_type)),
-                }
-            }
-            Some(price_key) => {
-                let rpc_price = get_price(&client, &price_key, settings.age, token_type).await?;
-                Some(rpc_price)
-            }
-        };
         Ok(Self {
-            settings: settings.clone(),
+            last_price_opt: None,
+            token_type,
+            age: settings.age,
             client,
-            price,
+            key: settings.price_key(token_type)?,
+            default_price: settings.default_price(token_type),
+            interval_duration: settings.interval().to_std()?,
+            stale_price_duration: settings.stale_price_duration(),
         })
     }
 
@@ -89,118 +83,133 @@ impl PriceGenerator {
         &mut self,
         file_sink: file_sink::FileSinkClient,
         shutdown: &triggered::Listener,
-        token_type: BlockchainTokenTypeV1,
-    ) -> anyhow::Result<()> {
-        tracing::info!("started price generator for: {:?}", token_type);
-        let mut price_timer = time::interval(self.settings.interval().to_std()?);
-        price_timer.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+    ) -> Result<()> {
+        match (self.key, self.default_price) {
+            (Some(key), _) => self.run_with_key(key, file_sink, shutdown).await,
+            (None, Some(defaut_price)) => {
+                self.run_with_default(defaut_price, file_sink, shutdown)
+                    .await
+            }
+            _ => {
+                tracing::warn!(
+                    "stopping price generator for {:?}, not configured",
+                    self.token_type
+                );
+                Ok(())
+            }
+        }
+    }
+
+    async fn run_with_default(
+        &self,
+        default_price: u64,
+        file_sink: file_sink::FileSinkClient,
+        shutdown: &triggered::Listener,
+    ) -> Result<()> {
+        tracing::info!(
+            "starting default price generator for {:?}, using price {default_price}",
+            self.token_type
+        );
+        let mut trigger = time::interval(self.interval_duration);
 
         loop {
-            if shutdown.is_triggered() {
-                break;
-            }
             tokio::select! {
                 _ = shutdown.clone() => break,
-                _ = price_timer.tick() => match self.handle_price_tick(&file_sink, token_type).await {
-                    Ok(()) => (),
-                    Err(err) => {
-                        tracing::error!("fatal price generator error: {err:?}");
-                        return Err(err)
-                    }
+                _ = trigger.tick() => {
+                    let price = Price::new(Utc::now(), default_price, self.token_type);
+                    let price_report = PriceReportV1::from(price);
+                    tracing::info!("updating {:?} with default price: {}", self.token_type, default_price);
+                    file_sink.write(price_report, []).await?;
                 }
             }
         }
-        tracing::info!("stopping price generator for {:?}", token_type);
+
+        tracing::info!("stopping default price generator for {:?}", self.token_type);
         Ok(())
     }
 
-    async fn handle_price_tick(
+    async fn run_with_key(
         &mut self,
-        file_sink: &file_sink::FileSinkClient,
-        token_type: BlockchainTokenTypeV1,
-    ) -> anyhow::Result<()> {
-        let timestamp = Utc::now().timestamp();
-        if let Some(price_key) = &self.settings.price_key(token_type) {
-            let new_price = self.maybe_new_price(price_key, token_type).await;
+        key: SolPubkey,
+        file_sink: file_sink::FileSinkClient,
+        shutdown: &triggered::Listener,
+    ) -> Result<()> {
+        tracing::info!("starting price generator for {:?}", self.token_type);
+        let mut trigger = time::interval(self.interval_duration);
 
-            match new_price {
-                None => Ok(()),
-                Some(mut new_price) => {
-                    // Just set the timestamp to latest for the "new" price
-                    new_price.timestamp = timestamp;
-
-                    tracing::info!(
-                        "updating price {} for {:?} at {:?}",
-                        new_price.price.to_string(),
-                        token_type,
-                        timestamp
-                    );
-
-                    let price_report = PriceReportV1::from(new_price.clone());
-                    tracing::debug!("price_report: {:?}", price_report);
-
-                    // Set this as the last price for generator
-                    self.price = Some(new_price);
-                    tracing::debug!("setting new price for generator: {:?}", self.price);
-
-                    file_sink.write(price_report, []).await?;
-
-                    Ok(())
-                }
-            }
-        } else {
-            // The following is mostly to accomodate testing when we don't have a price_key but
-            // have a default price value set in settings
-            match &self.settings.default_price(token_type) {
-                None => {
-                    // nothing to do
-                    tracing::info!("no price_key and no default_price for {:?}", token_type);
-                    Ok(())
-                }
-                Some(p) => {
-                    // We have a default price in settings
-                    tracing::info!("no price_key for {:?}, default_price: {:?}", token_type, p);
-                    let price = Price::new(timestamp, *p, token_type);
-                    let price_report = PriceReportV1::from(price.clone());
-                    self.price = Some(price);
-                    file_sink.write(price_report, []).await?;
-                    Ok(())
-                }
+        loop {
+            tokio::select! {
+                _ = shutdown.clone() => break,
+                _ = trigger.tick() => self.handle(&key, &file_sink).await?,
             }
         }
+
+        tracing::info!("stopping price generator for {:?}", self.token_type);
+        Ok(())
     }
 
-    /// Try to get a new price if we can via RPC, otherwise return old price
-    pub async fn maybe_new_price(
-        &self,
-        price_key: &SolPubkey,
-        token_type: BlockchainTokenTypeV1,
-    ) -> Option<Price> {
-        match get_price(&self.client, price_key, self.settings.age, token_type).await {
-            Ok(price) => {
+    async fn handle(
+        &mut self,
+        key: &SolPubkey,
+        file_sink: &file_sink::FileSinkClient,
+    ) -> Result<()> {
+        let price_opt = match get_price(&self.client, key, self.age, self.token_type).await {
+            Ok(new_price) => {
+                tracing::info!(
+                    "updating price for {:?} to {}",
+                    self.token_type,
+                    new_price.price
+                );
+                self.last_price_opt = Some(new_price.clone());
+
                 Metrics::update(
                     "price_update_counter".to_string(),
-                    token_type,
-                    price.price as f64,
+                    self.token_type,
+                    new_price.price as f64,
                 );
-                Some(price)
+
+                Some(new_price)
             }
-            Err(err) => match self.price.clone() {
-                None => {
-                    tracing::warn!("no known price for {:?}", token_type);
-                    None
+            Err(err) => {
+                tracing::error!(
+                    "error is retrieving new price for {:?}: {err:?}",
+                    self.token_type
+                );
+
+                match &self.last_price_opt {
+                    Some(price) if self.is_valid(price) => {
+                        Metrics::update(
+                            "price_stale_counter".to_string(),
+                            self.token_type,
+                            price.price as f64,
+                        );
+
+                        Some(Price::new(Utc::now(), price.price, price.token_type))
+                    }
+                    Some(_price) => {
+                        tracing::warn!(
+                            "stale price for {:?} is too old, discarding",
+                            self.token_type
+                        );
+                        self.last_price_opt = None;
+                        None
+                    }
+                    None => None,
                 }
-                Some(old_price) => {
-                    Metrics::update(
-                        "price_stale_counter".to_string(),
-                        token_type,
-                        old_price.price as f64,
-                    );
-                    tracing::warn!("rpc failure: {err:?}, reusing old price {:?}", old_price);
-                    Some(old_price)
-                }
-            },
+            }
+        };
+
+        if let Some(price) = price_opt {
+            let price_report = PriceReportV1::from(price);
+            tracing::debug!("price_report: {:?}", price_report);
+            file_sink.write(price_report, []).await?;
         }
+
+        Ok(())
+    }
+
+    fn is_valid(&self, price: &Price) -> bool {
+        price.timestamp > Utc::now() - self.stale_price_duration
     }
 }
 
@@ -213,24 +222,13 @@ pub async fn get_price(
     let mut price_account = client.get_account(price_key)?;
     tracing::debug!("price_account: {:?}", price_account);
 
-    let current_time = Utc::now().timestamp();
+    let current_time = Utc::now();
+    let current_timestamp = current_time.timestamp();
     let price_feed = load_price_feed_from_account(price_key, &mut price_account)?;
     tracing::debug!("price_feed: {:?}", price_feed);
 
-    match price_feed.get_price_no_older_than(current_time, age) {
-        None => {
-            tracing::error!("unable to fetch price at {:?}", current_time);
-            Err(PriceError::UnableToFetch.into())
-        }
-        Some(feed_price) => {
-            let value = feed_price.price;
-            tracing::info!(
-                "got price {:?} via rpc for {:?} at {:?}",
-                value,
-                token_type,
-                current_time
-            );
-            Ok(Price::new(current_time, value as u64, token_type))
-        }
-    }
+    price_feed
+        .get_price_no_older_than(current_timestamp, age)
+        .map(|feed_price| Price::new(current_time, feed_price.price as u64, token_type))
+        .ok_or_else(|| anyhow!("unable to fetch price"))
 }

--- a/price/src/price_generator.rs
+++ b/price/src/price_generator.rs
@@ -177,16 +177,20 @@ impl PriceGenerator {
                 );
 
                 match &self.last_price_opt {
-                    Some(price) if self.is_valid(price) => {
+                    Some(old_price) if self.is_valid(old_price) => {
                         Metrics::update(
                             "price_stale_counter".to_string(),
                             self.token_type,
-                            price.price as f64,
+                            old_price.price as f64,
                         );
 
-                        Some(Price::new(Utc::now(), price.price, price.token_type))
+                        Some(Price::new(
+                            Utc::now(),
+                            old_price.price,
+                            old_price.token_type,
+                        ))
                     }
-                    Some(_price) => {
+                    Some(_old_price) => {
                         tracing::warn!(
                             "stale price for {:?} is too old, discarding",
                             self.token_type

--- a/price/src/price_generator.rs
+++ b/price/src/price_generator.rs
@@ -11,13 +11,13 @@ use tokio::time;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Price {
-    pub timestamp: DateTime<Utc>,
-    pub price: u64,
-    pub token_type: BlockchainTokenTypeV1,
+    timestamp: DateTime<Utc>,
+    price: u64,
+    token_type: BlockchainTokenTypeV1,
 }
 
 impl Price {
-    pub fn new(timestamp: DateTime<Utc>, price: u64, token_type: BlockchainTokenTypeV1) -> Self {
+    fn new(timestamp: DateTime<Utc>, price: u64, token_type: BlockchainTokenTypeV1) -> Self {
         Self {
             timestamp,
             price,

--- a/price/src/settings.rs
+++ b/price/src/settings.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use chrono::Duration;
 use config::{Config, Environment, File};
 use helium_proto::BlockchainTokenTypeV1;
@@ -61,6 +61,9 @@ pub struct Settings {
     /// Cluster Configuration
     #[serde(default = "default_cluster")]
     pub cluster: ClusterConfig,
+    /// How long to use a stale price in minutes
+    #[serde(default = "default_stale_price_minutes")]
+    pub stale_price_minutes: u64,
 }
 
 pub fn default_source() -> String {
@@ -77,6 +80,10 @@ pub fn default_interval() -> i64 {
 
 pub fn default_age() -> u64 {
     60
+}
+
+pub fn default_stale_price_minutes() -> u64 {
+    12 * 60
 }
 
 pub fn default_cluster() -> ClusterConfig {
@@ -114,21 +121,15 @@ impl Settings {
         Duration::seconds(self.interval)
     }
 
-    pub fn price_key(&self, token_type: BlockchainTokenTypeV1) -> Option<SolPubkey> {
-        match token_type {
-            BlockchainTokenTypeV1::Hnt => self.cluster.hnt_price_key.as_ref().map(|key| {
-                SolPubkey::from_str(key).unwrap_or_else(|_| panic!("unable to parse {}", key))
-            }),
-            BlockchainTokenTypeV1::Hst => self.cluster.hst_price_key.as_ref().map(|key| {
-                SolPubkey::from_str(key).unwrap_or_else(|_| panic!("unable to parse {}", key))
-            }),
-            BlockchainTokenTypeV1::Mobile => self.cluster.mobile_price_key.as_ref().map(|key| {
-                SolPubkey::from_str(key).unwrap_or_else(|_| panic!("unable to parse {}", key))
-            }),
-            BlockchainTokenTypeV1::Iot => self.cluster.iot_price_key.as_ref().map(|key| {
-                SolPubkey::from_str(key).unwrap_or_else(|_| panic!("unable to parse {}", key))
-            }),
-        }
+    pub fn stale_price_duration(&self) -> Duration {
+        Duration::minutes(self.stale_price_minutes as i64)
+    }
+
+    pub fn price_key(&self, token_type: BlockchainTokenTypeV1) -> Result<Option<SolPubkey>> {
+        self.key(token_type)
+            .as_ref()
+            .map(|key| SolPubkey::from_str(key).map_err(|_| anyhow!("unable to parse {}", key)))
+            .transpose()
     }
 
     pub fn default_price(&self, token_type: BlockchainTokenTypeV1) -> Option<u64> {
@@ -137,6 +138,15 @@ impl Settings {
             BlockchainTokenTypeV1::Iot => self.cluster.iot_price,
             BlockchainTokenTypeV1::Mobile => self.cluster.mobile_price,
             BlockchainTokenTypeV1::Hst => self.cluster.hst_price,
+        }
+    }
+
+    fn key(&self, token_type: BlockchainTokenTypeV1) -> Option<String> {
+        match token_type {
+            BlockchainTokenTypeV1::Hnt => self.cluster.hnt_price_key.clone(),
+            BlockchainTokenTypeV1::Hst => self.cluster.hst_price_key.clone(),
+            BlockchainTokenTypeV1::Mobile => self.cluster.mobile_price_key.clone(),
+            BlockchainTokenTypeV1::Iot => self.cluster.iot_price_key.clone(),
         }
     }
 }

--- a/price/src/settings.rs
+++ b/price/src/settings.rs
@@ -141,12 +141,12 @@ impl Settings {
         }
     }
 
-    fn key(&self, token_type: BlockchainTokenTypeV1) -> Option<String> {
+    fn key(&self, token_type: BlockchainTokenTypeV1) -> &Option<String> {
         match token_type {
-            BlockchainTokenTypeV1::Hnt => self.cluster.hnt_price_key.clone(),
-            BlockchainTokenTypeV1::Hst => self.cluster.hst_price_key.clone(),
-            BlockchainTokenTypeV1::Mobile => self.cluster.mobile_price_key.clone(),
-            BlockchainTokenTypeV1::Iot => self.cluster.iot_price_key.clone(),
+            BlockchainTokenTypeV1::Hnt => &self.cluster.hnt_price_key,
+            BlockchainTokenTypeV1::Hst => &self.cluster.hst_price_key,
+            BlockchainTokenTypeV1::Mobile => &self.cluster.mobile_price_key,
+            BlockchainTokenTypeV1::Iot => &self.cluster.iot_price_key,
         }
     }
 }


### PR DESCRIPTION
Refactored price service to have 2 modes
1.  If token key is configured, then it will get new price from solana and output on configured cadence. It will also absorb downtimes and use the stale price up to the configured duration
2. If no key is configured, but a default value is, it will output the default price on the configured cadence
3. If no key or default price is configured, the price generator will stop with a value ` Ok(())` for that token.