### PR TITLE
Change file_sink and file_info_poller to handle shutdowns better while send data across mpsc channel

### DIFF
--- a/file_store/src/error.rs
+++ b/file_store/src/error.rs
@@ -28,6 +28,10 @@ pub enum Error {
     DbError(#[from] sqlx::Error),
     #[error("tokio join error")]
     JoinError(#[from] tokio::task::JoinError),
+    #[error("send timeout")]
+    SendTimeout,
+    #[error("shutting down")]
+    Shutdown,
 }
 
 #[derive(Error, Debug)]

--- a/file_store/src/file_sink.rs
+++ b/file_store/src/file_sink.rs
@@ -162,7 +162,7 @@ pub struct FileSinkClient {
 
 const OK_LABEL: Label = Label::from_static_parts("status", "ok");
 const ERROR_LABEL: Label = Label::from_static_parts("status", "error");
-const SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 impl FileSinkClient {
     pub async fn write<T: prost::Message>(

--- a/file_store/src/file_sink.rs
+++ b/file_store/src/file_sink.rs
@@ -11,7 +11,10 @@ use std::{
 use tokio::{
     fs::{self, File, OpenOptions},
     io::{AsyncWriteExt, BufWriter},
-    sync::{mpsc, oneshot},
+    sync::{
+        mpsc::{self, error::SendTimeoutError},
+        oneshot,
+    },
     time,
 };
 use tokio_util::codec::{length_delimited::LengthDelimitedCodec, FramedWrite};
@@ -62,10 +65,16 @@ pub struct FileSinkBuilder {
     deposits: Option<file_upload::MessageSender>,
     auto_commit: bool,
     metric: &'static str,
+    shutdown_listener: triggered::Listener,
 }
 
 impl FileSinkBuilder {
-    pub fn new(file_type: FileType, target_path: &Path, metric: &'static str) -> Self {
+    pub fn new(
+        file_type: FileType,
+        target_path: &Path,
+        metric: &'static str,
+        shutdown_listener: triggered::Listener,
+    ) -> Self {
         Self {
             prefix: file_type.to_string(),
             target_path: target_path.to_path_buf(),
@@ -75,6 +84,7 @@ impl FileSinkBuilder {
             deposits: None,
             auto_commit: true,
             metric,
+            shutdown_listener,
         }
     }
 
@@ -120,6 +130,7 @@ impl FileSinkBuilder {
         let client = FileSinkClient {
             sender: tx,
             metric: self.metric,
+            shutdown_listener: self.shutdown_listener.clone(),
         };
 
         metrics::register_counter!(client.metric, vec![OK_LABEL]);
@@ -135,6 +146,7 @@ impl FileSinkBuilder {
             staged_files: Vec::new(),
             auto_commit: self.auto_commit,
             active_sink: None,
+            shutdown_listener: self.shutdown_listener,
         };
         sink.init().await?;
         Ok((client, sink))
@@ -145,10 +157,12 @@ impl FileSinkBuilder {
 pub struct FileSinkClient {
     sender: MessageSender,
     metric: &'static str,
+    shutdown_listener: triggered::Listener,
 }
 
 const OK_LABEL: Label = Label::from_static_parts("status", "ok");
 const ERROR_LABEL: Label = Label::from_static_parts("status", "error");
+const SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 impl FileSinkClient {
     pub async fn write<T: prost::Message>(
@@ -160,27 +174,36 @@ impl FileSinkClient {
         let bytes = item.encode_to_vec();
         let labels = labels.into_iter().map(Label::from);
 
-        match self.sender.send(Message::Data(on_write_tx, bytes)).await {
-            Ok(_) => {
-                metrics::increment_counter!(
-                    self.metric,
-                    labels
-                        .chain(std::iter::once(OK_LABEL))
-                        .collect::<Vec<Label>>()
-                );
-                tracing::debug!("file_sink write succeeded for {:?}", self.metric);
-                Ok(on_write_rx)
+        tokio::select! {
+            _ = self.shutdown_listener.clone() => {
+                Err(Error::Shutdown)
             }
-            Err(e) => {
-                metrics::increment_counter!(
-                    self.metric,
-                    labels
-                        .chain(std::iter::once(ERROR_LABEL))
-                        .collect::<Vec<Label>>()
-                );
-                tracing::error!("file_sink write failed for {:?} with {e:?}", self.metric);
-                Err(Error::channel())
-            }
+            result = self.sender.send_timeout(Message::Data(on_write_tx, bytes), SEND_TIMEOUT) => match result {
+                Ok(_) => {
+                    metrics::increment_counter!(
+                        self.metric,
+                        labels
+                            .chain(std::iter::once(OK_LABEL))
+                            .collect::<Vec<Label>>()
+                    );
+                    tracing::debug!("file_sink write succeeded for {:?}", self.metric);
+                    Ok(on_write_rx)
+                }
+                Err(SendTimeoutError::Closed(_)) => {
+                    metrics::increment_counter!(
+                        self.metric,
+                        labels
+                            .chain(std::iter::once(ERROR_LABEL))
+                            .collect::<Vec<Label>>()
+                    );
+                    tracing::error!("file_sink write failed for {:?} channel closed", self.metric);
+                    Err(Error::channel())
+                }
+                Err(SendTimeoutError::Timeout(_)) => {
+                    tracing::error!("file_sink write failed due to send timeout");
+                    Err(Error::SendTimeout)
+                }
+            },
         }
     }
 
@@ -223,6 +246,7 @@ pub struct FileSink {
     auto_commit: bool,
 
     active_sink: Option<ActiveSink>,
+    shutdown_listener: triggered::Listener,
 }
 
 #[derive(Debug)]
@@ -285,7 +309,7 @@ impl FileSink {
         Ok(())
     }
 
-    pub async fn run(&mut self, shutdown: &triggered::Listener) -> Result {
+    pub async fn run(&mut self) -> Result {
         tracing::info!(
             "starting file sink {} in {}",
             self.prefix,
@@ -301,7 +325,7 @@ impl FileSink {
 
         loop {
             tokio::select! {
-                _ = shutdown.clone() => break,
+                _ = self.shutdown_listener.clone() => break,
                 _ = rollover_timer.tick() => self.maybe_roll().await?,
                 msg = self.messages.recv() => match msg {
                     Some(Message::Data(on_write_tx, bytes)) => {
@@ -490,16 +514,20 @@ mod tests {
         let tmp_dir = TempDir::new().expect("Unable to create temp dir");
         let (shutdown_trigger, shutdown_listener) = triggered::trigger();
 
-        let (file_sink_client, mut file_sink_server) =
-            FileSinkBuilder::new(FileType::EntropyReport, tmp_dir.path(), "fake_metric")
-                .roll_time(chrono::Duration::milliseconds(100))
-                .create()
-                .await
-                .expect("failed to create file sink");
+        let (file_sink_client, mut file_sink_server) = FileSinkBuilder::new(
+            FileType::EntropyReport,
+            tmp_dir.path(),
+            "fake_metric",
+            shutdown_listener.clone(),
+        )
+        .roll_time(chrono::Duration::milliseconds(100))
+        .create()
+        .await
+        .expect("failed to create file sink");
 
         let sink_thread = tokio::spawn(async move {
             file_sink_server
-                .run(&shutdown_listener)
+                .run()
                 .await
                 .expect("failed to complete file sink");
         });
@@ -531,18 +559,22 @@ mod tests {
         let (shutdown_trigger, shutdown_listener) = triggered::trigger();
         let (file_upload_tx, mut file_upload_rx) = file_upload::message_channel();
 
-        let (file_sink_client, mut file_sink_server) =
-            FileSinkBuilder::new(FileType::EntropyReport, tmp_dir.path(), "fake_metric")
-                .roll_time(chrono::Duration::milliseconds(100))
-                .auto_commit(false)
-                .deposits(Some(file_upload_tx))
-                .create()
-                .await
-                .expect("failed to create file sink");
+        let (file_sink_client, mut file_sink_server) = FileSinkBuilder::new(
+            FileType::EntropyReport,
+            tmp_dir.path(),
+            "fake_metric",
+            shutdown_listener.clone(),
+        )
+        .roll_time(chrono::Duration::milliseconds(100))
+        .auto_commit(false)
+        .deposits(Some(file_upload_tx))
+        .create()
+        .await
+        .expect("failed to create file sink");
 
         let sink_thread = tokio::spawn(async move {
             file_sink_server
-                .run(&shutdown_listener)
+                .run()
                 .await
                 .expect("failed to complete file sink");
         });

--- a/ingest/src/server_iot.rs
+++ b/ingest/src/server_iot.rs
@@ -123,6 +123,7 @@ pub async fn grpc_server(shutdown: triggered::Listener, settings: &Settings) -> 
         FileType::IotBeaconIngestReport,
         store_base_path,
         concat!(env!("CARGO_PKG_NAME"), "_beacon_report"),
+        shutdown.clone(),
     )
     .deposits(Some(file_upload_tx.clone()))
     .roll_time(Duration::minutes(5))
@@ -134,6 +135,7 @@ pub async fn grpc_server(shutdown: triggered::Listener, settings: &Settings) -> 
         FileType::IotWitnessIngestReport,
         store_base_path,
         concat!(env!("CARGO_PKG_NAME"), "_witness_report"),
+        shutdown.clone(),
     )
     .deposits(Some(file_upload_tx.clone()))
     .roll_time(Duration::minutes(5))
@@ -155,12 +157,8 @@ pub async fn grpc_server(shutdown: triggered::Listener, settings: &Settings) -> 
 
     tokio::try_join!(
         server,
-        beacon_report_sink_server
-            .run(&shutdown)
-            .map_err(Error::from),
-        witness_report_sink_server
-            .run(&shutdown)
-            .map_err(Error::from),
+        beacon_report_sink_server.run().map_err(Error::from),
+        witness_report_sink_server.run().map_err(Error::from),
         file_upload.run(&shutdown).map_err(Error::from),
     )
     .map(|_| ())

--- a/ingest/src/server_mobile.rs
+++ b/ingest/src/server_mobile.rs
@@ -218,6 +218,7 @@ pub async fn grpc_server(shutdown: triggered::Listener, settings: &Settings) -> 
             FileType::SubscriberLocationIngestReport,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_subscriber_location_report"),
+            shutdown.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))

--- a/ingest/src/server_mobile.rs
+++ b/ingest/src/server_mobile.rs
@@ -178,6 +178,7 @@ pub async fn grpc_server(shutdown: triggered::Listener, settings: &Settings) -> 
             FileType::CellHeartbeatIngestReport,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_heartbeat_report"),
+            shutdown.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))
@@ -190,6 +191,7 @@ pub async fn grpc_server(shutdown: triggered::Listener, settings: &Settings) -> 
             FileType::CellSpeedtestIngestReport,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_speedtest_report"),
+            shutdown.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))
@@ -204,6 +206,7 @@ pub async fn grpc_server(shutdown: triggered::Listener, settings: &Settings) -> 
                 env!("CARGO_PKG_NAME"),
                 "_mobile_data_transfer_session_report"
             ),
+            shutdown.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))
@@ -261,17 +264,11 @@ pub async fn grpc_server(shutdown: triggered::Listener, settings: &Settings) -> 
 
     tokio::try_join!(
         server,
-        heartbeat_report_sink_server
-            .run(&shutdown)
-            .map_err(Error::from),
-        speedtest_report_sink_server
-            .run(&shutdown)
-            .map_err(Error::from),
-        data_transfer_session_sink_server
-            .run(&shutdown)
-            .map_err(Error::from),
+        heartbeat_report_sink_server.run().map_err(Error::from),
+        speedtest_report_sink_server.run().map_err(Error::from),
+        data_transfer_session_sink_server.run().map_err(Error::from),
         subscriber_location_report_sink_server
-            .run(&shutdown)
+            .run()
             .map_err(Error::from),
         file_upload.run(&shutdown).map_err(Error::from),
     )

--- a/iot_packet_verifier/src/daemon.rs
+++ b/iot_packet_verifier/src/daemon.rs
@@ -137,6 +137,7 @@ impl Cmd {
             FileType::IotValidPacket,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_valid_packets"),
+            shutdown_listener.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .auto_commit(false)
@@ -147,6 +148,7 @@ impl Cmd {
             FileType::InvalidPacket,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_invalid_packets"),
+            shutdown_listener.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .auto_commit(false)
@@ -188,12 +190,8 @@ impl Cmd {
             burner.run(&shutdown_listener).map_err(Error::from),
             file_upload.run(&shutdown_listener).map_err(Error::from),
             verifier_daemon.run(&shutdown_listener).map_err(Error::from),
-            valid_packets_server
-                .run(&shutdown_listener)
-                .map_err(Error::from),
-            invalid_packets_server
-                .run(&shutdown_listener)
-                .map_err(Error::from),
+            valid_packets_server.run().map_err(Error::from),
+            invalid_packets_server.run().map_err(Error::from),
             config_server
                 .monitor_funds(
                     solana,

--- a/iot_verifier/src/main.rs
+++ b/iot_verifier/src/main.rs
@@ -101,6 +101,7 @@ impl Server {
             FileType::IotRewardShare,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_gateway_reward_shares"),
+            shutdown.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .auto_commit(false)
@@ -112,6 +113,7 @@ impl Server {
             FileType::RewardManifest,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_iot_reward_manifest"),
+            shutdown.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .auto_commit(false)
@@ -170,8 +172,8 @@ impl Server {
 
         tokio::try_join!(
             db_join_handle.map_err(Error::from),
-            gateway_rewards_server.run(&shutdown).map_err(Error::from),
-            reward_manifests_server.run(&shutdown).map_err(Error::from),
+            gateway_rewards_server.run().map_err(Error::from),
+            reward_manifests_server.run().map_err(Error::from),
             file_upload.run(&shutdown).map_err(Error::from),
             runner.run(
                 file_upload_tx.clone(),

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -99,6 +99,7 @@ impl Runner {
                 FileType::IotInvalidBeaconReport,
                 store_base_path,
                 concat!(env!("CARGO_PKG_NAME"), "_invalid_beacon_report"),
+                shutdown.clone(),
             )
             .deposits(Some(file_upload_tx.clone()))
             .roll_time(ChronoDuration::minutes(5))
@@ -110,6 +111,7 @@ impl Runner {
                 FileType::IotInvalidWitnessReport,
                 store_base_path,
                 concat!(env!("CARGO_PKG_NAME"), "_invalid_witness_report"),
+                shutdown.clone(),
             )
             .deposits(Some(file_upload_tx.clone()))
             .roll_time(ChronoDuration::minutes(5))
@@ -120,20 +122,16 @@ impl Runner {
             FileType::IotPoc,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_valid_poc"),
+            shutdown.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .roll_time(ChronoDuration::minutes(2))
         .create()
         .await?;
 
-        // spawn off the file sinks
-        // TODO: how to avoid all da cloning?
-        let shutdown2 = shutdown.clone();
-        let shutdown3 = shutdown.clone();
-        let shutdown4 = shutdown.clone();
-        tokio::spawn(async move { iot_invalid_beacon_sink_server.run(&shutdown2).await });
-        tokio::spawn(async move { iot_invalid_witness_sink_server.run(&shutdown3).await });
-        tokio::spawn(async move { iot_poc_sink_server.run(&shutdown4).await });
+        tokio::spawn(async move { iot_invalid_beacon_sink_server.run().await });
+        tokio::spawn(async move { iot_invalid_witness_sink_server.run().await });
+        tokio::spawn(async move { iot_poc_sink_server.run().await });
 
         loop {
             if shutdown.is_triggered() {

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -125,6 +125,7 @@ impl Cmd {
             FileType::ValidDataTransferSession,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_invalid_packets"),
+            shutdown_listener.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .auto_commit(true)
@@ -154,9 +155,7 @@ impl Cmd {
 
         tokio::try_join!(
             source_join_handle.map_err(Error::from),
-            valid_sessions_server
-                .run(&shutdown_listener)
-                .map_err(Error::from),
+            valid_sessions_server.run().map_err(Error::from),
             file_upload.run(&shutdown_listener).map_err(Error::from),
             daemon.run(&shutdown_listener).map_err(Error::from),
             conn_handler.map_err(Error::from),

--- a/mobile_verifier/src/cli/server.rs
+++ b/mobile_verifier/src/cli/server.rs
@@ -43,6 +43,7 @@ impl Cmd {
             FileType::ValidatedHeartbeat,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_heartbeat"),
+            shutdown_listener.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .auto_commit(false)
@@ -55,6 +56,7 @@ impl Cmd {
             FileType::SpeedtestAvg,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_speedtest_average"),
+            shutdown_listener.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .auto_commit(false)
@@ -67,6 +69,7 @@ impl Cmd {
             FileType::RadioRewardShare,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_radio_reward_shares"),
+            shutdown_listener.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .auto_commit(true)
@@ -78,6 +81,7 @@ impl Cmd {
             FileType::MobileRewardShare,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_radio_reward_shares"),
+            shutdown_listener.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .auto_commit(false)
@@ -89,6 +93,7 @@ impl Cmd {
             FileType::RewardManifest,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_reward_manifest"),
+            shutdown_listener.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .auto_commit(false)
@@ -123,22 +128,12 @@ impl Cmd {
 
         tokio::try_join!(
             db_join_handle.map_err(Error::from),
-            heartbeats_server
-                .run(&shutdown_listener)
-                .map_err(Error::from),
-            speedtest_avgs_server
-                .run(&shutdown_listener)
-                .map_err(Error::from),
-            radio_rewards_server
-                .run(&shutdown_listener)
-                .map_err(Error::from),
-            mobile_rewards_server
-                .run(&shutdown_listener)
-                .map_err(Error::from),
+            heartbeats_server.run().map_err(Error::from),
+            speedtest_avgs_server.run().map_err(Error::from),
+            radio_rewards_server.run().map_err(Error::from),
+            mobile_rewards_server.run().map_err(Error::from),
             file_upload.run(&shutdown_listener).map_err(Error::from),
-            reward_manifests_server
-                .run(&shutdown_listener)
-                .map_err(Error::from),
+            reward_manifests_server.run().map_err(Error::from),
             verifier_daemon.run(&shutdown_listener),
             tracker_process.map_err(Error::from),
         )?;

--- a/poc_entropy/src/main.rs
+++ b/poc_entropy/src/main.rs
@@ -82,6 +82,7 @@ impl Server {
             FileType::EntropyReport,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_report_submission"),
+            shutdown.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .roll_time(Duration::minutes(ENTROPY_SINK_ROLL_MINS))
@@ -99,7 +100,7 @@ impl Server {
             entropy_generator
                 .run(entropy_sink, &shutdown)
                 .map_err(Error::from),
-            entropy_sink_server.run(&shutdown).map_err(Error::from),
+            entropy_sink_server.run().map_err(Error::from),
             file_upload.run(&shutdown).map_err(Error::from),
         )
         .map(|_| ())

--- a/price/src/main.rs
+++ b/price/src/main.rs
@@ -90,6 +90,7 @@ impl Server {
             FileType::PriceReport,
             store_base_path,
             concat!(env!("CARGO_PKG_NAME"), "_report_submission"),
+            shutdown.clone(),
         )
         .deposits(Some(file_upload_tx.clone()))
         .roll_time(Duration::minutes(PRICE_SINK_ROLL_MINS))
@@ -109,7 +110,7 @@ impl Server {
             hst_price_generator
                 .run(price_sink, &shutdown)
                 .map_err(Error::from),
-            price_sink_server.run(&shutdown).map_err(Error::from),
+            price_sink_server.run().map_err(Error::from),
             file_upload.run(&shutdown).map_err(Error::from),
         )
         .map(|_| ())


### PR DESCRIPTION
During testing it was discovered 2 issues in the file_store crate that could cause shutdowns to hang.

in file_sink, we learned that calling `sender.send` and the channel is at capacity, it will not error when the receiver is dropped.  Address this by using `sender.send_timeout` and including a shutdown_listener in a `tokio::select`

In file_info_poller, changed to using `sender.try_send` and handling the Full Error by breaking the for loop and waiting for the next interval tick.gg