### PR TITLE
Bump to latest hextree release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2934,13 +2934,9 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hextree"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6ffc35fc0fb2af599742de1938d44cd18b0ae7cf7a7faf4b067f43cc863902"
-dependencies = [
- "bitfield",
- "thiserror",
-]
+checksum = "9bcae6addbacd470c8033b8f874feb49fa568c17ceadadbf98ee6ae4029cd2b6"
 
 [[package]]
 name = "histogram"

--- a/iot_config/src/region_map.rs
+++ b/iot_config/src/region_map.rs
@@ -46,7 +46,7 @@ impl RegionMap {
     }
 
     pub fn get_region(&self, location: Cell) -> Option<Region> {
-        self.region_hextree.get(location).cloned()
+        self.region_hextree.get(location).unzip().1.copied()
     }
 
     pub fn get_params(&self, region: &Region) -> Option<BlockchainRegionParamsV1> {


### PR DESCRIPTION
HexTree still has some minor churn, and this PR updates oracles to the latest v0.3.1 release with the goal of making sure oracles doesn't camp on an old version for too long. This should have no _noticeable_ effect on performance.
