### PR TITLE
delegate keys cache and child table

### DIFF
--- a/iot_config/migrations/9_delegate_keys.sql
+++ b/iot_config/migrations/9_delegate_keys.sql
@@ -1,0 +1,15 @@
+create table organization_delegate_keys (
+    delegate_pubkey text primary key not null,
+    oui bigint not null references organizations(oui) on delete cascade,
+
+    inserted_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+select trigger_updated_at('organization_delegate_keys');
+
+insert into organization_delegate_keys 
+    select delegate_pubkey, oui from organizations,
+    unnest(delegate_keys) as delegate_pubkey;
+
+alter table organizations drop column delegate_keys;

--- a/iot_config/src/route_service.rs
+++ b/iot_config/src/route_service.rs
@@ -1,7 +1,7 @@
 use crate::{
     admin::{AuthCache, KeyType},
     lora_field::{DevAddrConstraint, DevAddrRange, EuiPair, Skf},
-    org::{self, DbOrgError},
+    org::{self, OrgStoreError},
     route::{self, Route, RouteStorageError},
     telemetry, update_channel, verify_public_key, GrpcResult, GrpcStreamRequest, GrpcStreamResult,
     Settings,
@@ -132,7 +132,7 @@ impl RouteService {
         &self,
         route_id: &str,
         check_constraints: bool,
-    ) -> Result<DevAddrEuiValidator, DbOrgError> {
+    ) -> Result<DevAddrEuiValidator, OrgStoreError> {
         let admin_keys = self.auth_cache.get_keys_by_type(KeyType::Administrator);
 
         DevAddrEuiValidator::new(route_id, admin_keys, &self.pool, check_constraints).await
@@ -911,7 +911,7 @@ impl DevAddrEuiValidator {
         mut admin_keys: Vec<PublicKey>,
         db: impl sqlx::PgExecutor<'_> + Copy,
         check_constraints: bool,
-    ) -> Result<Self, DbOrgError> {
+    ) -> Result<Self, OrgStoreError> {
         let constraints = if check_constraints {
             Some(org::get_constraints_by_route(route_id, db).await?)
         } else {


### PR DESCRIPTION
Two major changes in one here:
- implements a simple cache of delegate keys for all orgs registering LNS's to the config service to restrict the scope of access to the gateway location RPC to only those servers running routers that need it (prevent script kiddies from mapping the network at the expense of the config service and its primary consumer services)
- prepares the delegate keys records for each org for more maintainable record-keeping when org update API is implemented (soon) by moving them out of an array column on the organizations table and into a dedicated child table of the organizations table linked by the OUI