### PR TITLE
fixing update order/operations for iot session key filter reconciliation

### DIFF
--- a/iot_config/src/route.rs
+++ b/iot_config/src/route.rs
@@ -768,6 +768,9 @@ async fn insert_skfs(skfs: &[Skf], db: impl sqlx::PgExecutor<'_>) -> anyhow::Res
 
     const SKF_INSERT_VALS: &str =
         " insert into route_session_key_filters (route_id, devaddr, session_key, max_copies) ";
+    // changes to existing records are always treated as an upsert and override the existing value
+    // instead of ignoring. this avoids reconciliation bugs attempting to update fields of an
+    // existing skf from succeeding on the HPRs but being ignored by the Config Service
     const SKF_INSERT_CONFLICT: &str =
         " on conflict (route_id, devaddr, session_key) update set max_copies = excluded.max_copies returning * ";
 

--- a/iot_config/src/route.rs
+++ b/iot_config/src/route.rs
@@ -713,16 +713,18 @@ pub async fn update_skfs(
 ) -> anyhow::Result<()> {
     let mut transaction = db.begin().await?;
 
-    let added_updates: Vec<(Skf, proto::ActionV1)> = insert_skfs(to_add, &mut transaction)
-        .await?
-        .into_iter()
-        .map(|added_skf| (added_skf, proto::ActionV1::Add))
-        .collect();
-
+    // Always process removes before adds to ensure updating existing values doesn't result in
+    // removing a value that was just added
     let removed_updates: Vec<(Skf, proto::ActionV1)> = remove_skfs(to_remove, &mut transaction)
         .await?
         .into_iter()
         .map(|removed_skf| (removed_skf, proto::ActionV1::Remove))
+        .collect();
+
+    let added_updates: Vec<(Skf, proto::ActionV1)> = insert_skfs(to_add, &mut transaction)
+        .await?
+        .into_iter()
+        .map(|added_skf| (added_skf, proto::ActionV1::Add))
         .collect();
 
     transaction.commit().await?;
@@ -767,7 +769,7 @@ async fn insert_skfs(skfs: &[Skf], db: impl sqlx::PgExecutor<'_>) -> anyhow::Res
     const SKF_INSERT_VALS: &str =
         " insert into route_session_key_filters (route_id, devaddr, session_key, max_copies) ";
     const SKF_INSERT_CONFLICT: &str =
-        " on conflict (route_id, devaddr, session_key) do nothing returning * ";
+        " on conflict (route_id, devaddr, session_key) update set max_copies = excluded.max_copies returning * ";
 
     let mut query_builder: sqlx::QueryBuilder<sqlx::Postgres> =
         sqlx::QueryBuilder::new(SKF_INSERT_VALS);


### PR DESCRIPTION
Because HPRs can send large batches of session key filter changes to reconcile with the central config service and the only operations supported are `add` and `remove` it's possible that changing the value of a session key filter's `max_copies` can result in the total removal of the filter if the request is processed in the current order (add the skf with the new max_copies value and then remove the filter entirely) so this change updates the order of operations to always process removals before processing adds.

This change also enforces that changes to the max_copies field are honored when requested where previously a session key filter record insert would be ignored if the filter/devaddr/route_id triple already existed on the server. 