### PR TITLE
Fix speedtest latency values exceeding i32 bounds

### DIFF
--- a/mobile_verifier/migrations/17_speedtests_latency_bigint.sql
+++ b/mobile_verifier/migrations/17_speedtests_latency_bigint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE speedtests ALTER COLUMN latency TYPE BIGINT;

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -37,7 +37,7 @@ impl FromRow<'_, PgRow> for Speedtest {
                 upload_speed: row.get::<i64, &str>("upload_speed") as u64,
                 download_speed: row.get::<i64, &str>("download_speed") as u64,
                 timestamp: row.get::<DateTime<Utc>, &str>("timestamp"),
-                latency: row.get::<i32, &str>("latency") as u32,
+                latency: row.get::<i64, &str>("latency") as u32,
             },
         })
     }


### PR DESCRIPTION
On devnet encountered a speedtest with a latency value of 4294966945.  This resulted in the mobile verifier crashing out when attempting to insert the speedtest to the DB with `Error: error returned from database: integer out of range`.

The proto defines latency as u32
The internal speedtest struct defines latency as u32
The DB has speedtest latency defined as i32 ( max value of 2,147,483,647 )

At the point of the insert the code casts latency to an i64.  When reading from the DB as part of a select, the code casts from an i32 to u32.

This fix alters the DB to have latency defined as BIGINT.  When reading from the DB it casts the value from an i64 to an i32, thereby enabling a full u32 value to be persisted to the DB.

There is likely a better fix for this but this unblocks my local verifier.  We should also try to understand how the speedtest had such a high latency value.  Feels like something erroneous occurred there. 

The speedtest report encounted is part of file `speedtest_report.1694861939591.gz`.  A copy of the report is below:

{
  "received_timestamp": "2023-09-16T11:09:50.810Z",
  "report": {
    "pubkey": "114HSjCTiNaghJAKA6MegdBjcPrAy8Xi2Tp9MCQwY8whGebR2md",
    "serial": "HL-2139-00001963",
    "timestamp": "2023-09-16T11:08:55Z",
    "upload_speed": 1405825,
    "download_speed": 28139712,
    "latency": 4294966945
  }
} 

