### PR TITLE
Add stream permission for hpr listing skfs or euis

### DIFF
--- a/iot_config/src/route_service.rs
+++ b/iot_config/src/route_service.rs
@@ -122,6 +122,21 @@ impl RouteService {
         }
     }
 
+    async fn verify_request_signature_or_stream<'a, R>(
+        &self,
+        signer: &PublicKey,
+        request: &R,
+        id: OrgId<'a>,
+    ) -> Result<(), Status>
+    where
+        R: MsgVerify,
+    {
+        if let Ok(()) = self.verify_request_signature(signer, request, id).await {
+            return Ok(());
+        }
+        self.verify_stream_request_signature(signer, request)
+    }
+
     fn sign_response(&self, response: &[u8]) -> Result<Vec<u8>, Status> {
         self.signing_key
             .sign(response)
@@ -418,8 +433,12 @@ impl iot_config::Route for RouteService {
         telemetry::count_request("route", "get-euis");
 
         let signer = verify_public_key(&request.signer)?;
-        self.verify_request_signature(&signer, &request, OrgId::RouteId(&request.route_id))
-            .await?;
+        self.verify_request_signature_or_stream(
+            &signer,
+            &request,
+            OrgId::RouteId(&request.route_id),
+        )
+        .await?;
 
         let pool = self.pool.clone();
         let (tx, rx) = tokio::sync::mpsc::channel(20);
@@ -739,8 +758,12 @@ impl iot_config::Route for RouteService {
         telemetry::count_request("route", "list-skfs");
 
         let signer = verify_public_key(&request.signer)?;
-        self.verify_request_signature(&signer, &request, OrgId::RouteId(&request.route_id))
-            .await?;
+        self.verify_request_signature_or_stream(
+            &signer,
+            &request,
+            OrgId::RouteId(&request.route_id),
+        )
+        .await?;
 
         let pool = self.pool.clone();
         let (tx, rx) = tokio::sync::mpsc::channel(20);

--- a/iot_config/src/route_service.rs
+++ b/iot_config/src/route_service.rs
@@ -594,8 +594,12 @@ impl iot_config::Route for RouteService {
         telemetry::count_request("route", "get-devaddr-ranges");
 
         let signer = verify_public_key(&request.signer)?;
-        self.verify_request_signature(&signer, &request, OrgId::RouteId(&request.route_id))
-            .await?;
+        self.verify_request_signature_or_stream(
+            &signer,
+            &request,
+            OrgId::RouteId(&request.route_id),
+        )
+        .await?;
 
         let (tx, rx) = tokio::sync::mpsc::channel(20);
         let pool = self.pool.clone();


### PR DESCRIPTION
Allows a sanity check from routing infrastructure to re-request information for a specific route without requiring reloading the entire database of routing information.

There can be times where the updating of a routes skfs or euis can be weird. 
An EUI/SKF can be added and removed in an order where HPRs end up with the record, but it no longer exists in the database. Subsequent requests to remove the record from the Config Service will "succeed", but not send any updates to HPRs because no update was made to the database.

Adding HPR permission to `list_skfs` and `get_euis` allows them to do a sanity check of a single route.