### PR TITLE
get beacon module from proto repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/gateway-rs.git?branch=main#ed478089129cd15dee864711865f7ded3dac713e"
+source = "git+https://github.com/helium/proto?branch=master#169886ab876cd4433b14e3cc7b6d8345e32ba576"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -1116,7 +1116,7 @@ dependencies = [
  "rand_chacha 0.3.0",
  "rust_decimal",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ solana-sdk = "1.14"
 solana-program = "1.11"
 spl-token = "3.5.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
-beacon = {git = "https://github.com/helium/gateway-rs.git", branch = "main"}
+beacon = { git = "https://github.com/helium/proto", branch = "master" }
 humantime = "2"
 metrics = "0"
 metrics-exporter-prometheus = "0"


### PR DESCRIPTION
Awaiting [proto PR](https://github.com/helium/proto/pull/334).

This allows `beacon` and `proto` to come from the same repo, streamlining the testing of proto branches from this repo.