### PR TITLE
handle unknown lora region in config service gateway api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,41 +983,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
-dependencies = [
- "async-trait",
- "axum-core 0.2.9",
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa 1.0.4",
- "matchit 0.5.0",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678c5130a507ae3a7c797f9a17393c14849300b8440eac47cdb90a5bdcb3a543"
 dependencies = [
  "async-trait",
- "axum-core 0.3.2",
+ "axum-core",
  "bitflags",
  "bytes",
  "futures-util",
@@ -1026,7 +997,7 @@ dependencies = [
  "http-body",
  "hyper",
  "itoa 1.0.4",
- "matchit 0.7.0",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1040,22 +1011,6 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
  "tower-layer",
  "tower-service",
 ]
@@ -1150,7 +1105,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/gateway-rs.git?branch=main#37abbf2033562ee932b690b123d7319f49e49948"
+source = "git+https://github.com/helium/gateway-rs.git?branch=main#e362b7537ad852c39f5c09523f4c721829c8617d"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -3003,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#67a0dfe91e15b415b496e3bf5f2a119a888a4064"
+source = "git+https://github.com/helium/proto?branch=master#6edba809feafb605b59b377fa15800b4443b5508"
 dependencies = [
  "bytes",
  "prost",
@@ -3805,12 +3760,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "matchit"
@@ -4661,7 +4610,7 @@ name = "poc-entropy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum 0.6.3",
+ "axum",
  "base64 0.21.0",
  "blake3",
  "bs58 0.4.0",
@@ -7220,13 +7169,13 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b9af819e54b8f33d453655bef9b9acc171568fb49523078d0cc4e7484200ec"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.5.17",
+ "axum",
  "base64 0.13.1",
  "bytes",
  "futures-core",

--- a/iot_config/src/admin_service.rs
+++ b/iot_config/src/admin_service.rs
@@ -127,7 +127,16 @@ impl iot_config::Admin for AdminService {
         let request = request.into_inner();
         self.verify_request_signature(&request).await?;
 
-        let region = request.region();
+        let region = Region::from_i32(request.region).ok_or(Status::invalid_argument(format!(
+            "invalid lora region {}",
+            request.region
+        )))?;
+
+        if region == Region::Unknown {
+            return Err(Status::invalid_argument(
+                "unable to override the 'UKNOWN' region",
+            ));
+        }
 
         let params = match request.params {
             Some(params) => params,

--- a/iot_config/src/gateway_service.rs
+++ b/iot_config/src/gateway_service.rs
@@ -9,7 +9,7 @@ use helium_proto::{
         GatewayLocationReqV1, GatewayLocationResV1, GatewayRegionParamsReqV1,
         GatewayRegionParamsResV1,
     },
-    Message,
+    Message, Region,
 };
 use hextree::Cell;
 use node_follower::{
@@ -84,7 +84,9 @@ impl iot_config::Gateway for GatewayService {
         let pubkey: &PublicKeyBinary = &pubkey.into();
         tracing::debug!(pubkey = pubkey.to_string(), "fetching region params");
 
-        let default_region = request.region();
+        let default_region = Region::from_i32(request.region).ok_or(Status::invalid_argument(
+            format!("invalid lora region {}", request.region),
+        ))?;
 
         let (region, gain) = match self
             .follower_service

--- a/iot_config/src/region_map.rs
+++ b/iot_config/src/region_map.rs
@@ -110,6 +110,14 @@ pub async fn build_params_map(
         let params = BlockchainRegionParamsV1::decode(region_row.params.as_slice())?;
         params_map.insert(region, params);
     }
+
+    // insert the Unknown region with Empty params
+    params_map.insert(
+        Region::Unknown,
+        BlockchainRegionParamsV1 {
+            region_params: vec![],
+        },
+    );
     Ok(params_map)
 }
 


### PR DESCRIPTION
This change is needed to handle gateways requesting region params when they do not have a valid or known default/fallback region set in their local settings.toml files when they make a request to the config service to get the current transmit parameters for their region.

The lookup/response from the config service will be prioritized as follows:
- If the gateway's pubkey/address is found on the current chain with an asserted location, that location will be mapped to a region and from there to region parameters and both will be returned to the gateway
- If the gateway supplies a valid lora region as its fallback and no gateway is found on-chain or the gateway is found to be not asserted the parameters for the fallback region supplied in the request will be returned to the gateway, along with the fallback region
- If the gateway's fallback region is not set or explicitly set to the new "Unknown" region, and no asserted region can be found, the "Unknown" region will be returned along with an *empty* parameters list

This change also changes the behavior of the API if the fallback region argument supplied in the gateway's request is not found to be a valid region. Where previously this would be converted to the enum default (first enum variant, us915) now it will return an "invalid argument" error to the client. For the purposes of this validation, the "unknown" region _is_ considered a valid region.