### PR TITLE
drop hardcoded sign key, replace with support for N keys via settings

### DIFF
--- a/denylist/src/denylist.rs
+++ b/denylist/src/denylist.rs
@@ -125,12 +125,12 @@ pub fn filter_from_bin(bin: &Vec<u8>, sign_keys: &[PublicKey]) -> Result<Xor32> 
     sign_keys
         .iter()
         .any(|key| {
-            if key.verify(buf, &signature).is_ok() {
-                tracing::info!(pubkey = %key, "valid denylist signer");
-                true
-            } else {
-                false
-            }
+            key.verify(buf, &signature)
+                .map(|res| {
+                    tracing::info!(pubkey = %key, "valid denylist signer");
+                    res
+                })
+                .is_ok()
         })
         .then(|| {
             let _serial = buf.get_u32_le();

--- a/denylist/src/denylist.rs
+++ b/denylist/src/denylist.rs
@@ -38,7 +38,7 @@ impl TryFrom<Vec<PublicKeyBinary>> for DenyList {
 }
 
 impl DenyList {
-    pub fn new(settings: Settings) -> Result<Self> {
+    pub fn new(settings: &Settings) -> Result<Self> {
         tracing::debug!("initializing new denylist");
         // if exists default to the local saved filter bin,
         // otherwise default to empty filter
@@ -126,7 +126,7 @@ pub fn filter_from_bin(bin: &Vec<u8>, valid_sign_keys: &Vec<PublicKey>) -> Resul
     for pubkey in valid_sign_keys {
         match pubkey.verify(buf, &signature) {
             Ok(_) => {
-                tracing::info!("updating filter to latest");
+                tracing::info!(%pubkey, "updating filter to latest");
                 let _serial = buf.get_u32_le();
                 let xor = bincode::deserialize::<Xor32>(buf)?;
                 return Ok(xor);

--- a/denylist/src/denylist.rs
+++ b/denylist/src/denylist.rs
@@ -1,16 +1,12 @@
-use crate::{client::DenyListClient, models::metadata::Asset, Error, Result};
+use crate::{client::DenyListClient, models::metadata::Asset, Error, Result, Settings};
 use bytes::Buf;
 use helium_crypto::{PublicKey, PublicKeyBinary, Verify};
 use serde::Serialize;
-use std::{fs, hash::Hasher, path, str::FromStr};
+use std::{fs, hash::Hasher, path};
 use twox_hash::XxHash64;
 use xorf::{Filter as XorFilter, Xor32};
 
 pub const SERIAL_SIZE: usize = 32;
-
-/// the pubkey used to verify the signature of denylist updates
-// TODO: is there a better home for this key ?
-const PUB_KEY_B58: &str = "1SbEYKju337P6aYsRd9DT2k4qgK5ZK62kXbSvnJgqeaxK3hqQrYURZjL";
 /// a copy of the last saved filter bin downloaded from github
 /// if present will be used to initialise the denylist upon verifier startup
 // TODO: look at using the tempfile crate to handle this
@@ -23,6 +19,7 @@ pub struct DenyList {
     pub client: DenyListClient,
     #[serde(skip_serializing)]
     pub filter: Xor32,
+    pub valid_sign_keys: Vec<PublicKey>,
 }
 
 impl TryFrom<Vec<PublicKeyBinary>> for DenyList {
@@ -35,12 +32,13 @@ impl TryFrom<Vec<PublicKeyBinary>> for DenyList {
             tag_name: 0,
             client,
             filter,
+            valid_sign_keys: vec![],
         })
     }
 }
 
 impl DenyList {
-    pub fn new() -> Result<Self> {
+    pub fn new(settings: Settings) -> Result<Self> {
         tracing::debug!("initializing new denylist");
         // if exists default to the local saved filter bin,
         // otherwise default to empty filter
@@ -54,7 +52,9 @@ impl DenyList {
             );
             Vec::new()
         });
-        let filter = filter_from_bin(&bin).unwrap_or_else(|_| Xor32::from(Vec::new()));
+        let valid_sign_keys = settings.valid_sign_keys()?;
+        let filter =
+            filter_from_bin(&bin, &valid_sign_keys).unwrap_or_else(|_| Xor32::from(Vec::new()));
         let client = DenyListClient::new()?;
         Ok(Self {
             // default tag to 0, proper tag name will be set on first
@@ -62,6 +62,7 @@ impl DenyList {
             tag_name: 0,
             client,
             filter,
+            valid_sign_keys,
         })
     }
 
@@ -93,7 +94,7 @@ impl DenyList {
                 tracing::debug!("found asset for tag");
                 let asset_url = &asset.browser_download_url;
                 let bin = self.client.get_bin(asset_url).await?;
-                if let Ok(filter) = filter_from_bin(&bin) {
+                if let Ok(filter) = filter_from_bin(&bin, &self.valid_sign_keys) {
                     self.filter = filter;
                     self.tag_name = new_tag_name;
                     save_local_filter_bin(&bin, FILTER_BIN_PATH)?;
@@ -113,7 +114,7 @@ impl DenyList {
 }
 
 /// deconstruct bytes into the filter component parts
-pub fn filter_from_bin(bin: &Vec<u8>) -> Result<Xor32> {
+pub fn filter_from_bin(bin: &Vec<u8>, valid_sign_keys: &Vec<PublicKey>) -> Result<Xor32> {
     if bin.is_empty() {
         return Err(Error::InvalidBinary("invalid filter bin".to_string()));
     }
@@ -122,21 +123,21 @@ pub fn filter_from_bin(bin: &Vec<u8>) -> Result<Xor32> {
     let _version = buf.get_u8();
     let signature_len = buf.get_u16_le() as usize;
     let signature = buf.copy_to_bytes(signature_len).to_vec();
-    let pubkey = PublicKey::from_str(PUB_KEY_B58)?;
-    match pubkey.verify(buf, &signature) {
-        Ok(_) => {
-            tracing::info!("updating filter to latest");
-            let _serial = buf.get_u32_le();
-            let xor = bincode::deserialize::<Xor32>(buf)?;
-            Ok(xor)
-        }
-        Err(_) => {
-            tracing::warn!("filter signature verification failed");
-            Err(Error::InvalidBinary(
-                "filter signature verification failed".to_string(),
-            ))
+    for pubkey in valid_sign_keys {
+        match pubkey.verify(buf, &signature) {
+            Ok(_) => {
+                tracing::info!("updating filter to latest");
+                let _serial = buf.get_u32_le();
+                let xor = bincode::deserialize::<Xor32>(buf)?;
+                return Ok(xor);
+            }
+            Err(_) => continue,
         }
     }
+    tracing::warn!("filter signature verification failed");
+    Err(Error::InvalidBinary(
+        "filter signature verification failed".to_string(),
+    ))
 }
 
 fn public_key_hash<R: AsRef<[u8]>>(public_key: R) -> u64 {

--- a/denylist/src/denylist.rs
+++ b/denylist/src/denylist.rs
@@ -124,10 +124,11 @@ pub fn filter_from_bin(bin: &Vec<u8>, sign_keys: &[PublicKey]) -> Result<Xor32> 
     let signature = buf.copy_to_bytes(signature_len).to_vec();
     sign_keys
         .iter()
-        .any(|key| {
-            key.verify(buf, &signature)
+        .any(|pubkey| {
+            pubkey
+                .verify(buf, &signature)
                 .map(|res| {
-                    tracing::info!(pubkey = %key, "valid denylist signer");
+                    tracing::info!(%pubkey, "valid denylist signer");
                     res
                 })
                 .is_ok()

--- a/denylist/src/denylist.rs
+++ b/denylist/src/denylist.rs
@@ -134,7 +134,7 @@ pub fn filter_from_bin(bin: &Vec<u8>, sign_keys: &[PublicKey]) -> Result<Xor32> 
                 .is_ok()
         })
         .then(|| {
-            let _serial = buf.get_u32_le();
+            buf.advance(4);
             bincode::deserialize::<Xor32>(buf)
         })
         .transpose()?

--- a/denylist/src/settings.rs
+++ b/denylist/src/settings.rs
@@ -1,3 +1,4 @@
+use crate::{Error, Result};
 use config::{Config, Environment, File};
 use helium_crypto::PublicKey;
 use serde::Deserialize;
@@ -40,7 +41,7 @@ impl Settings {
     /// Environemnt overrides have the same name as the entries in the settings
     /// file in uppercase and prefixed with "DENYLIST_". For example
     /// "DENYLIST_LOG" will override the log setting.
-    pub fn new<P: AsRef<Path>>(path: Option<P>) -> Result<Self, config::ConfigError> {
+    pub fn new<P: AsRef<Path>>(path: Option<P>) -> Result<Self> {
         let mut builder = Config::builder();
 
         if let Some(file) = path {
@@ -54,13 +55,14 @@ impl Settings {
             .add_source(Environment::with_prefix("DENYLIST").separator("_"))
             .build()
             .and_then(|config| config.try_deserialize())
+            .map_err(Error::from)
     }
 
     pub fn trigger_interval(&self) -> Duration {
         Duration::from_secs(self.trigger)
     }
 
-    pub fn valid_sign_keys(&self) -> Result<Vec<PublicKey>, helium_crypto::Error> {
+    pub fn valid_sign_keys(&self) -> std::result::Result<Vec<PublicKey>, helium_crypto::Error> {
         self.valid_sign_keys
             .iter()
             .map(|pubkey| PublicKey::from_str(pubkey))

--- a/denylist/src/settings.rs
+++ b/denylist/src/settings.rs
@@ -19,7 +19,7 @@ pub struct Settings {
     // vec of b58 helium encoded pubkeys
     // used to verify signature of denylist filters
     #[serde(default)]
-    pub valid_sign_keys: Vec<String>,
+    pub sign_keys: Vec<String>,
 }
 
 pub fn default_log() -> String {
@@ -62,8 +62,8 @@ impl Settings {
         Duration::from_secs(self.trigger)
     }
 
-    pub fn valid_sign_keys(&self) -> std::result::Result<Vec<PublicKey>, helium_crypto::Error> {
-        self.valid_sign_keys
+    pub fn sign_keys(&self) -> std::result::Result<Vec<PublicKey>, helium_crypto::Error> {
+        self.sign_keys
             .iter()
             .map(|pubkey| PublicKey::from_str(pubkey))
             .collect()

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -73,7 +73,7 @@ impl Runner {
         let beacon_max_retries = settings.beacon_max_retries;
         let witness_max_retries = settings.witness_max_retries;
         let deny_list_latest_url = settings.denylist.denylist_url.clone();
-        let mut deny_list = DenyList::new(settings.denylist.clone())?;
+        let mut deny_list = DenyList::new(&settings.denylist)?;
         // force update to latest in order to update the tag name
         // when first run, the denylist will load the local filter
         // but we dont save the tag name so it defaults to 0

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -73,7 +73,7 @@ impl Runner {
         let beacon_max_retries = settings.beacon_max_retries;
         let witness_max_retries = settings.witness_max_retries;
         let deny_list_latest_url = settings.denylist.denylist_url.clone();
-        let mut deny_list = DenyList::new()?;
+        let mut deny_list = DenyList::new(settings.denylist.clone())?;
         // force update to latest in order to update the tag name
         // when first run, the denylist will load the local filter
         // but we dont save the tag name so it defaults to 0


### PR DESCRIPTION
Linked ops PR: https://github.com/novalabsxyz/ops/pull/775

Replaces a single hardcoded sign key used to verify the signature of denylist updates with N keys defined via settings 