### PR TITLE
ensure packet ids are unique, handle dups

### DIFF
--- a/file_store/src/iot_packet.rs
+++ b/file_store/src/iot_packet.rs
@@ -110,6 +110,7 @@ impl TryFrom<ValidPacket> for IotValidPacket {
 impl IotValidPacket {
     pub fn packet_id(&self) -> Vec<u8> {
         let mut hasher = Hasher::new();
+        let now = Utc::now().timestamp_micros() as u64;
         hasher.update(self.gateway.as_ref());
         hasher.update(self.payload_hash.as_ref());
         hasher.update(
@@ -118,6 +119,7 @@ impl IotValidPacket {
                 .encode_timestamp_millis()
                 .to_le_bytes(),
         );
+        hasher.update(&now.to_le_bytes());
         hasher.finalize().as_bytes().to_vec()
     }
 }


### PR DESCRIPTION
The iot packet verifier can output dups, as such using only the fields contained within the verified packet will result in dups being dropped when being inserted into the DB.

This adds a now timestamp component to the packet ID field in the DB to ensure dups get inserted correctly