### PR TITLE
IoT Config locked route updates and shutdown listeners

### DIFF
--- a/iot_config/src/main.rs
+++ b/iot_config/src/main.rs
@@ -95,6 +95,7 @@ impl Daemon {
             region_map.clone(),
             auth_cache.clone(),
             delegate_key_cache,
+            shutdown_listener.clone(),
         )?;
         let route_svc = RouteService::new(
             settings,
@@ -108,6 +109,7 @@ impl Daemon {
             pool.clone(),
             route_svc.clone_update_channel(),
             delegate_key_updater,
+            shutdown_listener.clone(),
         )?;
         let admin_svc = AdminService::new(
             settings,

--- a/iot_config/src/org_service.rs
+++ b/iot_config/src/org_service.rs
@@ -1,7 +1,6 @@
 use crate::{
     admin::{AuthCache, KeyType},
-    broadcast_update,
-    helium_netids, lora_field, org,
+    broadcast_update, helium_netids, lora_field, org,
     route::list_routes,
     telemetry, verify_public_key, GrpcResult, Settings,
 };
@@ -462,7 +461,10 @@ impl iot_config::Org for OrgService {
                     signature: vec![],
                 };
                 update.signature = self.sign_response(&update.encode_to_vec())?;
-                if broadcast_update(update, self.route_update_tx.clone()).await.is_err() {
+                if broadcast_update(update, self.route_update_tx.clone())
+                    .await
+                    .is_err()
+                {
                     tracing::info!(
                         route_id = route_id,
                         "all subscribers disconnected; route disable incomplete"
@@ -533,7 +535,10 @@ impl iot_config::Org for OrgService {
                     signature: vec![],
                 };
                 update.signature = self.sign_response(&update.encode_to_vec())?;
-                if broadcast_update(update, self.route_update_tx.clone()).await.is_err() {
+                if broadcast_update(update, self.route_update_tx.clone())
+                    .await
+                    .is_err()
+                {
                     tracing::info!(
                         route_id = route_id,
                         "all subscribers disconnected; route enable incomplete"

--- a/iot_config/src/route.rs
+++ b/iot_config/src/route.rs
@@ -155,7 +155,8 @@ pub async fn create_route(
         })
         .and_then(|signature| {
             update.signature = signature;
-            broadcast_update(update, update_tx).map_err(|_| anyhow!("failed broadcasting route create"))
+            broadcast_update(update, update_tx)
+                .map_err(|_| anyhow!("failed broadcasting route create"))
         })
         .await;
 
@@ -219,7 +220,8 @@ pub async fn update_route(
         })
         .and_then(|signature| {
             update_res.signature = signature;
-            broadcast_update(update_res, update_tx).map_err(|_| anyhow!("failed broadcasting route update"))
+            broadcast_update(update_res, update_tx)
+                .map_err(|_| anyhow!("failed broadcasting route update"))
         })
         .await;
 

--- a/iot_config/src/route.rs
+++ b/iot_config/src/route.rs
@@ -137,28 +137,27 @@ pub async fn create_route(
 
     transaction.commit().await?;
 
-    if new_route.active && !new_route.locked {
-        let timestamp = Utc::now().encode_timestamp();
-        let signer = signing_key.public_key().into();
-        let mut update = proto::RouteStreamResV1 {
-            action: proto::ActionV1::Add.into(),
-            data: Some(proto::route_stream_res_v1::Data::Route(
-                new_route.clone().into(),
-            )),
-            timestamp,
-            signer,
-            signature: vec![],
-        };
-        _ = signing_key
-            .sign(&update.encode_to_vec())
-            .map_err(|err| tracing::error!("error signing route stream response: {err:?}"))
-            .and_then(|signature| {
-                update.signature = signature;
-                update_tx.send(update).map_err(|err| {
-                    tracing::warn!("error broadcasting route stream response: {err:?}")
-                })
-            });
+    let timestamp = Utc::now().encode_timestamp();
+    let signer = signing_key.public_key().into();
+    let mut update = proto::RouteStreamResV1 {
+        action: proto::ActionV1::Add.into(),
+        data: Some(proto::route_stream_res_v1::Data::Route(
+            new_route.clone().into(),
+        )),
+        timestamp,
+        signer,
+        signature: vec![],
     };
+    _ = futures::future::ready(signing_key.sign(&update.encode_to_vec()))
+        .map_err(|err| {
+            tracing::error!(error = ?err, "error signing route create");
+            anyhow!("error signing route create")
+        })
+        .and_then(|signature| {
+            update.signature = signature;
+            broadcast_update(update, update_tx).map_err(|_| anyhow!("failed broadcasting route create"))
+        })
+        .await;
 
     Ok(new_route)
 }
@@ -213,15 +212,16 @@ pub async fn update_route(
         signature: vec![],
     };
 
-    _ = signing_key
-        .sign(&update_res.encode_to_vec())
-        .map_err(|err| tracing::error!("error signing route stream response: {err:?}"))
+    _ = futures::future::ready(signing_key.sign(&update_res.encode_to_vec()))
+        .map_err(|err| {
+            tracing::error!(error = ?err, "error signing route update");
+            anyhow!("error signing route update")
+        })
         .and_then(|signature| {
             update_res.signature = signature;
-            update_tx
-                .send(update_res)
-                .map_err(|err| tracing::warn!("error broadcasting route stream response: {err:?}"))
-        });
+            broadcast_update(update_res, update_tx).map_err(|_| anyhow!("failed broadcasting route update"))
+        })
+        .await;
 
     Ok(updated_route)
 }
@@ -523,7 +523,6 @@ pub fn active_route_stream<'a>(
         select r.id, r.oui, r.net_id, r.max_copies, r.server_host, r.server_port, r.server_protocol_opts, r.active, r.ignore_empty_skf, o.locked
             from routes r
             join organizations o on r.oui = o.oui
-            where o.locked = false and r.active = true
             group by r.id, o.locked
         "#,
     )


### PR DESCRIPTION
Ensures that locked/disabled routes are still broadcast to the HPR servers so they are always available. HPRs check for a route's status (active and not disabled) anyway so they are _only_ removed from the HPR when they are purposely deleted by an admin or operator.

Also adds more shutdown listeners to the long-running grpc streaming handlers to try and force the config service to respect and properly respond to sigterm messages sent from systemd when the service is being shut down (such as for update deployments).