### PR TITLE
fail region params lookup on db error

### DIFF
--- a/iot_config/src/gateway_service.rs
+++ b/iot_config/src/gateway_service.rs
@@ -198,7 +198,7 @@ impl iot_config::Gateway for GatewayService {
                     %default_region,
                     "gateway lookup failed"
                 );
-                telemetry::count_region_lookup(default_region, Region::Unknown);
+                telemetry::count_region_lookup(default_region, None);
                 return Err(Status::internal(status.message().to_string()));
             }
             Ok(GatewayInfo { metadata, .. }) => match metadata {
@@ -213,7 +213,7 @@ impl iot_config::Gateway for GatewayService {
                 Some(metadata) => (metadata.region, metadata.gain),
             },
         };
-        telemetry::count_region_lookup(default_region, region);
+        telemetry::count_region_lookup(default_region, Some(region));
 
         let params = self.region_map.get_params(&region);
 

--- a/iot_config/src/telemetry.rs
+++ b/iot_config/src/telemetry.rs
@@ -31,13 +31,15 @@ pub fn gauge_hexes(cells: usize) {
 
 pub fn count_region_lookup(
     default_region: helium_proto::Region,
-    reported_region: helium_proto::Region,
+    reported_region: Option<helium_proto::Region>,
 ) {
+    let reported_region =
+        reported_region.map_or_else(|| "LOOKUP_FAILED".to_string(), |region| region.to_string());
     metrics::increment_counter!(
         REGION_LOOKUP_METRIC,
         // per metrics docs, &str should be preferred for performance; should the regions be
         // mapped through a match of region => &'static str of the name?
-        "default_region" => default_region.to_string(), "reported_region" => reported_region.to_string()
+        "default_region" => default_region.to_string(), "reported_region" => reported_region
     );
 }
 


### PR DESCRIPTION
when gateway isn't found on the solana chain (the query succeeds but no record is returned) continue to return the "fallback" response of the region passed in the incoming request and a 0 gain but now in the event of a failure to lookup the requested gateway return a failure to the gateway requesting the region params