### PR TITLE
make retry limit for poc reports configurable

### DIFF
--- a/iot_verifier/pkg/settings-template.toml
+++ b/iot_verifier/pkg/settings-template.toml
@@ -46,6 +46,17 @@ entropy_lifespan = 180
 # File store poll interval for incoming entropy reports, in seconds
 entropy_interval = 300
 
+# runner runs at 30 sec intervals
+# 60 permits retries for up to 30 mins
+beacon_max_retries = 60
+
+# witnesses are processed per beacon
+# as such the retry can be much less as if the beacon fails
+# then the witnesses auto fail too
+# if the beacon is processed successfully, then any one witness
+# can only fail 5 times before we move on without it
+witness_max_retries = 5
+
 [database]
 
 # Postgres Connection Information

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -42,6 +42,8 @@ pub struct Runner {
     beacon_interval: ChronoDuration,
     beacon_interval_tolerance: ChronoDuration,
     max_witnesses_per_poc: u64,
+    beacon_max_retries: u64,
+    witness_max_retries: u64,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -64,12 +66,16 @@ impl Runner {
         let beacon_interval = settings.beacon_interval();
         let beacon_interval_tolerance = settings.beacon_interval_tolerance();
         let max_witnesses_per_poc = settings.max_witnesses_per_poc;
+        let beacon_max_retries = settings.beacon_max_retries;
+        let witness_max_retries = settings.witness_max_retries;
         Ok(Self {
             pool,
             cache,
             beacon_interval,
             beacon_interval_tolerance,
             max_witnesses_per_poc,
+            beacon_max_retries,
+            witness_max_retries,
         })
     }
 
@@ -166,7 +172,8 @@ impl Runner {
         hex_density_map: impl HexDensityMap,
     ) -> anyhow::Result<()> {
         tracing::info!("starting query get_next_beacons");
-        let db_beacon_reports = Report::get_next_beacons(&self.pool).await?;
+        let db_beacon_reports =
+            Report::get_next_beacons(&self.pool, self.beacon_max_retries).await?;
         tracing::info!("completed query get_next_beacons");
         if db_beacon_reports.is_empty() {
             tracing::info!("no beacons ready for verification");
@@ -236,7 +243,9 @@ impl Runner {
         let beacon = &beacon_report.report;
         let beacon_received_ts = beacon_report.received_timestamp;
 
-        let db_witnesses = Report::get_witnesses_for_beacon(&self.pool, packet_data).await?;
+        let db_witnesses =
+            Report::get_witnesses_for_beacon(&self.pool, packet_data, self.witness_max_retries)
+                .await?;
         let witness_len = db_witnesses.len();
         tracing::debug!("found {witness_len} witness for beacon");
 

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -74,6 +74,14 @@ pub struct Settings {
     /// File store poll interval for incoming packets, in seconds. (Default is 900; 15 minutes)
     #[serde(default = "default_packet_interval")]
     pub packet_interval: i64,
+    /// the max number of times a beacon report will be retried
+    /// after this the report will be ignored and eventually be purged
+    #[serde(default = "default_beacon_max_retries")]
+    pub beacon_max_retries: u64,
+    /// the max number of times a witness report will be retried
+    /// after this the report will be ignored and eventually be purged
+    #[serde(default = "default_witness_max_retries")]
+    pub witness_max_retries: u64,
 }
 
 // Default: 60 minutes
@@ -149,6 +157,21 @@ pub fn default_max_witnesses_per_poc() -> u64 {
 
 fn default_packet_interval() -> i64 {
     900
+}
+
+// runner runs at 30 sec intervals
+// 60 permits retries for up to 30 mins
+fn default_beacon_max_retries() -> u64 {
+    60
+}
+
+// witnesses are processed per beacon
+// as such the retry can be much less as if the beacon fails
+// then the witnesses auto fail too
+// if the beacon is processed successfully, then any one witness
+// can only fail 5 times before we move on without it
+fn default_witness_max_retries() -> u64 {
+    5
 }
 
 impl Settings {


### PR DESCRIPTION
Make the retry limit for poc reports configurable and allow the verifier to be more easily configured to be more tolerant of failure or downtime