### PR TITLE
converting helius-fed database to new foundation schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3238,6 +3238,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.0",
+ "bs58 0.4.0",
  "chrono",
  "clap 3.2.23",
  "config",

--- a/iot_config/Cargo.toml
+++ b/iot_config/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 anyhow = {workspace = true}
 async-trait = {workspace = true}
 base64 = {workspace = true}
+bs58 = {version = "0.4", features=["check"]}
 chrono = {workspace = true}
 clap = {workspace = true}
 config = {workspace = true}

--- a/iot_config/src/gateway_info.rs
+++ b/iot_config/src/gateway_info.rs
@@ -130,6 +130,7 @@ pub(crate) mod db {
     use futures::stream::{Stream, StreamExt};
     use helium_crypto::PublicKeyBinary;
     use sqlx::{PgExecutor, Row};
+    use std::str::FromStr;
 
     pub struct IotMetadata {
         pub address: PublicKeyBinary,
@@ -143,13 +144,16 @@ pub(crate) mod db {
         db: impl PgExecutor<'_>,
         address: &PublicKeyBinary,
     ) -> anyhow::Result<Option<IotMetadata>> {
+        let entity_key = bs58::decode(address.to_string()).into_vec()?;
         Ok(sqlx::query_as::<_, IotMetadata>(
             r#"
-            select hotspot_key::text, location, elevation, gain, is_full_hotspot from iot_metadata
-            where hotspot_key = $1
+            select kta.entity_key, infos.location::bigint, infos.elevation, infos.gain, infos.is_full_hotspot
+            from iot_hotspot_infos infos
+            join key_to_assets kta on infos.asset = kta.asset
+            where kta.entity_key = $1
             "#,
         )
-        .bind(address)
+        .bind(entity_key)
         .fetch_optional(db)
         .await?)
     }
@@ -159,7 +163,9 @@ pub(crate) mod db {
     ) -> impl Stream<Item = IotMetadata> + 'a {
         sqlx::query_as::<_, IotMetadata>(
             r#"
-            select hotspot_key::text, location, elevation, gain, is_full_hotspot from iot_metadata
+            select kta.entity_key, infos.location::bigint, infos.elevation, infos.gain, infos.is_full_hotspot
+            from iot_hotspot_infos infos
+            join key_to_assets kta on infos.asset = kta.asset
             "#,
         )
         .fetch(db)
@@ -170,7 +176,10 @@ pub(crate) mod db {
     impl sqlx::FromRow<'_, sqlx::postgres::PgRow> for IotMetadata {
         fn from_row(row: &sqlx::postgres::PgRow) -> sqlx::Result<Self> {
             Ok(Self {
-                address: row.get::<PublicKeyBinary, &str>("hotspot_key"),
+                address: PublicKeyBinary::from_str(
+                    &bs58::encode(row.get::<&[u8], &str>("entity_key")).into_string(),
+                )
+                .map_err(|err| sqlx::Error::Decode(Box::new(err)))?,
                 location: row.get::<Option<i64>, &str>("location").map(|v| v as u64),
                 elevation: row.get::<Option<i32>, &str>("elevation"),
                 gain: row.get::<Option<i32>, &str>("gain"),


### PR DESCRIPTION
the new database being fed from the solana chain stores the helium crypto public key address of the hotspots as a binary buffer of the b58 decoded address string, as well as splitting the hotspot metadata info between the `iot_hotspot_infos` table where the metadata is stored and the `key_to_assets` table where the encoded pubkey address is stored. this change enables querying the new schema structure by the iot_config server (mobile_config server pending) without changing the RPC API the rest of the oracles use to lookup or stream hotspot on-chain metadata