### PR TITLE
assume beacon interval defined in seconds

### DIFF
--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -94,7 +94,7 @@ impl Runner {
         poc_sink: FileSinkClient,
         hex_density_map: HexDensityMap,
     ) -> anyhow::Result<Self> {
-        let beacon_interval = settings.beacon_interval();
+        let beacon_interval = settings.beacon_interval()?;
         let max_witnesses_per_poc = settings.max_witnesses_per_poc;
         let beacon_max_retries = settings.beacon_max_retries;
         let witness_max_retries = settings.witness_max_retries;

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -8,7 +8,7 @@ use crate::{
     reward_share::GatewayPocShare,
     telemetry, Settings,
 };
-use chrono::Utc;
+use chrono::{Duration as ChronoDuration, Utc};
 use denylist::DenyList;
 use file_store::{
     file_sink::FileSinkClient,
@@ -42,7 +42,7 @@ const HIP15_TX_REWARD_UNIT_CAP: Decimal = Decimal::TWO;
 
 pub struct Runner {
     pool: PgPool,
-    beacon_interval: u64,
+    beacon_interval: ChronoDuration,
     max_witnesses_per_poc: u64,
     beacon_max_retries: u64,
     witness_max_retries: u64,
@@ -94,7 +94,7 @@ impl Runner {
         poc_sink: FileSinkClient,
         hex_density_map: HexDensityMap,
     ) -> anyhow::Result<Self> {
-        let beacon_interval = settings.beacon_interval;
+        let beacon_interval = settings.beacon_interval();
         let max_witnesses_per_poc = settings.max_witnesses_per_poc;
         let beacon_max_retries = settings.beacon_max_retries;
         let witness_max_retries = settings.witness_max_retries;

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -1,3 +1,4 @@
+use anyhow::bail;
 use chrono::Duration;
 use config::{Config, Environment, File};
 use serde::Deserialize;
@@ -247,7 +248,12 @@ impl Settings {
     pub fn region_params_refresh_interval(&self) -> time::Duration {
         time::Duration::from_secs(self.region_params_refresh_interval)
     }
-    pub fn beacon_interval(&self) -> Duration {
-        Duration::seconds(self.beacon_interval as i64)
+    pub fn beacon_interval(&self) -> anyhow::Result<Duration> {
+        // validate the beacon_interval value is a factor of 24, if not bail out
+        if (24 * 60 * 60) % self.beacon_interval != 0 {
+            bail!("beacon interval is not a factor of 24")
+        } else {
+            Ok(Duration::seconds(self.beacon_interval as i64))
+        }
     }
 }

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -37,7 +37,7 @@ pub struct Settings {
     pub reward_offset_minutes: i64,
     #[serde(default = "default_max_witnesses_per_poc")]
     pub max_witnesses_per_poc: u64,
-    /// The cadence at which hotspots are permitted to beacon (in hours)
+    /// The cadence at which hotspots are permitted to beacon (in seconds)
     /// this should be a factor of 24 so that we can have clear
     /// beaconing bucket sizes
     #[serde(default = "default_beacon_interval")]
@@ -246,5 +246,8 @@ impl Settings {
     }
     pub fn region_params_refresh_interval(&self) -> time::Duration {
         time::Duration::from_secs(self.region_params_refresh_interval)
+    }
+    pub fn beacon_interval(&self) -> Duration {
+        Duration::seconds(self.beacon_interval as i64)
     }
 }


### PR DESCRIPTION
Assume beacon interval is defined in settings as seconds
Convert beacon interval from seconds to Duration via settings accessor
Use beacon interval as duration throughout iot verifier
