### PR TITLE
filter hotspots not registered on chain from data transfer rewards

### DIFF
--- a/iot_verifier/src/main.rs
+++ b/iot_verifier/src/main.rs
@@ -182,7 +182,7 @@ impl Server {
             ),
             entropy_loader.run(entropy_loader_receiver, &shutdown),
             loader.run(&shutdown, &gateway_cache),
-            packet_loader.run(pk_loader_receiver, &shutdown),
+            packet_loader.run(pk_loader_receiver, &shutdown, &gateway_cache),
             purger.run(&shutdown),
             rewarder.run(price_tracker, &shutdown),
             density_scaler.run(&shutdown).map_err(Error::from),


### PR DESCRIPTION
addresses an edge case in the the flow of data verification from the iot-packet-verifier to the iot-verifier wherein an otherwise valid iot packet report may have had its data routed by a gateway not registered to the solana chain, thereby making the packet report valid but the gateway still invalid for claiming rewards for the transfer.

gateways may receive data transfer rewards without having been _location asserted_ but they may not if they have never even registered on solana and received an on-chain identity.