### PR TITLE
fix double-encoding-to-vec on crypto signing responses

### DIFF
--- a/iot_config/src/admin_service.rs
+++ b/iot_config/src/admin_service.rs
@@ -136,7 +136,7 @@ impl iot_config::Admin for AdminService {
             signer,
             signature: vec![],
         };
-        resp.signature = self.sign_response(&resp.encode_to_vec())?;
+        resp.signature = self.sign_response(&resp)?;
 
         Ok(Response::new(resp))
     }
@@ -173,7 +173,7 @@ impl iot_config::Admin for AdminService {
             signer,
             signature: vec![],
         };
-        resp.signature = self.sign_response(&resp.encode_to_vec())?;
+        resp.signature = self.sign_response(&resp)?;
 
         Ok(Response::new(resp))
     }
@@ -236,7 +236,7 @@ impl iot_config::Admin for AdminService {
             signer,
             signature: vec![],
         };
-        resp.signature = self.sign_response(&resp.encode_to_vec())?;
+        resp.signature = self.sign_response(&resp)?;
 
         Ok(Response::new(resp))
     }
@@ -263,7 +263,7 @@ impl iot_config::Admin for AdminService {
             signature: vec![],
             timestamp,
         };
-        resp.signature = self.sign_response(&resp.encode_to_vec())?;
+        resp.signature = self.sign_response(&resp)?;
         tracing::debug!(region = region.to_string(), "returning region params");
         Ok(Response::new(resp))
     }

--- a/iot_config/src/gateway_service.rs
+++ b/iot_config/src/gateway_service.rs
@@ -212,7 +212,7 @@ impl iot_config::Gateway for GatewayService {
             signer: self.signing_key.public_key().into(),
             signature: vec![],
         };
-        resp.signature = self.sign_response(&resp.encode_to_vec())?;
+        resp.signature = self.sign_response(&resp)?;
 
         Ok(Response::new(resp))
     }

--- a/iot_config/src/session_key_service.rs
+++ b/iot_config/src/session_key_service.rs
@@ -282,7 +282,7 @@ impl iot_config::SessionKeyFilter for SessionKeyFilterService {
             signer: self.signing_key.public_key().into(),
             signature: vec![],
         };
-        resp.signature = self.sign_response(&resp.encode_to_vec())?;
+        resp.signature = self.sign_response(&resp)?;
         Ok(Response::new(resp))
     }
 


### PR DESCRIPTION
corrects a bug where we're calling `encode_to_vec` on messages to sign and then passing _that_ encoded response to a service impl method that does the same encoding again, thereby double-encoding the response before sending