### PR TITLE
handle gateway info metadata struct

### DIFF
--- a/iot_verifier/src/gateway_cache.rs
+++ b/iot_verifier/src/gateway_cache.rs
@@ -23,8 +23,8 @@ pub struct GatewayCache {
 pub enum GatewayCacheError {
     #[error("gateway not found: {0}")]
     GatewayNotFound(PublicKeyBinary),
-    #[error("error querying iot config service")]
-    IotConfigClient(#[from] IotConfigClientError),
+    #[error("gateway not asserted: {0}")]
+    GatewayNotAsserted(PublicKeyBinary),
 }
 
 impl GatewayCache {
@@ -73,7 +73,13 @@ impl GatewayCache {
                         _ = self.insert(res.clone()).await;
                         Ok(res)
                     }
-                    _ => Err(GatewayCacheError::GatewayNotFound(address.clone())),
+                    Err(IotConfigClientError::GatewayNotAsserted(_)) => {
+                        Err(GatewayCacheError::GatewayNotAsserted(address.clone()))
+                    }
+                    Err(IotConfigClientError::GatewayNotFound(_)) => {
+                        Err(GatewayCacheError::GatewayNotFound(address.clone()))
+                    }
+                    Err(_) => Err(GatewayCacheError::GatewayNotFound(address.clone())),
                 }
             }
         }

--- a/iot_verifier/src/reward_share.rs
+++ b/iot_verifier/src/reward_share.rs
@@ -18,7 +18,7 @@ const DEFAULT_PREC: u32 = 15;
 lazy_static! {
     // TODO: year 1 emissions allocate 30% of total to PoC with 6% to beacons and 24% to witnesses but subsequent years back
     // total PoC percentage off 1.5% each year; determine how beacons and witnesses will split the subsequent years' allocations
-    static ref REWARDS_PER_DAY: Decimal = (Decimal::from(60_000_000_000_u64) / Decimal::from(365)) * Decimal::from(1_000_000); // 16_438_356_164_383_560
+    static ref REWARDS_PER_DAY: Decimal = (Decimal::from(60_000_000_000_u64) / Decimal::from(365)) * Decimal::from(1_000_000); // 164_383_561_643_835
     static ref BEACON_REWARDS_PER_DAY_PERCENT: Decimal = dec!(0.06);
     static ref WITNESS_REWARDS_PER_DAY_PERCENT: Decimal = dec!(0.24);
     // Data transfer is allocated 50% of daily rewards

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -335,7 +335,7 @@ impl Runner {
 
                     let valid_beacon_report = IotValidBeaconReport {
                         received_timestamp: beacon_received_ts,
-                        location: beacon_info.location,
+                        location: Some(beacon_info.location),
                         hex_scale: beacon_verify_result
                             .hex_scale
                             .ok_or(RunnerError::NotFound("invalid hex scaling factor"))?,

--- a/iot_verifier/src/tx_scaler.rs
+++ b/iot_verifier/src/tx_scaler.rs
@@ -86,10 +86,8 @@ impl Server {
             .map_err(sqlx::Error::from)?;
         let mut gw_stream = self.iot_config_client.gateway_stream().await?;
         while let Some(gateway_info) = gw_stream.next().await {
-            if let Some(h3index) = gateway_info.location {
-                if active_gateways.contains_key(&gateway_info.address.as_ref().to_vec()) {
-                    global_map.increment_unclipped(h3index)
-                }
+            if active_gateways.contains_key(&gateway_info.address.as_ref().to_vec()) {
+                global_map.increment_unclipped(gateway_info.location)
             }
         }
         global_map.reduce_global();


### PR DESCRIPTION
*** NOTE ***  this has a dep on a yet to be created proto branch which will return a gateway metadata struct containing asserted related fields.  Until that proto is available it maps the existing gateway info proto to a newly updated internal GatewayInfo struct.

With this change, when resolving gateway info for a beaconer or a witness, we only return the gateway info if it contains the expected asserted related fields.  These will be contained within an Option field of gateway info, if this is None it is assumed the gateway is not yet asserted and an appropriate error is returned.

The verifier will only proceed to verifying a beacon or witness if the asserted data is available, otherwise a verification fail is returned immediately.  