### PR TITLE
Fix S3 from guessing the content type, which it will occasionally guess as XML

### DIFF
--- a/file_store/src/file_store.rs
+++ b/file_store/src/file_store.rs
@@ -167,6 +167,7 @@ impl FileStore {
                 .bucket(&self.bucket)
                 .key(file.file_name().map(|name| name.to_string_lossy()).unwrap())
                 .body(byte_stream)
+                .content_type("application/octet-stream")
                 .send()
                 .map_ok(|_| ())
                 .map_err(Error::s3_error)


### PR DESCRIPTION
If you're wondering why downloading files will randomly give you an XML file, this is why