### PR TITLE
initial pass at handling non hardcoded reward emissions

### DIFF
--- a/file_store/src/emissions.rs
+++ b/file_store/src/emissions.rs
@@ -1,0 +1,82 @@
+use crate::Result;
+use chrono::{DateTime, Datelike, Utc};
+use rust_decimal::prelude::*;
+use rust_decimal_macros::dec;
+use serde::{Deserialize, Serialize};
+use std::{fs::File, io::Read};
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct Emission {
+    pub start_time: DateTime<Utc>,
+    pub yearly_emissions: Decimal,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct EmissionsSchedule {
+    pub schedule: Vec<Emission>,
+}
+
+impl EmissionsSchedule {
+    pub async fn from_file(filepath: String) -> Result<EmissionsSchedule> {
+        let mut file = File::open(filepath)?;
+        let mut data = String::new();
+        file.read_to_string(&mut data)?;
+        let emissions: Vec<Emission> = serde_json::from_str(&data)?;
+        Ok(EmissionsSchedule {
+            schedule: emissions,
+        })
+    }
+
+    pub fn yearly_emissions(&self, datetime: DateTime<Utc>) -> Result<Decimal> {
+        let mut schedule = self.schedule.clone();
+        // todo: move sort to struct initialisation, having it here makes tests a lil easier for time being
+        schedule.sort_by(|a, b| b.start_time.cmp(&a.start_time));
+        let res = schedule
+            .into_iter()
+            .find(|emission| datetime >= emission.start_time)
+            .ok_or("failed to find emissions for specified date {datetime}")
+            .unwrap();
+        Ok(res.yearly_emissions * Decimal::from(1_000_000))
+    }
+
+    pub fn daily_emissions(&self, datetime: DateTime<Utc>) -> Result<Decimal> {
+        let cur_year = datetime.year();
+        let cur_month = datetime.month();
+        let num_days = if is_leap_year(cur_year, cur_month) {
+            dec!(366)
+        } else {
+            dec!(365)
+        };
+        let yearly_emissions = self.yearly_emissions(datetime)?;
+        Ok(yearly_emissions / num_days)
+    }
+}
+
+fn is_leap_year(cur_year: i32, cur_month: u32) -> bool {
+    let next_year = cur_year + 1;
+    let is_current_year_a_leap = is_year_a_leap(cur_year) && cur_month < 8;
+    let is_next_year_a_leap = is_year_a_leap(next_year) && cur_month >= 8;
+    is_current_year_a_leap || is_next_year_a_leap
+}
+
+fn is_year_a_leap(year: i32) -> bool {
+    year % 4 == 0 && (year % 100 != 0 || (year % 100 == 0 && year % 400 == 0))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_leap_year() {
+        assert_eq!(false, is_leap_year(2023, 7));
+        assert!(is_leap_year(2023, 8));
+        assert!(is_leap_year(2024, 7));
+        assert_eq!(false, is_leap_year(2024, 8));
+
+        assert_eq!(false, is_leap_year(2027, 7));
+        assert!(is_leap_year(2027, 8));
+        assert!(is_leap_year(2028, 7));
+        assert_eq!(false, is_leap_year(2028, 8));
+    }
+}

--- a/file_store/src/emissions.rs
+++ b/file_store/src/emissions.rs
@@ -11,13 +11,21 @@ pub struct Emission {
     pub yearly_emissions: Decimal,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct EmissionsSchedule {
     pub schedule: Vec<Emission>,
 }
 
 impl EmissionsSchedule {
-    pub async fn from_file(filepath: String) -> Result<EmissionsSchedule> {
+    pub fn default() -> Result<Self> {
+        let data = schedule();
+        let emissions: Vec<Emission> = serde_json::from_str(&data)?;
+        Ok(EmissionsSchedule {
+            schedule: emissions,
+        })
+    }
+
+    pub async fn from_file(filepath: String) -> Result<Self> {
         let mut file = File::open(filepath)?;
         let mut data = String::new();
         file.read_to_string(&mut data)?;
@@ -42,17 +50,21 @@ impl EmissionsSchedule {
     pub fn daily_emissions(&self, datetime: DateTime<Utc>) -> Result<Decimal> {
         let cur_year = datetime.year();
         let cur_month = datetime.month();
-        let num_days = if is_leap_year(cur_year, cur_month) {
-            dec!(366)
-        } else {
-            dec!(365)
-        };
+        let num_days = num_days_this_period(cur_year, cur_month);
         let yearly_emissions = self.yearly_emissions(datetime)?;
         Ok(yearly_emissions / num_days)
     }
 }
 
-fn is_leap_year(cur_year: i32, cur_month: u32) -> bool {
+fn num_days_this_period(year: i32, month: u32) -> Decimal {
+    if is_leap_epoch(year, month) {
+        dec!(366)
+    } else {
+        dec!(365)
+    }
+}
+
+fn is_leap_epoch(cur_year: i32, cur_month: u32) -> bool {
     let next_year = cur_year + 1;
     let is_current_year_a_leap = is_year_a_leap(cur_year) && cur_month < 8;
     let is_next_year_a_leap = is_year_a_leap(next_year) && cur_month >= 8;
@@ -63,20 +75,36 @@ fn is_year_a_leap(year: i32) -> bool {
     year % 4 == 0 && (year % 100 != 0 || (year % 100 == 0 && year % 400 == 0))
 }
 
+fn schedule() -> String {
+    "[{
+        \"start_time\": \"2022-08-01T00:00:01Z\",
+        \"yearly_emissions\": 65000000000
+      },
+      {
+        \"start_time\": \"2023-08-01T00:00:01Z\",
+        \"yearly_emissions\": 32500000000
+      },
+      {
+          \"start_time\": \"2024-08-01T00:00:01Z\",
+          \"yearly_emissions\": 16250000000
+      }]"
+    .to_string()
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[test]
     fn test_leap_year() {
-        assert_eq!(false, is_leap_year(2023, 7));
-        assert!(is_leap_year(2023, 8));
-        assert!(is_leap_year(2024, 7));
-        assert_eq!(false, is_leap_year(2024, 8));
+        assert_eq!(false, is_leap_epoch(2023, 7));
+        assert!(is_leap_epoch(2023, 8));
+        assert!(is_leap_epoch(2024, 7));
+        assert_eq!(false, is_leap_epoch(2024, 8));
 
-        assert_eq!(false, is_leap_year(2027, 7));
-        assert!(is_leap_year(2027, 8));
-        assert!(is_leap_year(2028, 7));
-        assert_eq!(false, is_leap_year(2028, 8));
+        assert_eq!(false, is_leap_epoch(2027, 7));
+        assert!(is_leap_epoch(2027, 8));
+        assert!(is_leap_epoch(2028, 7));
+        assert_eq!(false, is_leap_epoch(2028, 8));
     }
 }

--- a/file_store/src/error.rs
+++ b/file_store/src/error.rs
@@ -56,6 +56,8 @@ pub enum DecodeError {
     UnsupportedStatusReason(String, i32),
     #[error("invalid unix timestamp {0}")]
     InvalidTimestamp(u64),
+    #[error("json error")]
+    Json(#[from] serde_json::Error),
 }
 
 #[derive(Error, Debug)]

--- a/file_store/src/lib.rs
+++ b/file_store/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod emissions;
 pub mod entropy_report;
 mod error;
 mod file_info;

--- a/iot_verifier/src/iot-ex1.json
+++ b/iot_verifier/src/iot-ex1.json
@@ -1,0 +1,15 @@
+[
+    {
+      "start_time": "2022-08-01T00:00:01Z",
+      "yearly_emissions": 65000000000
+    },
+    {
+      "start_time": "2023-08-01T00:00:01Z",
+      "yearly_emissions": 32500000000
+    },
+    {
+        "start_time": "2024-08-01T00:00:01Z",
+        "yearly_emissions": 16250000000
+    }
+
+]

--- a/iot_verifier/src/reward_share.rs
+++ b/iot_verifier/src/reward_share.rs
@@ -485,19 +485,11 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_default_emission_schedule() {
-        let emissions_schedule = EmissionsSchedule::default().unwrap();
-        let yearly_emissions = emissions_schedule.yearly_emissions(Utc::now()).unwrap();
-        let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
-        assert_eq!(dec!(32_500_000_000_000_000), yearly_emissions);
-        assert_eq!(dec!(88_797_814_207_650.27322404371585), daily_emissions);
-        // todo assert rest of years
-    }
-
-    #[test]
-    fn test_non_gateway_reward_shares() {
+    async fn test_non_gateway_reward_shares() {
         let epoch_duration = Duration::hours(1);
-        let emissions_schedule = EmissionsSchedule::default().unwrap();
+        let emissions_schedule = EmissionsSchedule::from_file("./src/iot-ex1.json".to_string())
+            .await
+            .unwrap();
         let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
 
         let total_tokens_for_period = daily_emissions / dec!(24);
@@ -508,13 +500,15 @@ mod test {
         assert_eq!(258_993_624_772, operation_tokens_for_period);
     }
 
-    #[test]
+    #[tokio::test]
     // test reward distribution where there is a fixed dc spend per gateway
     // with the total dc spend across all gateways being significantly lower than the
     // total epoch dc rewards amount
     // this results in a significant redistribution of dc rewards to POC
-    fn test_reward_share_calculation_fixed_dc_spend_with_transfer_distribution() {
-        let emissions_schedule = EmissionsSchedule::default().unwrap();
+    async fn test_reward_share_calculation_fixed_dc_spend_with_transfer_distribution() {
+        let emissions_schedule = EmissionsSchedule::from_file("./src/iot-ex1.json".to_string())
+            .await
+            .unwrap();
         let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
 
         let iot_price = dec!(359);
@@ -698,10 +692,12 @@ mod test {
         assert_eq!(poc_diff, 5);
     }
 
-    #[test]
+    #[tokio::test]
     // test reward distribution where there is zero transfer of dc rewards to poc
-    fn test_reward_share_calculation_without_data_transfer_distribution() {
-        let emissions_schedule = EmissionsSchedule::default().unwrap();
+    async fn test_reward_share_calculation_without_data_transfer_distribution() {
+        let emissions_schedule = EmissionsSchedule::from_file("./src/iot-ex1.json".to_string())
+            .await
+            .unwrap();
         let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
         let iot_price = dec!(359);
 
@@ -878,10 +874,12 @@ mod test {
         assert_eq!(poc_diff, 6);
     }
 
-    #[test]
+    #[tokio::test]
     // test reward distribution where there is transfer of dc rewards to poc
-    fn test_reward_share_calculation_with_data_transfer_distribution() {
-        let emissions_schedule = EmissionsSchedule::default().unwrap();
+    async fn test_reward_share_calculation_with_data_transfer_distribution() {
+        let emissions_schedule = EmissionsSchedule::from_file("./src/iot-ex1.json".to_string())
+            .await
+            .unwrap();
         let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
         let iot_price = dec!(359);
 

--- a/iot_verifier/src/reward_share.rs
+++ b/iot_verifier/src/reward_share.rs
@@ -453,8 +453,7 @@ fn compute_rewards(rewards_per_share: Decimal, shares: Decimal) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    use chrono::prelude::*;
-    use file_store::emissions::{Emission, EmissionsSchedule};
+    use file_store::emissions::EmissionsSchedule;
 
     fn reward_shares_in_dec(
         beacon_shares: Decimal,
@@ -472,20 +471,6 @@ mod test {
         }
     }
 
-    fn default_emissions_schedule() -> EmissionsSchedule {
-        let schedule = vec![
-            Emission {
-                start_time: Utc.with_ymd_and_hms(2023, 8, 1, 0, 0, 1).unwrap(),
-                yearly_emissions: dec!(32_500_000_000),
-            },
-            Emission {
-                start_time: Utc.with_ymd_and_hms(2022, 8, 1, 0, 0, 1).unwrap(),
-                yearly_emissions: dec!(65_000_000_000),
-            },
-        ];
-        EmissionsSchedule { schedule }
-    }
-
     #[tokio::test]
     async fn test_emission_schedule_file() {
         // todo: maybe move this test to filestore
@@ -496,12 +481,23 @@ mod test {
         let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
         assert_eq!(dec!(32_500_000_000_000_000), yearly_emissions);
         assert_eq!(dec!(88_797_814_207_650.27322404371585), daily_emissions);
+        // todo assert rest of years
+    }
+
+    #[tokio::test]
+    async fn test_default_emission_schedule() {
+        let emissions_schedule = EmissionsSchedule::default().unwrap();
+        let yearly_emissions = emissions_schedule.yearly_emissions(Utc::now()).unwrap();
+        let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
+        assert_eq!(dec!(32_500_000_000_000_000), yearly_emissions);
+        assert_eq!(dec!(88_797_814_207_650.27322404371585), daily_emissions);
+        // todo assert rest of years
     }
 
     #[test]
     fn test_non_gateway_reward_shares() {
         let epoch_duration = Duration::hours(1);
-        let emissions_schedule = default_emissions_schedule();
+        let emissions_schedule = EmissionsSchedule::default().unwrap();
         let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
 
         let total_tokens_for_period = daily_emissions / dec!(24);
@@ -518,7 +514,7 @@ mod test {
     // total epoch dc rewards amount
     // this results in a significant redistribution of dc rewards to POC
     fn test_reward_share_calculation_fixed_dc_spend_with_transfer_distribution() {
-        let emissions_schedule = default_emissions_schedule();
+        let emissions_schedule = EmissionsSchedule::default().unwrap();
         let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
 
         let iot_price = dec!(359);
@@ -705,7 +701,7 @@ mod test {
     #[test]
     // test reward distribution where there is zero transfer of dc rewards to poc
     fn test_reward_share_calculation_without_data_transfer_distribution() {
-        let emissions_schedule = default_emissions_schedule();
+        let emissions_schedule = EmissionsSchedule::default().unwrap();
         let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
         let iot_price = dec!(359);
 
@@ -885,7 +881,7 @@ mod test {
     #[test]
     // test reward distribution where there is transfer of dc rewards to poc
     fn test_reward_share_calculation_with_data_transfer_distribution() {
-        let emissions_schedule = default_emissions_schedule();
+        let emissions_schedule = EmissionsSchedule::default().unwrap();
         let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
         let iot_price = dec!(359);
 

--- a/iot_verifier/src/reward_share.rs
+++ b/iot_verifier/src/reward_share.rs
@@ -16,9 +16,6 @@ const DEFAULT_PREC: u32 = 15;
 // rewards in IoT Bones ( iot @ 10^6 ) per 24 hours based on emission curve year 1
 // TODO: expand to cover the full multi-year emission curve
 lazy_static! {
-    // TODO: year 1 emissions allocate 30% of total to PoC with 6% to beacons and 24% to witnesses but subsequent years back
-    // total PoC percentage off 1.5% each year; determine how beacons and witnesses will split the subsequent years' allocations
-    static ref REWARDS_PER_DAY: Decimal = (Decimal::from(32_500_000_000_u64) / Decimal::from(366)) * Decimal::from(1_000_000); //  88_797_814_207_650.273224043715847
     static ref BEACON_REWARDS_PER_DAY_PERCENT: Decimal = dec!(0.06);
     static ref WITNESS_REWARDS_PER_DAY_PERCENT: Decimal = dec!(0.24);
     // Data transfer is allocated 50% of daily rewards
@@ -39,29 +36,28 @@ fn get_tokens_by_duration(tokens: Decimal, duration: Duration) -> Decimal {
 }
 
 fn get_scheduled_poc_tokens(
+    daily_emissions: Decimal,
     duration: Duration,
     dc_transfer_remainder: Decimal,
 ) -> (Decimal, Decimal) {
     (
-        get_tokens_by_duration(*REWARDS_PER_DAY * *BEACON_REWARDS_PER_DAY_PERCENT, duration)
+        get_tokens_by_duration(daily_emissions * *BEACON_REWARDS_PER_DAY_PERCENT, duration)
             + (dc_transfer_remainder * *BEACON_DC_REMAINER_PERCENT),
-        get_tokens_by_duration(
-            *REWARDS_PER_DAY * *WITNESS_REWARDS_PER_DAY_PERCENT,
-            duration,
-        ) + (dc_transfer_remainder * *WITNESS_DC_REMAINER_PERCENT),
+        get_tokens_by_duration(daily_emissions * *WITNESS_REWARDS_PER_DAY_PERCENT, duration)
+            + (dc_transfer_remainder * *WITNESS_DC_REMAINER_PERCENT),
     )
 }
 
-fn get_scheduled_dc_tokens(duration: Duration) -> Decimal {
+fn get_scheduled_dc_tokens(daily_emissions: Decimal, duration: Duration) -> Decimal {
     get_tokens_by_duration(
-        *REWARDS_PER_DAY * *DATA_TRANSFER_REWARDS_PER_DAY_PERCENT,
+        daily_emissions * *DATA_TRANSFER_REWARDS_PER_DAY_PERCENT,
         duration,
     )
 }
 
-fn get_scheduled_ops_fund_tokens(duration: Duration) -> u64 {
+fn get_scheduled_ops_fund_tokens(daily_emissions: Decimal, duration: Duration) -> u64 {
     get_tokens_by_duration(
-        *REWARDS_PER_DAY * *OPERATIONS_REWARDS_PER_DAY_PERCENT,
+        daily_emissions * *OPERATIONS_REWARDS_PER_DAY_PERCENT,
         duration,
     )
     .round_dp_with_strategy(0, RoundingStrategy::ToZero)
@@ -302,6 +298,7 @@ impl GatewayShares {
 
     pub fn into_iot_reward_shares(
         self,
+        daily_emissions: Decimal,
         reward_period: &'_ Range<DateTime<Utc>>,
         iot_price: Decimal,
     ) -> impl Iterator<Item = proto::IotRewardShare> + '_ {
@@ -310,7 +307,7 @@ impl GatewayShares {
         let (total_beacon_shares, total_witness_shares, total_dc_shares) = self.total_shares();
         // the total number of iot rewards for dc transfer this epoch
         let total_dc_transfer_rewards =
-            get_scheduled_dc_tokens(reward_period.end - reward_period.start);
+            get_scheduled_dc_tokens(daily_emissions, reward_period.end - reward_period.start);
 
         // convert the total spent data transfer DC to it equiv iot bone value
         // the rewards distributed to gateways will be equal to this
@@ -326,6 +323,7 @@ impl GatewayShares {
         // the total amounts of iot rewards this epoch for beacons, witnesses
         // taking into account any remaining dc transfer rewards
         let (total_beacon_rewards, total_witness_rewards) = get_scheduled_poc_tokens(
+            daily_emissions,
             reward_period.end - reward_period.start,
             dc_transfer_rewards_unused,
         );
@@ -377,9 +375,15 @@ impl GatewayShares {
 pub mod operational_rewards {
     use super::*;
 
-    pub fn compute(reward_period: &Range<DateTime<Utc>>) -> proto::IotRewardShare {
+    pub fn compute(
+        daily_emissions: Decimal,
+        reward_period: &Range<DateTime<Utc>>,
+    ) -> proto::IotRewardShare {
         let op_fund_reward = proto::OperationalReward {
-            amount: get_scheduled_ops_fund_tokens(reward_period.end - reward_period.start),
+            amount: get_scheduled_ops_fund_tokens(
+                daily_emissions,
+                reward_period.end - reward_period.start,
+            ),
         };
         proto::IotRewardShare {
             start_period: reward_period.start.encode_timestamp(),
@@ -449,6 +453,8 @@ fn compute_rewards(rewards_per_share: Decimal, shares: Decimal) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
+    use chrono::prelude::*;
+    use file_store::emissions::{Emission, EmissionsSchedule};
 
     fn reward_shares_in_dec(
         beacon_shares: Decimal,
@@ -466,13 +472,43 @@ mod test {
         }
     }
 
+    fn default_emissions_schedule() -> EmissionsSchedule {
+        let schedule = vec![
+            Emission {
+                start_time: Utc.with_ymd_and_hms(2023, 8, 1, 0, 0, 1).unwrap(),
+                yearly_emissions: dec!(32_500_000_000),
+            },
+            Emission {
+                start_time: Utc.with_ymd_and_hms(2022, 8, 1, 0, 0, 1).unwrap(),
+                yearly_emissions: dec!(65_000_000_000),
+            },
+        ];
+        EmissionsSchedule { schedule }
+    }
+
+    #[tokio::test]
+    async fn test_emission_schedule_file() {
+        // todo: maybe move this test to filestore
+        let emissions_schedule = EmissionsSchedule::from_file("./src/iot-ex1.json".to_string())
+            .await
+            .unwrap();
+        let yearly_emissions = emissions_schedule.yearly_emissions(Utc::now()).unwrap();
+        let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
+        assert_eq!(dec!(32_500_000_000_000_000), yearly_emissions);
+        assert_eq!(dec!(88_797_814_207_650.27322404371585), daily_emissions);
+    }
+
     #[test]
     fn test_non_gateway_reward_shares() {
         let epoch_duration = Duration::hours(1);
-        let total_tokens_for_period = *REWARDS_PER_DAY / dec!(24);
+        let emissions_schedule = default_emissions_schedule();
+        let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
+
+        let total_tokens_for_period = daily_emissions / dec!(24);
         println!("total_tokens_for_period: {total_tokens_for_period}");
 
-        let operation_tokens_for_period = get_scheduled_ops_fund_tokens(epoch_duration);
+        let operation_tokens_for_period =
+            get_scheduled_ops_fund_tokens(daily_emissions, epoch_duration);
         assert_eq!(258_993_624_772, operation_tokens_for_period);
     }
 
@@ -482,6 +518,9 @@ mod test {
     // total epoch dc rewards amount
     // this results in a significant redistribution of dc rewards to POC
     fn test_reward_share_calculation_fixed_dc_spend_with_transfer_distribution() {
+        let emissions_schedule = default_emissions_schedule();
+        let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
+
         let iot_price = dec!(359);
         let gw1: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
             .parse()
@@ -504,7 +543,8 @@ mod test {
 
         let now = Utc::now();
         let reward_period = (now - Duration::minutes(10))..now;
-        let total_data_transfer_tokens_for_period = get_scheduled_dc_tokens(Duration::minutes(10));
+        let total_data_transfer_tokens_for_period =
+            get_scheduled_dc_tokens(daily_emissions, Duration::minutes(10));
         println!("total data transfer scheduled tokens: {total_data_transfer_tokens_for_period}");
 
         let gw1_dc_spend = dec!(502);
@@ -555,7 +595,7 @@ mod test {
         let gw_shares = GatewayShares { shares };
         let mut rewards: HashMap<PublicKeyBinary, proto::GatewayReward> = HashMap::new();
         let gw_reward_shares: Vec<proto::IotRewardShare> = gw_shares
-            .into_iot_reward_shares(&reward_period, iot_price)
+            .into_iot_reward_shares(daily_emissions, &reward_period, iot_price)
             .collect();
         for reward in gw_reward_shares {
             if let Some(ProtoReward::GatewayReward(gateway_reward)) = reward.reward {
@@ -647,8 +687,11 @@ mod test {
             + gw6_rewards.beacon_amount
             + gw6_rewards.witness_amount;
 
-        let (exp_total_beacon_tokens, exp_total_witness_tokens) =
-            get_scheduled_poc_tokens(Duration::minutes(10), total_unused_data_transfer_tokens);
+        let (exp_total_beacon_tokens, exp_total_witness_tokens) = get_scheduled_poc_tokens(
+            daily_emissions,
+            Duration::minutes(10),
+            total_unused_data_transfer_tokens,
+        );
         let exp_sum_poc_tokens = exp_total_beacon_tokens + exp_total_witness_tokens;
         println!("max poc rewards: {exp_sum_poc_tokens}");
         println!("total actual poc rewards distributed: {sum_poc_amounts}");
@@ -662,7 +705,10 @@ mod test {
     #[test]
     // test reward distribution where there is zero transfer of dc rewards to poc
     fn test_reward_share_calculation_without_data_transfer_distribution() {
+        let emissions_schedule = default_emissions_schedule();
+        let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
         let iot_price = dec!(359);
+
         let gw1: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
             .parse()
             .expect("failed gw1 parse");
@@ -684,7 +730,8 @@ mod test {
 
         let now = Utc::now();
         let reward_period = (now - Duration::minutes(10))..now;
-        let total_data_transfer_tokens_for_period = get_scheduled_dc_tokens(Duration::minutes(10));
+        let total_data_transfer_tokens_for_period =
+            get_scheduled_dc_tokens(daily_emissions, Duration::minutes(10));
         println!("total data transfer scheduled tokens: {total_data_transfer_tokens_for_period}");
 
         // get the expected total amount of dc we need to spend
@@ -739,7 +786,7 @@ mod test {
         let gw_shares = GatewayShares { shares };
         let mut rewards: HashMap<PublicKeyBinary, proto::GatewayReward> = HashMap::new();
         let gw_reward_shares: Vec<proto::IotRewardShare> = gw_shares
-            .into_iot_reward_shares(&reward_period, iot_price)
+            .into_iot_reward_shares(daily_emissions, &reward_period, iot_price)
             .collect();
         for reward in gw_reward_shares {
             if let Some(ProtoReward::GatewayReward(gateway_reward)) = reward.reward {
@@ -824,7 +871,7 @@ mod test {
             + gw6_rewards.beacon_amount
             + gw6_rewards.witness_amount;
         let (exp_total_beacon_tokens, exp_total_witness_tokens) =
-            get_scheduled_poc_tokens(Duration::minutes(10), Decimal::ZERO);
+            get_scheduled_poc_tokens(daily_emissions, Duration::minutes(10), Decimal::ZERO);
         let exp_sum_poc_tokens = exp_total_beacon_tokens + exp_total_witness_tokens;
         println!("max poc rewards: {exp_sum_poc_tokens}");
         println!("total actual poc rewards distributed: {sum_poc_amounts}");
@@ -838,7 +885,10 @@ mod test {
     #[test]
     // test reward distribution where there is transfer of dc rewards to poc
     fn test_reward_share_calculation_with_data_transfer_distribution() {
+        let emissions_schedule = default_emissions_schedule();
+        let daily_emissions = emissions_schedule.daily_emissions(Utc::now()).unwrap();
         let iot_price = dec!(359);
+
         let gw1: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
             .parse()
             .expect("failed gw1 parse");
@@ -860,7 +910,8 @@ mod test {
 
         let now = Utc::now();
         let reward_period = (now - Duration::minutes(10))..now;
-        let total_data_transfer_tokens_for_period = get_scheduled_dc_tokens(Duration::minutes(10));
+        let total_data_transfer_tokens_for_period =
+            get_scheduled_dc_tokens(daily_emissions, Duration::minutes(10));
         println!("total_data_transfer_tokens_for_period: {total_data_transfer_tokens_for_period}");
 
         // get the expected total amount of dc we need to spend
@@ -907,7 +958,7 @@ mod test {
         let gw_shares = GatewayShares { shares };
         let mut rewards: HashMap<PublicKeyBinary, proto::GatewayReward> = HashMap::new();
         let gw_reward_shares: Vec<proto::IotRewardShare> = gw_shares
-            .into_iot_reward_shares(&reward_period, iot_price)
+            .into_iot_reward_shares(daily_emissions, &reward_period, iot_price)
             .collect();
         for reward in gw_reward_shares {
             if let Some(ProtoReward::GatewayReward(gateway_reward)) = reward.reward {
@@ -989,8 +1040,11 @@ mod test {
         let expected_data_transfer_tokens_for_poc = total_data_transfer_tokens_for_period
             - Decimal::from_u64(sum_data_transfer_amounts).unwrap();
         println!("expected_data_transfer_tokens_for_poc: {expected_data_transfer_tokens_for_poc}");
-        let (exp_total_beacon_tokens, exp_total_witness_tokens) =
-            get_scheduled_poc_tokens(Duration::minutes(10), expected_data_transfer_tokens_for_poc);
+        let (exp_total_beacon_tokens, exp_total_witness_tokens) = get_scheduled_poc_tokens(
+            daily_emissions,
+            Duration::minutes(10),
+            expected_data_transfer_tokens_for_poc,
+        );
         let exp_sum_poc_tokens = exp_total_beacon_tokens + exp_total_witness_tokens;
         println!("max poc rewards: {exp_sum_poc_tokens}");
         println!("total actual poc rewards distributed: {sum_poc_amounts}");

--- a/iot_verifier/src/rewarder.rs
+++ b/iot_verifier/src/rewarder.rs
@@ -81,7 +81,7 @@ impl Rewarder {
         scheduler: &Scheduler,
         iot_price: Decimal,
     ) -> anyhow::Result<()> {
-        let emissions_schedule = EmissionsSchedule::default()?;
+        let emissions_schedule = EmissionsSchedule::from_file("./iot-ex1.json".to_string()).await?;
         let daily_emissions = emissions_schedule.daily_emissions(Utc::now())?;
 
         let gateway_reward_shares =

--- a/iot_verifier/src/rewarder.rs
+++ b/iot_verifier/src/rewarder.rs
@@ -81,7 +81,7 @@ impl Rewarder {
         scheduler: &Scheduler,
         iot_price: Decimal,
     ) -> anyhow::Result<()> {
-        let emissions_schedule = EmissionsSchedule::from_file("./iot.json".to_string()).await?;
+        let emissions_schedule = EmissionsSchedule::default()?;
         let daily_emissions = emissions_schedule.daily_emissions(Utc::now())?;
 
         let gateway_reward_shares =


### PR DESCRIPTION
wip

This derives the yearly reward emissions from a managed JSON file, rather than codifying the rewards curve.  This provides for a more flexible implementation and allows for deviations from the expected norm to occur. For example a codified curve would have had issues with the recent halvening, which did not occur exactly on the 1st August ( from the oracle verifiers perspective ).  Same with the upcoming change to move rewards moving from 1am to 12am.  

