### PR TITLE
ensure mobile subscriber id is properly credited for mobile rewards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5230,6 +5230,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.0",
+ "bs58 0.4.0",
  "chrono",
  "clap 4.1.11",
  "config",

--- a/reward_index/Cargo.toml
+++ b/reward_index/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 
 [dependencies]
 anyhow = {workspace = true}
+bs58 = {workspace = true}
 config = {workspace = true}
 clap = {workspace = true}
 thiserror = {workspace = true}

--- a/reward_index/src/indexer.rs
+++ b/reward_index/src/indexer.rs
@@ -146,19 +146,13 @@ impl Indexer {
                         },
                         r.dc_transfer_reward,
                     )),
-                    Some(MobileReward::SubscriberReward(r)) => {
-                        let key = match str::from_utf8(&r.subscriber_id) {
-                            Ok(k) => k.to_string(),
-                            Err(_e) => bail!("got an invalid subscriber id"),
-                        };
-                        Ok((
-                            RewardKey {
-                                key,
-                                reward_type: RewardType::MobileSubscriber,
-                            },
-                            r.discovery_location_amount,
-                        ))
-                    }
+                    Some(MobileReward::SubscriberReward(r)) => Ok((
+                        RewardKey {
+                            key: bs58::encode(&r.subscriber_id).into_string(),
+                            reward_type: RewardType::MobileSubscriber,
+                        },
+                        r.discovery_location_amount,
+                    )),
                     _ => bail!("got an invalid reward share"),
                 }
             }


### PR DESCRIPTION
The rest of the oracles pipeline treats mobile subscriber_ids as a `&[u8]` or `Vec<u8>` but the foundation reward index database expects the rewardable entity to be a `text` field. According to the nft metadata field for the mobile subscriber rewardable entity the expected serialization is `KeySerialization::B58` so this change aligns the mobile subscriber rewards inserted into the database with the value expected by the on-chain claims program