### PR TITLE
Add support for denied edges in the denylist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,7 +1118,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#744b09229b6066fc84b0f310113b74dc31f09ba1"
+source = "git+https://github.com/helium/proto?branch=master#6cfd6dc952349e31187c7071dbbcd86780eb97e6"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -1128,7 +1128,7 @@ dependencies = [
  "rand_chacha 0.3.0",
  "rust_decimal",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "thiserror",
 ]
 
@@ -2966,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#744b09229b6066fc84b0f310113b74dc31f09ba1"
+source = "git+https://github.com/helium/proto?branch=master#6cfd6dc952349e31187c7071dbbcd86780eb97e6"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ tracing-subscriber = { version = "0", default-features=false, features = ["env-f
 rust_decimal = "1"
 rust_decimal_macros = "1"
 base64 = ">=0.21"
-sha2 = "*"
+sha2 = "0.10"
 tonic = {version = "0", features = ["tls", "tls-roots"]}
 http = "*"
 triggered = "0"

--- a/denylist/src/denylist.rs
+++ b/denylist/src/denylist.rs
@@ -37,6 +37,22 @@ impl TryFrom<Vec<PublicKeyBinary>> for DenyList {
     }
 }
 
+impl TryFrom<Vec<(PublicKeyBinary, PublicKeyBinary)>> for DenyList {
+    type Error = Error;
+    fn try_from(v: Vec<(PublicKeyBinary, PublicKeyBinary)>) -> Result<Self> {
+        let keys: Vec<u64> = v.into_iter().map(|e| edge_hash((e.0.as_ref(), e.1.as_ref()))).collect();
+        let filter = Xor32::from(&keys);
+        let client = DenyListClient::new()?;
+        Ok(Self {
+            tag_name: 0,
+            client,
+            filter,
+            sign_keys: vec![],
+        })
+    }
+}
+
+
 impl DenyList {
     pub fn new(settings: &Settings) -> Result<Self> {
         tracing::debug!("initializing new denylist");

--- a/denylist/src/denylist.rs
+++ b/denylist/src/denylist.rs
@@ -40,7 +40,10 @@ impl TryFrom<Vec<PublicKeyBinary>> for DenyList {
 impl TryFrom<Vec<(PublicKeyBinary, PublicKeyBinary)>> for DenyList {
     type Error = Error;
     fn try_from(v: Vec<(PublicKeyBinary, PublicKeyBinary)>) -> Result<Self> {
-        let keys: Vec<u64> = v.into_iter().map(|e| edge_hash((e.0.as_ref(), e.1.as_ref()))).collect();
+        let keys: Vec<u64> = v
+            .into_iter()
+            .map(|e| edge_hash((e.0.as_ref(), e.1.as_ref())))
+            .collect();
         let filter = Xor32::from(&keys);
         let client = DenyListClient::new()?;
         Ok(Self {
@@ -51,7 +54,6 @@ impl TryFrom<Vec<(PublicKeyBinary, PublicKeyBinary)>> for DenyList {
         })
     }
 }
-
 
 impl DenyList {
     pub fn new(settings: &Settings) -> Result<Self> {

--- a/iot_verifier/src/poc.rs
+++ b/iot_verifier/src/poc.rs
@@ -506,13 +506,13 @@ fn verify_edge_denylist(
         tracing::debug!(
             "report verification failed, reason: {:?}.
             beacon: {}, witness {}, tagname: {}",
-            InvalidReason::Denied,
+            InvalidReason::DeniedEdge,
             beaconer,
             witness,
             deny_list.tag_name
         );
         return Err(InvalidResponse {
-            reason: InvalidReason::Denied,
+            reason: InvalidReason::DeniedEdge,
             details: Some(InvalidDetails {
                 data: Some(invalid_details::Data::DenylistTag(
                     deny_list.tag_name.to_string(),
@@ -1198,15 +1198,33 @@ mod tests {
 
     #[test]
     fn test_verify_edge_denylist() {
-        let deny_list: DenyList = vec![(PublicKeyBinary::from_str(DENIED_PUBKEY1).unwrap(), PublicKeyBinary::from_str(DENIED_PUBKEY2).unwrap())]
-            .try_into()
-            .unwrap();
-        assert!(verify_edge_denylist(&PublicKeyBinary::from_str(PUBKEY1).unwrap(), &PublicKeyBinary::from_str(PUBKEY2).unwrap(), &deny_list).is_ok());
-        assert!(verify_edge_denylist(&PublicKeyBinary::from_str(DENIED_PUBKEY1).unwrap(), &PublicKeyBinary::from_str(PUBKEY2).unwrap(), &deny_list).is_ok());
-        assert!(verify_edge_denylist(&PublicKeyBinary::from_str(PUBKEY1).unwrap(), &PublicKeyBinary::from_str(DENIED_PUBKEY2).unwrap(), &deny_list).is_ok());
+        let deny_list: DenyList = vec![(
+            PublicKeyBinary::from_str(DENIED_PUBKEY1).unwrap(),
+            PublicKeyBinary::from_str(DENIED_PUBKEY2).unwrap(),
+        )]
+        .try_into()
+        .unwrap();
+        assert!(verify_edge_denylist(
+            &PublicKeyBinary::from_str(PUBKEY1).unwrap(),
+            &PublicKeyBinary::from_str(PUBKEY2).unwrap(),
+            &deny_list
+        )
+        .is_ok());
+        assert!(verify_edge_denylist(
+            &PublicKeyBinary::from_str(DENIED_PUBKEY1).unwrap(),
+            &PublicKeyBinary::from_str(PUBKEY2).unwrap(),
+            &deny_list
+        )
+        .is_ok());
+        assert!(verify_edge_denylist(
+            &PublicKeyBinary::from_str(PUBKEY1).unwrap(),
+            &PublicKeyBinary::from_str(DENIED_PUBKEY2).unwrap(),
+            &deny_list
+        )
+        .is_ok());
         assert_eq!(
             Err(InvalidResponse {
-                reason: InvalidReason::Denied,
+                reason: InvalidReason::DeniedEdge,
                 details: Some(InvalidDetails {
                     data: Some(invalid_details::Data::DenylistTag("0".to_string()))
                 }),
@@ -1220,7 +1238,7 @@ mod tests {
         // edges are not directional
         assert_eq!(
             Err(InvalidResponse {
-                reason: InvalidReason::Denied,
+                reason: InvalidReason::DeniedEdge,
                 details: Some(InvalidDetails {
                     data: Some(invalid_details::Data::DenylistTag("0".to_string()))
                 }),
@@ -1232,7 +1250,6 @@ mod tests {
             )
         );
     }
-
 
     #[test]
     fn test_verify_capability() {


### PR DESCRIPTION
This change adds support for denying of hotspot-hotspot edges when the denylist system considers an edge invalid because of one of its classifiers but is unable to assign blame to a specific hotspot. This allows the denylist to deny earnings for bad edges without accidentally denying hotspots that are simply adjacent or enmeshed in a cluster of badly behaving hotspots, or anoymous radio repeater devices.

Hotspot edges are not directional, so A->B is considered the same as B->A. To accomplish this, the hotspot keys are always lexiographically ordered when constructing the hash to check the denylist.