### PR TITLE
iot-config handle ignore_empty_skf routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#9208f4f93afa9741f4bd52a1ea12073c6905d0a0"
+source = "git+https://github.com/helium/proto?branch=master#c10a73fc89d895f439bc82efbbc8cd11ed880546"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -1007,7 +1007,7 @@ dependencies = [
  "rand_chacha 0.3.0",
  "rust_decimal",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "thiserror",
 ]
 
@@ -1916,7 +1916,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "structopt",
  "thiserror",
  "tracing",
@@ -2347,7 +2347,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "strum",
  "strum_macros",
@@ -2765,7 +2765,7 @@ dependencies = [
  "p256",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "signature",
  "solana-sdk",
  "sqlx",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#9208f4f93afa9741f4bd52a1ea12073c6905d0a0"
+source = "git+https://github.com/helium/proto?branch=master#c10a73fc89d895f439bc82efbbc8cd11ed880546"
 dependencies = [
  "bytes",
  "prost",
@@ -3102,7 +3102,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "thiserror",
  "tokio",
  "tonic",
@@ -3248,7 +3248,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -3813,7 +3813,7 @@ dependencies = [
  "poc-metrics",
  "prost",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "solana",
  "sqlx",
  "thiserror",
@@ -3857,7 +3857,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -5049,7 +5049,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -5690,7 +5690,7 @@ dependencies = [
  "helium-sub-daos",
  "metrics",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "solana-client",
  "solana-program",
  "solana-sdk",

--- a/iot_config/migrations/20230626183323_skip_empty_skf_routes.sql
+++ b/iot_config/migrations/20230626183323_skip_empty_skf_routes.sql
@@ -1,0 +1,4 @@
+alter table routes add column ignore_empty_skf bool;
+update routes set ignore_empty_skf = 'f';
+alter table routes alter column ignore_empty_skf set default false;
+alter table routes alter column ignore_empty_skf set not null;


### PR DESCRIPTION
per https://github.com/helium/proto/pull/337, the HPRs need to be able to toggle routing or ignoring data packets for routes that have empty session key filters associated with them