### PR TITLE
bubble up route uuid parse errors to user

### DIFF
--- a/iot_config/src/route_service.rs
+++ b/iot_config/src/route_service.rs
@@ -134,10 +134,13 @@ impl RouteService {
     where
         R: MsgVerify,
     {
-        if let Ok(()) = self.verify_request_signature(signer, request, id).await {
+        if self
+            .verify_stream_request_signature(signer, request)
+            .is_ok()
+        {
             return Ok(());
         }
-        self.verify_stream_request_signature(signer, request)
+        self.verify_request_signature(signer, request, id).await
     }
 
     fn sign_response(&self, response: &[u8]) -> Result<Vec<u8>, Status> {


### PR DESCRIPTION
alternative to https://github.com/helium/oracles/pull/597 to expose the route id uuid parsing error to the user when it occurs instead of swallowing it in a less descriptive "auth error".

my basic approach to returning errors to the caller of a public-facing API is to provide as few details as possible for an attacker to exploit and then slowly add more details to make the system usable for the normal good operators just trying to use the system as designed, hence the large default reliance on "not much to see here". i think this is definitely a case where providing the detail of a typoed or invalid UUID format is reasonable detail to return to the user.