### PR TITLE
include max copies in skfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#88c9d849d6303956f2641852e9600cb73ded7dfc"
+source = "git+https://github.com/helium/proto?branch=macpie/skf_max_copies#5d8b250a4a1043053ac8d3e0a8b6f7100833d214"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -2863,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#88c9d849d6303956f2641852e9600cb73ded7dfc"
+source = "git+https://github.com/helium/proto?branch=macpie/skf_max_copies#5d8b250a4a1043053ac8d3e0a8b6f7100833d214"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,14 +57,14 @@ sqlx = {version = "0", features = [
 ]}
 
 helium-crypto = {version = "0.6.8", features=["sqlx-postgres", "multisig"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "macpie/skf_max_copies", features = ["services"]}
 hextree = "*"
 solana-client = "1.14"
 solana-sdk = "1.14"
 solana-program = "1.11"
 spl-token = "3.5.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
-beacon = { git = "https://github.com/helium/proto", branch = "master" }
+beacon = { git = "https://github.com/helium/proto", branch = "macpie/skf_max_copies" }
 humantime = "2"
 metrics = "0"
 metrics-exporter-prometheus = "0"

--- a/iot_config/migrations/11_skf_max_copies.sql
+++ b/iot_config/migrations/11_skf_max_copies.sql
@@ -1,0 +1,5 @@
+alter table route_session_key_filters add column max_copies int;
+
+update route_session_key_filters set max_copies = 0;
+
+alter table route_session_key_filters alter column max_copies set not null;

--- a/iot_config/src/lora_field.rs
+++ b/iot_config/src/lora_field.rs
@@ -116,14 +116,21 @@ pub struct Skf {
     pub route_id: String,
     pub devaddr: DevAddrField,
     pub session_key: String,
+    pub max_copies: u32,
 }
 
 impl Skf {
-    pub fn new(route_id: String, devaddr: DevAddrField, session_key: String) -> Self {
+    pub fn new(
+        route_id: String,
+        devaddr: DevAddrField,
+        session_key: String,
+        max_copies: u32,
+    ) -> Self {
         Self {
             route_id,
             devaddr,
             session_key,
+            max_copies,
         }
     }
 }
@@ -136,6 +143,7 @@ impl FromRow<'_, PgRow> for Skf {
                 .to_string(),
             devaddr: row.get::<i32, &str>("devaddr").into(),
             session_key: row.get::<String, &str>("session_key"),
+            max_copies: row.get::<i32, &str>("max_copies") as u32,
         })
     }
 }
@@ -572,6 +580,7 @@ impl From<proto::SkfV1> for Skf {
             route_id: filter.route_id,
             devaddr: filter.devaddr.into(),
             session_key: filter.session_key,
+            max_copies: filter.max_copies,
         }
     }
 }
@@ -582,6 +591,7 @@ impl From<&proto::SkfV1> for Skf {
             route_id: filter.route_id.to_owned(),
             devaddr: filter.devaddr.into(),
             session_key: filter.session_key.to_owned(),
+            max_copies: filter.max_copies,
         }
     }
 }
@@ -592,6 +602,7 @@ impl From<Skf> for proto::SkfV1 {
             route_id: filter.route_id,
             devaddr: filter.devaddr.into(),
             session_key: filter.session_key,
+            max_copies: filter.max_copies,
         }
     }
 }
@@ -602,6 +613,7 @@ impl From<&Skf> for proto::SkfV1 {
             route_id: filter.route_id.to_owned(),
             devaddr: filter.devaddr.into(),
             session_key: filter.session_key.to_owned(),
+            max_copies: filter.max_copies,
         }
     }
 }

--- a/iot_config/src/route_service.rs
+++ b/iot_config/src/route_service.rs
@@ -852,6 +852,7 @@ impl iot_config::Route for RouteService {
                         request.route_id.clone(),
                         update.devaddr.into(),
                         update.session_key,
+                        update.max_copies,
                     ),
                 )
             })


### PR DESCRIPTION
adding a max_copies field to the session key filter records will allow the helium packet routers to do more granular routing and restrict multi-buy routing for devices that have not explicitly requested multiple copies per packet