### PR TITLE
correctly hex decode asserted location

### DIFF
--- a/mobile_config/src/gateway_info.rs
+++ b/mobile_config/src/gateway_info.rs
@@ -22,7 +22,7 @@ pub struct GatewayInfo {
 impl From<GatewayInfoProto> for GatewayInfo {
     fn from(info: GatewayInfoProto) -> Self {
         let metadata = if let Some(ref metadata) = info.metadata {
-            u64::from_str_radix(&metadata.location, 26)
+            u64::from_str_radix(&metadata.location, 16)
                 .map(|location| GatewayMetadata { location })
                 .ok()
         } else {


### PR DESCRIPTION
incorrectly decoding the asserted location from string to u64 with the incorrect radix