### PR TITLE
move denylist check from loader to the runner verification list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,7 +1118,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#d86b3e3394e8d9f014fcef3ee08740b3fe269e99"
+source = "git+https://github.com/helium/proto?branch=master#7d85f190b207a3ac8d6ad081e2f70e45eecd1a3a"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#d86b3e3394e8d9f014fcef3ee08740b3fe269e99"
+source = "git+https://github.com/helium/proto?branch=master#7d85f190b207a3ac8d6ad081e2f70e45eecd1a3a"
 dependencies = [
  "bytes",
  "prost",

--- a/file_store/src/iot_invalid_poc.rs
+++ b/file_store/src/iot_invalid_poc.rs
@@ -17,6 +17,9 @@ pub struct IotInvalidBeaconReport {
     pub received_timestamp: DateTime<Utc>,
     pub reason: InvalidReason,
     pub report: IotBeaconReport,
+    pub location: Option<u64>,
+    pub gain: i32,
+    pub elevation: i32,
 }
 
 #[derive(Serialize, Clone)]
@@ -75,6 +78,9 @@ impl TryFrom<LoraInvalidBeaconReportV1> for IotInvalidBeaconReport {
                 .report
                 .ok_or_else(|| Error::not_found("iot invalid beacon report v1"))?
                 .try_into()?,
+            location: v.location.parse().ok(),
+            gain: v.gain,
+            elevation: v.elevation,
         })
     }
 }
@@ -87,6 +93,12 @@ impl From<IotInvalidBeaconReport> for LoraInvalidBeaconReportV1 {
             received_timestamp,
             reason: v.reason as i32,
             report: Some(report),
+            location: v
+                .location
+                .map(|l| l.to_string())
+                .unwrap_or_else(String::new),
+            gain: v.gain,
+            elevation: v.elevation,
         }
     }
 }

--- a/iot_verifier/src/loader.rs
+++ b/iot_verifier/src/loader.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use chrono::DateTime;
 use chrono::{Duration as ChronoDuration, Utc};
-use denylist::DenyList;
 use file_store::{
     iot_beacon_report::IotBeaconIngestReport,
     iot_witness_report::IotWitnessIngestReport,
@@ -17,7 +16,7 @@ use file_store::{
 use futures::{stream, StreamExt};
 use helium_crypto::PublicKeyBinary;
 use sqlx::PgPool;
-use std::{hash::Hasher, ops::DerefMut, time::Duration};
+use std::{hash::Hasher, ops::DerefMut};
 use tokio::{
     sync::Mutex,
     time::{self, MissedTickBehavior},
@@ -34,9 +33,6 @@ pub struct Loader {
     window_width: ChronoDuration,
     ingestor_rollup_time: ChronoDuration,
     max_lookback_age: ChronoDuration,
-    deny_list_latest_url: String,
-    deny_list_trigger_interval: Duration,
-    deny_list: DenyList,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -45,13 +41,10 @@ pub enum NewLoaderError {
     FileStoreError(#[from] file_store::Error),
     #[error("db_store error: {0}")]
     DbStoreError(#[from] db_store::Error),
-    #[error("denylist error: {0}")]
-    DenyListError(#[from] denylist::Error),
 }
 
 pub enum ValidGatewayResult {
     Valid,
-    Denied,
     Unknown,
 }
 
@@ -63,7 +56,6 @@ impl Loader {
         let window_width = settings.poc_loader_window_width();
         let ingestor_rollup_time = settings.ingestor_rollup_time();
         let max_lookback_age = settings.loader_window_max_lookback_age();
-        let deny_list = DenyList::new()?;
         Ok(Self {
             pool,
             ingest_store,
@@ -71,9 +63,6 @@ impl Loader {
             window_width,
             ingestor_rollup_time,
             max_lookback_age,
-            deny_list_latest_url: settings.denylist.denylist_url.clone(),
-            deny_list_trigger_interval: settings.denylist.trigger_interval(),
-            deny_list,
         })
     }
 
@@ -85,21 +74,12 @@ impl Loader {
         tracing::info!("started verifier loader");
         let mut report_timer = time::interval(self.poll_time);
         report_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
-        let mut denylist_timer = time::interval(self.deny_list_trigger_interval);
-        denylist_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
         loop {
             if shutdown.is_triggered() {
                 break;
             }
             tokio::select! {
                 _ = shutdown.clone() => break,
-                _ = denylist_timer.tick() =>
-                    match self.handle_denylist_tick().await {
-                    Ok(()) => (),
-                    Err(err) => {
-                        tracing::error!("fatal loader error, denylist_tick triggered: {err:?}");
-                    }
-                },
                 _ = report_timer.tick() => match self.handle_report_tick(gateway_cache).await {
                     Ok(()) => (),
                     Err(err) => {
@@ -109,23 +89,6 @@ impl Loader {
             }
         }
         tracing::info!("stopping verifier loader");
-        Ok(())
-    }
-
-    async fn handle_denylist_tick(&mut self) -> anyhow::Result<()> {
-        tracing::info!("handling denylist tick");
-        // sink any errors whilst updating the denylist
-        // the verifier should not stop just because github
-        // could not be reached for example
-        match self
-            .deny_list
-            .update_to_latest(&self.deny_list_latest_url)
-            .await
-        {
-            Ok(()) => (),
-            Err(e) => tracing::warn!("failed to update denylist: {e}"),
-        }
-        tracing::info!("completed handling denylist tick");
         Ok(())
     }
 
@@ -375,11 +338,6 @@ impl Loader {
                         };
                         Ok(Some(res))
                     }
-                    ValidGatewayResult::Denied => {
-                        metrics.increment_beacons_denied();
-                        Ok(None)
-                    }
-
                     ValidGatewayResult::Unknown => {
                         metrics.increment_beacons_unknown();
                         Ok(None)
@@ -409,10 +367,6 @@ impl Loader {
                                     };
                                     metrics.increment_witnesses();
                                     Ok(Some(res))
-                                }
-                                ValidGatewayResult::Denied => {
-                                    metrics.increment_witnesses_denied();
-                                    Ok(None)
                                 }
                                 ValidGatewayResult::Unknown => {
                                     metrics.increment_witnesses_unknown();
@@ -445,10 +399,6 @@ impl Loader {
         pub_key: &PublicKeyBinary,
         gateway_cache: &GatewayCache,
     ) -> ValidGatewayResult {
-        if self.check_gw_denied(pub_key).await {
-            tracing::debug!("dropping denied gateway : {:?}", &pub_key);
-            return ValidGatewayResult::Denied;
-        }
         if self.check_unknown_gw(pub_key, gateway_cache).await {
             tracing::debug!("dropping unknown gateway: {:?}", &pub_key);
             return ValidGatewayResult::Unknown;
@@ -462,10 +412,6 @@ impl Loader {
         gateway_cache: &GatewayCache,
     ) -> bool {
         gateway_cache.resolve_gateway_info(pub_key).await.is_err()
-    }
-
-    async fn check_gw_denied(&self, pub_key: &PublicKeyBinary) -> bool {
-        self.deny_list.check_key(pub_key).await
     }
 }
 

--- a/iot_verifier/src/main.rs
+++ b/iot_verifier/src/main.rs
@@ -164,7 +164,7 @@ impl Server {
 
         // init da processes
         let mut loader = loader::Loader::from_settings(settings, pool.clone()).await?;
-        let mut runner = runner::Runner::from_settings(settings, pool.clone()).await?;
+        let mut runner = runner::Runner::new(settings, pool.clone()).await?;
         let purger = purger::Purger::from_settings(settings, pool.clone()).await?;
         let mut density_scaler =
             DensityScaler::from_settings(settings, pool, gateway_updater_receiver.clone()).await?;

--- a/iot_verifier/src/purger.rs
+++ b/iot_verifier/src/purger.rs
@@ -198,6 +198,9 @@ impl Purger {
             received_timestamp,
             reason: InvalidReason::Stale,
             report: beacon.clone(),
+            location: None,
+            gain: 0,
+            elevation: 0,
         }
         .into();
 


### PR DESCRIPTION
Linked proto pr: https://github.com/helium/proto/pull/362

Moves the denylist check from the loader ( where invalids are dropped ) and into the runner's POC verification list.  The denylist becomes a regular verification alongside the existing POC verifications and results in failed reports getting outputted to S3.

If a beacon is verified `valid` then the verifications are executed for each individual witness which and now includes the denylist check.  The `iot_poc` file outputted to s3 will include metadata enrichment ( location, elevation & gain) for the beacon report and all witnesses (including for both valid and invalid witnesses) and will now include "DENIED" value for the invalid_reason where applicable.

If a beacon is verified `invalid`, all witnesses for that beacon are automatically rendered invalid without any verification checks being run on the witnesses.  These invalid beacons will be in the `iot_invalid_beacon` files on S3, whilst the invalid beacons will be in the `iot_invalid_witness` files on s3.  The beacon's invalid reason will be set to DENIED, as will be that of the witnesses.  The witnesses `participant_side` field will be set to `beacon` to indicate they inherit the fail reason from the parent beacon.  
In this scenario the beacon will now have the inclusion of the metadata enrichment fields but the witnesses will not ( as they are failed automatically without any verification checks and never get as far as checking for gateway info  )  

Copy of a denied list witness take from iot_poc file on s3

{
      "elevation": 17,
      "gain": 150,
      "hex_scale": 0,
      "invalid_reason": 9,
      "location": "631297351876270079",
      "participant_side": 3,
      "received_timestamp": 1691089905009,
      "report": {
        "data": [
          239,
          35,
          61,
          135,
          158,
          232,
          184,
          89,
          48,
          157,
          37,
          158,
          230,
          172,
          5,
          2,
          188,
          170,
          18,
          31,
          169,
          53,
          141,
          208,
          132,
          16,
          70,
          190,
          193,
          168,
          230,
          10,
          148,
          115,
          221,
          27,
          166,
          119,
          219,
          251,
          15,
          38,
          121,
          53,
          147,
          215,
          62,
          215,
          22,
          30,
          209
        ],
        "datarate": 0,
        "frequency": 868500000,
        "pub_key": [
          0,
          85,
          177,
          144,
          172,
          73,
          106,
          126,
          231,
          181,
          29,
          143,
          15,
          76,
          161,
          167,
          214,
          235,
          129,
          46,
          249,
          28,
          95,
          88,
          174,
          174,
          63,
          29,
          179,
          102,
          157,
          134,
          212
        ],
        "signal": -970,
        "signature": [
          48,
          69,
          2,
          32,
          77,
          51,
          210,
          116,
          69,
          239,
          222,
          234,
          235,
          226,
          144,
          137,
          162,
          70,
          30,
          185,
          24,
          166,
          118,
          246,
          243,
          151,
          183,
          213,
          61,
          103,
          103,
          49,
          17,
          190,
          248,
          146,
          2,
          33,
          0,
          157,
          177,
          203,
          146,
          100,
          97,
          74,
          168,
          153,
          228,
          5,
          52,
          0,
          217,
          123,
          251,
          221,
          211,
          222,
          84,
          232,
          173,
          89,
          111,
          28,
          228,
          164,
          47,
          42,
          4,
          212,
          155
        ],
        "snr": 48,
        "timestamp": 1691089904532604633,
        "tmst": 3832218681
      },
      "reward_unit": 0,
      "status": 1
    },
