### PR TITLE
add filestore new support

### DIFF
--- a/file_store/src/file_store.rs
+++ b/file_store/src/file_store.rs
@@ -71,11 +71,7 @@ impl FileStore {
                 .map_err(DecodeError::from)?,
             _ => None,
         };
-        let region = if region.is_some() {
-            Region::new(region.unwrap())
-        } else {
-            Region::new(settings::default_region())
-        };
+        let region = Region::new(region.unwrap_or_else(settings::default_region));
         let region_provider = RegionProviderChain::first_try(region).or_default_provider();
 
         let mut config = aws_config::from_env().region(region_provider);

--- a/file_store/src/settings.rs
+++ b/file_store/src/settings.rs
@@ -18,7 +18,7 @@ pub struct Settings {
     pub secret_access_key: Option<String>,
 }
 
-fn default_region() -> String {
+pub fn default_region() -> String {
     "us-west-2".to_string()
 }
 


### PR DESCRIPTION
Support non settings based creation of a filestore. Specifically added to allow the subscriber location service to instantiate a filestore without using a settings file