### PR TITLE
update oracles to replace h3ron with h3o

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_ops"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7460f7dd8e100147b82a63afca1a20eb6c231ee36b90ba7272e14951cb58af59"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,6 +1631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
+name = "const_panic"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6051f239ecec86fde3410901ab7860d458d160371533842974fc61f96d15879b"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2454,6 +2466,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float_eq"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a80e3145d8ad11ba0995949bbcf48b9df2be62772b3d351ef017dff6ecb853"
+
+[[package]]
 name = "float_next_after"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2642,6 +2660,7 @@ dependencies = [
  "approx",
  "num-traits",
  "rstar",
+ "serde",
 ]
 
 [[package]]
@@ -2651,6 +2670,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdbd3cdc1856ca7736763d2784671c2c9b0093f0ee47e2bed0059feed6afca89"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "geojson"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d728c1df1fbf328d74151efe6cb0586f79ee813346ea981add69bd22c9241b"
+dependencies = [
+ "geo-types",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -2696,12 +2728,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
 name = "group"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,29 +2758,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "h3ron"
-version = "0.16.0"
+name = "h3o"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d71b40c852263f760233f189e324930e1672276f1c91fe079bd9fd58e590600"
+checksum = "b043acc132a9a7d07a8fb9c4b49cc2459f163bb73ab22cdcdefe6b76b3a7df96"
 dependencies = [
  "ahash 0.8.2",
+ "auto_ops",
+ "either",
+ "float_eq",
  "geo",
- "geo-types",
- "h3ron-h3-sys",
- "hashbrown 0.12.3",
- "thiserror",
-]
-
-[[package]]
-name = "h3ron-h3-sys"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c039f9d6d4fc8b77f31739cd5290a70476888f9b57375395d75b9cf1c49f10"
-dependencies = [
- "cc",
- "geo-types",
- "glob",
- "regex",
+ "geojson",
+ "konst",
 ]
 
 [[package]]
@@ -3286,7 +3301,7 @@ dependencies = [
  "futures-util",
  "geo",
  "geo-types",
- "h3ron",
+ "h3o",
  "helium-crypto",
  "helium-proto",
  "http-serde",
@@ -3464,6 +3479,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "konst"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9a8bb6c7c71d151b25936b03e012a4c00daea99e3a3797c6ead66b0a0d55e2"
+dependencies = [
+ "const_panic",
+ "konst_kernel",
+ "typewit",
+]
+
+[[package]]
+name = "konst_kernel"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55d2ab266022e7309df89ed712bddc753e3a3c395c3ced1bb2e4470ec2a8146d"
+dependencies = [
+ "typewit",
 ]
 
 [[package]]
@@ -7218,7 +7253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -7227,6 +7262,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "typewit"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c52b4cb7830f995903b2fcff3f523d21efc1c11f6c1596dd544b7925a64ff56"
 
 [[package]]
 name = "uint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ prost = "*"
 once_cell = "1"
 lazy_static = "1"
 config = {version="0", default-features=false, features=["toml"]}
-h3ron = "*"
+h3o = "0"
 xorf = {version = "0", features = ["serde"] }
 bytes = "*"
 structopt = "0"

--- a/iot_verifier/Cargo.toml
+++ b/iot_verifier/Cargo.toml
@@ -32,7 +32,7 @@ chrono = { workspace = true }
 helium-proto = { workspace = true }
 helium-crypto = {workspace = true }
 async-trait = {workspace = true}
-h3ron = {workspace = true}
+h3o = {workspace = true, features = ["geo"]}
 geo-types = {workspace = true}
 geo = {workspace = true}
 xorf = {workspace = true}

--- a/iot_verifier/src/hex_density.rs
+++ b/iot_verifier/src/hex_density.rs
@@ -1,9 +1,10 @@
 use file_store::SCALING_PRECISION;
-use h3ron::{FromH3Index, H3Cell, Index};
+use h3o::{CellIndex, Resolution};
 use itertools::Itertools;
+use lazy_static::lazy_static;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
-use std::{cmp, collections::HashMap, ops::Range, sync::Arc};
+use std::{cmp, collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
 
 pub struct HexResConfig {
@@ -22,28 +23,27 @@ impl HexResConfig {
     }
 }
 
-type HexMap = HashMap<H3Cell, u64>;
+type HexMap = HashMap<CellIndex, u64>;
 
-const DENSITY_TGT_RES: u8 = 4;
-const MAX_RES: u8 = 11;
-const USED_RES: Range<u8> = DENSITY_TGT_RES..MAX_RES;
-const SCALING_RES: Range<u8> = DENSITY_TGT_RES..MAX_RES + 2;
+const MAX_RES: Resolution = Resolution::Eleven;
+const USED_RES: [Resolution; 7] = [Resolution::Ten, Resolution::Nine, Resolution::Eight, Resolution::Seven, Resolution::Six, Resolution::Five, Resolution::Four];
+const SCALING_RES: [Resolution; 10] = [Resolution::Thirteen, Resolution::Twelve, Resolution::Eleven, Resolution::Ten, Resolution::Nine, Resolution::Eight, Resolution::Seven, Resolution::Six, Resolution::Five, Resolution::Four];
 
-static HIP17_RES_CONFIG: [Option<HexResConfig>; 11] = [
-    // Hex resolutions 0 - 3 and 11 and 12 are currently ignored when calculating density;
-    // For completeness sake their on-chain settings are N=2, TGT=100_000, MAX=100_000
-    None,                                 // 0
-    None,                                 // 1
-    None,                                 // 2
-    None,                                 // 3
-    Some(HexResConfig::new(1, 250, 800)), // 4
-    Some(HexResConfig::new(1, 100, 400)), // 5
-    Some(HexResConfig::new(1, 25, 100)),  // 6
-    Some(HexResConfig::new(2, 5, 20)),    // 7
-    Some(HexResConfig::new(2, 1, 4)),     // 8
-    Some(HexResConfig::new(2, 1, 2)),     // 9
-    Some(HexResConfig::new(2, 1, 1)),     // 10
-];
+lazy_static! {
+    static ref HIP17_RES_CONFIG: HashMap<Resolution, HexResConfig> = {
+        // Hex resolutions 0 - 3 and 11 and 12 are currently ignored when calculating density;
+        // For completeness sake their on-chain settings are N=2, TGT=100_000, MAX=100_000
+        let mut configs = HashMap::new();
+        configs.insert(Resolution::Four, HexResConfig::new(1, 250, 800));
+        configs.insert(Resolution::Five, HexResConfig::new(1, 100, 400));
+        configs.insert(Resolution::Six, HexResConfig::new(1, 25, 100));
+        configs.insert(Resolution::Seven, HexResConfig::new(2, 5, 20));
+        configs.insert(Resolution::Eight, HexResConfig::new(2, 1, 4));
+        configs.insert(Resolution::Nine, HexResConfig::new(2, 1, 2));
+        configs.insert(Resolution::Ten, HexResConfig::new(2, 1, 1));
+        configs
+    };
+}
 
 #[async_trait::async_trait]
 pub trait HexDensityMap: Clone {
@@ -75,7 +75,7 @@ impl HexDensityMap for SharedHexDensityMap {
 pub struct GlobalHexMap {
     clipped_hexes: HexMap,
     unclipped_hexes: HexMap,
-    asserted_hexes: Vec<H3Cell>,
+    asserted_hexes: Vec<CellIndex>,
 }
 
 impl GlobalHexMap {
@@ -88,24 +88,25 @@ impl GlobalHexMap {
     }
 
     pub fn increment_unclipped(&mut self, index: u64) {
-        let cell = H3Cell::from_h3index(index);
-        if let Ok(parent) = cell.get_parent(MAX_RES) {
-            self.unclipped_hexes
-                .entry(parent)
-                .and_modify(|count| *count += 1)
-                .or_insert(1);
-            self.clipped_hexes
-                .entry(parent)
-                .and_modify(|count| *count += 1)
-                .or_insert(1);
-            self.asserted_hexes.push(cell);
+        if let Ok(cell) = CellIndex::try_from(index) {
+            if let Some(parent) = cell.parent(MAX_RES) {
+                self.unclipped_hexes
+                    .entry(parent)
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+                self.clipped_hexes
+                    .entry(parent)
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+                self.asserted_hexes.push(cell);
+            }
         }
     }
 
     pub fn reduce_global(&mut self) {
         // At the point this reduce is triggered the only keys present in the unclipped
         // hexmap are the res 11 parent keys
-        let starting_hexes: Vec<H3Cell> =
+        let starting_hexes: Vec<CellIndex> =
             self.unclipped_hexes.clone().into_keys().unique().collect();
         reduce_hex_res(
             &mut self.unclipped_hexes,
@@ -118,8 +119,8 @@ impl GlobalHexMap {
 fn rollup_child_count(
     unclipped_map: &mut HexMap,
     clipped_map: &mut HexMap,
-    cell: H3Cell,
-    parent: H3Cell,
+    cell: CellIndex,
+    parent: CellIndex,
 ) {
     let cell_count = clipped_map.get(&cell).map_or(0, |count| *count);
 
@@ -136,24 +137,24 @@ fn rollup_child_count(
         .or_insert(cell_count);
 }
 
-fn reduce_hex_res(unclipped: &mut HexMap, clipped: &mut HexMap, hex_list: Vec<H3Cell>) {
-    let mut hexes_at_res: Vec<H3Cell> = hex_list;
-    for res in USED_RES.rev() {
+fn reduce_hex_res(unclipped: &mut HexMap, clipped: &mut HexMap, hex_list: Vec<CellIndex>) {
+    let mut hexes_at_res: Vec<CellIndex> = hex_list;
+    for res in USED_RES {
         std::mem::take(&mut hexes_at_res)
             .into_iter()
             .for_each(|cell| {
-                if let Ok(parent) = cell.get_parent(res) {
+                if let Some(parent) = cell.parent(res) {
                     rollup_child_count(unclipped, clipped, cell, parent);
                     hexes_at_res.push(parent);
                 }
             });
-        let density_tgt = get_res_tgt(res);
+        let density_tgt = get_res_tgt(&res);
         hexes_at_res = hexes_at_res
             .into_iter()
             .unique()
             .map(|parent_cell| {
                 let occupied_count = occupied_count(clipped, &parent_cell, density_tgt);
-                let limit = limit(res, occupied_count);
+                let limit = limit(&res, occupied_count);
                 if let Some(count) = unclipped.get(&parent_cell) {
                     let actual = cmp::min(limit, *count);
                     clipped.insert(parent_cell, actual);
@@ -164,26 +165,22 @@ fn reduce_hex_res(unclipped: &mut HexMap, clipped: &mut HexMap, hex_list: Vec<H3
     }
 }
 
-fn occupied_count(cell_map: &HexMap, hex: &H3Cell, density_tgt: u64) -> u64 {
-    match hex.grid_disk(1) {
-        Ok(k_ring) => k_ring.into_iter().fold(0, |count, cell| {
-            cell_map.get(&cell).map_or(count, |population| {
-                if *population >= density_tgt {
-                    count + 1
-                } else {
-                    count
-                }
-            })
-        }),
-        Err(_) => 0,
-    }
+fn occupied_count(cell_map: &HexMap, hex: &CellIndex, density_tgt: u64) -> u64 {
+    let k_ring = hex.grid_disk::<Vec<_>>(1);
+    k_ring.into_iter().fold(0, |count, cell| {
+        cell_map.get(&cell).map_or(count, |population| {
+            if *population >= density_tgt {
+                count + 1
+            } else {
+                count
+            }
+        })
+    })
 }
 
-fn limit(res: u8, occupied_count: u64) -> u64 {
+fn limit(res: &h3o::Resolution, occupied_count: u64) -> u64 {
     let res_config = HIP17_RES_CONFIG
-        .get(res as usize)
-        .unwrap()
-        .as_ref()
+        .get(res)
         .unwrap();
     let occupied_neighbor_diff = occupied_count.saturating_sub(res_config.neighbors);
     let max = cmp::max((occupied_neighbor_diff) + 1, 1);
@@ -193,8 +190,8 @@ fn limit(res: u8, occupied_count: u64) -> u64 {
 pub fn compute_hex_density_map(global_map: &GlobalHexMap) -> HashMap<u64, Decimal> {
     let mut map: HashMap<u64, Decimal> = HashMap::new();
     for hex in &global_map.asserted_hexes {
-        let scale: Decimal = SCALING_RES.rev().fold(dec!(1.0), |scale, res| {
-            hex.get_parent(res).map_or(scale, |parent| {
+        let scale: Decimal = SCALING_RES.iter().fold(dec!(1.0), |scale, res| {
+            hex.parent(*res).map_or(scale, |parent| {
                 match (
                     global_map.unclipped_hexes.get(&parent),
                     global_map.clipped_hexes.get(&parent),
@@ -209,16 +206,14 @@ pub fn compute_hex_density_map(global_map: &GlobalHexMap) -> HashMap<u64, Decima
             })
         });
         let trunc_scale = scale.round_dp(SCALING_PRECISION);
-        map.insert(hex.h3index(), trunc_scale);
+        map.insert(u64::from(*hex), trunc_scale);
     }
     map
 }
 
-fn get_res_tgt(res: u8) -> u64 {
+fn get_res_tgt(res: &Resolution) -> u64 {
     HIP17_RES_CONFIG
-        .get(res as usize)
-        .unwrap()
-        .as_ref()
+        .get(res)
         .map(|config| config.target)
         .unwrap()
 }

--- a/iot_verifier/src/hex_density.rs
+++ b/iot_verifier/src/hex_density.rs
@@ -26,8 +26,27 @@ impl HexResConfig {
 type HexMap = HashMap<CellIndex, u64>;
 
 const MAX_RES: Resolution = Resolution::Eleven;
-const USED_RES: [Resolution; 7] = [Resolution::Ten, Resolution::Nine, Resolution::Eight, Resolution::Seven, Resolution::Six, Resolution::Five, Resolution::Four];
-const SCALING_RES: [Resolution; 10] = [Resolution::Thirteen, Resolution::Twelve, Resolution::Eleven, Resolution::Ten, Resolution::Nine, Resolution::Eight, Resolution::Seven, Resolution::Six, Resolution::Five, Resolution::Four];
+const USED_RES: [Resolution; 7] = [
+    Resolution::Ten,
+    Resolution::Nine,
+    Resolution::Eight,
+    Resolution::Seven,
+    Resolution::Six,
+    Resolution::Five,
+    Resolution::Four,
+];
+const SCALING_RES: [Resolution; 10] = [
+    Resolution::Thirteen,
+    Resolution::Twelve,
+    Resolution::Eleven,
+    Resolution::Ten,
+    Resolution::Nine,
+    Resolution::Eight,
+    Resolution::Seven,
+    Resolution::Six,
+    Resolution::Five,
+    Resolution::Four,
+];
 
 lazy_static! {
     static ref HIP17_RES_CONFIG: HashMap<Resolution, HexResConfig> = {
@@ -179,9 +198,7 @@ fn occupied_count(cell_map: &HexMap, hex: &CellIndex, density_tgt: u64) -> u64 {
 }
 
 fn limit(res: &h3o::Resolution, occupied_count: u64) -> u64 {
-    let res_config = HIP17_RES_CONFIG
-        .get(res)
-        .unwrap();
+    let res_config = HIP17_RES_CONFIG.get(res).unwrap();
     let occupied_neighbor_diff = occupied_count.saturating_sub(res_config.neighbors);
     let max = cmp::max((occupied_neighbor_diff) + 1, 1);
     cmp::min(res_config.max, res_config.target * max)

--- a/iot_verifier/src/poc.rs
+++ b/iot_verifier/src/poc.rs
@@ -571,9 +571,7 @@ fn verify_witness_region(
 fn verify_witness_distance(beacon_loc: u64, witness_loc: u64) -> GenericVerifyResult {
     let witness_distance = match calc_distance(beacon_loc, witness_loc) {
         Ok(d) => d,
-        Err(_) => {
-            return Err(InvalidReason::MaxDistanceExceeded)
-        }
+        Err(_) => return Err(InvalidReason::MaxDistanceExceeded),
     };
     if witness_distance / 1000 > POC_DISTANCE_LIMIT {
         tracing::debug!(
@@ -684,8 +682,12 @@ pub enum CalcDistanceError {
 fn calc_cell_distance(p1: u64, p2: u64) -> Result<u32, CalcDistanceError> {
     let p1_cell = CellIndex::try_from(p1)?;
     let p2_cell = CellIndex::try_from(p2)?;
-    let source_parent = p1_cell.parent(POC_CELL_PARENT_RES).ok_or(CalcDistanceError::H3ParentError)?;
-    let dest_parent = p2_cell.parent(POC_CELL_PARENT_RES).ok_or(CalcDistanceError::H3ParentError)?;
+    let source_parent = p1_cell
+        .parent(POC_CELL_PARENT_RES)
+        .ok_or(CalcDistanceError::H3ParentError)?;
+    let dest_parent = p2_cell
+        .parent(POC_CELL_PARENT_RES)
+        .ok_or(CalcDistanceError::H3ParentError)?;
     let cell_distance = source_parent.grid_distance(dest_parent)? as u32;
     Ok(cell_distance)
 }
@@ -711,8 +713,7 @@ fn hex_adjustment(loc: &CellIndex) -> f64 {
     let res = loc.resolution();
     // Distance from hex center to edge, sqrt(3)*edge_length/2.
     let edge_length = res.edge_length_m();
-    edge_length * (f64::round(f64::sqrt(3.0) * f64::powf(10.0, 3.0)) / f64::powf(10.0, 3.0))
-        / 2.0
+    edge_length * (f64::round(f64::sqrt(3.0) * f64::powf(10.0, 3.0)) / f64::powf(10.0, 3.0)) / 2.0
 }
 
 fn generate_beacon(

--- a/iot_verifier/src/poc.rs
+++ b/iot_verifier/src/poc.rs
@@ -13,8 +13,8 @@ use file_store::{
     iot_valid_poc::IotVerifiedWitnessReport,
     iot_witness_report::IotWitnessIngestReport,
 };
-use geo::{point, prelude::*, vincenty_distance::FailedToConvergeError};
-use h3ron::{to_geo::ToCoordinate, H3Cell, H3DirectedEdge, Index};
+use geo::{point, prelude::*, vincenty_distance::FailedToConvergeError, Coord};
+use h3o::{CellIndex, LatLng, Resolution};
 use helium_crypto::PublicKeyBinary;
 use helium_proto::{
     services::poc_lora::{InvalidParticipantSide, InvalidReason, VerificationStatus},
@@ -38,7 +38,7 @@ const POC_DISTANCE_LIMIT: u32 = 100;
 /// the minimum distance in cells between a beaconer and witness
 const POC_CELL_DISTANCE_MINIMUM: u32 = 8;
 /// the resolution at which parent cell distance is derived
-const POC_CELL_PARENT_RES: u8 = 11;
+const POC_CELL_PARENT_RES: Resolution = Resolution::Eleven;
 
 lazy_static! {
     /// Scaling factor when inactive gateway is not found in the tx scaling map (20%).
@@ -571,7 +571,9 @@ fn verify_witness_region(
 fn verify_witness_distance(beacon_loc: u64, witness_loc: u64) -> GenericVerifyResult {
     let witness_distance = match calc_distance(beacon_loc, witness_loc) {
         Ok(d) => d,
-        Err(_) => return Err(InvalidReason::MaxDistanceExceeded),
+        Err(_) => {
+            return Err(InvalidReason::MaxDistanceExceeded)
+        }
     };
     if witness_distance / 1000 > POC_DISTANCE_LIMIT {
         tracing::debug!(
@@ -671,42 +673,46 @@ fn calc_fpsl(freq: u64, distance_mtrs: u32) -> f64 {
 pub enum CalcDistanceError {
     #[error("convergence error: {0}")]
     ConvergenceError(#[from] FailedToConvergeError),
-    #[error("h3ron error: {0}")]
-    H3ronError(#[from] h3ron::Error),
+    #[error("h3 invalid cell: {0}")]
+    H3CellError(#[from] h3o::error::InvalidCellIndex),
+    #[error("h3 invalid parent")]
+    H3ParentError,
+    #[error("uncomputable hex grid distance")]
+    H3DistanceError(#[from] h3o::error::LocalIjError),
 }
 
 fn calc_cell_distance(p1: u64, p2: u64) -> Result<u32, CalcDistanceError> {
-    let p1_cell = H3Cell::new(p1);
-    let p2_cell = H3Cell::new(p2);
-    let source_parent = H3Cell::get_parent(&p1_cell, POC_CELL_PARENT_RES)?;
-    let dest_parent = H3Cell::get_parent(&p2_cell, POC_CELL_PARENT_RES)?;
-    let cell_distance = H3Cell::grid_distance_to(&source_parent, dest_parent)? as u32;
+    let p1_cell = CellIndex::try_from(p1)?;
+    let p2_cell = CellIndex::try_from(p2)?;
+    let source_parent = p1_cell.parent(POC_CELL_PARENT_RES).ok_or(CalcDistanceError::H3ParentError)?;
+    let dest_parent = p2_cell.parent(POC_CELL_PARENT_RES).ok_or(CalcDistanceError::H3ParentError)?;
+    let cell_distance = source_parent.grid_distance(dest_parent)? as u32;
     Ok(cell_distance)
 }
 
 fn calc_distance(p1: u64, p2: u64) -> Result<u32, CalcDistanceError> {
-    let p1_cell = H3Cell::new(p1);
-    let p2_cell = H3Cell::new(p2);
-    let p1_coord = H3Cell::to_coordinate(&p1_cell)?;
-    let p2_coord = H3Cell::to_coordinate(&p2_cell)?;
+    let p1_cell = CellIndex::try_from(p1)?;
+    let p2_cell = CellIndex::try_from(p2)?;
+    let p1_latlng: LatLng = p1_cell.into();
+    let p2_latlng: LatLng = p2_cell.into();
+    let p1_coord: Coord = p1_latlng.into();
+    let p2_coord: Coord = p2_latlng.into();
 
     let (p1_x, p1_y) = p1_coord.x_y();
     let (p2_x, p2_y) = p2_coord.x_y();
     let p1_geo = point!(x: p1_x, y: p1_y);
     let p2_geo = point!(x: p2_x, y: p2_y);
     let distance = p1_geo.vincenty_distance(&p2_geo)?;
-    let adj_distance = distance - hex_adjustment(&p1_cell)? - hex_adjustment(&p2_cell)?;
+    let adj_distance = distance - hex_adjustment(&p1_cell) - hex_adjustment(&p2_cell);
     Ok(adj_distance.round() as u32)
 }
 
-fn hex_adjustment(loc: &H3Cell) -> Result<f64, h3ron::Error> {
-    // Distance from hex center to edge, sqrt(3)*edge_length/2.
+fn hex_adjustment(loc: &CellIndex) -> f64 {
     let res = loc.resolution();
-    let edge_length = H3DirectedEdge::edge_length_avg_m(res)?;
-    Ok(
-        edge_length * (f64::round(f64::sqrt(3.0) * f64::powf(10.0, 3.0)) / f64::powf(10.0, 3.0))
-            / 2.0,
-    )
+    // Distance from hex center to edge, sqrt(3)*edge_length/2.
+    let edge_length = res.edge_length_m();
+    edge_length * (f64::round(f64::sqrt(3.0) * f64::powf(10.0, 3.0)) / f64::powf(10.0, 3.0))
+        / 2.0
 }
 
 fn generate_beacon(
@@ -802,7 +808,7 @@ mod tests {
 
     const BEACONER_GAIN: u64 = 20;
     const LOC0: u64 = 631615575095659519; // malta
-    const LOC1: u64 = 631615575095699519; // malta but a lil out from LOC0
+    const LOC1: u64 = 631615576056478207; // malta but a lil out from LOC0
     const LOC2: u64 = 631278052025960447; // armenia
     const LOC3: u64 = 627111975468974079; // 7 cells away from beaconer
     const LOC4: u64 = 627111975465463807; // 28 cells away from beaconer

--- a/solana/src/balance_monitor.rs
+++ b/solana/src/balance_monitor.rs
@@ -22,7 +22,7 @@ pub async fn start(
             let handle = tokio::spawn(async move {
                 run(app_metric_name, rpc_client, keypair.pubkey(), shutdown).await
             });
-            Box::pin(async move { handle.await })
+            Box::pin(handle)
         }
     })
 }


### PR DESCRIPTION
various other projects are switching away from the h3ron c-binding library for h3 index handling to the pure-rust h3o which does more error validation of indexes.

this also necessitated changing of one of the test case index u64 locations which proved to be an invalid cell address as a result of the switch.