### PR TITLE
use service provider proto string impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#e3258b53a170315fb321d38dc9f451fd80538de8"
+source = "git+https://github.com/helium/proto?branch=master#585704c871d32846a6e35d186a08443883545687"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -3047,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#e3258b53a170315fb321d38dc9f451fd80538de8"
+source = "git+https://github.com/helium/proto?branch=master#585704c871d32846a6e35d186a08443883545687"
 dependencies = [
  "bytes",
  "prost",

--- a/mobile_config/src/client/mod.rs
+++ b/mobile_config/src/client/mod.rs
@@ -24,8 +24,8 @@ pub enum ClientError {
     VerificationError(#[from] file_store::Error),
     #[error("error parsing gateway location {0}")]
     LocationParseError(#[from] std::num::ParseIntError),
-    #[error("unknown service provider name")]
-    UnknownServiceProvider,
+    #[error("unknown service provider {0}")]
+    UnknownServiceProvider(String),
 }
 
 macro_rules! call_with_retry {

--- a/mobile_verifier/src/data_session.rs
+++ b/mobile_verifier/src/data_session.rs
@@ -5,7 +5,7 @@ use futures::{
     TryFutureExt,
 };
 use helium_crypto::PublicKeyBinary;
-use helium_proto::services::poc_mobile::ServiceProvider;
+use helium_proto::ServiceProvider;
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, Row, Transaction};
 use std::{collections::HashMap, ops::Range, time::Instant};

--- a/reward_index/src/indexer.rs
+++ b/reward_index/src/indexer.rs
@@ -8,10 +8,8 @@ use futures::{stream, StreamExt, TryStreamExt};
 use helium_crypto::PublicKeyBinary;
 use helium_proto::{
     services::poc_lora::{iot_reward_share::Reward as IotReward, IotRewardShare},
-    services::poc_mobile::{
-        mobile_reward_share::Reward as MobileReward, MobileRewardShare, ServiceProvider,
-    },
-    Message,
+    services::poc_mobile::{mobile_reward_share::Reward as MobileReward, MobileRewardShare},
+    Message, ServiceProvider,
 };
 use poc_metrics::record_duration;
 use sqlx::{Pool, Postgres, Transaction};
@@ -163,7 +161,7 @@ impl Indexer {
                         if let Some(sp) = ServiceProvider::from_i32(r.service_provider_id) {
                             Ok((
                                 RewardKey {
-                                    key: service_provider_to_entity_key(sp)?,
+                                    key: sp.to_string(),
                                     reward_type: RewardType::MobileServiceProvider,
                                 },
                                 r.amount,
@@ -210,11 +208,5 @@ impl Indexer {
                 }
             }
         }
-    }
-}
-
-fn service_provider_to_entity_key(sp: ServiceProvider) -> anyhow::Result<String> {
-    match sp {
-        ServiceProvider::HeliumMobile => Ok("Helium Mobile".to_string()),
     }
 }


### PR DESCRIPTION
This makes use of centralised from_str and to_string impls added to the proto lib here https://github.com/helium/proto/pull/386 and removes the temp added local functions.

There is the option of updating mobile_config server  to return the Service Provider enum value but I am not convinced that is a good approach as it enforces a specific enum to what could be argued is a generic API (key_to_rewardable_entity) which translates a given key to a rewardable entity.  Baking in the assumption that a rewardable entity will always be a service provider enum would be a mistake.  

The other option is to drop the generic API (naming & usage ) and make it specific to returning a service provider entity key.  I ended up taking this approach but limited it to the mobile config client.  The server still returns the entity key as defined in the DB ( ie a string ), the client API then attempts to convert that to the relevant enum before passing the enum value to the caller.  This approach allows the client to have APIs which return either the enum value or the raw string.   I could well be overthinking this





