### PR TITLE
Remove unnecessary payer balance lookup in burn

### DIFF
--- a/iot_packet_verifier/src/daemon.rs
+++ b/iot_packet_verifier/src/daemon.rs
@@ -41,7 +41,7 @@ impl ManagedTask for Daemon {
 
 impl Daemon {
     pub async fn run(mut self, shutdown: triggered::Listener) -> Result<()> {
-        tracing::info!("starting daemon");
+        tracing::info!("Starting verifier daemon");
         loop {
             tokio::select! {
                 biased;
@@ -56,7 +56,7 @@ impl Daemon {
 
             }
         }
-        tracing::info!("stopping daemon");
+        tracing::info!("Stopping verifier daemon");
         Ok(())
     }
 


### PR DESCRIPTION
This also means we reduce the amount of time we hold the balance lock, thus speeding up the iot packet verifier throughput 