### PR TITLE
shrink region cache ttl

### DIFF
--- a/iot_verifier/src/region_cache.rs
+++ b/iot_verifier/src/region_cache.rs
@@ -6,7 +6,7 @@ use iot_config::client::{
 use retainer::Cache;
 use std::time::Duration;
 
-const CACHE_TTL: u64 = 86400;
+const CACHE_TTL: u64 = 10_800;
 
 pub struct RegionCache {
     pub iot_config_client: IotConfigClient,


### PR DESCRIPTION
lowering the ttl for the region cache in the iot-verifier to continue to cache region changes (reduce frequent network roundtrips to the config service) while minimizing the impact from region changes which, while happen infrequently, impact 10s-100s of thousands of hotspots at a time when they do occur