### PR TITLE
Andymck/beacon fixed windows

### DIFF
--- a/iot_verifier/pkg/settings-template.toml
+++ b/iot_verifier/pkg/settings-template.toml
@@ -11,11 +11,8 @@ cache = "/var/data/iot-verified"
 #
 # denylist_url = "https://api.github.com/repos/helium/denylist/releases/latest"
 
-# Default beacon interval ( 6 hours) (in seconds)
-beacon_interval = 21600
-
-# Default beacon interval tolerance ( 10 minutes) (in seconds)
-beacon_interval_tolerance = 600
+# Default beacon interval in hours
+beacon_interval = 6
 
 # how often the ingestors write out to s3
 # this is used to pad the witness loading `after` and `before` periods

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -37,12 +37,11 @@ pub struct Settings {
     pub reward_offset_minutes: i64,
     #[serde(default = "default_max_witnesses_per_poc")]
     pub max_witnesses_per_poc: u64,
-    /// The cadence at which hotspots are permitted to beacon (in seconds)
+    /// The cadence at which hotspots are permitted to beacon (in hours)
+    /// this should be a factor of 24 so that we can have clear
+    /// beaconing bucket sizes
     #[serde(default = "default_beacon_interval")]
-    pub beacon_interval: i64,
-    /// Tolerance applied to beacon intervals within which beacons will be accepted (in seconds)
-    #[serde(default = "default_beacon_interval_tolerance")]
-    pub beacon_interval_tolerance: i64,
+    pub beacon_interval: u64,
     /// Trigger interval for generating a transmit scaling map
     #[serde(default = "default_transmit_scale_interval")]
     pub transmit_scale_interval: i64,
@@ -136,13 +135,8 @@ pub fn default_poc_loader_poll_time() -> u64 {
     5 * 60
 }
 
-// Default: 10 minutes
-pub fn default_beacon_interval_tolerance() -> i64 {
-    10 * 60
-}
-
 // Default: 6 hours
-pub fn default_beacon_interval() -> i64 {
+pub fn default_beacon_interval() -> u64 {
     6 * 60 * 60
 }
 
@@ -215,14 +209,6 @@ impl Settings {
 
     pub fn reward_offset_duration(&self) -> Duration {
         Duration::minutes(self.reward_offset_minutes)
-    }
-
-    pub fn beacon_interval(&self) -> Duration {
-        Duration::seconds(self.beacon_interval)
-    }
-
-    pub fn beacon_interval_tolerance(&self) -> Duration {
-        Duration::seconds(self.beacon_interval_tolerance)
     }
 
     pub fn poc_loader_window_width(&self) -> Duration {


### PR DESCRIPTION
With this change hotspots can now beacon once and only once within N time buckets per day.  By default those buckets are 6 hours in width and based on UTC time.  
A beacon will pass the schedule verification if it is the first beacon for any one bucket irrespective of when it was received within that bucket window.  Any subsequent beacon within the same bucket will be rejected
