### PR TITLE
extend subscriber location reward 'genesis' period

### DIFF
--- a/mobile_verifier/src/subscriber_location.rs
+++ b/mobile_verifier/src/subscriber_location.rs
@@ -18,7 +18,7 @@ use sqlx::{PgPool, Postgres, Transaction};
 use std::ops::Range;
 use tokio::sync::mpsc::Receiver;
 
-const SUBSCRIBER_REWARD_PERIOD_LENGTH_IN_DAYS: i64 = 7;
+const SUBSCRIBER_REWARD_PERIOD_LENGTH_IN_DAYS: i64 = 14;
 
 pub type SubscriberValidatedLocations = Vec<Vec<u8>>;
 


### PR DESCRIPTION
extends the timeframe from within which subscribers who supplied an initial mapping location event will still be rewarded without having updated with subsequent events.