### PR TITLE
replicate the grpc retriable macro for the mobile config svc

### DIFF
--- a/iot_config/src/client/mod.rs
+++ b/iot_config/src/client/mod.rs
@@ -41,8 +41,7 @@ macro_rules! call_with_retry {
 
         let mut attempt = 1;
         loop {
-            let response = $rpc.await;
-            match response {
+            match $rpc.await {
                 Ok(resp) => break Ok(resp),
                 Err(status) => match status.code() {
                     Code::Cancelled | Code::DeadlineExceeded | Code::Unavailable => {

--- a/mobile_config/src/client/authorization_client.rs
+++ b/mobile_config/src/client/authorization_client.rs
@@ -1,4 +1,4 @@
-use super::{ClientError, Settings, CACHE_EVICTION_FREQUENCY};
+use super::{call_with_retry, ClientError, Settings, CACHE_EVICTION_FREQUENCY};
 use file_store::traits::MsgVerify;
 use helium_crypto::{Keypair, PublicKey, PublicKeyBinary, Sign};
 use helium_proto::{
@@ -53,7 +53,7 @@ impl AuthorizationClient {
         };
         request.signature = self.signing_key.sign(&request.encode_to_vec())?;
         tracing::debug!(pubkey = pubkey.to_string(), role = ?role, "verifying authorized key registered");
-        let response = match self.client.clone().verify(request).await {
+        let response = match call_with_retry!(self.client.clone().verify(request.clone())) {
             Ok(verify_res) => {
                 let response = verify_res.into_inner();
                 response.verify(&self.config_pubkey)?;

--- a/mobile_config/src/client/entity_client.rs
+++ b/mobile_config/src/client/entity_client.rs
@@ -1,4 +1,4 @@
-use super::{ClientError, Settings, CACHE_EVICTION_FREQUENCY};
+use super::{call_with_retry, ClientError, Settings, CACHE_EVICTION_FREQUENCY};
 use file_store::traits::MsgVerify;
 use helium_crypto::{Keypair, PublicKey, Sign};
 use helium_proto::{
@@ -48,7 +48,7 @@ impl EntityClient {
         };
         request.signature = self.signing_key.sign(&request.encode_to_vec())?;
         tracing::debug!(?entity_id, "verifying entity on-chain");
-        let response = match self.client.clone().verify(request).await {
+        let response = match call_with_retry!(self.client.clone().verify(request.clone())) {
             Ok(verify_res) => {
                 let response = verify_res.into_inner();
                 response.verify(&self.config_pubkey)?;


### PR DESCRIPTION
allow retrying the grpc calls using the mobile config service client to avoid network disruptions or delays on the config service side from crashing the service calling it from the client