### PR TITLE
If we are packaging a release, free up disk space

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Run tests
         run: cargo test -r
 
+        ## free up disk space if we are packaging a release from a tag
+      - uses: jlumbroso/free-disk-space@main
+        if: contains(github.ref, 'refs/tags/')
+
       - name: Debian packaging
         if: contains(github.ref, 'refs/tags/')
         env:


### PR DESCRIPTION
Problem to solve: We have hit a limit on packaging deb files on the default public build images.

Solution: Free up additional disk space by removing unneeded packages before we build our debian files