### PR TITLE
enrich denied reports with denylist tagname

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,7 +1118,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#7d85f190b207a3ac8d6ad081e2f70e45eecd1a3a"
+source = "git+https://github.com/helium/proto?branch=master#39c9f23f420bce305197788d2984fd8ffec8f385"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#7d85f190b207a3ac8d6ad081e2f70e45eecd1a3a"
+source = "git+https://github.com/helium/proto?branch=master#39c9f23f420bce305197788d2984fd8ffec8f385"
 dependencies = [
  "bytes",
  "prost",

--- a/file_store/src/iot_invalid_poc.rs
+++ b/file_store/src/iot_invalid_poc.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use helium_proto::services::poc_lora::{
-    InvalidParticipantSide, InvalidReason, LoraBeaconReportReqV1, LoraInvalidBeaconReportV1,
-    LoraInvalidWitnessReportV1, LoraWitnessReportReqV1,
+    InvalidDetails, InvalidParticipantSide, InvalidReason, LoraBeaconReportReqV1,
+    LoraInvalidBeaconReportV1, LoraInvalidWitnessReportV1, LoraWitnessReportReqV1,
 };
 use serde::Serialize;
 
@@ -16,6 +16,7 @@ use serde::Serialize;
 pub struct IotInvalidBeaconReport {
     pub received_timestamp: DateTime<Utc>,
     pub reason: InvalidReason,
+    pub invalid_details: Option<InvalidDetails>,
     pub report: IotBeaconReport,
     pub location: Option<u64>,
     pub gain: i32,
@@ -26,6 +27,7 @@ pub struct IotInvalidBeaconReport {
 pub struct IotInvalidWitnessReport {
     pub received_timestamp: DateTime<Utc>,
     pub reason: InvalidReason,
+    pub invalid_details: Option<InvalidDetails>,
     pub report: IotWitnessReport,
     pub participant_side: InvalidParticipantSide,
 }
@@ -70,7 +72,6 @@ impl TryFrom<LoraInvalidBeaconReportV1> for IotInvalidBeaconReport {
             InvalidReason::from_i32(inv_reason).ok_or_else(|| {
                 DecodeError::unsupported_invalid_reason("iot_invalid_beacon_report_v1", inv_reason)
             })?;
-
         Ok(Self {
             received_timestamp: v.timestamp()?,
             reason: invalid_reason,
@@ -81,6 +82,7 @@ impl TryFrom<LoraInvalidBeaconReportV1> for IotInvalidBeaconReport {
             location: v.location.parse().ok(),
             gain: v.gain,
             elevation: v.elevation,
+            invalid_details: v.invalid_details,
         })
     }
 }
@@ -99,6 +101,7 @@ impl From<IotInvalidBeaconReport> for LoraInvalidBeaconReportV1 {
                 .unwrap_or_else(String::new),
             gain: v.gain,
             elevation: v.elevation,
+            invalid_details: v.invalid_details,
         }
     }
 }
@@ -129,6 +132,7 @@ impl TryFrom<LoraInvalidWitnessReportV1> for IotInvalidWitnessReport {
                 .report
                 .ok_or_else(|| Error::not_found("iot invalid witness report"))?
                 .try_into()?,
+            invalid_details: v.invalid_details,
         })
     }
 }
@@ -142,6 +146,7 @@ impl From<IotInvalidWitnessReport> for LoraInvalidWitnessReportV1 {
             reason: v.reason as i32,
             report: Some(report),
             participant_side: v.participant_side as i32,
+            invalid_details: v.invalid_details,
         }
     }
 }

--- a/file_store/src/iot_valid_poc.rs
+++ b/file_store/src/iot_valid_poc.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use helium_proto::services::poc_lora::{
-    InvalidParticipantSide, InvalidReason, LoraBeaconReportReqV1, LoraPocV1,
+    InvalidDetails, InvalidParticipantSide, InvalidReason, LoraBeaconReportReqV1, LoraPocV1,
     LoraValidBeaconReportV1, LoraVerifiedWitnessReportV1, LoraWitnessReportReqV1,
     VerificationStatus,
 };
@@ -51,6 +51,7 @@ pub struct IotVerifiedWitnessReport {
     pub reward_unit: Decimal,
     pub invalid_reason: InvalidReason,
     pub participant_side: InvalidParticipantSide,
+    pub invalid_details: Option<InvalidDetails>,
 }
 
 #[derive(Serialize, Clone, Debug)]
@@ -186,7 +187,6 @@ impl TryFrom<LoraVerifiedWitnessReportV1> for IotVerifiedWitnessReport {
                     v.participant_side,
                 )
             })?;
-
         Ok(Self {
             received_timestamp,
             status,
@@ -201,6 +201,7 @@ impl TryFrom<LoraVerifiedWitnessReportV1> for IotVerifiedWitnessReport {
             reward_unit: Decimal::new(v.reward_unit as i64, SCALING_PRECISION),
             invalid_reason,
             participant_side,
+            invalid_details: v.invalid_details,
         })
     }
 }
@@ -223,6 +224,7 @@ impl From<IotVerifiedWitnessReport> for LoraVerifiedWitnessReportV1 {
             reward_unit: (v.reward_unit * SCALE_MULTIPLIER).to_u32().unwrap_or(0),
             invalid_reason: v.invalid_reason as i32,
             participant_side: v.participant_side as i32,
+            invalid_details: v.invalid_details,
         }
     }
 }
@@ -249,10 +251,14 @@ impl IotVerifiedWitnessReport {
             // valid, non-failed witnesses for the final validated poc report
             reward_unit: Decimal::ZERO,
             participant_side: InvalidParticipantSide::SideNone,
+            invalid_details: None,
         }
     }
+
+    #[allow(clippy::too_many_arguments)]
     pub fn invalid(
         invalid_reason: InvalidReason,
+        invalid_details: Option<InvalidDetails>,
         report: &IotWitnessReport,
         received_timestamp: DateTime<Utc>,
         location: Option<u64>,
@@ -264,6 +270,7 @@ impl IotVerifiedWitnessReport {
             received_timestamp,
             status: VerificationStatus::Invalid,
             invalid_reason,
+            invalid_details,
             report: report.clone(),
             location,
             gain,

--- a/iot_verifier/src/purger.rs
+++ b/iot_verifier/src/purger.rs
@@ -197,6 +197,7 @@ impl Purger {
         let invalid_beacon_proto: LoraInvalidBeaconReportV1 = IotInvalidBeaconReport {
             received_timestamp,
             reason: InvalidReason::Stale,
+            invalid_details: None,
             report: beacon.clone(),
             location: None,
             gain: 0,
@@ -230,6 +231,7 @@ impl Purger {
             received_timestamp,
             report: witness_report.report,
             reason: InvalidReason::Stale,
+            invalid_details: None,
             participant_side: InvalidParticipantSide::Witness,
         }
         .into();


### PR DESCRIPTION
Linked proto PR: https://github.com/helium/proto/pull/366

The proto adds an invalid_details field to invalid witness and  beacon reports and the verified witness report

Enables poc verifications to return additional context on why a report was declared invalid and for those details to be carried through to the protos hitting S3.

Currently the only poc verification check which is populating this field is the denylist check.  If a report is found to be on the denylist `invalid_details` will be set to the tagname of the list in use

A tag name looks like `2023072901`
