### PR TITLE
iot packet verifier ignores join packets

### DIFF
--- a/file_store/src/error.rs
+++ b/file_store/src/error.rs
@@ -56,6 +56,8 @@ pub enum DecodeError {
     UnsupportedStatusReason(String, i32),
     #[error("invalid unix timestamp {0}")]
     InvalidTimestamp(u64),
+    #[error("unsupported packet type, type: {0}, value: {1}")]
+    UnsupportedPacketType(String, i32),
 }
 
 #[derive(Error, Debug)]
@@ -110,6 +112,10 @@ impl DecodeError {
 
     pub fn unsupported_datarate<E: ToString>(msg1: E, msg2: i32) -> Error {
         Error::Decode(Self::UnsupportedDataRate(msg1.to_string(), msg2))
+    }
+
+    pub fn unsupported_packet_type<E: ToString>(msg1: E, msg2: i32) -> Error {
+        Error::Decode(Self::UnsupportedPacketType(msg1.to_string(), msg2))
     }
 
     pub fn unsupported_participant_side<E: ToString>(msg1: E, msg2: i32) -> Error {

--- a/file_store/src/iot_packet.rs
+++ b/file_store/src/iot_packet.rs
@@ -7,7 +7,10 @@ use blake3::Hasher;
 use chrono::{DateTime, Utc};
 use helium_crypto::PublicKeyBinary;
 use helium_proto::services::packet_verifier::ValidPacket;
-use helium_proto::{services::router::PacketRouterPacketReportV1, DataRate, Region};
+use helium_proto::{
+    services::router::{packet_router_packet_report_v1::PacketType, PacketRouterPacketReportV1},
+    DataRate, Region,
+};
 use serde::Serialize;
 
 #[derive(Serialize, Clone)]
@@ -23,6 +26,7 @@ pub struct PacketRouterPacketReport {
     pub gateway: PublicKeyBinary,
     pub payload_hash: Vec<u8>,
     pub payload_size: u32,
+    pub packet_type: PacketType,
     pub received_timestamp: DateTime<Utc>,
 }
 
@@ -77,6 +81,9 @@ impl TryFrom<PacketRouterPacketReportV1> for PacketRouterPacketReport {
         let region = Region::from_i32(v.region).ok_or_else(|| {
             DecodeError::unsupported_region("iot_packet_router_packet_report_v1", v.region)
         })?;
+        let packet_type = PacketType::from_i32(v.r#type).ok_or_else(|| {
+            DecodeError::unsupported_packet_type("iot_packet_router_packet_report_v1", v.r#type)
+        })?;
         let received_timestamp = v.timestamp()?;
         Ok(Self {
             received_timestamp,
@@ -90,6 +97,7 @@ impl TryFrom<PacketRouterPacketReportV1> for PacketRouterPacketReport {
             gateway: v.gateway.into(),
             payload_hash: v.payload_hash,
             payload_size: v.payload_size,
+            packet_type,
         })
     }
 }

--- a/iot_packet_verifier/src/verifier.rs
+++ b/iot_packet_verifier/src/verifier.rs
@@ -7,7 +7,7 @@ use futures::{Stream, StreamExt};
 use helium_crypto::PublicKeyBinary;
 use helium_proto::services::{
     packet_verifier::{InvalidPacket, InvalidPacketReason, ValidPacket},
-    router,
+    router::packet_router_packet_report_v1::PacketType,
 };
 use iot_config::client::{ClientError, OrgClient};
 use solana::SolanaNetwork;
@@ -67,7 +67,7 @@ where
         tokio::pin!(reports);
 
         while let Some(report) = reports.next().await {
-            if router::packet_router_packet_report_v1::PacketType::Join == report.packet_type {
+            if PacketType::Uplink != report.packet_type {
                 continue;
             }
 

--- a/iot_packet_verifier/src/verifier.rs
+++ b/iot_packet_verifier/src/verifier.rs
@@ -5,7 +5,10 @@ use file_store::{
 };
 use futures::{Stream, StreamExt};
 use helium_crypto::PublicKeyBinary;
-use helium_proto::services::packet_verifier::{InvalidPacket, InvalidPacketReason, ValidPacket};
+use helium_proto::services::{
+    packet_verifier::{InvalidPacket, InvalidPacketReason, ValidPacket},
+    router,
+};
 use iot_config::client::{ClientError, OrgClient};
 use solana::SolanaNetwork;
 use std::{
@@ -64,6 +67,10 @@ where
         tokio::pin!(reports);
 
         while let Some(report) = reports.next().await {
+            if router::packet_router_packet_report_v1::PacketType::Join == report.packet_type {
+                continue;
+            }
+
             let debit_amount = payload_size_to_dc(report.payload_size as u64);
 
             let payer = self

--- a/iot_packet_verifier/tests/integration_tests.rs
+++ b/iot_packet_verifier/tests/integration_tests.rs
@@ -155,6 +155,28 @@ fn packet_report(
     }
 }
 
+fn join_packet_report(
+    oui: u64,
+    timestamp: u64,
+    payload_size: u32,
+    payload_hash: Vec<u8>,
+) -> PacketRouterPacketReport {
+    PacketRouterPacketReport {
+        received_timestamp: Utc.timestamp_opt(timestamp as i64, 0).unwrap(),
+        oui,
+        net_id: 0,
+        rssi: 0,
+        frequency: 0,
+        snr: 0.0,
+        data_rate: DataRate::Fsk50,
+        region: Region::As9231,
+        gateway: PublicKeyBinary::from(vec![]),
+        payload_hash,
+        payload_size,
+        packet_type: PacketType::Join,
+    }
+}
+
 fn valid_packet(timestamp: u64, payload_size: u32, payload_hash: Vec<u8>) -> ValidPacket {
     ValidPacket {
         payload_size,
@@ -287,12 +309,15 @@ async fn test_verifier() {
         packet_report(0, 0, 24, vec![1]),
         packet_report(0, 1, 48, vec![2]),
         packet_report(0, 2, 1, vec![3]),
+        join_packet_report(0, 3, 1, vec![4]),
         // Packets for second OUI
         packet_report(1, 0, 24, vec![4]),
         packet_report(1, 1, 48, vec![5]),
         packet_report(1, 2, 1, vec![6]),
+        join_packet_report(1, 3, 1, vec![4]),
         // Packets for third OUI
         packet_report(2, 0, 24, vec![7]),
+        join_packet_report(2, 1, 1, vec![4]),
     ];
     // Set up orgs:
     let orgs = MockConfigServer::default();

--- a/iot_packet_verifier/tests/integration_tests.rs
+++ b/iot_packet_verifier/tests/integration_tests.rs
@@ -5,7 +5,10 @@ use futures::{Stream, StreamExt};
 use futures_util::stream;
 use helium_crypto::PublicKeyBinary;
 use helium_proto::{
-    services::packet_verifier::{InvalidPacket, InvalidPacketReason, ValidPacket},
+    services::{
+        packet_verifier::{InvalidPacket, InvalidPacketReason, ValidPacket},
+        router::packet_router_packet_report_v1::PacketType,
+    },
     DataRate, Region,
 };
 use iot_packet_verifier::{
@@ -148,6 +151,7 @@ fn packet_report(
         gateway: PublicKeyBinary::from(vec![]),
         payload_hash,
         payload_size,
+        packet_type: PacketType::Uplink,
     }
 }
 


### PR DESCRIPTION
Make lora join packets free for the iot network by having the iot packet verifier ignore them when determining if packets have been paid for. Join packets are skipped over when reviewing packet reports so they are not burned against the sending OUI's wallet and are likewise not marked as "invalid"