### PR TITLE
mobile config gateway grpc service supports batches of info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,6 +4079,7 @@ dependencies = [
  "hextree",
  "http",
  "http-serde",
+ "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
  "poc-metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#de51ede124884329e89b99b43d5d8c7bb7cc3012"
+source = "git+https://github.com/helium/proto?branch=master#5e38bab06b06321c3c13f42a6bb2382bbeaf2998"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -3047,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#de51ede124884329e89b99b43d5d8c7bb7cc3012"
+source = "git+https://github.com/helium/proto?branch=master#5e38bab06b06321c3c13f42a6bb2382bbeaf2998"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,14 +60,14 @@ sqlx = {version = "0", features = [
   "runtime-tokio-rustls"
 ]}
 helium-crypto = {version = "0.8.1", features=["sqlx-postgres", "multisig"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "jg/mobile-config-batch", features = ["services"]}
 hextree = "*"
 solana-client = "1.14"
 solana-sdk = "1.14"
 solana-program = "1.11"
 spl-token = "3.5.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
-beacon = { git = "https://github.com/helium/proto", branch = "master" }
+beacon = { git = "https://github.com/helium/proto", branch = "jg/mobile-config-batch" }
 humantime = "2"
 metrics = "0"
 metrics-exporter-prometheus = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,14 +60,14 @@ sqlx = {version = "0", features = [
   "runtime-tokio-rustls"
 ]}
 helium-crypto = {version = "0.8.1", features=["sqlx-postgres", "multisig"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "jg/mobile-config-batch", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
 hextree = "*"
 solana-client = "1.14"
 solana-sdk = "1.14"
 solana-program = "1.11"
 spl-token = "3.5.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
-beacon = { git = "https://github.com/helium/proto", branch = "jg/mobile-config-batch" }
+beacon = { git = "https://github.com/helium/proto", branch = "master" }
 humantime = "2"
 metrics = "0"
 metrics-exporter-prometheus = "0"

--- a/file_store/src/traits/msg_verify.rs
+++ b/file_store/src/traits/msg_verify.rs
@@ -82,6 +82,7 @@ impl_msg_verify!(mobile_config::EntityVerifyResV1, signature);
 impl_msg_verify!(mobile_config::GatewayInfoReqV1, signature);
 impl_msg_verify!(mobile_config::GatewayInfoStreamReqV1, signature);
 impl_msg_verify!(mobile_config::GatewayInfoResV1, signature);
+impl_msg_verify!(mobile_config::GatewayInfoBatchReqV1, signature);
 impl_msg_verify!(mobile_config::GatewayInfoStreamResV1, signature);
 
 #[cfg(test)]

--- a/mobile_config/Cargo.toml
+++ b/mobile_config/Cargo.toml
@@ -23,6 +23,7 @@ helium-proto = {workspace = true}
 hextree = {workspace = true}
 http = {workspace = true}
 http-serde = {workspace = true}
+lazy_static = {workspace = true}
 metrics = {workspace = true}
 metrics-exporter-prometheus = {workspace = true}
 poc-metrics = {path = "../metrics"}

--- a/mobile_config/src/key_cache.rs
+++ b/mobile_config/src/key_cache.rs
@@ -34,6 +34,7 @@ impl KeyCache {
         let cached_keys = self.cache_receiver.borrow();
         if (cached_keys.contains(&(signer.clone(), KeyRole::Administrator))
             || cached_keys.contains(&(signer.clone(), KeyRole::Oracle)))
+            || cached_keys.contains(&(signer.clone(), KeyRole::Carrier))
             && request.verify(signer).is_ok()
         {
             tracing::debug!(pubkey = signer.to_string(), "request authorized");

--- a/mobile_config/src/key_cache.rs
+++ b/mobile_config/src/key_cache.rs
@@ -35,7 +35,7 @@ impl KeyCache {
         if (cached_keys.contains(&(signer.clone(), KeyRole::Administrator))
             || cached_keys.contains(&(signer.clone(), KeyRole::Oracle)))
             || cached_keys.contains(&(signer.clone(), KeyRole::Carrier))
-            && request.verify(signer).is_ok()
+                && request.verify(signer).is_ok()
         {
             tracing::debug!(pubkey = signer.to_string(), "request authorized");
             Ok(())


### PR DESCRIPTION
in-between rpc for getting a batch of gateways' info in a single request, streamed back to the caller without having to request _all_ gateways' info