### PR TITLE
carry unallocated dc to poc pool, dont write unallocated dc proto

### DIFF
--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -288,18 +288,30 @@ pub async fn reward_poc_and_dc(
         bail!("The data transfer rewards scale cannot be converted to a float");
     };
     telemetry::data_transfer_rewards_scale(scale);
-
-    reward_poc(
+    // reward dc before poc so that we can calculate the unallocated dc reward
+    // and carry this into the poc pool
+    let dc_unallocated_amount = reward_dc(mobile_rewards, reward_period, transfer_rewards).await?;
+    // any poc unallocated gets attributed to the unallocated reward
+    let poc_unallocated_amount = reward_poc(
         pool,
         hex_service_client,
         mobile_rewards,
         speedtest_avg_sink,
         reward_period,
-        transfer_rewards_sum,
+        transfer_rewards_sum - dc_unallocated_amount,
+    )
+    .await?
+    .round_dp_with_strategy(0, RoundingStrategy::ToZero)
+    .to_u64()
+    .unwrap_or(0);
+
+    write_unallocated_reward(
+        mobile_rewards,
+        UnallocatedRewardType::Poc,
+        poc_unallocated_amount,
+        reward_period,
     )
     .await?;
-
-    reward_dc(mobile_rewards, reward_period, transfer_rewards).await?;
 
     Ok(())
 }
@@ -311,7 +323,7 @@ async fn reward_poc(
     speedtest_avg_sink: &FileSinkClient,
     reward_period: &Range<DateTime<Utc>>,
     transfer_reward_sum: Decimal,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Decimal> {
     let total_poc_rewards =
         reward_shares::get_scheduled_tokens_for_poc(reward_period.end - reward_period.start)
             - transfer_reward_sum;
@@ -333,7 +345,7 @@ async fn reward_poc(
     )
     .await?;
 
-    if let Some(mobile_reward_shares) =
+    let unallocated_poc_amount = if let Some(mobile_reward_shares) =
         coverage_points.into_rewards(total_poc_rewards, reward_period)
     {
         // handle poc reward outputs
@@ -346,28 +358,20 @@ async fn reward_poc(
                 // Await the returned one shot to ensure that we wrote the file
                 .await??;
         }
-        // write out any unallocated poc reward
-        let unallocated_poc_reward_amount = (total_poc_rewards
-            - Decimal::from(allocated_poc_rewards))
-        .round_dp_with_strategy(0, RoundingStrategy::ToZero)
-        .to_u64()
-        .unwrap_or(0);
-        write_unallocated_reward(
-            mobile_rewards,
-            UnallocatedRewardType::Poc,
-            unallocated_poc_reward_amount,
-            reward_period,
-        )
-        .await?;
+        // calculate any unallocated poc reward
+        total_poc_rewards - Decimal::from(allocated_poc_rewards)
+    } else {
+        // default unallocated poc reward to the total poc reward
+        total_poc_rewards
     };
-    Ok(())
+    Ok(unallocated_poc_amount)
 }
 
 pub async fn reward_dc(
     mobile_rewards: &FileSinkClient,
     reward_period: &Range<DateTime<Utc>>,
     transfer_rewards: TransferRewards,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Decimal> {
     // handle dc reward outputs
     let mut allocated_dc_rewards = 0_u64;
     let total_dc_rewards = transfer_rewards.total();
@@ -379,19 +383,11 @@ pub async fn reward_dc(
             // Await the returned one shot to ensure that we wrote the file
             .await??;
     }
-    // write out any unallocated dc reward
-    let unallocated_dc_reward_amount = (total_dc_rewards - Decimal::from(allocated_dc_rewards))
-        .round_dp_with_strategy(0, RoundingStrategy::ToZero)
-        .to_u64()
-        .unwrap_or(0);
-    write_unallocated_reward(
-        mobile_rewards,
-        UnallocatedRewardType::Data,
-        unallocated_dc_reward_amount,
-        reward_period,
-    )
-    .await?;
-    Ok(())
+    // for Dc we return the unallocated amount rather than writing it out to as an unallocated reward
+    // it then gets added to the poc pool
+    // we return the full decimal value just to ensure we allocate all to poc
+    let unallocated_dc_reward_amount = total_dc_rewards - Decimal::from(allocated_dc_rewards);
+    Ok(unallocated_dc_reward_amount)
 }
 
 pub async fn reward_mappers(
@@ -425,11 +421,11 @@ pub async fn reward_mappers(
     }
 
     // write out any unallocated mapping rewards
-    let unallocated_mapping_reward_amount = (total_mappers_pool
-        - Decimal::from(allocated_mapping_rewards))
-    .round_dp_with_strategy(0, RoundingStrategy::ToZero)
-    .to_u64()
-    .unwrap_or(0);
+    let unallocated_mapping_reward_amount = total_mappers_pool
+        .round_dp_with_strategy(0, RoundingStrategy::ToZero)
+        .to_u64()
+        .unwrap_or(0)
+        - allocated_mapping_rewards;
     write_unallocated_reward(
         mobile_rewards,
         UnallocatedRewardType::Mapper,
@@ -448,11 +444,11 @@ pub async fn reward_oracles(
     let total_oracle_rewards =
         reward_shares::get_scheduled_tokens_for_oracles(reward_period.end - reward_period.start);
     let allocated_oracle_rewards = 0_u64;
-    let unallocated_oracle_reward_amount = (total_oracle_rewards
-        - Decimal::from(allocated_oracle_rewards))
-    .round_dp_with_strategy(0, RoundingStrategy::ToZero)
-    .to_u64()
-    .unwrap_or(0);
+    let unallocated_oracle_reward_amount = total_oracle_rewards
+        .round_dp_with_strategy(0, RoundingStrategy::ToZero)
+        .to_u64()
+        .unwrap_or(0)
+        - allocated_oracle_rewards;
     write_unallocated_reward(
         mobile_rewards,
         UnallocatedRewardType::Oracle,
@@ -488,10 +484,11 @@ pub async fn reward_service_providers(
         mobile_rewards.write(sp_share.clone(), []).await?.await??;
     }
     // write out any unallocated service provider reward
-    let unallocated_sp_reward_amount = (total_sp_rewards - Decimal::from(allocated_sp_rewards))
+    let unallocated_sp_reward_amount = total_sp_rewards
         .round_dp_with_strategy(0, RoundingStrategy::ToZero)
         .to_u64()
-        .unwrap_or(0);
+        .unwrap_or(0)
+        - allocated_sp_rewards;
     write_unallocated_reward(
         mobile_rewards,
         UnallocatedRewardType::ServiceProvider,

--- a/mobile_verifier/tests/rewarder_poc_dc.rs
+++ b/mobile_verifier/tests/rewarder_poc_dc.rs
@@ -163,6 +163,14 @@ async fn receive_expected_rewards(
     mobile_rewards: &mut MockFileSinkReceiver,
 ) -> anyhow::Result<(Vec<RadioReward>, Vec<GatewayReward>, UnallocatedReward)> {
     // get the filestore outputs from rewards run
+
+    // expect 3 gateway rewards for dc transfer
+    let dc_reward1 = mobile_rewards.receive_gateway_reward().await;
+    let dc_reward2 = mobile_rewards.receive_gateway_reward().await;
+    let dc_reward3 = mobile_rewards.receive_gateway_reward().await;
+    let mut dc_rewards = vec![dc_reward1, dc_reward2, dc_reward3];
+    dc_rewards.sort_by(|a, b| b.hotspot_key.cmp(&a.hotspot_key));
+
     // we will have 3 radio rewards, 1 wifi radio and 2 cbrs radios
     let radio_reward1 = mobile_rewards.receive_radio_reward().await;
     let radio_reward2 = mobile_rewards.receive_radio_reward().await;
@@ -174,13 +182,6 @@ async fn receive_expected_rewards(
 
     // expect one unallocated reward for poc
     let unallocated_poc_reward = mobile_rewards.receive_unallocated_reward().await;
-
-    // expect 3 gateway rewards for dc transfer
-    let dc_reward1 = mobile_rewards.receive_gateway_reward().await;
-    let dc_reward2 = mobile_rewards.receive_gateway_reward().await;
-    let dc_reward3 = mobile_rewards.receive_gateway_reward().await;
-    let mut dc_rewards = vec![dc_reward1, dc_reward2, dc_reward3];
-    dc_rewards.sort_by(|a, b| b.hotspot_key.cmp(&a.hotspot_key));
 
     // should be no further msgs
     mobile_rewards.assert_no_messages();


### PR DESCRIPTION
This addresses the issue in mobile rewards where we calculate poc and dc rewards independently and potentially write out unallocated amounts for each.

With these changes any unallocated DC amount is now carried over into the poc pool.  We then only write out a single unallocated reward for POC.  