### PR TITLE
allowing for subscriber mapping rewards without radiopoc rewards

### DIFF
--- a/mobile_verifier/src/cli/reward_from_db.rs
+++ b/mobile_verifier/src/cli/reward_from_db.rs
@@ -44,7 +44,10 @@ impl Cmd {
 
         let mut total_rewards = 0_u64;
         let mut owner_rewards = HashMap::<_, u64>::new();
-        for reward in reward_shares.into_rewards(Decimal::ZERO, &epoch) {
+        let radio_rewards = reward_shares
+            .into_rewards(Decimal::ZERO, &epoch)
+            .ok_or(anyhow::anyhow!("no rewardable events"))?;
+        for reward in radio_rewards {
             if let Some(proto::mobile_reward_share::Reward::RadioReward(proto::RadioReward {
                 hotspot_key,
                 poc_reward,

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -170,22 +170,24 @@ impl Rewarder {
         };
         telemetry::data_transfer_rewards_scale(scale);
 
-        for mobile_reward_share in
+        if let Some(mobile_reward_shares) =
             poc_rewards.into_rewards(transfer_rewards.reward_sum(), reward_period)
         {
-            self.mobile_rewards
-                .write(mobile_reward_share, [])
-                .await?
-                // Await the returned one shot to ensure that we wrote the file
-                .await??;
-        }
+            for mobile_reward_share in mobile_reward_shares {
+                self.mobile_rewards
+                    .write(mobile_reward_share, [])
+                    .await?
+                    // Await the returned one shot to ensure that we wrote the file
+                    .await??;
+            }
 
-        for mobile_reward_share in transfer_rewards.into_rewards(reward_period) {
-            self.mobile_rewards
-                .write(mobile_reward_share, [])
-                .await?
-                // Await the returned one shot to ensure that we wrote the file
-                .await??;
+            for mobile_reward_share in transfer_rewards.into_rewards(reward_period) {
+                self.mobile_rewards
+                    .write(mobile_reward_share, [])
+                    .await?
+                    // Await the returned one shot to ensure that we wrote the file
+                    .await??;
+            }
         }
 
         // Mapper rewards currently include rewards for discovery mapping only.


### PR DESCRIPTION
In the event there is no rewardable PoC activity from the mobile/cbrs fleet, do a `check_div` on instead of standard division to avoid a divide-by-zero-induced panic and move on with attempting to reward for subscriber location mapping