### PR TITLE
file_store (helium-crypto) compiling issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ sqlx = {version = "0", features = [
   "macros",
   "runtime-tokio-rustls"
 ]}
-helium-crypto = {version = "0.8.0", features=["sqlx-postgres", "multisig"]}
+helium-crypto = {version = "0.8.0", default-features=false, features=["sqlx-postgres", "multisig"]}
 helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
 hextree = "*"
 solana-client = "1.14"


### PR DESCRIPTION
Fixes the same compiling issue https://github.com/helium/helium-crypto-rs/issues/63 with rsa 0.4.0 
But now it happens when I use `file_store` as a dependency