### PR TITLE
Add last_rewarded_end_time guage to mobile and iot verifier

### DIFF
--- a/iot_verifier/src/rewarder.rs
+++ b/iot_verifier/src/rewarder.rs
@@ -118,7 +118,10 @@ impl Rewarder {
             .await?
             .await??;
         self.reward_manifests_sink.commit().await?;
-
+        metrics::gauge!(
+            "last_rewarded_end_time",
+            scheduler.reward_period.end.timestamp() as f64
+        );
         Ok(())
     }
 }

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -227,6 +227,10 @@ impl Rewarder {
             .await??;
 
         self.reward_manifests.commit().await?;
+        metrics::gauge!(
+            "last_rewarded_end_time",
+            next_reward_period.start.timestamp() as f64
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
New metric that will allow us to make the reward alert more responsive

Plan is to write an alert that will evaluate

`time() - last_over_time(last_rewarded_end_time{}[25h]}` and ensure it is less than configured duration