### PR TITLE
write out non rewardable packet paper trail to s3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,12 +1106,11 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/gateway-rs.git?branch=main#7556cbac64062ab8fa003c0b5dc8aa4c8019ad18"
+source = "git+https://github.com/helium/gateway-rs.git?branch=main#ed478089129cd15dee864711865f7ded3dac713e"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
  "helium-proto",
- "lazy_static",
  "prost",
  "rand 0.8.5",
  "rand_chacha 0.3.0",
@@ -2864,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#a96075ee01deb7e89b3254733ccb8ad0d68d7dd8"
+source = "git+https://github.com/helium/proto?branch=master#169886ab876cd4433b14e3cc7b6d8345e32ba576"
 dependencies = [
  "bytes",
  "prost",
@@ -7264,7 +7263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/file_store/src/file_info.rs
+++ b/file_store/src/file_info.rs
@@ -117,6 +117,7 @@ pub const REWARD_MANIFEST: &str = "reward_manifest";
 pub const IOT_PACKET_REPORT: &str = "packetreport";
 pub const IOT_VALID_PACKET: &str = "iot_valid_packet";
 pub const INVALID_PACKET: &str = "invalid_packet";
+pub const NON_REWARDABLE_PACKET: &str = "non_rewardable_packet";
 pub const IOT_REWARD_SHARE: &str = "iot_reward_share";
 pub const DATA_TRANSFER_SESSION_INGEST_REPORT: &str = "data_transfer_session_ingest_report";
 pub const VALID_DATA_TRANSFER_SESSION: &str = "valid_data_transfer_session";
@@ -146,6 +147,7 @@ pub enum FileType {
     IotPacketReport,
     IotValidPacket,
     InvalidPacket,
+    NonRewardablePacket,
     IotRewardShare,
     DataTransferSessionIngestReport,
     ValidDataTransferSession,
@@ -180,6 +182,7 @@ impl fmt::Display for FileType {
             Self::IotPacketReport => IOT_PACKET_REPORT,
             Self::IotValidPacket => IOT_VALID_PACKET,
             Self::InvalidPacket => INVALID_PACKET,
+            Self::NonRewardablePacket => NON_REWARDABLE_PACKET,
             Self::IotRewardShare => IOT_REWARD_SHARE,
             Self::DataTransferSessionIngestReport => DATA_TRANSFER_SESSION_INGEST_REPORT,
             Self::ValidDataTransferSession => VALID_DATA_TRANSFER_SESSION,
@@ -215,6 +218,7 @@ impl FileType {
             Self::IotPacketReport => IOT_PACKET_REPORT,
             Self::IotValidPacket => IOT_VALID_PACKET,
             Self::InvalidPacket => INVALID_PACKET,
+            Self::NonRewardablePacket => NON_REWARDABLE_PACKET,
             Self::IotRewardShare => IOT_REWARD_SHARE,
             Self::DataTransferSessionIngestReport => DATA_TRANSFER_SESSION_INGEST_REPORT,
             Self::ValidDataTransferSession => VALID_DATA_TRANSFER_SESSION,
@@ -248,6 +252,7 @@ impl FromStr for FileType {
             IOT_PACKET_REPORT => Self::IotPacketReport,
             IOT_VALID_PACKET => Self::IotValidPacket,
             INVALID_PACKET => Self::InvalidPacket,
+            NON_REWARDABLE_PACKET => Self::NonRewardablePacket,
             IOT_REWARD_SHARE => Self::IotRewardShare,
             DATA_TRANSFER_SESSION_INGEST_REPORT => Self::DataTransferSessionIngestReport,
             VALID_DATA_TRANSFER_SESSION => Self::ValidDataTransferSession,

--- a/file_store/src/iot_packet.rs
+++ b/file_store/src/iot_packet.rs
@@ -108,6 +108,19 @@ impl TryFrom<ValidPacket> for IotValidPacket {
     }
 }
 
+impl From<IotValidPacket> for ValidPacket {
+    fn from(v: IotValidPacket) -> Self {
+        let ts = v.timestamp();
+        Self {
+            gateway: v.gateway.into(),
+            payload_hash: v.payload_hash,
+            payload_size: v.payload_size,
+            num_dcs: v.num_dcs,
+            packet_timestamp: ts,
+        }
+    }
+}
+
 impl IotValidPacket {
     pub fn packet_id(&self) -> Vec<u8> {
         let mut hasher = Hasher::new();

--- a/iot_verifier/src/metrics.rs
+++ b/iot_verifier/src/metrics.rs
@@ -1,5 +1,8 @@
 use std::cell::RefCell;
 
+const PACKET_COUNTER: &str = concat!(env!("CARGO_PKG_NAME"), "_", "packet");
+const NON_REWARDABLE_PACKET_COUNTER: &str =
+    concat!(env!("CARGO_PKG_NAME"), "_", "non_rewardable_packet");
 const LOADER_BEACON_COUNTER: &str = concat!(env!("CARGO_PKG_NAME"), "_", "loader_beacon");
 const LOADER_WITNESS_COUNTER: &str = concat!(env!("CARGO_PKG_NAME"), "_", "loader_witness");
 const LOADER_DROPPED_BEACON_COUNTER: &str = concat!(env!("CARGO_PKG_NAME"), "_", "dropped_beacon");
@@ -12,6 +15,14 @@ const INVALID_WITNESS_COUNTER: &str =
 pub struct Metrics;
 
 impl Metrics {
+    pub fn count_packets(count: u64) {
+        metrics::counter!(PACKET_COUNTER, count);
+    }
+
+    pub fn count_non_rewardable_packets(count: u64) {
+        metrics::counter!(NON_REWARDABLE_PACKET_COUNTER, count);
+    }
+
     pub fn count_loader_beacons(count: u64) {
         metrics::counter!(LOADER_BEACON_COUNTER, count);
     }
@@ -53,11 +64,21 @@ pub struct LoaderMetricTracker {
     witnesses_no_beacon: RefCell<u64>,
     witnesses_denied: RefCell<u64>,
     witnesses_unknown: RefCell<u64>,
+    packets: RefCell<u64>,
+    non_rewardable_packets: RefCell<u64>,
 }
 
 impl LoaderMetricTracker {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn increment_packets(&self) {
+        *self.packets.borrow_mut() += 1;
+    }
+
+    pub fn increment_non_rewardable_packets(&self) {
+        *self.non_rewardable_packets.borrow_mut() += 1;
     }
 
     pub fn increment_beacons(&self) {
@@ -97,6 +118,17 @@ impl LoaderMetricTracker {
         let witnesses_no_beacon = self.witnesses_no_beacon.into_inner();
         let witnesses_denied = self.witnesses_denied.into_inner();
         let witnesses_unknown = self.witnesses_unknown.into_inner();
+
+        let packets = self.packets.into_inner();
+        let non_rewardable_packets = self.non_rewardable_packets.into_inner();
+
+        if packets > 0 {
+            Metrics::count_packets(packets);
+        }
+
+        if non_rewardable_packets > 0 {
+            Metrics::count_non_rewardable_packets(packets);
+        }
 
         if beacons > 0 {
             Metrics::count_loader_beacons(beacons);

--- a/iot_verifier/src/packet_loader.rs
+++ b/iot_verifier/src/packet_loader.rs
@@ -1,11 +1,22 @@
-use crate::{gateway_cache::GatewayCache, reward_share::GatewayDCShare};
-use file_store::{file_info_poller::FileInfoStream, iot_packet::IotValidPacket};
+use crate::{
+    gateway_cache::GatewayCache, metrics::LoaderMetricTracker, reward_share::GatewayDCShare,
+    Settings,
+};
+use chrono::{Duration as ChronoDuration, Utc};
+use file_store::{
+    file_info_poller::FileInfoStream, file_sink, file_sink::FileSinkClient,
+    file_upload::MessageSender as FileUploadSender, iot_packet::IotValidPacket, FileType,
+};
 use futures::{StreamExt, TryStreamExt};
+use helium_proto::services::packet_verifier::ValidPacket;
+use helium_proto::services::poc_lora::{NonRewardablePacket, NonRewardablePacketReason};
 use sqlx::PgPool;
+use std::path::Path;
 use tokio::sync::mpsc::Receiver;
 
 pub struct PacketLoader {
     pub pool: PgPool,
+    pub cache: String,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -17,13 +28,34 @@ pub enum NewLoaderError {
 }
 
 impl PacketLoader {
+    pub fn from_settings(settings: &Settings, pool: PgPool) -> Self {
+        tracing::info!("from_settings packet loader");
+        let cache = settings.cache.clone();
+        Self { pool, cache }
+    }
+
     pub async fn run(
-        &mut self,
+        &self,
         mut receiver: Receiver<FileInfoStream<IotValidPacket>>,
         shutdown: &triggered::Listener,
         gateway_cache: &GatewayCache,
+        file_upload_tx: FileUploadSender,
     ) -> anyhow::Result<()> {
         tracing::info!("starting verifier iot packet loader");
+        let store_base_path = Path::new(&self.cache);
+        let (non_rewardable_packet_sink, mut non_rewardable_packet_server) =
+            file_sink::FileSinkBuilder::new(
+                FileType::NonRewardablePacket,
+                store_base_path,
+                concat!(env!("CARGO_PKG_NAME"), "_non_rewardable_packet"),
+                shutdown.clone(),
+            )
+            .deposits(Some(file_upload_tx.clone()))
+            .roll_time(ChronoDuration::minutes(5))
+            .create()
+            .await?;
+        tokio::spawn(async move { non_rewardable_packet_server.run().await });
+
         loop {
             if shutdown.is_triggered() {
                 break;
@@ -31,7 +63,17 @@ impl PacketLoader {
             tokio::select! {
                 _ = shutdown.clone() => break,
                 msg = receiver.recv() => if let Some(stream) =  msg {
-                    self.handle_packet(stream, gateway_cache).await?;
+                    let metrics = LoaderMetricTracker::new();
+                    match self.handle_packet_file(stream, gateway_cache, &non_rewardable_packet_sink, &metrics).await {
+                        Ok(()) => {
+                            // todo: maybe two actions below can occur in handle_packet
+                            // but wasnt able to get it to work ?
+                            metrics.record_metrics();
+                            non_rewardable_packet_sink.commit().await?;
+
+                        },
+                        Err(err) => { return Err(err)}
+                    }
                 }
             }
         }
@@ -39,30 +81,60 @@ impl PacketLoader {
         Ok(())
     }
 
-    async fn handle_packet(
+    async fn handle_packet_file(
         &self,
         file_info_stream: FileInfoStream<IotValidPacket>,
         gateway_cache: &GatewayCache,
+        non_rewardable_packet_sink: &FileSinkClient,
+        metrics: &LoaderMetricTracker,
     ) -> anyhow::Result<()> {
         let mut transaction = self.pool.begin().await?;
+
         file_info_stream
             .into_stream(&mut transaction)
             .await?
-            .map(|valid_packet| GatewayDCShare::share_from_packet(&valid_packet))
-            .map(anyhow::Ok)
-            .try_fold(transaction, |mut transaction, reward_share| async move {
-                if gateway_cache
-                    .resolve_gateway_info(&reward_share.hotspot_key)
-                    .await
-                    .is_ok()
-                {
-                    reward_share.save(&mut transaction).await?;
-                };
-                Ok(transaction)
+            .map(|valid_packet| {
+                (
+                    ValidPacket::from(valid_packet.clone()),
+                    GatewayDCShare::share_from_packet(&valid_packet),
+                )
             })
+            .map(anyhow::Ok)
+            .try_fold(
+                transaction,
+                |mut transaction, (valid_packet, reward_share)| async move {
+                    if gateway_cache
+                        .resolve_gateway_info(&reward_share.hotspot_key)
+                        .await
+                        .is_ok()
+                    {
+                        reward_share.save(&mut transaction).await?;
+                        metrics.increment_packets();
+                    } else {
+                        // the gateway doesnt exist, dont reward
+                        // write out a paper trail for an unrewardable packet
+                        let timestamp: u64 = Utc::now().timestamp_millis() as u64;
+                        let reason = NonRewardablePacketReason::GatewayNotFoundForPacket;
+                        let non_rewardable_packet_proto = NonRewardablePacket {
+                            packet: Some(valid_packet),
+                            reason: reason as i32,
+                            timestamp,
+                        };
+                        non_rewardable_packet_sink
+                            .write(
+                                non_rewardable_packet_proto,
+                                &[("reason", reason.as_str_name())],
+                            )
+                            .await?;
+                        metrics.increment_non_rewardable_packets();
+                    };
+                    Ok(transaction)
+                },
+            )
             .await?
             .commit()
             .await?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
depends on: https://github.com/helium/proto/pull/325

Writes out a paper trail to S3 for verified packets ( outputted by the iot packet verifier ) that are deemed not rewardable.  Currently this would only be in the scenario whereby the gateway does not exist but may in the future extend to additional scenarios ( such as duplicate or free packets )

Also adds metrics to the packet loader
