### PR TITLE
Modeled Coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,6 +2421,7 @@ dependencies = [
  "derive_builder",
  "futures",
  "futures-util",
+ "h3o",
  "helium-crypto",
  "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=map/modeled-coverage)",
  "hex-literal",
@@ -2446,6 +2447,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "triggered",
+ "uuid",
 ]
 
 [[package]]
@@ -2769,6 +2771,8 @@ dependencies = [
  "geo",
  "geojson",
  "konst",
+ "serde",
+ "serde_repr",
 ]
 
 [[package]]
@@ -2863,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=map/modeled-coverage#6831554b282810e7250e7c8c7c292468ab508b62"
+source = "git+https://github.com/helium/proto?branch=map/modeled-coverage#985a7e8c91e7e8b2c30e69cb313b4d78ebcc9fd3"
 dependencies = [
  "bytes",
  "prost",
@@ -3917,6 +3921,7 @@ dependencies = [
  "file-store",
  "futures",
  "futures-util",
+ "h3o",
  "helium-crypto",
  "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=map/modeled-coverage)",
  "http-serde",
@@ -3944,6 +3949,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "triggered",
+ "uuid",
 ]
 
 [[package]]
@@ -5525,6 +5531,17 @@ dependencies = [
  "itoa 1.0.4",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -7276,7 +7293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -7412,9 +7429,12 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "vcell"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7433,6 +7433,7 @@ version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
 dependencies = [
+ "getrandom 0.2.8",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,7 +1110,7 @@ source = "git+https://github.com/helium/proto?branch=master#9208f4f93afa9741f4bd
 dependencies = [
  "base64 0.21.0",
  "byteorder",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=master)",
  "prost",
  "rand 0.8.5",
  "rand_chacha 0.3.0",
@@ -2422,7 +2422,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=map/modeled-coverage)",
  "hex-literal",
  "http",
  "lazy_static",
@@ -2863,6 +2863,20 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
+source = "git+https://github.com/helium/proto?branch=map/modeled-coverage#6831554b282810e7250e7c8c7c292468ab508b62"
+dependencies = [
+ "bytes",
+ "prost",
+ "prost-build",
+ "serde",
+ "serde_json",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
+name = "helium-proto"
+version = "0.1.0"
 source = "git+https://github.com/helium/proto?branch=master#9208f4f93afa9741f4bd52a1ea12073c6905d0a0"
 dependencies = [
  "bytes",
@@ -3176,7 +3190,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=map/modeled-coverage)",
  "http",
  "metrics",
  "metrics-exporter-prometheus",
@@ -3227,7 +3241,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=map/modeled-coverage)",
  "hextree",
  "http",
  "http-serde",
@@ -3263,7 +3277,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=map/modeled-coverage)",
  "http",
  "http-serde",
  "iot-config",
@@ -3301,7 +3315,7 @@ dependencies = [
  "futures-util",
  "h3o",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=map/modeled-coverage)",
  "http-serde",
  "humantime",
  "iot-config",
@@ -3835,7 +3849,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=map/modeled-coverage)",
  "hextree",
  "http",
  "http-serde",
@@ -3870,7 +3884,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=map/modeled-coverage)",
  "http",
  "http-serde",
  "metrics",
@@ -3904,7 +3918,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=map/modeled-coverage)",
  "http-serde",
  "humantime",
  "lazy_static",
@@ -4498,7 +4512,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=map/modeled-coverage)",
  "http",
  "hyper",
  "jsonrpsee",
@@ -4575,7 +4589,7 @@ dependencies = [
  "file-store",
  "futures",
  "futures-util",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=map/modeled-coverage)",
  "metrics",
  "metrics-exporter-prometheus",
  "poc-metrics",
@@ -5101,7 +5115,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=map/modeled-coverage)",
  "http-serde",
  "lazy_static",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ itertools = "*"
 data-credits = {git = "https://github.com/helium/helium-program-library.git", tag = "v0.1.0"}
 helium-sub-daos = {git = "https://github.com/helium/helium-program-library.git", tag = "v0.1.0"}
 price-oracle = {git = "https://github.com/helium/helium-program-library.git", tag = "v0.1.0"}
-uuid = {version = "1.3.4", features = ["serde"]}
+uuid = {version = "1.3.4", features = ["v4", "serde"]}
 
 [patch.crates-io]
 sqlx = { git = "https://github.com/helium/sqlx.git", rev = "92a2268f02e0cac6fccb34d3e926347071dbb88d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ sqlx = {version = "0", features = [
 ]}
 
 helium-crypto = {version = "0.6.8", features=["sqlx-postgres", "multisig"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "map/modeled-coverage", features = ["services"]}
 hextree = "*"
 solana-client = "1.14"
 solana-sdk = "1.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,8 +83,8 @@ prost = "*"
 once_cell = "1"
 lazy_static = "1"
 config = {version="0", default-features=false, features=["toml"]}
-h3o = "0"
-xorf = {version = "0", features = ["serde"] }
+h3o = {version = "0", features = ["serde"]}
+xorf = {version = "0", features = ["serde"]}
 bytes = "*"
 structopt = "0"
 bincode = "1"
@@ -97,6 +97,7 @@ itertools = "*"
 data-credits = {git = "https://github.com/helium/helium-program-library.git", tag = "v0.1.0"}
 helium-sub-daos = {git = "https://github.com/helium/helium-program-library.git", tag = "v0.1.0"}
 price-oracle = {git = "https://github.com/helium/helium-program-library.git", tag = "v0.1.0"}
+uuid = {version = "1.3.4", features = ["serde"]}
 
 [patch.crates-io]
 sqlx = { git = "https://github.com/helium/sqlx.git", rev = "92a2268f02e0cac6fccb34d3e926347071dbb88d" }

--- a/file_store/Cargo.toml
+++ b/file_store/Cargo.toml
@@ -46,6 +46,8 @@ sqlx = {workspace = true}
 async-trait = {workspace = true}
 derive_builder = "0"
 retainer = {workspace = true}
+uuid = {workspace = true}
+h3o = {workspace = true}
 
 [dev-dependencies]
 hex-literal = "0"

--- a/file_store/src/coverage.rs
+++ b/file_store/src/coverage.rs
@@ -1,0 +1,78 @@
+use crate::{
+    error::DecodeError,
+    traits::{MsgDecode, TimestampDecode},
+    Error, Result,
+};
+use chrono::{DateTime, Utc};
+use helium_crypto::PublicKeyBinary;
+use helium_proto::services::poc_mobile::{
+    CoverageObjectIngestReportV1, CoverageObjectReqV1,
+    RadioHexSignalLevel as RadioHexSignalLevelProto, SignalLevel,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RadioHexSignalLevel {
+    pub location: h3o::CellIndex,
+    pub signal_level: SignalLevel,
+    pub signal_power: f64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CoverageObject {
+    pub pub_key: PublicKeyBinary,
+    pub uuid: Uuid,
+    pub cbsd_id: String,
+    pub coverage_claim_time: DateTime<Utc>,
+    pub indoor: bool,
+    pub coverage: Vec<RadioHexSignalLevel>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CoverageObjectIngestReport {
+    pub received_timestamp: DateTime<Utc>,
+    pub report: CoverageObject,
+}
+
+impl MsgDecode for CoverageObject {
+    type Msg = CoverageObjectReqV1;
+}
+
+impl MsgDecode for CoverageObjectIngestReport {
+    type Msg = CoverageObjectIngestReportV1;
+}
+
+impl TryFrom<CoverageObjectReqV1> for CoverageObject {
+    type Error = Error;
+
+    fn try_from(v: CoverageObjectReqV1) -> Result<Self> {
+        let coverage: Result<Vec<RadioHexSignalLevel>> = v
+            .coverage
+            .into_iter()
+            .map(RadioHexSignalLevel::try_from)
+            .collect();
+        Ok(Self {
+            pub_key: v.pub_key.into(),
+            uuid: Uuid::from_slice(&v.uuid).map_err(DecodeError::from)?,
+            cbsd_id: v.cbsd_id,
+            coverage_claim_time: v.coverage_claim_time.to_timestamp()?,
+            indoor: v.indoor,
+            coverage: coverage?,
+        })
+    }
+}
+
+impl TryFrom<RadioHexSignalLevelProto> for RadioHexSignalLevel {
+    type Error = Error;
+
+    fn try_from(v: RadioHexSignalLevelProto) -> Result<Self> {
+        Ok(Self {
+            signal_level: SignalLevel::from_i32(v.signal_level).ok_or_else(|| {
+                DecodeError::unsupported_signal_level("coverage_object_req_v1", v.signal_level)
+            })?,
+            signal_power: v.signal_power,
+            location: v.location.parse().map_err(DecodeError::from)?,
+        })
+    }
+}

--- a/file_store/src/coverage.rs
+++ b/file_store/src/coverage.rs
@@ -43,6 +43,20 @@ impl MsgDecode for CoverageObjectIngestReport {
     type Msg = CoverageObjectIngestReportV1;
 }
 
+impl TryFrom<CoverageObjectIngestReportV1> for CoverageObjectIngestReport {
+    type Error = Error;
+
+    fn try_from(v: CoverageObjectIngestReportV1) -> Result<Self> {
+        Ok(Self {
+            received_timestamp: v.received_timestamp.to_timestamp_millis()?,
+            report: v
+                .report
+                .ok_or_else(|| Error::not_found("ingest coverage object report"))?
+                .try_into()?,
+        })
+    }
+}
+
 impl TryFrom<CoverageObjectReqV1> for CoverageObject {
     type Error = Error;
 
@@ -74,5 +88,15 @@ impl TryFrom<RadioHexSignalLevelProto> for RadioHexSignalLevel {
             signal_power: v.signal_power,
             location: v.location.parse().map_err(DecodeError::from)?,
         })
+    }
+}
+
+impl Into<RadioHexSignalLevelProto> for RadioHexSignalLevel {
+    fn into(self) -> RadioHexSignalLevelProto {
+        RadioHexSignalLevelProto {
+            signal_level: self.signal_level as i32,
+            signal_power: self.signal_power,
+            location: self.location.to_string(),
+        }
     }
 }

--- a/file_store/src/error.rs
+++ b/file_store/src/error.rs
@@ -136,7 +136,7 @@ impl DecodeError {
 
     pub fn unsupported_signal_level(msg1: impl ToString, msg2: i32) -> Error {
         Error::Decode(Self::UnsupportedSignalLevel(msg1.to_string(), msg2))
-    }                 
+    }
 }
 
 impl From<helium_crypto::Error> for Error {

--- a/file_store/src/error.rs
+++ b/file_store/src/error.rs
@@ -54,8 +54,14 @@ pub enum DecodeError {
     UnsupportedParticipantSide(String, i32),
     #[error("unsupported verification status, type: {0}, value: {1}")]
     UnsupportedStatusReason(String, i32),
+    #[error("unsupported signal level, type: {0}, value: {1}")]
+    UnsupportedSignalLevel(String, i32),
     #[error("invalid unix timestamp {0}")]
     InvalidTimestamp(u64),
+    #[error("Uuid error: {0}")]
+    UuidError(#[from] uuid::Error),
+    #[error("Ivalid cell index error: {0}")]
+    InvalidCellIndexError(#[from] h3o::error::InvalidCellIndex),
 }
 
 #[derive(Error, Debug)]
@@ -127,6 +133,10 @@ impl DecodeError {
     pub fn unsupported_status_reason<E: ToString>(msg1: E, msg2: i32) -> Error {
         Error::Decode(Self::UnsupportedInvalidReason(msg1.to_string(), msg2))
     }
+
+    pub fn unsupported_signal_level(msg1: impl ToString, msg2: i32) -> Error {
+        Error::Decode(Self::UnsupportedSignalLevel(msg1.to_string(), msg2))
+    }                 
 }
 
 impl From<helium_crypto::Error> for Error {

--- a/file_store/src/file_info.rs
+++ b/file_store/src/file_info.rs
@@ -123,6 +123,7 @@ pub const DATA_TRANSFER_SESSION_INGEST_REPORT: &str = "data_transfer_session_ing
 pub const VALID_DATA_TRANSFER_SESSION: &str = "valid_data_transfer_session";
 pub const PRICE_REPORT: &str = "price_report";
 pub const MOBILE_REWARD_SHARE: &str = "mobile_reward_share";
+pub const COVERAGE_OBJECT: &str = "coverage_object";
 pub const COVERAGE_OBJECT_INGEST_REPORT: &str = "coverage_object_ingest_report";
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Copy, strum::EnumCount)]
@@ -156,6 +157,7 @@ pub enum FileType {
     MobileRewardShare,
     SubscriberLocationReq,
     SubscriberLocationIngestReport,
+    CoverageObject,
     CoverageObjectIngestReport,
 }
 
@@ -190,6 +192,7 @@ impl fmt::Display for FileType {
             Self::ValidDataTransferSession => VALID_DATA_TRANSFER_SESSION,
             Self::PriceReport => PRICE_REPORT,
             Self::MobileRewardShare => MOBILE_REWARD_SHARE,
+            Self::CoverageObject => COVERAGE_OBJECT,
             Self::CoverageObjectIngestReport => COVERAGE_OBJECT_INGEST_REPORT,
         };
         f.write_str(s)
@@ -227,6 +230,7 @@ impl FileType {
             Self::ValidDataTransferSession => VALID_DATA_TRANSFER_SESSION,
             Self::PriceReport => PRICE_REPORT,
             Self::MobileRewardShare => MOBILE_REWARD_SHARE,
+            Self::CoverageObject => COVERAGE_OBJECT,
             Self::CoverageObjectIngestReport => COVERAGE_OBJECT_INGEST_REPORT,
         }
     }
@@ -262,6 +266,7 @@ impl FromStr for FileType {
             VALID_DATA_TRANSFER_SESSION => Self::ValidDataTransferSession,
             PRICE_REPORT => Self::PriceReport,
             MOBILE_REWARD_SHARE => Self::MobileRewardShare,
+            COVERAGE_OBJECT => Self::CoverageObject,
             COVERAGE_OBJECT_INGEST_REPORT => Self::CoverageObjectIngestReport,
             _ => return Err(Error::from(io::Error::from(io::ErrorKind::InvalidInput))),
         };

--- a/file_store/src/file_info.rs
+++ b/file_store/src/file_info.rs
@@ -123,6 +123,7 @@ pub const DATA_TRANSFER_SESSION_INGEST_REPORT: &str = "data_transfer_session_ing
 pub const VALID_DATA_TRANSFER_SESSION: &str = "valid_data_transfer_session";
 pub const PRICE_REPORT: &str = "price_report";
 pub const MOBILE_REWARD_SHARE: &str = "mobile_reward_share";
+pub const COVERAGE_OBJECT_INGEST_REPORT: &str = "coverage_object_ingest_report";
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Copy, strum::EnumCount)]
 #[serde(rename_all = "snake_case")]
@@ -155,6 +156,7 @@ pub enum FileType {
     MobileRewardShare,
     SubscriberLocationReq,
     SubscriberLocationIngestReport,
+    CoverageObjectIngestReport,
 }
 
 impl fmt::Display for FileType {
@@ -188,6 +190,7 @@ impl fmt::Display for FileType {
             Self::ValidDataTransferSession => VALID_DATA_TRANSFER_SESSION,
             Self::PriceReport => PRICE_REPORT,
             Self::MobileRewardShare => MOBILE_REWARD_SHARE,
+            Self::CoverageObjectIngestReport => COVERAGE_OBJECT_INGEST_REPORT,
         };
         f.write_str(s)
     }
@@ -224,6 +227,7 @@ impl FileType {
             Self::ValidDataTransferSession => VALID_DATA_TRANSFER_SESSION,
             Self::PriceReport => PRICE_REPORT,
             Self::MobileRewardShare => MOBILE_REWARD_SHARE,
+            Self::CoverageObjectIngestReport => COVERAGE_OBJECT_INGEST_REPORT,
         }
     }
 }
@@ -258,6 +262,7 @@ impl FromStr for FileType {
             VALID_DATA_TRANSFER_SESSION => Self::ValidDataTransferSession,
             PRICE_REPORT => Self::PriceReport,
             MOBILE_REWARD_SHARE => Self::MobileRewardShare,
+            COVERAGE_OBJECT_INGEST_REPORT => Self::CoverageObjectIngestReport,
             _ => return Err(Error::from(io::Error::from(io::ErrorKind::InvalidInput))),
         };
         Ok(result)

--- a/file_store/src/heartbeat.rs
+++ b/file_store/src/heartbeat.rs
@@ -1,4 +1,5 @@
 use crate::{
+    error::DecodeError,
     traits::{MsgDecode, MsgTimestamp, TimestampDecode},
     Error, Result,
 };
@@ -6,6 +7,7 @@ use chrono::{DateTime, Utc};
 use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_mobile::{CellHeartbeatIngestReportV1, CellHeartbeatReqV1};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CellHeartbeat {
@@ -18,6 +20,7 @@ pub struct CellHeartbeat {
     pub operation_mode: bool,
     pub cbsd_category: String,
     pub cbsd_id: String,
+    pub coverage_object: Uuid,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -47,6 +50,7 @@ impl TryFrom<CellHeartbeatReqV1> for CellHeartbeat {
             operation_mode: v.operation_mode,
             cbsd_category: v.cbsd_category,
             cbsd_id: v.cbsd_id,
+            coverage_object: Uuid::from_slice(&v.coverage_object).map_err(DecodeError::from)?,
         })
     }
 }

--- a/file_store/src/lib.rs
+++ b/file_store/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod coverage;
 pub mod entropy_report;
 mod error;
 mod file_info;

--- a/file_store/src/traits/msg_verify.rs
+++ b/file_store/src/traits/msg_verify.rs
@@ -6,7 +6,8 @@ use helium_proto::services::{
 };
 use helium_proto::{
     services::poc_mobile::{
-        CellHeartbeatReqV1, DataTransferSessionReqV1, SpeedtestReqV1, SubscriberLocationReqV1,
+        CellHeartbeatReqV1, CoverageObjectReqV1, DataTransferSessionReqV1, SpeedtestReqV1,
+        SubscriberLocationReqV1,
     },
     Message,
 };
@@ -34,6 +35,7 @@ impl_msg_verify!(SpeedtestReqV1, signature);
 impl_msg_verify!(LoraBeaconReportReqV1, signature);
 impl_msg_verify!(LoraWitnessReportReqV1, signature);
 impl_msg_verify!(DataTransferSessionReqV1, signature);
+impl_msg_verify!(CoverageObjectReqV1, signature);
 impl_msg_verify!(iot_config::OrgCreateHeliumReqV1, signature);
 impl_msg_verify!(iot_config::OrgCreateRoamerReqV1, signature);
 impl_msg_verify!(iot_config::OrgUpdateReqV1, signature);

--- a/ingest/src/settings.rs
+++ b/ingest/src/settings.rs
@@ -30,8 +30,6 @@ pub struct Settings {
     pub token: Option<String>,
     /// Target output bucket details Metrics settings
     pub metrics: poc_metrics::Settings,
-    /// PCS public key:
-    pub pcs_pubkey: PublicKey,
 }
 
 pub fn default_listen_addr() -> String {

--- a/ingest/src/settings.rs
+++ b/ingest/src/settings.rs
@@ -1,5 +1,5 @@
 use config::{Config, Environment, File};
-use helium_crypto::Network;
+use helium_crypto::{Network, PublicKey};
 use serde::Deserialize;
 use std::{
     net::{AddrParseError, SocketAddr},
@@ -30,6 +30,8 @@ pub struct Settings {
     pub token: Option<String>,
     /// Target output bucket details Metrics settings
     pub metrics: poc_metrics::Settings,
+    /// PCS public key:
+    pub pcs_pubkey: PublicKey,
 }
 
 pub fn default_listen_addr() -> String {

--- a/mobile_verifier/Cargo.toml
+++ b/mobile_verifier/Cargo.toml
@@ -44,3 +44,5 @@ price = {path = "../price"}
 rand = {workspace = true}
 async-trait = {workspace = true}
 retainer = {workspace = true}
+uuid = {workspace = true}
+h3o = {workspace = true}

--- a/mobile_verifier/migrations/13_modeled_coverage.sql
+++ b/mobile_verifier/migrations/13_modeled_coverage.sql
@@ -1,0 +1,16 @@
+CREATE TYPE signal_level as ENUM (
+       'no',
+       'low',
+       'medium',
+       'high'
+);
+
+CREATE TABLE hex_coverage (
+       uuid UUID NOT NULL,
+       hex INTEGER NOT NULL,
+       indoor BOOLEAN NOT NULL,
+       cbsd_id TEXT NOT NULL,
+       signal_level signal_level NOT NULL,
+       coverage_claim_time TIMESTAMPTZ NOT NULL
+       PRIMARY KEY (uuid, hex)
+);

--- a/mobile_verifier/src/cli/reward_from_db.rs
+++ b/mobile_verifier/src/cli/reward_from_db.rs
@@ -1,6 +1,6 @@
 use crate::{
     heartbeats::HeartbeatReward,
-    reward_shares::{get_scheduled_tokens_for_poc_and_dc, PocShares},
+    reward_shares::{get_scheduled_tokens_for_poc_and_dc, CoveragePoints},
     speedtests::{Average, SpeedtestAverages},
     Settings,
 };
@@ -40,7 +40,8 @@ impl Cmd {
 
         let heartbeats = HeartbeatReward::validated(&pool, &epoch);
         let speedtests = SpeedtestAverages::validated(&pool, epoch.end).await?;
-        let reward_shares = PocShares::aggregate(heartbeats, speedtests.clone()).await?;
+        let reward_shares =
+            CoveragePoints::aggregate_points(&pool, heartbeats, speedtests.clone()).await?;
 
         let mut total_rewards = 0_u64;
         let mut owner_rewards = HashMap::<_, u64>::new();

--- a/mobile_verifier/src/cli/server.rs
+++ b/mobile_verifier/src/cli/server.rs
@@ -1,15 +1,16 @@
 use crate::{
-    heartbeats::HeartbeatDaemon, rewarder::Rewarder, speedtests::SpeedtestDaemon, Settings, coverage::CoverageDaemon,
+    coverage::CoverageDaemon, heartbeats::HeartbeatDaemon, rewarder::Rewarder,
+    speedtests::SpeedtestDaemon, Settings,
 };
 use anyhow::{Error, Result};
 use chrono::Duration;
 use file_store::{
-    file_info_poller::LookbackBehavior, file_sink, file_source, file_upload,
-    heartbeat::CellHeartbeatIngestReport, speedtest::CellSpeedtestIngestReport, FileStore,
-    FileType, coverage::CoverageObjectIngestReport,
+    coverage::CoverageObjectIngestReport, file_info_poller::LookbackBehavior, file_sink,
+    file_source, file_upload, heartbeat::CellHeartbeatIngestReport,
+    speedtest::CellSpeedtestIngestReport, FileStore, FileType,
 };
 use futures_util::TryFutureExt;
-use mobile_config::{GatewayClient, client::AuthorizationClient};
+use mobile_config::{client::AuthorizationClient, GatewayClient};
 use price::PriceTracker;
 use tokio::signal;
 
@@ -102,17 +103,18 @@ impl Cmd {
         .await?;
 
         // Coverage objects
-        let (valid_coverage_objs, mut valid_coverage_objs_server) = file_sink::FileSinkBuilder::new(
-            FileType::CoverageObject,
-            store_base_path,
-            concat!(env!("CARGO_PKG_NAME"), "_coverage_object"),
-            shutdown_listener.clone(),
-        )
-        .deposits(Some(file_upload_tx.clone()))
-        .auto_commit(false)
-        .roll_time(Duration::minutes(15))
-        .create()
-        .await?;
+        let (valid_coverage_objs, mut valid_coverage_objs_server) =
+            file_sink::FileSinkBuilder::new(
+                FileType::CoverageObject,
+                store_base_path,
+                concat!(env!("CARGO_PKG_NAME"), "_coverage_object"),
+                shutdown_listener.clone(),
+            )
+            .deposits(Some(file_upload_tx.clone()))
+            .auto_commit(false)
+            .roll_time(Duration::minutes(15))
+            .create()
+            .await?;
 
         // Mobile rewards
         let (mobile_rewards, mut mobile_rewards_server) = file_sink::FileSinkBuilder::new(

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -49,22 +49,9 @@ impl From<SignalLevelProto> for SignalLevel {
         }
     }
 }
-/*
-pub struct CoverageCache {
-    pool: Pool<Postgres>,
-    objs: Arc<Cache<Uuid, CoverageObject>>,
-}
-
-impl CoverageCache {
-    pub fn get(&self, key: &Uuid) -> CacheReadGuard<'_, CoverageObject> {
-        todo!()
-    }
-}
-*/
 
 pub struct CoverageDaemon {
     pool: Pool<Postgres>,
-    //    cache: CoverageCache,
     auth_client: AuthorizationClient,
     coverage_objs: Receiver<FileInfoStream<CoverageObjectIngestReport>>,
     file_sink: FileSinkClient,
@@ -182,12 +169,12 @@ impl CoverageDaemon {
 
 #[derive(FromRow)]
 pub struct HexCoverage {
-    uuid: Uuid,
-    hex: i64,
-    indoor: bool,
-    cbsd_id: String,
-    signal_level: SignalLevel,
-    coverage_claim_time: DateTime<Utc>,
+    pub uuid: Uuid,
+    pub hex: i64,
+    pub indoor: bool,
+    pub cbsd_id: String,
+    pub signal_level: SignalLevel,
+    pub coverage_claim_time: DateTime<Utc>,
 }
 
 #[derive(Eq, Ord)]
@@ -227,9 +214,9 @@ impl CoverageLevel {
 
 #[derive(PartialEq, Debug)]
 pub struct CoverageReward {
-    cbsd_id: String,
-    points: Decimal,
-    hotspot: PublicKeyBinary,
+    pub cbsd_id: String,
+    pub points: Decimal,
+    pub hotspot: PublicKeyBinary,
 }
 
 pub const MAX_RADIOS_PER_HEX: usize = 5;
@@ -302,6 +289,7 @@ impl CoveredHexes {
             })
             .flatten()
             .flatten()
+            .filter(|r| r.points > Decimal::ZERO)
     }
 }
 

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -75,7 +75,7 @@ impl CoverageDaemon {
         pool: Pool<Postgres>,
         auth_client: AuthorizationClient,
         coverage_objs: Receiver<FileInfoStream<CoverageObjectIngestReport>>,
-        file_sink: FileSinkClient
+        file_sink: FileSinkClient,
     ) -> Self {
         Self {
             pool,

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -1,0 +1,162 @@
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, BinaryHeap, HashMap},
+    sync::Arc,
+};
+
+use chrono::{DateTime, Utc};
+use file_store::{coverage::CoverageObjectIngestReport, file_info_poller::FileInfoStream};
+use futures::stream::{StreamExt, TryStreamExt};
+use h3o::CellIndex;
+use helium_crypto::PublicKeyBinary;
+use helium_proto::services::poc_mobile::SignalLevel as SignalLevelProto;
+use mobile_config::client::AuthorizationClient;
+use retainer::{entry::CacheReadGuard, Cache};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use sqlx::{FromRow, Pool, Postgres, Type};
+use tokio::sync::mpsc::Receiver;
+use uuid::Uuid;
+
+use crate::heartbeats::HeartbeatReward;
+
+#[derive(PartialOrd, Ord, PartialEq, Eq, Type)]
+pub enum SignalLevel {
+    No,
+    Low,
+    Medium,
+    High,
+}
+/*
+pub struct CoverageCache {
+    pool: Pool<Postgres>,
+    objs: Arc<Cache<Uuid, CoverageObject>>,
+}
+
+impl CoverageCache {
+    pub fn get(&self, key: &Uuid) -> CacheReadGuard<'_, CoverageObject> {
+        todo!()
+    }
+}
+*/
+
+pub struct CoverageDaemon {
+    pool: Pool<Postgres>,
+    //    cache: CoverageCache,
+    auth_client: AuthorizationClient,
+    coverages_objs: Receiver<FileInfoStream<CoverageObjectIngestReport>>,
+}
+
+#[derive(FromRow)]
+pub struct HexCoverage {
+    uuid: Uuid,
+    hex: i64,
+    indoor: bool,
+    cbsd_id: String,
+    signal_level: SignalLevel,
+    coverage_claim_time: DateTime<Utc>,
+}
+
+#[derive(Eq, Ord)]
+struct CoverageLevel {
+    coverage_claim_time: DateTime<Utc>,
+    hotspot: PublicKeyBinary,
+    indoor: bool,
+    signal_level: SignalLevel,
+}
+
+impl PartialEq for CoverageLevel {
+    fn eq(&self, other: &Self) -> bool {
+        self.signal_level == other.signal_level
+            && self.coverage_claim_time == other.coverage_claim_time
+    }
+}
+
+impl PartialOrd for CoverageLevel {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(
+            self.signal_level
+                .cmp(&other.signal_level)
+                .then_with(|| self.coverage_claim_time.cmp(&other.coverage_claim_time)),
+        )
+    }
+}
+
+impl CoverageLevel {
+    fn coverage_points(&self) -> anyhow::Result<Decimal> {
+        Ok(match (self.indoor, self.signal_level) {
+            (true, SignalLevel::High) => dec!(400),
+            (true, SignalLevel::Low) => dec!(100),
+            (false, SignalLevel::High) => dec!(16),
+            (false, SignalLevel::Medium) => dec!(8),
+            (false, SignalLevel::Low) => dec!(4),
+            (_, SignalLevel::No) => dec!(0),
+            _ => anyhow::bail!("Indoor radio cannot have a signal level of medium"),
+        })
+    }
+}
+
+pub struct CoverageReward {
+    points: Decimal,
+    hotspot: PublicKeyBinary,
+}
+
+pub const MAX_RADIOS_PER_HEX: usize = 5;
+
+pub struct CoveredHexes {
+    hexes: HashMap<CellIndex, BinaryHeap<CoverageLevel>>,
+}
+
+impl CoveredHexes {
+    pub async fn fetch_heartbeat_coverage(
+        &mut self,
+        pool: &Pool<Postgres>,
+        hotspot: &PublicKeyBinary,
+        cbsd_id: &str,
+        coverage_obj: &Uuid,
+    ) -> Result<(), sqlx::Error> {
+        let mut covered_hexes =
+            sqlx::query_as("SELECT * FROM coverage WHERE cbsd_id = $1 AND uuid = $2")
+                .bind(cbsd_id)
+                .bind(coverage_obj)
+                .fetch(pool);
+
+        while let Some(HexCoverage {
+            hex,
+            indoor,
+            signal_level,
+            coverage_claim_time,
+            ..
+        }) = covered_hexes.next().await.transpose()?
+        {
+            self.hexes
+                .entry(CellIndex::try_from(hex as u64).unwrap())
+                .or_default()
+                .push(CoverageLevel {
+                    coverage_claim_time,
+                    indoor,
+                    signal_level,
+                    hotspot: hotspot.clone(),
+                });
+        }
+
+        Ok(())
+    }
+
+    pub fn into_iter(self) -> impl Iterator<Item = CoverageReward> {
+        self.hexes
+            .into_values()
+            .map(|radios| {
+                radios
+                    .into_sorted_vec()
+                    .into_iter()
+                    .rev()
+                    .take(MAX_RADIOS_PER_HEX)
+                    .map(|cl| CoverageReward {
+                        points: cl.coverage_points().unwrap(),
+                        hotspot: cl.hotspot,
+                    })
+            })
+            .flatten()
+    }
+}

--- a/mobile_verifier/src/heartbeats.rs
+++ b/mobile_verifier/src/heartbeats.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, sqlx::FromRow)]
 pub struct HeartbeatKey {
-    coverage_object: Uuid, 
+    coverage_object: Uuid,
     hotspot_key: PublicKeyBinary,
     cbsd_id: String,
     cell_type: CellType,
@@ -113,7 +113,11 @@ impl HeartbeatDaemon {
 
         while let Some(heartbeat) = validated_heartbeats.next().await.transpose()? {
             heartbeat.write(&self.file_sink).await?;
-            let key = (heartbeat.cbsd_id.clone(), heartbeat.truncated_timestamp()?, heartbeat.coverage_object);
+            let key = (
+                heartbeat.cbsd_id.clone(),
+                heartbeat.truncated_timestamp()?,
+                heartbeat.coverage_object,
+            );
 
             if cache.get(&key).await.is_none() {
                 heartbeat.save(&mut transaction).await?;

--- a/mobile_verifier/src/lib.rs
+++ b/mobile_verifier/src/lib.rs
@@ -1,10 +1,10 @@
 mod cell_type;
+mod coverage;
 mod heartbeats;
 mod ingest;
 mod reward_shares;
 mod settings;
 mod speedtests;
-mod coverage;
 
 pub mod cli;
 pub mod rewarder;

--- a/mobile_verifier/src/lib.rs
+++ b/mobile_verifier/src/lib.rs
@@ -4,6 +4,7 @@ mod ingest;
 mod reward_shares;
 mod settings;
 mod speedtests;
+mod coverage;
 
 pub mod cli;
 pub mod rewarder;


### PR DESCRIPTION
This is mostly complete, there are two remaining tasks that should be relatively quick to complete:

- [ ] Convert unit tests in the reward_share module over
- [ ] Add a cache to the heartbeat deamon to fetch coverage objects so we can invalidate heartbeats that use incorrect coverage objects