### PR TITLE
Use jemalloc for long-running, high-churn services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3281,6 +3281,7 @@ dependencies = [
  "hextree",
  "http",
  "http-serde",
+ "jemallocator",
  "libflate",
  "metrics",
  "metrics-exporter-prometheus",
@@ -3316,6 +3317,7 @@ dependencies = [
  "helium-proto",
  "http",
  "http-serde",
+ "jemallocator",
  "metrics",
  "poc-metrics",
  "prost",
@@ -3357,6 +3359,7 @@ dependencies = [
  "humantime",
  "iot-config",
  "itertools",
+ "jemallocator",
  "lazy_static",
  "metrics",
  "once_cell",
@@ -3407,6 +3410,26 @@ name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.3+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9bd5d616ea7ed58b571b2e209a65759664d7fb021a0819d7a790afc67e47ca1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "jobserver"
@@ -3868,6 +3891,7 @@ dependencies = [
  "hextree",
  "http",
  "http-serde",
+ "jemallocator",
  "metrics",
  "metrics-exporter-prometheus",
  "poc-metrics",
@@ -3902,6 +3926,7 @@ dependencies = [
  "helium-proto",
  "http",
  "http-serde",
+ "jemallocator",
  "metrics",
  "mobile-config",
  "poc-metrics",
@@ -3975,6 +4000,7 @@ dependencies = [
  "helium-proto",
  "http-serde",
  "humantime",
+ "jemallocator",
  "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
@@ -5893,7 +5919,7 @@ dependencies = [
  "helium-sub-daos",
  "metrics",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "solana-client",
  "solana-program",
  "solana-sdk",
@@ -7414,7 +7440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ spl-token = "3.5.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
 beacon = {git = "https://github.com/helium/gateway-rs.git", branch = "main"}
 humantime = "2"
+jemallocator = "0.5"
 metrics = "0"
 metrics-exporter-prometheus = "0"
 tracing = "0"

--- a/iot_config/Cargo.toml
+++ b/iot_config/Cargo.toml
@@ -22,6 +22,7 @@ helium-proto = {workspace = true}
 hextree = {workspace = true}
 http = {workspace = true}
 http-serde = {workspace = true}
+jemallocator = {workspace = true}
 libflate = "1"
 metrics = {workspace = true}
 metrics-exporter-prometheus = {workspace = true}

--- a/iot_config/src/main.rs
+++ b/iot_config/src/main.rs
@@ -9,10 +9,16 @@ use iot_config::{
     region_map::RegionMapReader, route_service::RouteService,
     session_key_service::SessionKeyFilterService, settings::Settings, AdminService,
 };
+use jemallocator::Jemalloc;
 use std::{path::PathBuf, time::Duration};
 use tokio::signal;
 use tonic::transport;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+// We use jemalloc due to high allocation churn and fragmentation
+// when using the system allocator, particularly in region maps.
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[derive(Debug, clap::Parser)]
 #[clap(version = env!("CARGO_PKG_VERSION"))]

--- a/iot_packet_verifier/Cargo.toml
+++ b/iot_packet_verifier/Cargo.toml
@@ -18,6 +18,7 @@ futures-util = {workspace = true}
 file-store = {path = "../file_store"}
 helium-proto = {workspace = true}
 helium-crypto = {workspace = true, features = ["sqlx-postgres", "multisig", "solana"]}
+jemallocator = {workspace = true}
 metrics = {workspace = true}
 poc-metrics = {path = "../metrics"}
 prost = {workspace = true}
@@ -32,7 +33,3 @@ tracing-subscriber = {workspace = true}
 triggered = {workspace = true}
 http = {workspace = true}
 http-serde = {workspace = true}
-
-
-
-

--- a/iot_packet_verifier/src/main.rs
+++ b/iot_packet_verifier/src/main.rs
@@ -1,8 +1,14 @@
 use anyhow::Result;
 use clap::Parser;
 use iot_packet_verifier::{daemon, settings::Settings};
+use jemallocator::Jemalloc;
 use std::path::PathBuf;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+// We use jemalloc due to high allocation churn and fragmentation
+// when using the system allocator.
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[derive(clap::Parser)]
 #[clap(version = env!("CARGO_PKG_VERSION"))]

--- a/iot_verifier/Cargo.toml
+++ b/iot_verifier/Cargo.toml
@@ -31,6 +31,7 @@ prost = {workspace = true}
 chrono = { workspace = true }
 helium-proto = { workspace = true }
 helium-crypto = {workspace = true }
+jemallocator = {workspace = true}
 async-trait = {workspace = true}
 h3ron = {workspace = true}
 geo-types = {workspace = true}

--- a/iot_verifier/src/main.rs
+++ b/iot_verifier/src/main.rs
@@ -12,15 +12,20 @@ use iot_verifier::{
     poc_report::Report, purger, region_cache::RegionCache, rewarder::Rewarder, runner,
     tx_scaler::Server as DensityScaler, Settings,
 };
+use jemallocator::Jemalloc;
 use price::PriceTracker;
 use std::path;
 use tokio::signal;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+// We use jemalloc due to high allocation churn and fragmentation when
+// using the system allocator.
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 #[derive(Debug, clap::Parser)]
 #[clap(version = env!("CARGO_PKG_VERSION"))]
 #[clap(about = "Helium POC IOT Verifier")]
-
 pub struct Cli {
     /// Optional configuration file to use. If present the toml file at the
     /// given path will be loaded. Environemnt variables can override the

--- a/mobile_config/Cargo.toml
+++ b/mobile_config/Cargo.toml
@@ -22,6 +22,7 @@ helium-proto = {workspace = true}
 hextree = {workspace = true}
 http = {workspace = true}
 http-serde = {workspace = true}
+jemallocator = {workspace = true}
 metrics = {workspace = true}
 metrics-exporter-prometheus = {workspace = true}
 poc-metrics = {path = "../metrics"}

--- a/mobile_config/src/main.rs
+++ b/mobile_config/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::{Error, Result};
 use clap::Parser;
 use futures_util::TryFutureExt;
 use helium_proto::services::mobile_config::{AdminServer, GatewayServer, RouterServer};
+use jemallocator::Jemalloc;
 use mobile_config::{
     admin_service::AdminService, gateway_service::GatewayService, key_cache::KeyCache,
     router_service::RouterService, settings::Settings,
@@ -10,6 +11,11 @@ use std::{path::PathBuf, time::Duration};
 use tokio::signal;
 use tonic::transport;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+// We use jemalloc due to high allocation churn and fragmentation when
+// using the system allocator.
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[derive(Debug, clap::Parser)]
 #[clap(version = env!("CARGO_PKG_VERSION"))]

--- a/mobile_packet_verifier/Cargo.toml
+++ b/mobile_packet_verifier/Cargo.toml
@@ -18,6 +18,7 @@ futures-util = {workspace = true}
 file-store = {path = "../file_store"}
 helium-proto = {workspace = true}
 helium-crypto = {workspace = true, features = ["sqlx-postgres", "multisig", "solana"]}
+jemallocator = {workspace = true}
 metrics = {workspace = true}
 poc-metrics = {path = "../metrics"}
 prost = {workspace = true}

--- a/mobile_packet_verifier/src/main.rs
+++ b/mobile_packet_verifier/src/main.rs
@@ -1,8 +1,14 @@
 use anyhow::Result;
 use clap::Parser;
+use jemallocator::Jemalloc;
 use mobile_packet_verifier::{daemon, settings::Settings};
 use std::path::PathBuf;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+// We use jemalloc due to high allocation churn and fragmentation
+// when using the system allocator.
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[derive(clap::Parser)]
 #[clap(version = env!("CARGO_PKG_VERSION"))]

--- a/mobile_verifier/Cargo.toml
+++ b/mobile_verifier/Cargo.toml
@@ -42,3 +42,4 @@ poc-metrics = {path = "../metrics"}
 price = {path = "../price"}
 rand = {workspace = true}
 async-trait = {workspace = true}
+jemallocator = {workspace = true}

--- a/mobile_verifier/src/main.rs
+++ b/mobile_verifier/src/main.rs
@@ -1,11 +1,17 @@
 use anyhow::Result;
 use clap::Parser;
+use jemallocator::Jemalloc;
 use mobile_verifier::{
     cli::{generate, reward_from_db, server},
     Settings,
 };
 use std::path;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+// We use jemalloc due to high allocation churn and fragmentation when
+// using the system allocator.
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[derive(clap::Parser)]
 #[clap(version = env!("CARGO_PKG_VERSION"))]


### PR DESCRIPTION
We've noticed poor-memory reuse in iot_config, particularly when updating regions. There is a step-change in memory utilization when regenerating region params, as can be expected, but memory goes up a little bit on subsequent regens, when in theory there should be enough deallocated memory laying around to handle the needs. There's no guarantee that this change will reduce memory usage, so it should be tested on a problem service. However, it would almost certainly speed up heap allocations in a tight lip, like construction regions.

Let me know if I missed some other targets. Or if we'd prefer to just add `jemalloc` to every `main.rs` in this repo.
