### PR TITLE
emit metric gauge whenever reward indexer processes rewards

### DIFF
--- a/reward_index/src/indexer.rs
+++ b/reward_index/src/indexer.rs
@@ -1,5 +1,6 @@
 use crate::{reward_index, settings, Settings};
 use anyhow::{anyhow, bail, Result};
+use chrono::Utc;
 use file_store::{
     file_info_poller::FileInfoStream, reward_manifest::RewardManifest, FileInfo, FileStore,
 };
@@ -78,6 +79,10 @@ impl Indexer {
                     }
                     txn.commit().await?;
                     tracing::info!(file = %key, "Completed processing reward file");
+                    metrics::gauge!(
+                        "last_reward_processed_time",
+                        Utc::now().timestamp() as f64,
+                    );
                 }
             }
         }


### PR DESCRIPTION
emit a trackable gauge metric whenever the reward indexer processes a reward file to allow alerting when a defined period of time has passed without updating the value as expected