### PR TITLE
allow router operators to authorize routing location requests

### DIFF
--- a/iot_config/src/gateway_service.rs
+++ b/iot_config/src/gateway_service.rs
@@ -106,7 +106,9 @@ impl iot_config::Gateway for GatewayService {
         telemetry::count_request("gateway", "location");
 
         let signer = verify_public_key(&request.signer)?;
-        self.verify_request_signature(&signer, &request)?;
+        request
+            .verify(&signer)
+            .map_err(|_| Status::permission_denied("invalid request signature"))?;
 
         let address: &PublicKeyBinary = &request.gateway.into();
 


### PR DESCRIPTION
the router operators requesting location information for gateways are not among the registered infrastructure or oracle keys so this check cannot reasonably be made against keys in the "administrative" store.