### PR TITLE
Add gateway info producer and consumer data in gateway cache and density scaler

### DIFF
--- a/iot_verifier/src/gateway_cache.rs
+++ b/iot_verifier/src/gateway_cache.rs
@@ -1,93 +1,37 @@
-use futures::stream::StreamExt;
+use crate::gateway_updater::MessageReceiver;
 use helium_crypto::PublicKeyBinary;
-use iot_config::{
-    client::{Client as IotConfigClient, ClientError as IotConfigClientError},
-    gateway_info::{GatewayInfo, GatewayInfoResolver},
-};
-use retainer::Cache;
-use std::{sync::Arc, time::Duration};
-use tokio::task::JoinHandle;
-
-/// how long each cached items takes to expire ( 12 hours in seconds)
-const CACHE_TTL: Duration = Duration::from_secs(12 * (60 * 60));
-/// how often to evict expired items from the cache ( every 1 hour)
-const CACHE_EVICTION_FREQUENCY: Duration = Duration::from_secs(60 * 60);
+use iot_config::gateway_info::GatewayInfo;
 
 pub struct GatewayCache {
-    pub iot_config_client: IotConfigClient,
-    pub cache: Arc<Cache<PublicKeyBinary, GatewayInfo>>,
-    pub cache_monitor: JoinHandle<()>,
+    gateway_cache_receiver: MessageReceiver,
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum GatewayCacheError {
     #[error("gateway not found: {0}")]
     GatewayNotFound(PublicKeyBinary),
-    #[error("error querying iot config service")]
-    IotConfigClient(#[from] IotConfigClientError),
 }
 
 impl GatewayCache {
-    pub fn from_settings(iot_config_client: IotConfigClient) -> Self {
-        let cache = Arc::new(Cache::<PublicKeyBinary, GatewayInfo>::new());
-        let clone = cache.clone();
-        // monitor cache to handle evictions
-        let cache_monitor =
-            tokio::spawn(async move { clone.monitor(4, 0.25, CACHE_EVICTION_FREQUENCY).await });
+    pub fn new(gateway_cache_receiver: MessageReceiver) -> Self {
         Self {
-            iot_config_client,
-            cache,
-            cache_monitor,
+            gateway_cache_receiver,
         }
-    }
-
-    pub async fn prewarm(&self) -> anyhow::Result<()> {
-        tracing::info!("starting prewarming gateway cache");
-        let mut gw_stream = self
-            .iot_config_client
-            .clone()
-            .stream_gateways_info()
-            .await?;
-        while let Some(gateway_info) = gw_stream.next().await {
-            _ = self.insert(gateway_info).await;
-        }
-        tracing::info!("completed prewarming gateway cache");
-        Ok(())
     }
 
     pub async fn resolve_gateway_info(
         &self,
         address: &PublicKeyBinary,
     ) -> Result<GatewayInfo, GatewayCacheError> {
-        match self.cache.get(address).await {
+        match self.gateway_cache_receiver.borrow().get(address) {
             Some(hit) => {
-                metrics::increment_counter!("oracles_iot_verifier_gateway_cache_hit");
-                Ok(hit.value().clone())
+                metrics::increment_counter!("oracles_iot_verifier_gateway_found");
+                Ok(hit.clone())
             }
             _ => {
-                match self
-                    .iot_config_client
-                    .clone()
-                    .resolve_gateway_info(address)
-                    .await
-                {
-                    Ok(Some(res)) => {
-                        tracing::debug!("cache miss: {:?}", address);
-                        metrics::increment_counter!("oracles_iot_verifier_gateway_cache_miss");
-                        _ = self.insert(res.clone()).await;
-                        Ok(res)
-                    }
-                    Ok(None) => Err(GatewayCacheError::GatewayNotFound(address.clone())),
-                    Err(err) => Err(GatewayCacheError::IotConfigClient(err)),
-                }
+                metrics::increment_counter!("oracles_iot_verifier_gateway_not_found");
+                Err(GatewayCacheError::GatewayNotFound(address.clone()))
             }
         }
-    }
-
-    pub async fn insert(&self, gateway: GatewayInfo) -> anyhow::Result<()> {
-        self.cache
-            .insert(gateway.address.clone(), gateway, CACHE_TTL)
-            .await;
-        Ok(())
     }
 }

--- a/iot_verifier/src/gateway_cache.rs
+++ b/iot_verifier/src/gateway_cache.rs
@@ -25,11 +25,11 @@ impl GatewayCache {
     ) -> Result<GatewayInfo, GatewayCacheError> {
         match self.gateway_cache_receiver.borrow().get(address) {
             Some(hit) => {
-                metrics::increment_counter!("oracles_iot_verifier_gateway_found");
+                metrics::increment_counter!("oracles_iot_verifier_gateway_cache_hit");
                 Ok(hit.clone())
             }
-            _ => {
-                metrics::increment_counter!("oracles_iot_verifier_gateway_not_found");
+            None => {
+                metrics::increment_counter!("oracles_iot_verifier_gateway_cache_miss");
                 Err(GatewayCacheError::GatewayNotFound(address.clone()))
             }
         }

--- a/iot_verifier/src/gateway_updater.rs
+++ b/iot_verifier/src/gateway_updater.rs
@@ -1,0 +1,89 @@
+use crate::Settings;
+use chrono::Duration;
+use futures::stream::StreamExt;
+use helium_crypto::PublicKeyBinary;
+use iot_config::{
+    client::{Client as IotConfigClient, ClientError as IotConfigClientError},
+    gateway_info::{GatewayInfo, GatewayInfoResolver},
+};
+use std::collections::HashMap;
+use tokio::sync::watch;
+use tokio::time;
+
+pub type GatewayMap = HashMap<PublicKeyBinary, GatewayInfo>;
+pub type MessageSender = watch::Sender<GatewayMap>;
+pub type MessageReceiver = watch::Receiver<GatewayMap>;
+
+pub struct GatewayUpdater {
+    iot_config_client: IotConfigClient,
+    refresh_interval: Duration,
+    pub receiver: MessageReceiver,
+    sender: MessageSender,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GatewayUpdaterError {
+    #[error("gateway not found: {0}")]
+    GatewayNotFound(PublicKeyBinary),
+    #[error("error querying iot config service")]
+    IotConfigClient(#[from] IotConfigClientError),
+}
+
+impl GatewayUpdater {
+    pub async fn from_settings(
+        settings: &Settings,
+        iot_config_client: IotConfigClient,
+    ) -> Result<Self, GatewayUpdaterError> {
+        let gateway_map = refresh_gateways(iot_config_client.clone()).await?;
+        let (sender, receiver) = watch::channel(gateway_map);
+        Ok(Self {
+            iot_config_client,
+            refresh_interval: settings.gateway_refresh_interval(),
+            receiver,
+            sender,
+        })
+    }
+
+    pub async fn run(&self, shutdown: &triggered::Listener) -> Result<(), GatewayUpdaterError> {
+        tracing::info!("starting gateway_updater");
+
+        let mut trigger_timer = time::interval(
+            self.refresh_interval
+                .to_std()
+                .expect("valid interval in seconds"),
+        );
+
+        loop {
+            if shutdown.is_triggered() {
+                tracing::info!("stopping gateway_updater");
+                return Ok(());
+            }
+
+            tokio::select! {
+                _ = trigger_timer.tick() => self.handle_refresh_tick().await?,
+                _ = shutdown.clone() => return Ok(()),
+            }
+        }
+    }
+
+    async fn handle_refresh_tick(&self) -> Result<(), GatewayUpdaterError> {
+        tracing::info!("handling refresh tick");
+        let updated_gateway_map = refresh_gateways(self.iot_config_client.clone()).await?;
+        _ = self.sender.send(updated_gateway_map);
+        Ok(())
+    }
+}
+
+pub async fn refresh_gateways(
+    iot_config_client: IotConfigClient,
+) -> Result<GatewayMap, GatewayUpdaterError> {
+    tracing::info!("refreshing gateways");
+    let mut gateways = GatewayMap::new();
+    let mut gw_stream = iot_config_client.clone().stream_gateways_info().await?;
+    while let Some(gateway_info) = gw_stream.next().await {
+        gateways.insert(gateway_info.address.clone(), gateway_info);
+    }
+    let gateway_count = gateways.len();
+    tracing::info!("completed refreshing gateways, total gateways: {gateway_count}");
+    Ok(gateways)
+}

--- a/iot_verifier/src/lib.rs
+++ b/iot_verifier/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod entropy;
 pub mod entropy_loader;
 pub mod gateway_cache;
+pub mod gateway_updater;
 mod hex_density;
 pub mod last_beacon;
 pub mod loader;

--- a/iot_verifier/src/loader.rs
+++ b/iot_verifier/src/loader.rs
@@ -109,7 +109,6 @@ impl Loader {
             }
         }
         tracing::info!("stopping verifier loader");
-        gateway_cache.cache_monitor.abort();
         Ok(())
     }
 

--- a/iot_verifier/src/main.rs
+++ b/iot_verifier/src/main.rs
@@ -87,9 +87,9 @@ impl Server {
 
         let iot_config_client = IotConfigClient::from_settings(&settings.iot_config_client)?;
 
-        let gateway_updater =
+        let (gateway_updater_receiver, gateway_updater) =
             GatewayUpdater::from_settings(settings, iot_config_client.clone()).await?;
-        let gateway_cache = GatewayCache::new(gateway_updater.receiver.clone());
+        let gateway_cache = GatewayCache::new(gateway_updater_receiver.clone());
 
         let region_cache = RegionCache::from_settings(iot_config_client.clone())?;
 
@@ -168,7 +168,7 @@ impl Server {
         let mut runner = runner::Runner::from_settings(settings, pool.clone()).await?;
         let purger = purger::Purger::from_settings(settings, pool.clone()).await?;
         let mut density_scaler =
-            DensityScaler::from_settings(settings, pool, gateway_updater.receiver.clone()).await?;
+            DensityScaler::from_settings(settings, pool, gateway_updater_receiver.clone()).await?;
         let (price_tracker, price_receiver) =
             PriceTracker::start(&settings.price_tracker, shutdown.clone()).await?;
 

--- a/iot_verifier/src/main.rs
+++ b/iot_verifier/src/main.rs
@@ -8,9 +8,9 @@ use file_store::{
 use futures::TryFutureExt;
 use iot_config::client::Client as IotConfigClient;
 use iot_verifier::{
-    entropy_loader, gateway_cache::GatewayCache, loader, metrics::Metrics, packet_loader,
-    poc_report::Report, purger, region_cache::RegionCache, rewarder::Rewarder, runner,
-    tx_scaler::Server as DensityScaler, Settings,
+    entropy_loader, gateway_cache::GatewayCache, gateway_updater::GatewayUpdater, loader,
+    metrics::Metrics, packet_loader, poc_report::Report, purger, region_cache::RegionCache,
+    rewarder::Rewarder, runner, tx_scaler::Server as DensityScaler, Settings,
 };
 use price::PriceTracker;
 use std::path;
@@ -87,8 +87,10 @@ impl Server {
 
         let iot_config_client = IotConfigClient::from_settings(&settings.iot_config_client)?;
 
-        let gateway_cache = GatewayCache::from_settings(iot_config_client.clone());
-        _ = gateway_cache.prewarm().await;
+        let gateway_updater =
+            GatewayUpdater::from_settings(settings, iot_config_client.clone()).await?;
+        let gateway_cache = GatewayCache::new(gateway_updater.receiver.clone());
+
         let region_cache = RegionCache::from_settings(iot_config_client.clone())?;
 
         let (file_upload_tx, file_upload_rx) = file_upload::message_channel();
@@ -166,12 +168,13 @@ impl Server {
         let mut runner = runner::Runner::from_settings(settings, pool.clone()).await?;
         let purger = purger::Purger::from_settings(settings, pool.clone()).await?;
         let mut density_scaler =
-            DensityScaler::from_settings(settings, pool, iot_config_client).await?;
+            DensityScaler::from_settings(settings, pool, gateway_updater.receiver.clone()).await?;
         let (price_tracker, price_receiver) =
             PriceTracker::start(&settings.price_tracker, shutdown.clone()).await?;
 
         tokio::try_join!(
             db_join_handle.map_err(Error::from),
+            gateway_updater.run(&shutdown).map_err(Error::from),
             gateway_rewards_server.run().map_err(Error::from),
             reward_manifests_server.run().map_err(Error::from),
             file_upload.run(&shutdown).map_err(Error::from),

--- a/iot_verifier/src/poc.rs
+++ b/iot_verifier/src/poc.rs
@@ -118,7 +118,6 @@ impl Poc {
             Err(GatewayCacheError::GatewayNotFound(_)) => {
                 return Ok(VerifyBeaconResult::gateway_not_found())
             }
-            Err(err) => return Err(VerificationError::GatewayCache(err)),
         };
         let beaconer_metadata = match beaconer_info.metadata {
             Some(ref metadata) => metadata,
@@ -238,7 +237,6 @@ impl Poc {
                     InvalidParticipantSide::Witness,
                 ));
             }
-            Err(err) => return Err(VerificationError::GatewayCache(err)),
         };
         let witness_metadata = match witness_info.metadata {
             Some(ref metadata) => metadata,

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -82,6 +82,14 @@ pub struct Settings {
     /// after this the report will be ignored and eventually be purged
     #[serde(default = "default_witness_max_retries")]
     pub witness_max_retries: u64,
+    /// interval at which gateways are refreshed
+    #[serde(default = "default_gateway_refresh_interval")]
+    pub gateway_refresh_interval: i64,
+}
+
+// Default: 30 minutes
+fn default_gateway_refresh_interval() -> i64 {
+    30 * 60
 }
 
 // Default: 60 minutes
@@ -238,5 +246,8 @@ impl Settings {
     }
     pub fn packet_interval(&self) -> Duration {
         Duration::seconds(self.packet_interval)
+    }
+    pub fn gateway_refresh_interval(&self) -> Duration {
+        Duration::seconds(self.gateway_refresh_interval)
     }
 }


### PR DESCRIPTION
Replaces the gateway info retainer cache and the density scaler's separate streaming of gateway info from config service with a single tokio watch producer.  The producer will periodically ( default 30 mins ) stream all gateways from config service and the resulting gateway map will be consumed by the gateway info cache and the density scalers.

This way the gateway cache and the density scaler are always in sync.  It also eliminates any individual requests to the config service for gateway info.