### PR TITLE
halt rewards if data below threshold

### DIFF
--- a/iot_verifier/migrations/12_bootstrap_reward_halt_override.sql
+++ b/iot_verifier/migrations/12_bootstrap_reward_halt_override.sql
@@ -1,0 +1,17 @@
+CREATE TYPE reward_type as enum('beacon', 'witness', 'packet');
+
+insert into meta
+    (key, value)
+values
+    ('halt_rewards_override', 'false')
+on conflict
+    (key)
+do nothing;
+
+CREATE TABLE rewards_history (
+    reward_type reward_type,
+    count bigint NOT NULL,
+    epoch_ts timestamptz NOT NULL,
+    created_at timestamptz  NOT NULL default now()
+);
+

--- a/iot_verifier/src/main.rs
+++ b/iot_verifier/src/main.rs
@@ -115,16 +115,9 @@ impl Server {
         .create()
         .await?;
 
-        let rewarder = Rewarder {
-            pool: pool.clone(),
-            rewards_sink,
-            reward_manifests_sink,
-            reward_period_hours: settings.rewards,
-            reward_offset: settings.reward_offset_duration(),
-            rewards_retry_interval: settings.rewards_retry_interval(),
-            rewards_max_delay_duration: settings.rewards_max_delay_duration(),
-        };
-
+        let rewarder =
+            Rewarder::from_settings(settings, pool.clone(), rewards_sink, reward_manifests_sink)
+                .await?;
         // setup the entropy loader continious source
         let max_lookback_age = settings.loader_window_max_lookback_age();
         let mut entropy_loader = EntropyLoader { pool: pool.clone() };

--- a/iot_verifier/src/main.rs
+++ b/iot_verifier/src/main.rs
@@ -121,6 +121,8 @@ impl Server {
             reward_manifests_sink,
             reward_period_hours: settings.rewards,
             reward_offset: settings.reward_offset_duration(),
+            rewards_retry_interval: settings.rewards_retry_interval(),
+            rewards_max_delay_duration: settings.rewards_max_delay_duration(),
         };
 
         // setup the entropy loader continious source

--- a/iot_verifier/src/main.rs
+++ b/iot_verifier/src/main.rs
@@ -116,8 +116,7 @@ impl Server {
         .await?;
 
         let rewarder =
-            Rewarder::from_settings(settings, pool.clone(), rewards_sink, reward_manifests_sink)
-                .await?;
+            Rewarder::from_settings(settings, pool.clone(), rewards_sink, reward_manifests_sink)?;
         // setup the entropy loader continious source
         let max_lookback_age = settings.loader_window_max_lookback_age();
         let mut entropy_loader = EntropyLoader { pool: pool.clone() };

--- a/iot_verifier/src/packet_loader.rs
+++ b/iot_verifier/src/packet_loader.rs
@@ -50,6 +50,7 @@ impl PacketLoader {
             .map(anyhow::Ok)
             .try_fold(transaction, |mut transaction, reward_share| async move {
                 reward_share.save(&mut transaction).await?;
+                metrics::increment_counter!("oracles_iot_verifier_packet_count");
                 Ok(transaction)
             })
             .await?

--- a/iot_verifier/src/reward_share.rs
+++ b/iot_verifier/src/reward_share.rs
@@ -216,6 +216,7 @@ impl RewardShares {
 #[derive(Default)]
 pub struct GatewayShares {
     pub shares: HashMap<PublicKeyBinary, RewardShares>,
+    // track the total number of aggregated beacons, witnesses and packets this period
     pub total_beacon_count: u64,
     pub total_witness_count: u64,
     pub total_packet_count: u64,
@@ -563,6 +564,7 @@ mod test {
 
         let gw_shares = GatewayShares {
             shares,
+            // default counts to zero
             total_beacon_count: 0,
             total_witness_count: 0,
             total_packet_count: 0,
@@ -754,6 +756,7 @@ mod test {
 
         let gw_shares = GatewayShares {
             shares,
+            // default counts to zero
             total_beacon_count: 0,
             total_witness_count: 0,
             total_packet_count: 0,
@@ -929,6 +932,7 @@ mod test {
 
         let gw_shares = GatewayShares {
             shares,
+            // default counts to zero
             total_beacon_count: 0,
             total_witness_count: 0,
             total_packet_count: 0,

--- a/iot_verifier/src/rewarder.rs
+++ b/iot_verifier/src/rewarder.rs
@@ -301,25 +301,11 @@ async fn save_history(
 ) -> anyhow::Result<()> {
     history_db::insert(
         txn,
-        RewardType::Beacon,
         total_beacon_count as i64,
-        epoch_end,
-    )
-    .await?;
-    history_db::insert(
-        txn,
-        RewardType::Witness,
         total_witness_count as i64,
-        epoch_end,
-    )
-    .await?;
-    history_db::insert(
-        txn,
-        RewardType::Packet,
         total_packet_count as i64,
-        epoch_end,
-    )
-    .await?;
+        epoch_end
+    ).await?;
     Ok(())
 }
 

--- a/iot_verifier/src/rewarder.rs
+++ b/iot_verifier/src/rewarder.rs
@@ -1,22 +1,47 @@
+use std::time::Duration;
+
 use crate::{
     reward_share::{operational_rewards, GatewayShares},
     scheduler::Scheduler,
 };
-use chrono::{DateTime, Duration, TimeZone, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
 use db_store::meta;
 use file_store::{file_sink, traits::TimestampEncode};
 use helium_proto::RewardManifest;
+
 use price::PriceTracker;
 use rust_decimal::prelude::*;
+use rust_decimal_macros::dec;
 use sqlx::{PgExecutor, Pool, Postgres};
 use tokio::time::sleep;
+
+const HALT_REWARDS_DB_KEY: &str = "halt_rewards_override";
+// set min counts for the number of beacon, witnesses and packets we expect
+// to be within a rewardable period
+// note: these are floor levels, the averages are expected to be higher
+//       but if we drop below the levels defined here, rewards will be delayed
+//       enabling a manual review
+const BEACON_MIN_REWARDABLE_COUNT: u64 = 800_000; // 200K gateways @ 4 beacons per day
+const WITNESS_MIN_REWARDABLE_COUNT: u64 = 4_000_000; // 5 witnesses per above beacon
+const PACKET_MIN_REWARDABLE_COUNT: u64 = 100_000; // TODO: work out a sensible packet floor level
+const AVG_SCALING_FACTOR: Decimal = dec!(0.8);
 
 pub struct Rewarder {
     pub pool: Pool<Postgres>,
     pub rewards_sink: file_sink::FileSinkClient,
     pub reward_manifests_sink: file_sink::FileSinkClient,
     pub reward_period_hours: i64,
-    pub reward_offset: Duration,
+    pub reward_offset: ChronoDuration,
+    pub rewards_retry_interval: Duration,
+    pub rewards_max_delay_duration: ChronoDuration,
+}
+
+#[derive(sqlx::Type, Debug, Clone, PartialEq, Eq, Hash)]
+#[sqlx(type_name = "reward_type", rename_all = "snake_case")]
+pub enum RewardType {
+    Beacon,
+    Witness,
+    Packet,
 }
 
 impl Rewarder {
@@ -27,7 +52,7 @@ impl Rewarder {
     ) -> anyhow::Result<()> {
         tracing::info!("Starting iot verifier rewarder");
 
-        let reward_period_length = Duration::hours(self.reward_period_hours);
+        let reward_period_length = ChronoDuration::hours(self.reward_period_hours);
 
         loop {
             let now = Utc::now();
@@ -39,7 +64,7 @@ impl Rewarder {
                 self.reward_offset,
             );
 
-            if scheduler.should_reward(now) {
+            let sleep_duration = if scheduler.should_reward(now) {
                 let iot_price = price_tracker
                     .price(&helium_proto::BlockchainTokenTypeV1::Iot)
                     .await?;
@@ -48,9 +73,9 @@ impl Rewarder {
                     scheduler.reward_period
                 );
                 self.reward(&scheduler, Decimal::from(iot_price)).await?
-            }
-
-            let sleep_duration = scheduler.sleep_duration(Utc::now())?;
+            } else {
+                scheduler.sleep_until_next_epoch(Utc::now())?
+            };
 
             tracing::info!(
                 "Sleeping for {}",
@@ -69,10 +94,23 @@ impl Rewarder {
         &mut self,
         scheduler: &Scheduler,
         iot_price: Decimal,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Duration> {
         let gateway_reward_shares =
             GatewayShares::aggregate(&self.pool, &scheduler.reward_period).await?;
+        // get a count of our summed shares by reward type
+        let GatewayShares {
+            total_beacon_count,
+            total_packet_count,
+            total_witness_count,
+            ..
+        } = gateway_reward_shares;
 
+        if !self
+            .threshold_check(&gateway_reward_shares, scheduler)
+            .await?
+        {
+            return Ok(self.rewards_retry_interval);
+        }
         for reward_share in
             gateway_reward_shares.into_iot_reward_shares(&scheduler.reward_period, iot_price)
         {
@@ -105,6 +143,20 @@ impl Rewarder {
             &mut transaction,
         )
         .await?;
+
+        clear_halt_rewards_override(&mut transaction).await?;
+
+        save_history(
+            &mut transaction,
+            total_beacon_count,
+            total_witness_count,
+            total_packet_count,
+            scheduler.reward_period.end,
+        )
+        .await?;
+
+        history_db::purge(&mut transaction).await?;
+
         transaction.commit().await?;
 
         // now that the db has been purged, safe to write out the manifest
@@ -120,8 +172,66 @@ impl Rewarder {
             .await?
             .await??;
         self.reward_manifests_sink.commit().await?;
+        let sleep_duration = scheduler.sleep_until_next_epoch(Utc::now())?;
+        Ok(sleep_duration)
+    }
 
-        Ok(())
+    async fn threshold_check(
+        &self,
+        gateway_reward_shares: &GatewayShares,
+        scheduler: &Scheduler,
+    ) -> anyhow::Result<bool> {
+        let duration_since_last_rewards_end =
+            scheduler.time_since_last_reward_period_ended(Utc::now());
+        let halt_rewards_override = fetch_halt_rewards_override(&self.pool).await?;
+        // get the current averages from historic data in the db
+        let (scaled_beacon_avg, scaled_witness_avg, scaled_packet_avg) =
+            self.get_historic_averages().await?;
+
+        tracing::info!(%gateway_reward_shares.total_beacon_count,
+            %gateway_reward_shares.total_witness_count,
+            %gateway_reward_shares.total_packet_count,
+            %scaled_beacon_avg,
+            %scaled_witness_avg,
+            %scaled_packet_avg,
+            %halt_rewards_override);
+
+        // if we are above our thesholds then we are good to reward
+        if gateway_reward_shares.total_beacon_count >= scaled_beacon_avg
+            && gateway_reward_shares.total_witness_count >= scaled_witness_avg
+            && gateway_reward_shares.total_packet_count >= scaled_packet_avg
+        {
+            return Ok(true);
+        }
+        // we are below our thresholds
+        // fail this check until a max duration after when the rewards
+        // were meant to be triggered, unless the override has been set
+        // if override is set then we will keep failing until it is cleared
+        if duration_since_last_rewards_end > self.rewards_max_delay_duration
+            && !halt_rewards_override
+        {
+            return Ok(true);
+        }
+        tracing::warn!(
+            "rewards failed threshold check.  rewarding for this epoch has been suspended..."
+        );
+        Ok(false)
+    }
+
+    async fn get_historic_averages(&self) -> anyhow::Result<(u64, u64, u64)> {
+        let beacon_avg =
+            history_db::get_avg(&self.pool, RewardType::Beacon, BEACON_MIN_REWARDABLE_COUNT)
+                .await?;
+        let witness_avg = history_db::get_avg(
+            &self.pool,
+            RewardType::Witness,
+            WITNESS_MIN_REWARDABLE_COUNT,
+        )
+        .await?;
+        let packet_avg =
+            history_db::get_avg(&self.pool, RewardType::Packet, PACKET_MIN_REWARDABLE_COUNT)
+                .await?;
+        Ok((beacon_avg, witness_avg, packet_avg))
     }
 }
 
@@ -140,4 +250,109 @@ async fn save_rewarded_timestamp(
     db: impl PgExecutor<'_>,
 ) -> db_store::Result<()> {
     meta::store(db, timestamp_key, value.timestamp()).await
+}
+
+pub async fn fetch_halt_rewards_override(db: impl sqlx::PgExecutor<'_>) -> db_store::Result<bool> {
+    Ok(sqlx::query_scalar::<_, bool>(
+        r#"
+    SELECT EXISTS(SELECT value from meta where key = $1 and value = 'true')
+    "#,
+    )
+    .bind(HALT_REWARDS_DB_KEY)
+    .fetch_one(db)
+    .await?)
+}
+
+async fn clear_halt_rewards_override(
+    txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> db_store::Result<()> {
+    meta::store(txn, HALT_REWARDS_DB_KEY, "false").await
+}
+
+async fn save_history(
+    txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    total_beacon_count: u64,
+    total_witness_count: u64,
+    total_packet_count: u64,
+    epoch_end: DateTime<Utc>,
+) -> anyhow::Result<()> {
+    history_db::insert(
+        txn,
+        RewardType::Beacon,
+        total_beacon_count as i64,
+        epoch_end,
+    )
+    .await?;
+    history_db::insert(
+        txn,
+        RewardType::Witness,
+        total_witness_count as i64,
+        epoch_end,
+    )
+    .await?;
+    history_db::insert(
+        txn,
+        RewardType::Packet,
+        total_packet_count as i64,
+        epoch_end,
+    )
+    .await?;
+    Ok(())
+}
+
+mod history_db {
+    use super::*;
+
+    pub async fn insert(
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        reward_type: RewardType,
+        count: i64,
+        epoch_ts: DateTime<Utc>,
+    ) -> anyhow::Result<()> {
+        sqlx::query(
+            r#"
+        INSERT INTO rewards_history(reward_type, count, epoch_ts) VALUES($1, $2, $3)
+        "#,
+        )
+        .bind(reward_type)
+        .bind(count)
+        .bind(epoch_ts)
+        .execute(tx)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn get_avg(
+        db: impl sqlx::PgExecutor<'_>,
+        reward_type: RewardType,
+        default: u64,
+    ) -> anyhow::Result<u64> {
+        let result = sqlx::query_scalar::<_, Decimal>(
+            r#"
+        SELECT COALESCE(AVG(count), 0) FROM rewards_history where reward_type = $1
+        "#,
+        )
+        .bind(reward_type)
+        .fetch_one(db)
+        .await?;
+        let result = (result * AVG_SCALING_FACTOR).to_u64().unwrap_or(default);
+        if result < default {
+            Ok(default)
+        } else {
+            Ok(result)
+        }
+    }
+    pub async fn purge(db: impl sqlx::PgExecutor<'_>) -> anyhow::Result<()> {
+        //TODO make max history period a setting?
+        sqlx::query(
+            r#"
+        DELETE FROM rewards_history where created_at <  NOW() - INTERVAL '90 DAYS'
+        "#,
+        )
+        .execute(db)
+        .await?;
+
+        Ok(())
+    }
 }

--- a/iot_verifier/src/rewarder.rs
+++ b/iot_verifier/src/rewarder.rs
@@ -328,17 +328,19 @@ mod history_db {
 
     pub async fn insert(
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-        reward_type: RewardType,
-        count: i64,
+        beacon_count: i64,
+        witness_count: i64,
+        packet_count: i64,
         epoch_ts: DateTime<Utc>,
     ) -> anyhow::Result<()> {
         sqlx::query(
             r#"
-        INSERT INTO rewards_history(reward_type, count, epoch_ts) VALUES($1, $2, $3)
+        INSERT INTO rewards_history (reward_type, count, epoch_ts) VALUES ('beacon', $1, $4), ('witness', $2, $4), ('packet', $3, $4)
         "#,
         )
-        .bind(reward_type)
-        .bind(count)
+        .bind(beacon_count)
+        .bind(witness_count)
+        .bind(packet_count)
         .bind(epoch_ts)
         .execute(tx)
         .await?;

--- a/iot_verifier/src/rewarder.rs
+++ b/iot_verifier/src/rewarder.rs
@@ -42,7 +42,7 @@ pub enum RewardType {
 }
 
 impl Rewarder {
-    pub async fn from_settings(
+    pub fn from_settings(
         settings: &Settings,
         pool: PgPool,
         rewards_sink: file_sink::FileSinkClient,

--- a/iot_verifier/src/scheduler.rs
+++ b/iot_verifier/src/scheduler.rs
@@ -34,7 +34,7 @@ impl Scheduler {
         self.reward_period.end..(self.reward_period.end + self.reward_period_length)
     }
 
-    pub fn sleep_duration(
+    pub fn sleep_until_next_epoch(
         &self,
         now: DateTime<Utc>,
     ) -> Result<std::time::Duration, OutOfRangeError> {
@@ -49,6 +49,10 @@ impl Scheduler {
         };
 
         duration.to_std().map_err(|_| OutOfRangeError)
+    }
+
+    pub fn time_since_last_reward_period_ended(&self, now: DateTime<Utc>) -> Duration {
+        now - self.reward_period.end
     }
 }
 
@@ -87,7 +91,7 @@ mod tests {
         assert_eq!(
             standard_duration(1410).unwrap(),
             scheduler
-                .sleep_duration(now)
+                .sleep_until_next_epoch(now)
                 .expect("failed sleep duration check")
         );
     }
@@ -111,7 +115,7 @@ mod tests {
         assert_eq!(
             standard_duration(1440).unwrap(),
             scheduler
-                .sleep_duration(now)
+                .sleep_until_next_epoch(now)
                 .expect("failed sleep duration check")
         );
     }
@@ -135,7 +139,7 @@ mod tests {
         assert_eq!(
             standard_duration(15).unwrap(),
             scheduler
-                .sleep_duration(now)
+                .sleep_until_next_epoch(now)
                 .expect("failed sleep duration check")
         );
     }

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -79,6 +79,18 @@ pub struct Settings {
     pub rewards_retry_interval: u64,
     #[serde(default = "default_rewards_max_delay_duration")]
     pub rewards_max_delay_duration: i64,
+
+    // set min counts for the number of beacon, witnesses and packets we expect
+    // to be within a rewardable period
+    // note: these are floor levels, the averages are expected to be higher
+    //       but if we drop below the levels defined here, rewards will be suspended
+    //       enabling a manual review
+    #[serde(default = "default_beacon_min_rewardable_count")]
+    pub beacon_min_rewardable_count: u64,
+    #[serde(default = "default_witness_min_rewardable_count")]
+    pub witness_min_rewardable_count: u64,
+    #[serde(default = "default_packet_min_rewardable_count")]
+    pub packet_min_rewardable_count: u64,
 }
 
 // Default: 60 minutes
@@ -164,6 +176,24 @@ pub fn default_rewards_retry_interval() -> u64 {
 // Default: 3 hours
 pub fn default_rewards_max_delay_duration() -> i64 {
     60 * 60 * 3
+}
+
+// Default: 800_000
+// 200K gateways @ 4 beacons per day
+pub fn default_beacon_min_rewardable_count() -> u64 {
+    800_000
+}
+
+// Default: 4_000_000
+// 5 witnesses per above beacon
+pub fn default_witness_min_rewardable_count() -> u64 {
+    4_000_000
+}
+
+// Default: 100_000
+// TODO: determine a sensible packet floor level
+pub fn default_packet_min_rewardable_count() -> u64 {
+    100_000
 }
 
 impl Settings {

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -2,6 +2,7 @@ use chrono::Duration;
 use config::{Config, Environment, File};
 use serde::Deserialize;
 use std::path::Path;
+use std::time::Duration as StdDuration;
 use tokio::time;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -74,6 +75,10 @@ pub struct Settings {
     /// File store poll interval for incoming packets, in seconds. (Default is 900; 15 minutes)
     #[serde(default = "default_packet_interval")]
     pub packet_interval: i64,
+    #[serde(default = "default_rewards_retry_interval")]
+    pub rewards_retry_interval: u64,
+    #[serde(default = "default_rewards_max_delay_duration")]
+    pub rewards_max_delay_duration: i64,
 }
 
 // Default: 60 minutes
@@ -151,6 +156,16 @@ fn default_packet_interval() -> i64 {
     900
 }
 
+// Default: 1 hour
+pub fn default_rewards_retry_interval() -> u64 {
+    60 * 60
+}
+
+// Default: 3 hours
+pub fn default_rewards_max_delay_duration() -> i64 {
+    60 * 60 * 3
+}
+
 impl Settings {
     /// Load Settings from a given path. Settings are loaded from a given
     /// optional path and can be overriden with environment variables.
@@ -215,5 +230,13 @@ impl Settings {
     }
     pub fn packet_interval(&self) -> Duration {
         Duration::seconds(self.packet_interval)
+    }
+
+    pub fn rewards_retry_interval(&self) -> StdDuration {
+        StdDuration::from_secs(self.rewards_retry_interval)
+    }
+
+    pub fn rewards_max_delay_duration(&self) -> Duration {
+        Duration::seconds(self.rewards_max_delay_duration)
     }
 }


### PR DESCRIPTION
This adds a threshold check to the rewards generation.  If the volume of any of the 3 rewardable entities ( beacons, witnesses or packets ) for the rewardable period is below a minimum level then the rewards will be suspended for the epoch.  

The minimum volumes are derived from the average volume for each entity type over the last 90 days.   Each time rewards are run we store the volumes for that epoch in the DB and thus feeds into the dataset for the average calculations.

When rewards are suspended, they will be retried every hour until a max duration ( defaults to 3 hours but customisable via settings ) has passed.  At that point the rewards will proceed as normal for the original epoch *unless* the key 'halt_rewards_override' in the meta table has been set too true.  The rewards will not run whilst halt_rewards_override is 'true'.

The intent with this change is to suspend rewards if volume is unexpectedly low and to allow the dataset to be reviewed manually.  Rather than stopping the verifier and forcing a backlog of loader events, the verifier will continue other operations and provide a window for manual review and possible intervention. Once that window expires the verifier will assume all is good and subsequently process the rewards.  If manual review highlights some sort of issue with which we should not process the rewards, the user can intervene and set the meta key `halt_rewards_override` too true.  This will force rewards to remain suspended until the key is subsequently set to false ( or a non true value ).