### PR TITLE
Gateway cache related tweaks

### DIFF
--- a/iot_verifier/src/gateway_cache.rs
+++ b/iot_verifier/src/gateway_cache.rs
@@ -73,7 +73,7 @@ impl GatewayCache {
                 Ok(hit.value().clone())
             }
             _ => {
-                tracing::debug!("cache miss: {:?}", address);
+                tracing::debug!(?address, "cache miss");
                 metrics::increment_counter!("oracles_iot_verifier_gateway_cache_miss");
                 match self
                     .iot_config_client


### PR DESCRIPTION
Various improvements identified after an outage between iot verifier and the config service.

1. fire cache miss metric irrespective of result of config service request
2. Add metric to track config service request errors
3. add jitter to the TTL for each entry to the cache
