### PR TITLE
Make file_store usable outside of oracles

### DIFF
--- a/file_store/src/cli/bucket.rs
+++ b/file_store/src/cli/bucket.rs
@@ -66,7 +66,7 @@ pub struct FileFilter {
 impl FileFilter {
     pub fn list(&self, store: &FileStore) -> FileInfoStream {
         store.list(
-            self.prefix.clone(),
+            &self.prefix,
             self.after.as_ref().map(|dt| Utc.from_utc_datetime(dt)),
             self.before.as_ref().map(|dt| Utc.from_utc_datetime(dt)),
         )

--- a/file_store/src/cli/bucket.rs
+++ b/file_store/src/cli/bucket.rs
@@ -53,18 +53,18 @@ pub struct FileFilter {
     /// Optional start time to look for (inclusive). Defaults to the oldest
     /// timestamp in the bucket.
     #[clap(long)]
-    after: Option<NaiveDateTime>,
+    pub after: Option<NaiveDateTime>,
     /// Optional end time to look for (exclusive). Defaults to the latest
     /// available timestamp in the bucket.
     #[clap(long)]
-    before: Option<NaiveDateTime>,
+    pub before: Option<NaiveDateTime>,
     /// The file type prefix to search for
     #[clap(long)]
-    prefix: String,
+    pub prefix: String,
 }
 
 impl FileFilter {
-    fn list(&self, store: &FileStore) -> FileInfoStream {
+    pub fn list(&self, store: &FileStore) -> FileInfoStream {
         store.list(
             self.prefix.clone(),
             self.after.as_ref().map(|dt| Utc.from_utc_datetime(dt)),

--- a/file_store/src/cli/info.rs
+++ b/file_store/src/cli/info.rs
@@ -17,10 +17,7 @@ use helium_proto::{
     EntropyReportV1, Message, PriceReportV1,
 };
 use serde_json::json;
-use std::{
-    path::PathBuf,
-    str::FromStr,
-};
+use std::{path::PathBuf, str::FromStr};
 
 /// Print information about a given store file.
 #[derive(Debug, clap::Args)]

--- a/file_store/src/file_info.rs
+++ b/file_store/src/file_info.rs
@@ -8,7 +8,7 @@ use std::{fmt, io, os::unix::fs::MetadataExt, path::Path, str::FromStr};
 #[derive(Debug, Clone, Serialize)]
 pub struct FileInfo {
     pub key: String,
-    pub file_type: FileType,
+    pub prefix: String,
     pub timestamp: DateTime<Utc>,
     pub size: usize,
 }
@@ -24,13 +24,13 @@ impl FromStr for FileInfo {
         let cap = RE
             .captures(s)
             .ok_or_else(|| DecodeError::file_info("failed to decode file info"))?;
-        let file_type = FileType::from_str(&cap[1])?;
+        let prefix = cap[1].to_owned();
         let timestamp = u64::from_str(&cap[2])
             .map_err(|_| DecodeError::file_info("failed to decode timestamp"))?
             .to_timestamp_millis()?;
         Ok(Self {
             key,
-            file_type,
+            prefix,
             timestamp,
             size: 0,
         })
@@ -59,7 +59,7 @@ impl From<(FileType, DateTime<Utc>)> for FileInfo {
     fn from(v: (FileType, DateTime<Utc>)) -> Self {
         Self {
             key: format!("{}.{}.gz", &v.0, v.1.timestamp_millis()),
-            file_type: v.0,
+            prefix: v.0.to_string(),
             timestamp: v.1,
             size: 0,
         }

--- a/file_store/src/file_info.rs
+++ b/file_store/src/file_info.rs
@@ -66,6 +66,17 @@ impl From<(FileType, DateTime<Utc>)> for FileInfo {
     }
 }
 
+impl From<(String, DateTime<Utc>)> for FileInfo {
+    fn from(v: (String, DateTime<Utc>)) -> Self {
+        Self {
+            key: format!("{}.{}.gz", &v.0, v.1.timestamp_millis()),
+            prefix: v.0,
+            timestamp: v.1,
+            size: 0,
+        }
+    }
+}
+
 impl TryFrom<&aws_sdk_s3::model::Object> for FileInfo {
     type Error = Error;
     fn try_from(value: &aws_sdk_s3::model::Object) -> Result<Self> {

--- a/file_store/src/file_info_poller.rs
+++ b/file_store/src/file_info_poller.rs
@@ -95,7 +95,7 @@ where
                 }
                 _ = cleanup_trigger.tick() => self.clean(&cache).await?,
                 _ = poll_trigger.tick() => {
-                    let files = self.store.list_all(self.file_type, after, before).await?;
+                    let files = self.store.list_all(self.file_type.to_str(), after, before).await?;
                     for file in files {
                         if !is_already_processed(&self.db, &cache, &file).await? {
                             if send_stream(&sender, &self.store, file.clone()).await? {

--- a/file_store/src/file_info_poller.rs
+++ b/file_store/src/file_info_poller.rs
@@ -246,7 +246,7 @@ mod db {
         INSERT INTO files_processed(file_name, file_type, file_timestamp, processed_at) VALUES($1, $2, $3, $4)
         "#)
     .bind(file_info.key)
-    .bind(file_info.file_type.to_str())
+    .bind(&file_info.prefix)
     .bind(file_info.timestamp)
     .bind(Utc::now())
     .execute(tx)

--- a/file_store/src/file_sink.rs
+++ b/file_store/src/file_sink.rs
@@ -638,7 +638,8 @@ mod tests {
             .to_str()
             .and_then(|file_name| FileInfo::from_str(file_name).ok())
             .map_or(false, |file_info| {
-                file_info.file_type == FileType::EntropyReport
+                FileType::from_str(&file_info.prefix).expect("entropy report prefix")
+                    == FileType::EntropyReport
             })
     }
 }

--- a/file_store/src/file_store.rs
+++ b/file_store/src/file_store.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::DecodeError, BytesMutStream, Error, FileInfo, FileInfoStream, FileType, Result, Settings,
+    error::DecodeError, BytesMutStream, Error, FileInfo, FileInfoStream, Result, Settings,
 };
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::{types::ByteStream, Client, Endpoint, Region};
@@ -57,27 +57,27 @@ impl FileStore {
         })
     }
 
-    pub async fn list_all<A, B, F>(
+    pub async fn list_all<A, B, P>(
         &self,
-        file_type: F,
+        file_type: P,
         after: A,
         before: B,
     ) -> Result<Vec<FileInfo>>
     where
-        F: Into<FileType> + Copy,
+        P: ToString + std::fmt::Display,
         A: Into<Option<DateTime<Utc>>> + Copy,
         B: Into<Option<DateTime<Utc>>> + Copy,
     {
         self.list(file_type, after, before).try_collect().await
     }
 
-    pub fn list<A, B, F>(&self, file_type: F, after: A, before: B) -> FileInfoStream
+    pub fn list<A, B, P>(&self, prefix: P, after: A, before: B) -> FileInfoStream
     where
-        F: Into<FileType> + Copy,
+        P: ToString,
         A: Into<Option<DateTime<Utc>>> + Copy,
         B: Into<Option<DateTime<Utc>>> + Copy,
     {
-        let file_type = file_type.into();
+        let file_type = prefix.to_string();
         let before = before.into();
         let after = after.into();
 

--- a/file_store/src/file_store.rs
+++ b/file_store/src/file_store.rs
@@ -57,23 +57,21 @@ impl FileStore {
         })
     }
 
-    pub async fn list_all<A, B, P>(
+    pub async fn list_all<A, B>(
         &self,
-        file_type: P,
+        file_type: &str,
         after: A,
         before: B,
     ) -> Result<Vec<FileInfo>>
     where
-        P: ToString + std::fmt::Display,
         A: Into<Option<DateTime<Utc>>> + Copy,
         B: Into<Option<DateTime<Utc>>> + Copy,
     {
         self.list(file_type, after, before).try_collect().await
     }
 
-    pub fn list<A, B, P>(&self, prefix: P, after: A, before: B) -> FileInfoStream
+    pub fn list<A, B>(&self, prefix: &str, after: A, before: B) -> FileInfoStream
     where
-        P: ToString,
         A: Into<Option<DateTime<Utc>>> + Copy,
         B: Into<Option<DateTime<Utc>>> + Copy,
     {

--- a/file_store/src/lib.rs
+++ b/file_store/src/lib.rs
@@ -22,6 +22,7 @@ pub mod speedtest;
 pub mod traits;
 
 pub use crate::file_store::FileStore;
+pub use cli::bucket::FileFilter;
 pub use error::{Error, Result};
 pub use file_info::{FileInfo, FileType};
 pub use file_sink::{FileSink, FileSinkBuilder};

--- a/iot_verifier/src/loader.rs
+++ b/iot_verifier/src/loader.rs
@@ -220,7 +220,7 @@ impl Loader {
         tracing::info!(
             "checking for new ingest files of type {file_type} after {after} and before {before}"
         );
-        let infos = store.list_all(file_type, after, before).await?;
+        let infos = store.list_all(file_type.to_str(), after, before).await?;
         if infos.is_empty() {
             tracing::info!("no available ingest files of type {file_type}");
             return Ok(());

--- a/iot_verifier/src/loader.rs
+++ b/iot_verifier/src/loader.rs
@@ -16,7 +16,7 @@ use file_store::{
 use futures::{stream, StreamExt};
 use helium_crypto::PublicKeyBinary;
 use sqlx::PgPool;
-use std::{hash::Hasher, ops::DerefMut, str::FromStr, time::Duration};
+use std::{hash::Hasher, ops::DerefMut, str::FromStr};
 use tokio::{
     sync::Mutex,
     time::{self, MissedTickBehavior},

--- a/price/src/price_tracker.rs
+++ b/price/src/price_tracker.rs
@@ -183,7 +183,7 @@ async fn process_files(
     after: DateTime<Utc>,
 ) -> Result<Option<DateTime<Utc>>, PriceTrackerError> {
     file_store
-        .list(FileType::PriceReport, after, None)
+        .list(FileType::PriceReport.to_str(), after, None)
         .map_err(PriceTrackerError::from)
         .and_then(|file| process_file(file_store, file, sender))
         .try_fold(None, |_old, ts| async move { Ok(Some(ts)) })


### PR DESCRIPTION
Convert the internal FileInfo struct from file-store to have a generic "prefix" instead of an internally defined enum FileType to allow external apps/libraries that use file-store as a dependency to build FileInfos for their own types (when using for searching the S3 records for instance).

This is intended as a minimal refactor; a longer-term solution would be to implement a FileInfo trait that encapsulates the functionality in question and better exposes some common functionality used in the file store cli commands for extension (such as "listing" a collection of files into a stream, filtered by an input type and decoded)