### PR TITLE
make mobile cli input more semantic

### DIFF
--- a/mobile_config_cli/src/cmds/gateway.rs
+++ b/mobile_config_cli/src/cmds/gateway.rs
@@ -44,7 +44,7 @@ pub async fn info(args: GetHotspot) -> Result<Msg> {
 pub async fn info_batch(args: GetHotspotBatch) -> Result<Msg> {
     let mut client = client::GatewayClient::new(&args.config_host, &args.config_pubkey).await?;
     match client
-        .info_batch(&args.hotspots, args.batch_size, &args.keypair.to_keypair()?)
+        .info_batch(&args.hotspot, args.batch_size, &args.keypair.to_keypair()?)
         .await
     {
         Ok(info_stream) => {
@@ -53,7 +53,7 @@ pub async fn info_batch(args: GetHotspotBatch) -> Result<Msg> {
         }
         Err(err) => Msg::err(format!(
             "failed to retrieve {:?} info: {}",
-            &args.hotspots, err
+            &args.hotspot, err
         )),
     }
 }

--- a/mobile_config_cli/src/cmds/mod.rs
+++ b/mobile_config_cli/src/cmds/mod.rs
@@ -155,7 +155,7 @@ pub struct GetHotspot {
 #[derive(Debug, Args)]
 pub struct GetHotspotBatch {
     #[arg(long)]
-    pub hotspots: Vec<PublicKey>,
+    pub hotspot: Vec<PublicKey>,
     #[arg(short, long, default_value = "5")]
     pub batch_size: u32,
     #[arg(from_global)]


### PR DESCRIPTION
Since this is a clap-based CLI, the way a vec of input arguments works would be `mobile-cli gateway info-batch --hotspot <key1> --hotspot <key2> ...` where the flag name is just repeated as many times as necessary to supply all the elements of the input vec. naming this batch flag `hotspot` instead of `hotspots` makes more sense in the way the CLI is used