### PR TITLE
do not stream updates for routes that have been deleted

### DIFF
--- a/iot_config/src/route.rs
+++ b/iot_config/src/route.rs
@@ -560,7 +560,8 @@ pub fn eui_stream<'a>(
         r#"
         select eui.route_id, eui.app_eui, eui.dev_eui, eui.deleted
         from route_eui_pairs eui
-        where eui.updated_at >= $1
+        join routes r on eui.route_id = r.id
+        where eui.updated_at >= $1 and r.deleted = false
         "#,
     )
     .bind(since)
@@ -578,7 +579,8 @@ pub fn devaddr_range_stream<'a>(
         r#"
         select devaddr.route_id, devaddr.start_addr, devaddr.end_addr, devaddr.deleted
         from route_devaddr_ranges devaddr
-        where devaddr.updated_at >= $1
+        join routes r on devaddr.route_id = r.id
+        where devaddr.updated_at >= $1 and r.deleted = false
         "#,
     )
     .bind(since)
@@ -598,7 +600,8 @@ pub fn skf_stream<'a>(
         r#"
         select skf.route_id, skf.devaddr, skf.session_key, skf.max_copies, skf.deleted
         from route_session_key_filters skf
-        where skf.updated_at >= $1
+        join routes r on skf.route_id = r.id
+        where skf.updated_at >= $1 and r.deleted = false
         "#,
     )
     .bind(since)


### PR DESCRIPTION
In a scenario such as:

1. Add Route
2. Add SKF
3. Remove Route

If a stream is created requesting updates since before the first action, it will receive:

1. Remove Route
2. Add SKF

With these changes, the route removal will be streamed, allowing HPR to clean up related configuration, and the Adds afterwards will be ignored.