### PR TITLE
Allow fallible errors from external implementations of file source

### DIFF
--- a/file_store/src/error.rs
+++ b/file_store/src/error.rs
@@ -60,6 +60,8 @@ pub enum DecodeError {
     InvalidTimestamp(u64),
     #[error("unsupported packet type, type: {0}, value: {1}")]
     UnsupportedPacketType(String, i32),
+    #[error("file stream try decode error: {0}")]
+    FileStreamTryDecode(String),
 }
 
 #[derive(Error, Debug)]
@@ -134,6 +136,10 @@ impl DecodeError {
 
     pub fn unsupported_status_reason<E: ToString>(msg1: E, msg2: i32) -> Error {
         Error::Decode(Self::UnsupportedInvalidReason(msg1.to_string(), msg2))
+    }
+
+    pub fn file_stream_try_decode<E: ToString>(msg: E) -> Error {
+        Error::Decode(Self::FileStreamTryDecode(msg.to_string()))
     }
 }
 

--- a/file_store/src/error.rs
+++ b/file_store/src/error.rs
@@ -103,6 +103,10 @@ impl Error {
     {
         Self::from(err.into())
     }
+
+    pub fn file_stream_try_decode<E: ToString>(msg: E) -> Error {
+        DecodeError::file_stream_try_decode(msg)
+    }
 }
 
 impl DecodeError {


### PR DESCRIPTION
In order to implement the streaming file info poller the trait bounds require the implementer to define an impl of the `MsgDecode` trait which itself requires the `TryFrom` of the source to the destination type but also explicitly defines the TryFrom associated Error type as being file_store::Error. This allows passing errors from external instances of the MsgDecode trait without having to force them into one of the limited pre-defined list of FileStore error variants.