### PR TITLE
Refactor to support IotRewardShare and multiple sub reward types.  Add support for operation fund rewards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/gateway-rs.git?branch=main#e362b7537ad852c39f5c09523f4c721829c8617d"
+source = "git+https://github.com/helium/gateway-rs.git?branch=main#3ad4f7ea4d0fd2f058340ad070982ca2b2f4a883"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -2909,7 +2909,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#6edba809feafb605b59b377fa15800b4443b5508"
+source = "git+https://github.com/helium/proto?branch=master#4a5ac3f020dc18bbf075c6738375fb09c0dcd443"
 dependencies = [
  "bytes",
  "prost",

--- a/file_store/src/file_info.rs
+++ b/file_store/src/file_info.rs
@@ -115,7 +115,7 @@ pub const REWARD_MANIFEST: &str = "reward_manifest";
 pub const IOT_PACKET_REPORT: &str = "packetreport";
 pub const IOT_VALID_PACKET: &str = "iot_valid_packet";
 pub const INVALID_PACKET: &str = "invalid_packet";
-pub const GATEWAY_REWARD_SHARE: &str = "gateway_reward_share";
+pub const IOT_REWARD_SHARE: &str = "iot_reward_share";
 pub const DATA_TRANSFER_SESSION_INGEST_REPORT: &str = "data_transfer_session_ingest_report";
 pub const VALID_DATA_TRANSFER_SESSION: &str = "valid_data_transfer_session";
 pub const PRICE_REPORT: &str = "price_report";
@@ -143,7 +143,7 @@ pub enum FileType {
     IotPacketReport,
     IotValidPacket,
     InvalidPacket,
-    GatewayRewardShare,
+    IotRewardShare,
     DataTransferSessionIngestReport,
     ValidDataTransferSession,
     PriceReport,
@@ -172,7 +172,7 @@ impl fmt::Display for FileType {
             Self::IotPacketReport => IOT_PACKET_REPORT,
             Self::IotValidPacket => IOT_VALID_PACKET,
             Self::InvalidPacket => INVALID_PACKET,
-            Self::GatewayRewardShare => GATEWAY_REWARD_SHARE,
+            Self::IotRewardShare => IOT_REWARD_SHARE,
             Self::DataTransferSessionIngestReport => DATA_TRANSFER_SESSION_INGEST_REPORT,
             Self::ValidDataTransferSession => VALID_DATA_TRANSFER_SESSION,
             Self::PriceReport => PRICE_REPORT,
@@ -204,7 +204,7 @@ impl FileType {
             Self::IotPacketReport => IOT_PACKET_REPORT,
             Self::IotValidPacket => IOT_VALID_PACKET,
             Self::InvalidPacket => INVALID_PACKET,
-            Self::GatewayRewardShare => GATEWAY_REWARD_SHARE,
+            Self::IotRewardShare => IOT_REWARD_SHARE,
             Self::DataTransferSessionIngestReport => DATA_TRANSFER_SESSION_INGEST_REPORT,
             Self::ValidDataTransferSession => VALID_DATA_TRANSFER_SESSION,
             Self::PriceReport => PRICE_REPORT,
@@ -236,7 +236,7 @@ impl FromStr for FileType {
             IOT_PACKET_REPORT => Self::IotPacketReport,
             IOT_VALID_PACKET => Self::IotValidPacket,
             INVALID_PACKET => Self::InvalidPacket,
-            GATEWAY_REWARD_SHARE => Self::GatewayRewardShare,
+            IOT_REWARD_SHARE => Self::IotRewardShare,
             DATA_TRANSFER_SESSION_INGEST_REPORT => Self::DataTransferSessionIngestReport,
             VALID_DATA_TRANSFER_SESSION => Self::ValidDataTransferSession,
             PRICE_REPORT => Self::PriceReport,

--- a/iot_verifier/src/main.rs
+++ b/iot_verifier/src/main.rs
@@ -20,6 +20,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 #[derive(Debug, clap::Parser)]
 #[clap(version = env!("CARGO_PKG_VERSION"))]
 #[clap(about = "Helium POC IOT Verifier")]
+
 pub struct Cli {
     /// Optional configuration file to use. If present the toml file at the
     /// given path will be loaded. Environemnt variables can override the
@@ -93,8 +94,8 @@ impl Server {
 
         let store_base_path = std::path::Path::new(&settings.cache);
         // Gateway reward shares sink
-        let (gateway_rewards_sink, mut gateway_rewards_server) = file_sink::FileSinkBuilder::new(
-            FileType::GatewayRewardShare,
+        let (rewards_sink, mut gateway_rewards_server) = file_sink::FileSinkBuilder::new(
+            FileType::IotRewardShare,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_gateway_reward_shares"),
         )
@@ -116,7 +117,7 @@ impl Server {
 
         let rewarder = Rewarder {
             pool: pool.clone(),
-            gateway_rewards_sink,
+            rewards_sink,
             reward_manifests_sink,
             reward_period_hours: settings.rewards,
             reward_offset: settings.reward_offset_duration(),

--- a/iot_verifier/src/reward_share.rs
+++ b/iot_verifier/src/reward_share.rs
@@ -4,7 +4,7 @@ use file_store::{iot_packet::IotValidPacket, iot_valid_poc::IotPoc, traits::Time
 use futures::stream::TryStreamExt;
 use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_lora as proto;
-
+use helium_proto::services::poc_lora::iot_reward_share::Reward as ProtoReward;
 use lazy_static::lazy_static;
 use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
@@ -23,6 +23,8 @@ lazy_static! {
     static ref WITNESS_REWARDS_PER_DAY_PERCENT: Decimal = dec!(0.24);
     // Data transfer is allocated 50% of daily rewards
     static ref DATA_TRANSFER_REWARDS_PER_DAY_PERCENT: Decimal = dec!(0.50);
+    // Operations fund is allocated 7% of daily rewards
+    static ref OPERATIONS_REWARDS_PER_DAY_PERCENT: Decimal = dec!(0.07);
     // dc remainer distributed at ration of 4:1 in favour of witnesses
     // ie WITNESS_REWARDS_PER_DAY_PERCENT:BEACON_REWARDS_PER_DAY_PERCENT
     static ref WITNESS_DC_REMAINER_PERCENT: Decimal = dec!(0.80);
@@ -60,6 +62,16 @@ fn get_scheduled_dc_tokens(duration: Duration) -> Decimal {
         *REWARDS_PER_DAY * *DATA_TRANSFER_REWARDS_PER_DAY_PERCENT,
         duration,
     )
+}
+
+fn get_scheduled_ops_fund_tokens(duration: Duration) -> u64 {
+    get_tokens_by_duration(
+        *REWARDS_PER_DAY * *OPERATIONS_REWARDS_PER_DAY_PERCENT,
+        duration,
+    )
+    .round_dp_with_strategy(0, RoundingStrategy::ToZero)
+    .to_u64()
+    .unwrap_or(0)
 }
 
 #[derive(sqlx::FromRow)]
@@ -295,7 +307,7 @@ impl GatewayShares {
         self,
         reward_period: &'_ Range<DateTime<Utc>>,
         iot_price: Decimal,
-    ) -> impl Iterator<Item = proto::GatewayRewardShare> + '_ {
+    ) -> impl Iterator<Item = proto::IotRewardShare> + '_ {
         // the total number of shares for beacons, witnesses and data transfer
         // dc shares here is the sum of all spent data transfer DC this epoch
         let (total_beacon_shares, total_witness_shares, total_dc_shares) = self.total_shares();
@@ -330,30 +342,52 @@ impl GatewayShares {
         // compute the awards per hotspot
         self.shares
             .into_iter()
-            .map(
-                move |(hotspot_key, reward_shares)| proto::GatewayRewardShare {
-                    hotspot_key: hotspot_key.into(),
-                    beacon_amount: compute_rewards(
-                        beacon_rewards_per_share,
-                        reward_shares.beacon_shares,
-                    ),
-                    witness_amount: compute_rewards(
-                        witness_rewards_per_share,
-                        reward_shares.witness_shares,
-                    ),
-                    dc_transfer_amount: compute_rewards(
-                        dc_transfer_rewards_per_share,
-                        reward_shares.dc_shares,
-                    ),
-                    start_period: reward_period.start.encode_timestamp(),
-                    end_period: reward_period.end.encode_timestamp(),
-                },
-            )
+            .map(move |(hotspot_key, reward_shares)| proto::GatewayReward {
+                hotspot_key: hotspot_key.into(),
+                beacon_amount: compute_rewards(
+                    beacon_rewards_per_share,
+                    reward_shares.beacon_shares,
+                ),
+                witness_amount: compute_rewards(
+                    witness_rewards_per_share,
+                    reward_shares.witness_shares,
+                ),
+                dc_transfer_amount: compute_rewards(
+                    dc_transfer_rewards_per_share,
+                    reward_shares.dc_shares,
+                ),
+            })
             .filter(|reward_share| {
                 reward_share.beacon_amount > 0
                     || reward_share.witness_amount > 0
                     || reward_share.dc_transfer_amount > 0
             })
+            .map(|gateway_reward| proto::IotRewardShare {
+                start_period: reward_period.start.encode_timestamp(),
+                end_period: reward_period.end.encode_timestamp(),
+                reward: Some(ProtoReward::GatewayReward(gateway_reward)),
+            })
+    }
+}
+
+#[derive(Default)]
+pub struct OperationalRewards {
+    pub rewards: Vec<proto::IotRewardShare>,
+}
+
+impl OperationalRewards {
+    pub fn compute(reward_period: &Range<DateTime<Utc>>) -> Self {
+        let mut operational_rewards = Self::default();
+        let op_fund_reward = proto::OperationalReward {
+            amount: get_scheduled_ops_fund_tokens(reward_period.end - reward_period.start),
+        };
+        let op_fund_share = proto::IotRewardShare {
+            start_period: reward_period.start.encode_timestamp(),
+            end_period: reward_period.end.encode_timestamp(),
+            reward: Some(ProtoReward::OperationalReward(op_fund_reward))
+        };
+        operational_rewards.rewards.push(op_fund_share);
+        operational_rewards
     }
 }
 
@@ -422,6 +456,16 @@ mod test {
             dc_shares: dc_shares
                 .round_dp_with_strategy(DEFAULT_PREC, RoundingStrategy::MidpointNearestEven),
         }
+    }
+
+    #[test]
+    fn test_non_gateway_reward_shares() {
+        let epoch_duration = Duration::hours(1);
+        let total_tokens_for_period = *REWARDS_PER_DAY / dec!(24);
+        println!("total_tokens_for_period: {total_tokens_for_period}");
+
+        let operation_tokens_for_period = get_scheduled_ops_fund_tokens(epoch_duration);
+        assert_eq!(479452054794, operation_tokens_for_period);
     }
 
     #[test]
@@ -499,21 +543,20 @@ mod test {
             gw6.clone(),
             reward_shares_in_dec(dec!(150), dec!(350), gw6_dc_spend),
         ); // 0.0150, 0.0350
-        let gw_shares = GatewayShares { shares };
 
-        let rewards: HashMap<PublicKeyBinary, proto::GatewayRewardShare> = gw_shares
+        let gw_shares = GatewayShares { shares };
+        let mut rewards: HashMap<PublicKeyBinary, proto::GatewayReward> = HashMap::new();
+        let gw_reward_shares: Vec<proto::IotRewardShare> = gw_shares
             .into_gateway_reward_shares(&reward_period, iot_price)
-            .map(|reward| {
-                (
-                    reward
-                        .hotspot_key
-                        .clone()
-                        .try_into()
-                        .expect("failed to decode hotspot_key"),
-                    reward,
-                )
-            })
             .collect();
+        for reward in gw_reward_shares {
+            if let Some(ProtoReward::GatewayReward(gateway_reward)) = reward.reward {
+                rewards.insert(
+                    gateway_reward.hotspot_key.clone().try_into().unwrap(),
+                    gateway_reward,
+                );
+            }
+        }
 
         let gw1_rewards = rewards
             .get(&gw1)
@@ -679,21 +722,20 @@ mod test {
             gw6.clone(),
             reward_shares_in_dec(dec!(150), dec!(350), total_dc_to_spend * dec!(0.8)),
         ); // 0.0150, 0.0350
-        let gw_shares = GatewayShares { shares };
 
-        let rewards: HashMap<PublicKeyBinary, proto::GatewayRewardShare> = gw_shares
+        let gw_shares = GatewayShares { shares };
+        let mut rewards: HashMap<PublicKeyBinary, proto::GatewayReward> = HashMap::new();
+        let gw_reward_shares: Vec<proto::IotRewardShare> = gw_shares
             .into_gateway_reward_shares(&reward_period, iot_price)
-            .map(|reward| {
-                (
-                    reward
-                        .hotspot_key
-                        .clone()
-                        .try_into()
-                        .expect("failed to decode hotspot_key"),
-                    reward,
-                )
-            })
             .collect();
+        for reward in gw_reward_shares {
+            if let Some(ProtoReward::GatewayReward(gateway_reward)) = reward.reward {
+                rewards.insert(
+                    gateway_reward.hotspot_key.clone().try_into().unwrap(),
+                    gateway_reward,
+                );
+            }
+        }
 
         let gw1_rewards = rewards
             .get(&gw1)
@@ -840,21 +882,20 @@ mod test {
             gw6.clone(),
             reward_shares_in_dec(dec!(150), dec!(350), total_dc_to_spend * dec!(0.2)),
         ); // 0.0150, 0.0350
-        let gw_shares = GatewayShares { shares };
 
-        let rewards: HashMap<PublicKeyBinary, proto::GatewayRewardShare> = gw_shares
+        let gw_shares = GatewayShares { shares };
+        let mut rewards: HashMap<PublicKeyBinary, proto::GatewayReward> = HashMap::new();
+        let gw_reward_shares: Vec<proto::IotRewardShare> = gw_shares
             .into_gateway_reward_shares(&reward_period, iot_price)
-            .map(|reward| {
-                (
-                    reward
-                        .hotspot_key
-                        .clone()
-                        .try_into()
-                        .expect("failed to decode hotspot_key"),
-                    reward,
-                )
-            })
             .collect();
+        for reward in gw_reward_shares {
+            if let Some(ProtoReward::GatewayReward(gateway_reward)) = reward.reward {
+                rewards.insert(
+                    gateway_reward.hotspot_key.clone().try_into().unwrap(),
+                    gateway_reward,
+                );
+            }
+        }
 
         let gw1_rewards = rewards
             .get(&gw1)

--- a/iot_verifier/src/reward_share.rs
+++ b/iot_verifier/src/reward_share.rs
@@ -370,24 +370,18 @@ impl GatewayShares {
     }
 }
 
-#[derive(Default)]
-pub struct OperationalRewards {
-    pub rewards: Vec<proto::IotRewardShare>,
-}
+pub mod operational_rewards {
+    use super::*;
 
-impl OperationalRewards {
-    pub fn compute(reward_period: &Range<DateTime<Utc>>) -> Self {
-        let mut operational_rewards = Self::default();
+    pub fn compute(reward_period: &Range<DateTime<Utc>>) -> proto::IotRewardShare {
         let op_fund_reward = proto::OperationalReward {
             amount: get_scheduled_ops_fund_tokens(reward_period.end - reward_period.start),
         };
-        let op_fund_share = proto::IotRewardShare {
+        proto::IotRewardShare {
             start_period: reward_period.start.encode_timestamp(),
             end_period: reward_period.end.encode_timestamp(),
             reward: Some(ProtoReward::OperationalReward(op_fund_reward)),
-        };
-        operational_rewards.rewards.push(op_fund_share);
-        operational_rewards
+        }
     }
 }
 

--- a/iot_verifier/src/reward_share.rs
+++ b/iot_verifier/src/reward_share.rs
@@ -303,7 +303,7 @@ impl GatewayShares {
         Ok(())
     }
 
-    pub fn into_gateway_reward_shares(
+    pub fn into_iot_reward_shares(
         self,
         reward_period: &'_ Range<DateTime<Utc>>,
         iot_price: Decimal,
@@ -547,7 +547,7 @@ mod test {
         let gw_shares = GatewayShares { shares };
         let mut rewards: HashMap<PublicKeyBinary, proto::GatewayReward> = HashMap::new();
         let gw_reward_shares: Vec<proto::IotRewardShare> = gw_shares
-            .into_gateway_reward_shares(&reward_period, iot_price)
+            .into_iot_reward_shares(&reward_period, iot_price)
             .collect();
         for reward in gw_reward_shares {
             if let Some(ProtoReward::GatewayReward(gateway_reward)) = reward.reward {
@@ -726,7 +726,7 @@ mod test {
         let gw_shares = GatewayShares { shares };
         let mut rewards: HashMap<PublicKeyBinary, proto::GatewayReward> = HashMap::new();
         let gw_reward_shares: Vec<proto::IotRewardShare> = gw_shares
-            .into_gateway_reward_shares(&reward_period, iot_price)
+            .into_iot_reward_shares(&reward_period, iot_price)
             .collect();
         for reward in gw_reward_shares {
             if let Some(ProtoReward::GatewayReward(gateway_reward)) = reward.reward {
@@ -886,7 +886,7 @@ mod test {
         let gw_shares = GatewayShares { shares };
         let mut rewards: HashMap<PublicKeyBinary, proto::GatewayReward> = HashMap::new();
         let gw_reward_shares: Vec<proto::IotRewardShare> = gw_shares
-            .into_gateway_reward_shares(&reward_period, iot_price)
+            .into_iot_reward_shares(&reward_period, iot_price)
             .collect();
         for reward in gw_reward_shares {
             if let Some(ProtoReward::GatewayReward(gateway_reward)) = reward.reward {

--- a/iot_verifier/src/reward_share.rs
+++ b/iot_verifier/src/reward_share.rs
@@ -384,7 +384,7 @@ impl OperationalRewards {
         let op_fund_share = proto::IotRewardShare {
             start_period: reward_period.start.encode_timestamp(),
             end_period: reward_period.end.encode_timestamp(),
-            reward: Some(ProtoReward::OperationalReward(op_fund_reward))
+            reward: Some(ProtoReward::OperationalReward(op_fund_reward)),
         };
         operational_rewards.rewards.push(op_fund_share);
         operational_rewards

--- a/iot_verifier/src/rewarder.rs
+++ b/iot_verifier/src/rewarder.rs
@@ -73,7 +73,7 @@ impl Rewarder {
         let operational_rewards = OperationalRewards::compute(&scheduler.reward_period);
 
         for reward_share in
-            gateway_reward_shares.into_gateway_reward_shares(&scheduler.reward_period, iot_price)
+            gateway_reward_shares.into_iot_reward_shares(&scheduler.reward_period, iot_price)
         {
             self.rewards_sink
                 .write(reward_share, [])

--- a/iot_verifier/src/rewarder.rs
+++ b/iot_verifier/src/rewarder.rs
@@ -1,4 +1,7 @@
-use crate::{reward_share::operational_rewards, reward_share::GatewayShares, scheduler::Scheduler};
+use crate::{
+    reward_share::{operational_rewards, GatewayShares},
+    scheduler::Scheduler,
+};
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use db_store::meta;
 use file_store::{file_sink, traits::TimestampEncode};

--- a/reward_index/migrations/5_add_type_to_index.sql
+++ b/reward_index/migrations/5_add_type_to_index.sql
@@ -1,3 +1,3 @@
-CREATE TYPE reward_type as enum('mobile', 'iot_gateway', 'iot_operational');
+CREATE TYPE reward_type as enum('mobile_gateway', 'iot_gateway', 'iot_operational');
 
 ALTER TABLE reward_index ADD reward_type reward_type;

--- a/reward_index/migrations/5_add_type_to_index.sql
+++ b/reward_index/migrations/5_add_type_to_index.sql
@@ -1,0 +1,1 @@
+ALTER TABLE reward_index ADD reward_type text;

--- a/reward_index/migrations/5_add_type_to_index.sql
+++ b/reward_index/migrations/5_add_type_to_index.sql
@@ -1,1 +1,3 @@
-ALTER TABLE reward_index ADD reward_type text;
+CREATE TYPE reward_type as enum('mobile', 'iot_gateway', 'iot_operational');
+
+ALTER TABLE reward_index ADD reward_type reward_type;

--- a/reward_index/src/indexer.rs
+++ b/reward_index/src/indexer.rs
@@ -10,7 +10,6 @@ use helium_proto::{
 };
 use poc_metrics::record_duration;
 use sqlx::{Pool, Postgres, Transaction};
-use std::fmt;
 use std::{collections::HashMap, str::FromStr};
 use tokio::sync::mpsc::Receiver;
 
@@ -21,21 +20,12 @@ pub struct Indexer {
     op_fund_key: Vec<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(sqlx::Type, Debug, Clone, PartialEq, Eq, Hash)]
+#[sqlx(type_name = "reward_type", rename_all = "snake_case")]
 pub enum RewardType {
     Mobile,
     IotGateway,
     IotOperational,
-}
-
-impl fmt::Display for RewardType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Mobile => f.write_str("mobile"),
-            Self::IotGateway => f.write_str("iot_gateway"),
-            Self::IotOperational => f.write_str("iot_operational"),
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -118,7 +108,7 @@ impl Indexer {
                 &mut *txn,
                 &reward_key.key,
                 amount,
-                reward_key.reward_type.to_string(),
+                reward_key.reward_type,
                 &manifest_time,
             )
             .await?;

--- a/reward_index/src/indexer.rs
+++ b/reward_index/src/indexer.rs
@@ -23,7 +23,7 @@ pub struct Indexer {
 #[derive(sqlx::Type, Debug, Clone, PartialEq, Eq, Hash)]
 #[sqlx(type_name = "reward_type", rename_all = "snake_case")]
 pub enum RewardType {
-    Mobile,
+    MobileGateway,
     IotGateway,
     IotOperational,
 }
@@ -123,7 +123,7 @@ impl Indexer {
                 let share = RadioRewardShare::decode(msg)?;
                 let key = RewardKey {
                     key: share.hotspot_key,
-                    reward_type: RewardType::Mobile,
+                    reward_type: RewardType::MobileGateway,
                 };
                 Ok((key, share.amount))
             }

--- a/reward_index/src/indexer.rs
+++ b/reward_index/src/indexer.rs
@@ -1,5 +1,5 @@
 use crate::{reward_index, settings, Settings};
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use file_store::{
     file_info_poller::FileInfoStream, reward_manifest::RewardManifest, FileInfo, FileStore,
 };
@@ -50,7 +50,12 @@ impl Indexer {
             mode: settings.mode,
             verifier_store: FileStore::from_settings(&settings.verifier).await?,
             pool,
-            op_fund_key: settings.operation_fund_key(),
+            op_fund_key: match settings.mode {
+                settings::Mode::Iot => settings
+                    .operation_fund_key()
+                    .ok_or_else(|| anyhow!("operation fund key is required for IOT mode"))?,
+                settings::Mode::Mobile => vec![],
+            },
         })
     }
 

--- a/reward_index/src/reward_index.rs
+++ b/reward_index/src/reward_index.rs
@@ -1,9 +1,8 @@
 use chrono::{DateTime, Utc};
-use helium_crypto::PublicKey;
 
 pub async fn insert<'c, E>(
     executor: E,
-    address: &PublicKey,
+    address: &Vec<u8>,
     amount: u64,
     timestamp: &DateTime<Utc>,
 ) -> Result<(), sqlx::Error>
@@ -18,8 +17,8 @@ where
     sqlx::query(
         r#"
         insert into reward_index (
-                address, 
-                rewards, 
+                address,
+                rewards,
                 last_reward
             ) values ($1, $2, $3)
             on conflict(address) do update set

--- a/reward_index/src/reward_index.rs
+++ b/reward_index/src/reward_index.rs
@@ -4,6 +4,7 @@ pub async fn insert<'c, E>(
     executor: E,
     address: &Vec<u8>,
     amount: u64,
+    reward_type: String,
     timestamp: &DateTime<Utc>,
 ) -> Result<(), sqlx::Error>
 where
@@ -20,7 +21,8 @@ where
                 address,
                 rewards,
                 last_reward
-            ) values ($1, $2, $3)
+                reward_type
+            ) values ($1, $2, $3, $4)
             on conflict(address) do update set
                 rewards = reward_index.rewards + EXCLUDED.rewards,
                 last_reward = EXCLUDED.last_reward
@@ -29,6 +31,7 @@ where
     .bind(address)
     .bind(amount as i64)
     .bind(timestamp)
+    .bind(reward_type)
     .execute(executor)
     .await?;
 

--- a/reward_index/src/reward_index.rs
+++ b/reward_index/src/reward_index.rs
@@ -1,10 +1,11 @@
+use crate::indexer::RewardType;
 use chrono::{DateTime, Utc};
 
 pub async fn insert<'c, E>(
     executor: E,
     address: &Vec<u8>,
     amount: u64,
-    reward_type: String,
+    reward_type: RewardType,
     timestamp: &DateTime<Utc>,
 ) -> Result<(), sqlx::Error>
 where

--- a/reward_index/src/reward_index.rs
+++ b/reward_index/src/reward_index.rs
@@ -21,7 +21,7 @@ where
         insert into reward_index (
                 address,
                 rewards,
-                last_reward
+                last_reward,
                 reward_type
             ) values ($1, $2, $3, $4)
             on conflict(address) do update set

--- a/reward_index/src/settings.rs
+++ b/reward_index/src/settings.rs
@@ -35,7 +35,7 @@ pub struct Settings {
     pub database: db_store::Settings,
     pub verifier: file_store::Settings,
     pub metrics: poc_metrics::Settings,
-    pub operation_fund_key: String,
+    pub operation_fund_key: Option<String>,
 }
 
 pub fn default_log() -> String {
@@ -69,8 +69,10 @@ impl Settings {
         Duration::seconds(self.interval)
     }
 
-    pub fn operation_fund_key(&self) -> Vec<u8> {
-        self.operation_fund_key.clone().into_bytes()
+    pub fn operation_fund_key(&self) -> Option<Vec<u8>> {
+        self.operation_fund_key
+            .clone()
+            .map(|string| string.into_bytes())
     }
 }
 

--- a/reward_index/src/settings.rs
+++ b/reward_index/src/settings.rs
@@ -35,6 +35,7 @@ pub struct Settings {
     pub database: db_store::Settings,
     pub verifier: file_store::Settings,
     pub metrics: poc_metrics::Settings,
+    pub operation_fund_key: String,
 }
 
 pub fn default_log() -> String {
@@ -66,6 +67,10 @@ impl Settings {
 
     pub fn interval(&self) -> Duration {
         Duration::seconds(self.interval)
+    }
+
+    pub fn operation_fund_key(&self) -> Vec<u8> {
+        self.operation_fund_key.clone().into_bytes()
     }
 }
 


### PR DESCRIPTION
Depends on proto branch: https://github.com/helium/proto

Refactor to replace GatewayRewardShare with IotRewardShare.  IotRewardShare now supports multiple reward types each with their own data requirements.

Adds output of operational fund rewards


