### PR TITLE
introducing lamport balance monitor for packet verifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5888,8 +5888,10 @@ dependencies = [
  "async-trait",
  "clap 3.2.23",
  "data-credits",
+ "futures",
  "helium-crypto",
  "helium-sub-daos",
+ "metrics",
  "serde",
  "sha2 0.10.6",
  "solana-client",
@@ -5899,6 +5901,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "triggered",
 ]
 
 [[package]]

--- a/iot_packet_verifier/src/daemon.rs
+++ b/iot_packet_verifier/src/daemon.rs
@@ -102,7 +102,7 @@ impl Cmd {
             None
         };
 
-        let pv_balance_monitor = solana::balance_monitor::start(
+        let sol_balance_monitor = solana::balance_monitor::start(
             env!("CARGO_PKG_NAME"),
             solana.clone(),
             shutdown_listener.clone(),
@@ -196,7 +196,7 @@ impl Cmd {
             )
             .map_err(Error::from),
             source_join_handle.map_err(Error::from),
-            pv_balance_monitor.map_err(Error::from),
+            sol_balance_monitor.map_err(Error::from),
         )?;
 
         Ok(())

--- a/iot_packet_verifier/src/daemon.rs
+++ b/iot_packet_verifier/src/daemon.rs
@@ -102,6 +102,13 @@ impl Cmd {
             None
         };
 
+        let pv_balance_monitor = solana::balance_monitor::start(
+            env!("CARGO_PKG_NAME"),
+            solana.clone(),
+            shutdown_listener.clone(),
+        )
+        .await?;
+
         // Set up the balance cache:
         let balances = BalanceCache::new(&mut pool, solana.clone()).await?;
 
@@ -189,6 +196,7 @@ impl Cmd {
             )
             .map_err(Error::from),
             source_join_handle.map_err(Error::from),
+            pv_balance_monitor.map_err(Error::from),
         )?;
 
         Ok(())

--- a/iot_packet_verifier/src/settings.rs
+++ b/iot_packet_verifier/src/settings.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Deserialize)]
 pub struct Settings {
     /// RUST_LOG compatible settings string. Defsault to
-    /// "mobile_verifier=debug,poc_store=info"
+    /// "iot_packet_verifier=debug,poc_store=info"
     #[serde(default = "default_log")]
     pub log: String,
     /// Cache location for generated verified reports

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -104,6 +104,13 @@ impl Cmd {
             None
         };
 
+        let pv_balance_monitor = solana::balance_monitor::start(
+            env!("CARGO_PKG_NAME"),
+            solana.clone(),
+            shutdown_listener.clone(),
+        )
+        .await?;
+
         let (file_upload_tx, file_upload_rx) = file_upload::message_channel();
         let file_upload =
             file_upload::FileUpload::from_settings(&settings.output, file_upload_rx).await?;
@@ -149,6 +156,7 @@ impl Cmd {
             file_upload.run(&shutdown_listener).map_err(Error::from),
             daemon.run(&shutdown_listener).map_err(Error::from),
             conn_handler.map_err(Error::from),
+            pv_balance_monitor.map_err(Error::from),
         )?;
 
         Ok(())

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -104,7 +104,7 @@ impl Cmd {
             None
         };
 
-        let pv_balance_monitor = solana::balance_monitor::start(
+        let sol_balance_monitor = solana::balance_monitor::start(
             env!("CARGO_PKG_NAME"),
             solana.clone(),
             shutdown_listener.clone(),
@@ -156,7 +156,7 @@ impl Cmd {
             file_upload.run(&shutdown_listener).map_err(Error::from),
             daemon.run(&shutdown_listener).map_err(Error::from),
             conn_handler.map_err(Error::from),
-            pv_balance_monitor.map_err(Error::from),
+            sol_balance_monitor.map_err(Error::from),
         )?;
 
         Ok(())

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -10,16 +10,19 @@ license.workspace = true
 async-trait = {workspace = true}
 anchor-lang = {workspace = true}
 anchor-client = {workspace = true}
-solana-client = {workspace = true}
-solana-sdk = {workspace = true}
-solana-program = {workspace = true}
-spl-token = {workspace = true}
-serde = {workspace = true}
-data-credits = {workspace = true}
-helium-sub-daos = {workspace = true}
-sha2 = {workspace = true}
-tokio = {workspace = true}
-helium-crypto = {workspace = true, features = ["solana"]}
-thiserror = {workspace = true}
-tracing = {workspace = true}
 clap = {workspace = true}
+data-credits = {workspace = true}
+futures = {workspace = true}
+helium-crypto = {workspace = true, features = ["solana"]}
+helium-sub-daos = {workspace = true}
+metrics = {workspace = true}
+serde = {workspace = true}
+sha2 = {workspace = true}
+solana-client = {workspace = true}
+solana-program = {workspace = true}
+solana-sdk = {workspace = true}
+spl-token = {workspace = true}
+thiserror = {workspace = true}
+tokio = {workspace = true}
+tracing = {workspace = true}
+triggered = {workspace = true}

--- a/solana/src/balance_monitor.rs
+++ b/solana/src/balance_monitor.rs
@@ -9,7 +9,8 @@ pub async fn start(
     app_account: &str,
     solana: Option<Arc<SolanaRpc>>,
     shutdown: triggered::Listener,
-) -> Result<futures::future::BoxFuture<'static, Result<(), tokio::task::JoinError>>, SolanaRpcError> {
+) -> Result<futures::future::BoxFuture<'static, Result<(), tokio::task::JoinError>>, SolanaRpcError>
+{
     Ok(match solana {
         None => Box::pin(async move { Ok(()) }),
         Some(rpc_client) => {
@@ -18,19 +19,20 @@ pub async fn start(
                 return Err(SolanaRpcError::InvalidKeypair)
             };
             let app_metric_name = format!("{app_account}-sol-balance");
-            let handle =
-                tokio::spawn(async move { run(app_metric_name, rpc_client, keypair.pubkey(), shutdown).await });
-            Box::pin(async move {
-                match handle.await {
-                    Ok(()) => Ok(()),
-                    Err(err) => Err(tokio::task::JoinError::from(err)),
-                }
-            })
+            let handle = tokio::spawn(async move {
+                run(app_metric_name, rpc_client, keypair.pubkey(), shutdown).await
+            });
+            Box::pin(async move { handle.await })
         }
     })
 }
 
-async fn run(metric_name: String, solana: Arc<SolanaRpc>, service_pubkey: Pubkey, shutdown: triggered::Listener) {
+async fn run(
+    metric_name: String,
+    solana: Arc<SolanaRpc>,
+    service_pubkey: Pubkey,
+    shutdown: triggered::Listener,
+) {
     let mut trigger = tokio::time::interval(DURATION);
 
     loop {

--- a/solana/src/balance_monitor.rs
+++ b/solana/src/balance_monitor.rs
@@ -1,0 +1,52 @@
+use crate::{SolanaRpc, SolanaRpcError};
+use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer};
+use std::{sync::Arc, time::Duration};
+
+// Check balance every 12 hours
+const DURATION: Duration = Duration::from_secs(43_200);
+
+pub async fn start(
+    app_account: &str,
+    solana: Option<Arc<SolanaRpc>>,
+    shutdown: triggered::Listener,
+) -> Result<futures::future::BoxFuture<'static, Result<(), tokio::task::JoinError>>, SolanaRpcError> {
+    Ok(match solana {
+        None => Box::pin(async move { Ok(()) }),
+        Some(rpc_client) => {
+            let Ok(keypair) = Keypair::from_bytes(&rpc_client.keypair) else {
+                tracing::error!("sol monitor: keypair failed to deserialize");
+                return Err(SolanaRpcError::InvalidKeypair)
+            };
+            let app_metric_name = format!("{app_account}-sol-balance");
+            let handle =
+                tokio::spawn(async move { run(app_metric_name, rpc_client, keypair.pubkey(), shutdown).await });
+            Box::pin(async move {
+                match handle.await {
+                    Ok(()) => Ok(()),
+                    Err(err) => Err(tokio::task::JoinError::from(err)),
+                }
+            })
+        }
+    })
+}
+
+async fn run(metric_name: String, solana: Arc<SolanaRpc>, service_pubkey: Pubkey, shutdown: triggered::Listener) {
+    let mut trigger = tokio::time::interval(DURATION);
+
+    loop {
+        let shutdown = shutdown.clone();
+
+        tokio::select! {
+            _ = shutdown => {
+                tracing::info!("sol monitor: shutting down");
+                break
+            }
+            _ = trigger.tick() => {
+                match solana.provider.get_balance(&service_pubkey).await {
+                    Ok(balance) => metrics::gauge!(metric_name.clone(), balance as f64),
+                    Err(err) => tracing::error!("sol monitor: failed to get account balance: {:?}", err.kind()),
+                }
+            }
+        }
+    }
+}

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod balance_monitor;
+
 use anchor_client::{RequestBuilder, RequestNamespace};
 use anchor_lang::AccountDeserialize;
 use async_trait::async_trait;


### PR DESCRIPTION
allow monitoring the lamport balance of oracles that burn lamports in order to process transactions directly on the solana chain. this will allow the oracles to avoid running too low on a balance to maintain operations without advance notice allowing the service maintainer to top up the account