### PR TITLE
allow mobile config service to register pcs signing keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,7 +1118,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=jg/allow-pcs-mobile-keys#711138cbf0175856ce2e12fe21696db3b97f8585"
+source = "git+https://github.com/helium/proto?branch=master#065699f13438ab7aa148df8d5b68efbaa53d6369"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -1128,7 +1128,7 @@ dependencies = [
  "rand_chacha 0.3.0",
  "rust_decimal",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "thiserror",
 ]
 
@@ -2066,7 +2066,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "structopt",
  "thiserror",
  "tracing",
@@ -2497,7 +2497,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "strum",
  "strum_macros",
@@ -2915,7 +2915,7 @@ dependencies = [
  "p256",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "signature",
  "solana-sdk",
  "sqlx",
@@ -2925,7 +2925,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=jg/allow-pcs-mobile-keys#711138cbf0175856ce2e12fe21696db3b97f8585"
+source = "git+https://github.com/helium/proto?branch=master#065699f13438ab7aa148df8d5b68efbaa53d6369"
 dependencies = [
  "bytes",
  "prost",
@@ -3261,7 +3261,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "thiserror",
  "tokio",
  "tonic",
@@ -3407,7 +3407,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -4015,7 +4015,7 @@ dependencies = [
  "poc-metrics",
  "prost",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "solana",
  "sqlx",
  "thiserror",
@@ -4059,7 +4059,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -5252,7 +5252,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sqlx",
  "thiserror",
  "tokio",
@@ -5893,7 +5893,7 @@ dependencies = [
  "helium-sub-daos",
  "metrics",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "solana-client",
  "solana-program",
  "solana-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,7 +1118,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#f1208e25b8966e0b480023439a53f5e159f9c0d0"
+source = "git+https://github.com/helium/proto?branch=jg/allow-pcs-mobile-keys#711138cbf0175856ce2e12fe21696db3b97f8585"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -1128,7 +1128,7 @@ dependencies = [
  "rand_chacha 0.3.0",
  "rust_decimal",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "thiserror",
 ]
 
@@ -2066,7 +2066,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "structopt",
  "thiserror",
  "tracing",
@@ -2497,7 +2497,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "sqlx",
  "strum",
  "strum_macros",
@@ -2915,7 +2915,7 @@ dependencies = [
  "p256",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "signature",
  "solana-sdk",
  "sqlx",
@@ -2925,7 +2925,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#f1208e25b8966e0b480023439a53f5e159f9c0d0"
+source = "git+https://github.com/helium/proto?branch=jg/allow-pcs-mobile-keys#711138cbf0175856ce2e12fe21696db3b97f8585"
 dependencies = [
  "bytes",
  "prost",
@@ -3261,7 +3261,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "thiserror",
  "tokio",
  "tonic",
@@ -3407,7 +3407,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "sqlx",
  "thiserror",
  "tokio",
@@ -4015,7 +4015,7 @@ dependencies = [
  "poc-metrics",
  "prost",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "solana",
  "sqlx",
  "thiserror",
@@ -4059,7 +4059,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "sqlx",
  "thiserror",
  "tokio",
@@ -5252,7 +5252,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "sqlx",
  "thiserror",
  "tokio",
@@ -5893,7 +5893,7 @@ dependencies = [
  "helium-sub-daos",
  "metrics",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "solana-client",
  "solana-program",
  "solana-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,14 +59,14 @@ sqlx = {version = "0", features = [
 ]}
 
 helium-crypto = {version = "0.6.8", features=["sqlx-postgres", "multisig"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "jg/allow-pcs-mobile-keys", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
 hextree = "*"
 solana-client = "1.14"
 solana-sdk = "1.14"
 solana-program = "1.11"
 spl-token = "3.5.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
-beacon = { git = "https://github.com/helium/proto", branch = "jg/allow-pcs-mobile-keys" }
+beacon = { git = "https://github.com/helium/proto", branch = "master" }
 humantime = "2"
 metrics = "0"
 metrics-exporter-prometheus = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,14 +59,14 @@ sqlx = {version = "0", features = [
 ]}
 
 helium-crypto = {version = "0.6.8", features=["sqlx-postgres", "multisig"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "jg/allow-pcs-mobile-keys", features = ["services"]}
 hextree = "*"
 solana-client = "1.14"
 solana-sdk = "1.14"
 solana-program = "1.11"
 spl-token = "3.5.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
-beacon = { git = "https://github.com/helium/proto", branch = "master" }
+beacon = { git = "https://github.com/helium/proto", branch = "jg/allow-pcs-mobile-keys" }
 humantime = "2"
 metrics = "0"
 metrics-exporter-prometheus = "0"

--- a/file_store/src/heartbeat.rs
+++ b/file_store/src/heartbeat.rs
@@ -102,6 +102,7 @@ mod tests {
                 cbsd_category: "category".to_string(),
                 cbsd_id: "id".to_string(),
                 signature: vec![],
+                coverage_object: vec![],
             }),
         };
 

--- a/ingest/src/server_mobile.rs
+++ b/ingest/src/server_mobile.rs
@@ -11,9 +11,10 @@ use futures_util::TryFutureExt;
 use helium_crypto::{Network, PublicKey};
 use helium_proto::services::poc_mobile::{
     self, CellHeartbeatIngestReportV1, CellHeartbeatReqV1, CellHeartbeatRespV1,
-    DataTransferSessionIngestReportV1, DataTransferSessionReqV1, DataTransferSessionRespV1,
-    SpeedtestIngestReportV1, SpeedtestReqV1, SpeedtestRespV1, SubscriberLocationIngestReportV1,
-    SubscriberLocationReqV1, SubscriberLocationRespV1,
+    CoverageObjectReqV1, CoverageObjectRespV1, DataTransferSessionIngestReportV1,
+    DataTransferSessionReqV1, DataTransferSessionRespV1, SpeedtestIngestReportV1, SpeedtestReqV1,
+    SpeedtestRespV1, SubscriberLocationIngestReportV1, SubscriberLocationReqV1,
+    SubscriberLocationRespV1,
 };
 use std::path::Path;
 use tonic::{metadata::MetadataValue, transport, Request, Response, Status};
@@ -170,6 +171,13 @@ impl poc_mobile::PocMobile for GrpcServer {
         Ok(Response::new(SubscriberLocationRespV1 {
             id: timestamp.to_string(),
         }))
+    }
+
+    async fn submit_coverage_object(
+        &self,
+        _request: Request<CoverageObjectReqV1>,
+    ) -> GrpcResult<CoverageObjectRespV1> {
+        unimplemented!()
     }
 }
 

--- a/mobile_config/migrations/20230708171204_add_pcs_key_role.sql
+++ b/mobile_config/migrations/20230708171204_add_pcs_key_role.sql
@@ -1,1 +1,1 @@
-ALTER TYPE key_role ADD VALUE IF NOT EXISTS 'pcs';-- Add migration script here
+ALTER TYPE key_role ADD VALUE IF NOT EXISTS 'pcs';

--- a/mobile_config/migrations/20230708171204_add_pcs_key_role.sql
+++ b/mobile_config/migrations/20230708171204_add_pcs_key_role.sql
@@ -1,0 +1,1 @@
+ALTER TYPE key_role ADD VALUE IF NOT EXISTS 'pcs';-- Add migration script here

--- a/mobile_config/src/admin_service.rs
+++ b/mobile_config/src/admin_service.rs
@@ -1,7 +1,7 @@
 use crate::{
-    key_cache::{self, CacheKeys, KeyCache, KeyRole},
+    key_cache::{self, CacheKeys, KeyCache},
     settings::Settings,
-    telemetry, verify_public_key, GrpcResult,
+    telemetry, verify_public_key, GrpcResult, KeyRole,
 };
 use anyhow::{anyhow, Result};
 use chrono::Utc;

--- a/mobile_config/src/authorization_service.rs
+++ b/mobile_config/src/authorization_service.rs
@@ -1,7 +1,4 @@
-use crate::{
-    key_cache::{KeyCache, KeyRole},
-    telemetry, verify_public_key, GrpcResult,
-};
+use crate::{key_cache::KeyCache, telemetry, verify_public_key, GrpcResult, KeyRole};
 use chrono::Utc;
 use file_store::traits::{MsgVerify, TimestampEncode};
 use helium_crypto::{Keypair, PublicKey, Sign};
@@ -116,6 +113,7 @@ impl From<NetworkKeyRole> for KeyRole {
         match role {
             NetworkKeyRole::MobileRouter => KeyRole::Router,
             NetworkKeyRole::MobileCarrier => KeyRole::Carrier,
+            NetworkKeyRole::MobilePcs => KeyRole::Pcs,
         }
     }
 }

--- a/mobile_config/src/key_cache.rs
+++ b/mobile_config/src/key_cache.rs
@@ -1,9 +1,7 @@
-use crate::settings::Settings;
+use crate::{settings::Settings, KeyRole};
 use anyhow::anyhow;
 use file_store::traits::MsgVerify;
 use helium_crypto::{PublicKey, PublicKeyBinary};
-use helium_proto::services::mobile_config::AdminKeyRole as ProtoKeyRole;
-use serde::Serialize;
 use std::collections::HashSet;
 use tokio::sync::watch;
 
@@ -94,63 +92,6 @@ impl KeyCache {
                 }
             })
             .collect()
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, sqlx::Type)]
-#[sqlx(type_name = "key_role", rename_all = "snake_case")]
-pub enum KeyRole {
-    Administrator,
-    Carrier,
-    Oracle,
-    Router,
-}
-
-impl KeyRole {
-    pub fn from_i32(v: i32) -> anyhow::Result<Self> {
-        ProtoKeyRole::from_i32(v)
-            .map(|kr| kr.into())
-            .ok_or_else(|| anyhow!("unsupported key role {}", v))
-    }
-}
-
-impl From<KeyRole> for ProtoKeyRole {
-    fn from(key_role: KeyRole) -> Self {
-        ProtoKeyRole::from(&key_role)
-    }
-}
-
-impl From<&KeyRole> for ProtoKeyRole {
-    fn from(skr: &KeyRole) -> Self {
-        match skr {
-            KeyRole::Administrator => ProtoKeyRole::Administrator,
-            KeyRole::Carrier => ProtoKeyRole::Carrier,
-            KeyRole::Oracle => ProtoKeyRole::Oracle,
-            KeyRole::Router => ProtoKeyRole::Router,
-        }
-    }
-}
-
-impl From<ProtoKeyRole> for KeyRole {
-    fn from(kt: ProtoKeyRole) -> Self {
-        match kt {
-            ProtoKeyRole::Administrator => KeyRole::Administrator,
-            ProtoKeyRole::Carrier => KeyRole::Carrier,
-            ProtoKeyRole::Oracle => KeyRole::Oracle,
-            ProtoKeyRole::Router => KeyRole::Router,
-        }
-    }
-}
-
-impl std::fmt::Display for KeyRole {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            Self::Administrator => "administrator",
-            Self::Carrier => "carrier",
-            Self::Oracle => "oracle",
-            Self::Router => "router",
-        };
-        f.write_str(s)
     }
 }
 

--- a/mobile_config/src/lib.rs
+++ b/mobile_config/src/lib.rs
@@ -80,11 +80,11 @@ impl From<ProtoKeyRole> for KeyRole {
 impl std::fmt::Display for KeyRole {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
-            Self::Administrator => "Administrator",
-            Self::Carrier => "Carrier",
-            Self::Oracle => "Oracle",
-            Self::Router => "Router",
-            Self::Pcs => "PCS",
+            Self::Administrator => "administrator",
+            Self::Carrier => "carrier",
+            Self::Oracle => "oracle",
+            Self::Router => "router",
+            Self::Pcs => "pcs",
         };
         f.write_str(s)
     }

--- a/mobile_config/src/lib.rs
+++ b/mobile_config/src/lib.rs
@@ -1,4 +1,6 @@
 use helium_crypto::PublicKey;
+use helium_proto::services::mobile_config::AdminKeyRole as ProtoKeyRole;
+use serde::Serialize;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Response, Status};
 
@@ -19,4 +21,71 @@ pub type GrpcStreamResult<T> = ReceiverStream<Result<T, Status>>;
 
 pub fn verify_public_key(bytes: &[u8]) -> Result<PublicKey, Status> {
     PublicKey::try_from(bytes).map_err(|_| Status::invalid_argument("invalid public key"))
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, sqlx::Type)]
+#[sqlx(type_name = "key_role", rename_all = "snake_case")]
+pub enum KeyRole {
+    Administrator,
+    Carrier,
+    Oracle,
+    Router,
+    Pcs,
+}
+
+impl KeyRole {
+    pub fn from_i32(v: i32) -> anyhow::Result<Self> {
+        ProtoKeyRole::from_i32(v)
+            .map(|kr| kr.into())
+            .ok_or_else(|| anyhow::anyhow!("unsupported key role {}", v))
+    }
+}
+
+impl From<KeyRole> for i32 {
+    fn from(value: KeyRole) -> Self {
+        ProtoKeyRole::from(value) as i32
+    }
+}
+
+impl From<KeyRole> for ProtoKeyRole {
+    fn from(key_role: KeyRole) -> Self {
+        Self::from(&key_role)
+    }
+}
+
+impl From<&KeyRole> for ProtoKeyRole {
+    fn from(skr: &KeyRole) -> Self {
+        match skr {
+            KeyRole::Administrator => Self::Administrator,
+            KeyRole::Carrier => Self::Carrier,
+            KeyRole::Oracle => Self::Oracle,
+            KeyRole::Router => Self::Router,
+            KeyRole::Pcs => Self::Pcs,
+        }
+    }
+}
+
+impl From<ProtoKeyRole> for KeyRole {
+    fn from(kt: ProtoKeyRole) -> Self {
+        match kt {
+            ProtoKeyRole::Administrator => Self::Administrator,
+            ProtoKeyRole::Carrier => Self::Carrier,
+            ProtoKeyRole::Oracle => Self::Oracle,
+            ProtoKeyRole::Router => Self::Router,
+            ProtoKeyRole::Pcs => Self::Pcs,
+        }
+    }
+}
+
+impl std::fmt::Display for KeyRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Administrator => "Administrator",
+            Self::Carrier => "Carrier",
+            Self::Oracle => "Oracle",
+            Self::Router => "Router",
+            Self::Pcs => "PCS",
+        };
+        f.write_str(s)
+    }
 }

--- a/mobile_config_cli/src/client.rs
+++ b/mobile_config_cli/src/client.rs
@@ -1,4 +1,5 @@
-use crate::{cmds::gateway::GatewayInfo, current_timestamp, KeyRole, NetworkKeyRole, Result};
+use crate::{cmds::gateway::GatewayInfo, current_timestamp, NetworkKeyRole, Result};
+
 use base64::Engine;
 use helium_crypto::{Keypair, PublicKey, Sign, Verify};
 use helium_proto::{
@@ -10,6 +11,7 @@ use helium_proto::{
     },
     Message,
 };
+use mobile_config::KeyRole;
 use std::str::FromStr;
 
 pub struct AdminClient {

--- a/mobile_config_cli/src/cmds/mod.rs
+++ b/mobile_config_cli/src/cmds/mod.rs
@@ -1,7 +1,8 @@
-use crate::{cmds::env::NetworkArg, KeyRole, NetworkKeyRole, Result};
+use crate::{cmds::env::NetworkArg, NetworkKeyRole, Result};
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
 use helium_crypto::PublicKey;
+use mobile_config::KeyRole;
 use std::path::PathBuf;
 
 pub mod admin;

--- a/mobile_config_cli/src/lib.rs
+++ b/mobile_config_cli/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 pub mod proto {
-    pub use helium_proto::services::mobile_config::{AdminKeyRole, NetworkKeyRole};
+    pub use helium_proto::services::mobile_config::NetworkKeyRole;
 }
 
 pub type Result<T = (), E = Error> = anyhow::Result<T, E>;
@@ -74,47 +74,13 @@ impl<S: ?Sized + serde::Serialize> PrettyJson for S {
 }
 
 #[derive(Debug, clap::ValueEnum, Clone, Copy, Serialize)]
-pub enum KeyRole {
-    Administrator,
-    Carrier,
-    Router,
-    Oracle,
-}
-
-impl From<KeyRole> for proto::AdminKeyRole {
-    fn from(value: KeyRole) -> Self {
-        match value {
-            KeyRole::Administrator => Self::Administrator,
-            KeyRole::Carrier => Self::Carrier,
-            KeyRole::Router => Self::Router,
-            KeyRole::Oracle => Self::Oracle,
-        }
-    }
-}
-
-impl From<KeyRole> for i32 {
-    fn from(value: KeyRole) -> Self {
-        proto::AdminKeyRole::from(value) as i32
-    }
-}
-
-impl Display for KeyRole {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            KeyRole::Administrator => write!(f, "Administrator"),
-            KeyRole::Carrier => write!(f, "Carrier"),
-            KeyRole::Oracle => write!(f, "Oracle"),
-            KeyRole::Router => write!(f, "Router"),
-        }
-    }
-}
-
-#[derive(Debug, clap::ValueEnum, Clone, Copy, Serialize)]
 pub enum NetworkKeyRole {
     #[value(alias("carrier"))]
     MobileCarrier,
     #[value(alias("router"))]
     MobileRouter,
+    #[value(alias("pcs"))]
+    MobilePcs,
 }
 
 impl From<NetworkKeyRole> for proto::NetworkKeyRole {
@@ -122,6 +88,7 @@ impl From<NetworkKeyRole> for proto::NetworkKeyRole {
         match value {
             NetworkKeyRole::MobileRouter => Self::MobileRouter,
             NetworkKeyRole::MobileCarrier => Self::MobileCarrier,
+            NetworkKeyRole::MobilePcs => Self::MobilePcs,
         }
     }
 }
@@ -137,6 +104,7 @@ impl Display for NetworkKeyRole {
         match self {
             NetworkKeyRole::MobileCarrier => write!(f, "Carrier"),
             NetworkKeyRole::MobileRouter => write!(f, "Router"),
+            NetworkKeyRole::MobilePcs => write!(f, "PCS"),
         }
     }
 }

--- a/mobile_config_cli/src/lib.rs
+++ b/mobile_config_cli/src/lib.rs
@@ -102,9 +102,9 @@ impl From<NetworkKeyRole> for i32 {
 impl Display for NetworkKeyRole {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            NetworkKeyRole::MobileCarrier => write!(f, "Carrier"),
-            NetworkKeyRole::MobileRouter => write!(f, "Router"),
-            NetworkKeyRole::MobilePcs => write!(f, "PCS"),
+            NetworkKeyRole::MobileCarrier => write!(f, "carrier"),
+            NetworkKeyRole::MobileRouter => write!(f, "router"),
+            NetworkKeyRole::MobilePcs => write!(f, "pcs"),
         }
     }
 }

--- a/mobile_verifier/src/heartbeats.rs
+++ b/mobile_verifier/src/heartbeats.rs
@@ -212,6 +212,7 @@ impl Heartbeat {
                     cell_type: self.cell_type.unwrap_or(CellType::Neutrino430) as i32, // Is this the right default?
                     validity: self.validity as i32,
                     timestamp: self.timestamp.timestamp() as u64,
+                    coverage_object: Vec::with_capacity(0), // Placeholder so the project compiles
                 },
                 [],
             )


### PR DESCRIPTION
depends on https://github.com/helium/proto/pull/352

allow the mobile config service to register pcs signing keys so the mobile verifier is able to validate subscriber location and data usage threshold reports submitted by a carrier's propagation calculation service

cleans up duplication of the KeyRole type shared by the mobile config service and its CLI

- temporarily adjusts mobile ingest service and cell heartbeat req messages to allow compilation to succeed with upstream changes already in the proto repo