### PR TITLE
add iot-config metrics

### DIFF
--- a/iot_config/src/gateway_service.rs
+++ b/iot_config/src/gateway_service.rs
@@ -2,7 +2,7 @@ use crate::{
     admin::AuthCache,
     gateway_info::{self, GatewayInfo},
     region_map::RegionMapReader,
-    verify_public_key, GrpcResult, GrpcStreamResult, Settings,
+    telemetry, verify_public_key, GrpcResult, GrpcStreamResult, Settings,
 };
 use anyhow::Result;
 use chrono::Utc;
@@ -68,6 +68,7 @@ impl iot_config::Gateway for GatewayService {
         request: Request<GatewayLocationReqV1>,
     ) -> GrpcResult<GatewayLocationResV1> {
         let request = request.into_inner();
+        telemetry::count_request("gateway", "location");
 
         let signer = verify_public_key(&request.signer)?;
         self.verify_request_signature(&signer, &request)?;
@@ -112,6 +113,7 @@ impl iot_config::Gateway for GatewayService {
         request: Request<GatewayRegionParamsReqV1>,
     ) -> GrpcResult<GatewayRegionParamsResV1> {
         let request = request.into_inner();
+        telemetry::count_request("gateway", "region-params");
 
         let pubkey = verify_public_key(&request.address)?;
         request
@@ -180,6 +182,7 @@ impl iot_config::Gateway for GatewayService {
             signature: vec![],
         };
         resp.signature = self.sign_response(&resp.encode_to_vec())?;
+        telemetry::count_region_lookup(default_region, region);
         tracing::debug!(
             pubkey = address.to_string(),
             region = region.to_string(),
@@ -190,6 +193,7 @@ impl iot_config::Gateway for GatewayService {
 
     async fn info(&self, request: Request<GatewayInfoReqV1>) -> GrpcResult<GatewayInfoResV1> {
         let request = request.into_inner();
+        telemetry::count_request("gateway", "info");
 
         let signer = verify_public_key(&request.signer)?;
         self.verify_request_signature(&signer, &request)?;
@@ -220,6 +224,7 @@ impl iot_config::Gateway for GatewayService {
         request: Request<GatewayInfoStreamReqV1>,
     ) -> GrpcResult<Self::info_streamStream> {
         let request = request.into_inner();
+        telemetry::count_request("gateway", "info-stream");
 
         let signer = verify_public_key(&request.signer)?;
         self.verify_request_signature(&signer, &request)?;

--- a/iot_config/src/lib.rs
+++ b/iot_config/src/lib.rs
@@ -12,6 +12,7 @@ pub mod route_service;
 pub mod session_key;
 pub mod session_key_service;
 pub mod settings;
+pub mod telemetry;
 
 pub use admin_service::AdminService;
 pub use client::{Client, Settings as ClientSettings};

--- a/iot_config/src/org_service.rs
+++ b/iot_config/src/org_service.rs
@@ -2,7 +2,7 @@ use crate::{
     admin::{AuthCache, KeyType},
     lora_field, org,
     route::list_routes,
-    verify_public_key, GrpcResult, Settings, HELIUM_NET_ID,
+    telemetry, verify_public_key, GrpcResult, Settings, HELIUM_NET_ID,
 };
 use anyhow::Result;
 use chrono::Utc;
@@ -76,6 +76,8 @@ impl OrgService {
 #[tonic::async_trait]
 impl iot_config::Org for OrgService {
     async fn list(&self, _request: Request<OrgListReqV1>) -> GrpcResult<OrgListResV1> {
+        telemetry::count_request("org", "list");
+
         let proto_orgs: Vec<OrgV1> = org::list(&self.pool)
             .await
             .map_err(|_| Status::internal("org list failed"))?
@@ -96,6 +98,7 @@ impl iot_config::Org for OrgService {
 
     async fn get(&self, request: Request<OrgGetReqV1>) -> GrpcResult<OrgResV1> {
         let request = request.into_inner();
+        telemetry::count_request("org", "get");
 
         let org = org::get_with_constraints(request.oui, &self.pool)
             .await
@@ -134,6 +137,7 @@ impl iot_config::Org for OrgService {
 
     async fn create_helium(&self, request: Request<OrgCreateHeliumReqV1>) -> GrpcResult<OrgResV1> {
         let request = request.into_inner();
+        telemetry::count_request("org", "create-helium");
 
         let signer = verify_public_key(&request.signer)?;
         self.verify_admin_request_signature(&signer, &request)?;
@@ -204,6 +208,7 @@ impl iot_config::Org for OrgService {
 
     async fn create_roamer(&self, request: Request<OrgCreateRoamerReqV1>) -> GrpcResult<OrgResV1> {
         let request = request.into_inner();
+        telemetry::count_request("org", "create-roamer");
 
         let signer = verify_public_key(&request.signer)?;
         self.verify_admin_request_signature(&signer, &request)?;
@@ -269,6 +274,7 @@ impl iot_config::Org for OrgService {
 
     async fn disable(&self, request: Request<OrgDisableReqV1>) -> GrpcResult<OrgDisableResV1> {
         let request = request.into_inner();
+        telemetry::count_request("org", "disable");
 
         let signer = verify_public_key(&request.signer)?;
         self.verify_request_signature(&signer, &request)?;
@@ -334,6 +340,7 @@ impl iot_config::Org for OrgService {
 
     async fn enable(&self, request: Request<OrgEnableReqV1>) -> GrpcResult<OrgEnableResV1> {
         let request = request.into_inner();
+        telemetry::count_request("org", "enable");
 
         let signer = verify_public_key(&request.signer)?;
         self.verify_request_signature(&signer, &request)?;

--- a/iot_config/src/telemetry.rs
+++ b/iot_config/src/telemetry.rs
@@ -1,0 +1,53 @@
+const RPC_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "grpc-request");
+const STREAM_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "grpc-stream");
+const REGION_HEX_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "region-hexes");
+const REGION_LOOKUP_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "region-lookup");
+const SKF_ADD_COUNT_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "skfs-added");
+const SKF_REMOVE_COUNT_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "skfs-removed");
+const EUI_ADD_COUNT_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "euis-added");
+const EUI_REMOVE_COUNT_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "euis-removed");
+const DEVADDR_ADD_COUNT_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "devaddrs-added");
+const DEVADDR_REMOVE_COUNT_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "devaddrs-removed");
+
+pub fn count_request(service: &'static str, rpc: &'static str) {
+    metrics::increment_counter!(RPC_METRIC, "service" => service, "rpc" => rpc);
+}
+
+pub fn gauge_hexes(cells: usize) {
+    metrics::gauge!(REGION_HEX_METRIC, cells as f64);
+}
+
+pub fn count_region_lookup(
+    default_region: helium_proto::Region,
+    reported_region: helium_proto::Region,
+) {
+    metrics::increment_counter!(
+        REGION_LOOKUP_METRIC,
+        // per metrics docs, &str should be preferred for performance; should the regions be
+        // mapped through a match of region => &'static str of the name?
+        "default_region" => default_region.to_string(), "reported_region" => reported_region.to_string()
+    );
+}
+
+pub fn count_skf_updates(adds: usize, removes: usize) {
+    metrics::counter!(SKF_ADD_COUNT_METRIC, adds as u64);
+    metrics::counter!(SKF_REMOVE_COUNT_METRIC, removes as u64);
+}
+
+pub fn count_eui_updates(adds: usize, removes: usize) {
+    metrics::counter!(EUI_ADD_COUNT_METRIC, adds as u64);
+    metrics::counter!(EUI_REMOVE_COUNT_METRIC, removes as u64);
+}
+
+pub fn count_devaddr_updates(adds: usize, removes: usize) {
+    metrics::counter!(DEVADDR_ADD_COUNT_METRIC, adds as u64);
+    metrics::counter!(DEVADDR_REMOVE_COUNT_METRIC, removes as u64);
+}
+
+pub fn stream_subscribe(stream: &'static str) {
+    metrics::increment_gauge!(STREAM_METRIC, 1.0, "stream" => stream);
+}
+
+pub fn stream_unsubscribe(stream: &'static str) {
+    metrics::decrement_gauge!(STREAM_METRIC, 1.0, "stream" => stream);
+}


### PR DESCRIPTION
Adds metrics collection to the iot-config service:
- increments a counter for every grpc request received labeled by the service and rpc for grouping queries
- updates counters for the high-volume streaming routing record updates (eui pair, devaddr ranges, and session key filters)
- sets a gauge counting the number of hex cells in the global location-to-region  hextree map
- increments a counter on gateway region params lookup responses, labeled by the default region argument and the region found on lookup