### PR TITLE
reciprocity checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,7 +1448,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#53373c6d7b6abe900a49a205593380787978bfb4"
+source = "git+https://github.com/helium/proto?branch=master#c2b1dfa06e6f726ab19cd50444b2a90dd6c841e0"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#53373c6d7b6abe900a49a205593380787978bfb4"
+source = "git+https://github.com/helium/proto?branch=master#c2b1dfa06e6f726ab19cd50444b2a90dd6c841e0"
 dependencies = [
  "bytes",
  "prost",

--- a/iot_verifier/migrations/14_last_witness.sql
+++ b/iot_verifier/migrations/14_last_witness.sql
@@ -1,0 +1,8 @@
+create table last_witness (
+    id bytea primary key not null,
+    timestamp timestamptz not null
+);
+-- seed last_witness with timestamps from last_beacon
+insert into last_witness (id, timestamp)
+select id, timestamp from last_beacon
+where timestamp > now() - interval '7 day';

--- a/iot_verifier/src/last_witness.rs
+++ b/iot_verifier/src/last_witness.rs
@@ -1,20 +1,22 @@
 use chrono::{DateTime, Utc};
+
+use helium_crypto::PublicKeyBinary;
 use serde::{Deserialize, Serialize};
 
 #[derive(sqlx::FromRow, Deserialize, Serialize, Debug)]
-#[sqlx(type_name = "last_beacon")]
-pub struct LastBeacon {
+#[sqlx(type_name = "last_witness")]
+pub struct LastWitness {
     pub id: Vec<u8>,
     pub timestamp: DateTime<Utc>,
 }
 
-impl LastBeacon {
+impl LastWitness {
     pub async fn insert_kv<'c, E>(executor: E, id: &[u8], val: &str) -> anyhow::Result<Self>
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
         Ok(sqlx::query_as::<_, Self>(
-            r#" insert into last_beacon ( id, timestamp )
+            r#" insert into last_witness ( id, timestamp )
             values ($1, $2)
             on conflict (key) do nothing
             returning *;
@@ -31,24 +33,9 @@ impl LastBeacon {
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
         Ok(
-            sqlx::query_as::<_, LastBeacon>(r#" select * from last_beacon where id = $1;"#)
+            sqlx::query_as::<_, LastWitness>(r#" select * from last_witness where id = $1;"#)
                 .bind(id)
                 .fetch_optional(executor)
-                .await?,
-        )
-    }
-
-    pub async fn get_all_since<'c, E>(
-        executor: E,
-        timestamp: DateTime<Utc>,
-    ) -> anyhow::Result<Vec<Self>>
-    where
-        E: sqlx::Executor<'c, Database = sqlx::Postgres> + 'c,
-    {
-        Ok(
-            sqlx::query_as::<_, Self>(r#" select * from last_beacon where timestamp >= $1; "#)
-                .bind(timestamp)
-                .fetch_all(executor)
                 .await?,
         )
     }
@@ -62,7 +49,7 @@ impl LastBeacon {
     {
         let height = sqlx::query_scalar(
             r#"
-            select timestamp from last_beacon
+            select timestamp from last_witness
             where id = $1
             "#,
         )
@@ -82,7 +69,7 @@ impl LastBeacon {
     {
         let _ = sqlx::query(
             r#"
-            insert into last_beacon (id, timestamp)
+            insert into last_witness (id, timestamp)
             values ($1, $2)
             on conflict (id) do update set
                 timestamp = EXCLUDED.timestamp
@@ -92,6 +79,26 @@ impl LastBeacon {
         .bind(timestamp)
         .execute(executor)
         .await?;
+        Ok(())
+    }
+
+    pub async fn bulk_update_last_timestamps(
+        db: impl sqlx::PgExecutor<'_> + sqlx::Acquire<'_, Database = sqlx::Postgres> + Copy,
+        ids: Vec<(PublicKeyBinary, DateTime<Utc>)>,
+    ) -> anyhow::Result<()> {
+        const NUMBER_OF_FIELDS_IN_QUERY: u16 = 2;
+        const MAX_BATCH_ENTRIES: usize = (u16::MAX / NUMBER_OF_FIELDS_IN_QUERY) as usize;
+        let mut txn = db.begin().await?;
+        for updates in ids.chunks(MAX_BATCH_ENTRIES) {
+            let mut query_builder: sqlx::QueryBuilder<sqlx::Postgres> =
+                sqlx::QueryBuilder::new(" insert into last_witness (id, timestamp) ");
+            query_builder.push_values(updates, |mut builder, (id, ts)| {
+                builder.push_bind(id.as_ref()).push_bind(ts);
+            });
+            query_builder.push(" on conflict (id) do update set timestamp = EXCLUDED.timestamp ");
+            query_builder.build().execute(&mut *txn).await?;
+        }
+        txn.commit().await?;
         Ok(())
     }
 }

--- a/iot_verifier/src/lib.rs
+++ b/iot_verifier/src/lib.rs
@@ -4,6 +4,7 @@ pub mod gateway_cache;
 pub mod gateway_updater;
 pub mod hex_density;
 pub mod last_beacon;
+pub mod last_witness;
 pub mod loader;
 pub mod meta;
 pub mod packet_loader;

--- a/iot_verifier/tests/runner_tests.rs
+++ b/iot_verifier/tests/runner_tests.rs
@@ -7,6 +7,7 @@ use futures_util::{stream, StreamExt as FuturesStreamExt};
 use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_lora::{
     InvalidParticipantSide, InvalidReason, LoraBeaconReportReqV1, LoraWitnessReportReqV1,
+    VerificationStatus,
 };
 use helium_proto::Region as ProtoRegion;
 use iot_config::{
@@ -17,9 +18,13 @@ use iot_verifier::{
     gateway_cache::GatewayCache, gateway_updater::GatewayUpdater, poc_report::Report,
     region_cache::RegionCache, runner::Runner, tx_scaler::Server as DensityScaler,
 };
+use lazy_static::lazy_static;
 use sqlx::PgPool;
 use std::{self, str::FromStr, time::Duration};
 
+lazy_static! {
+    static ref BEACON_INTERVAL: ChronoDuration = ChronoDuration::seconds(21600);
+}
 #[derive(Debug, Clone)]
 pub struct MockIotConfigClient {
     resolve_gateway: GatewayInfo,
@@ -60,7 +65,7 @@ struct TestContext {
 }
 
 impl TestContext {
-    async fn setup(pool: PgPool) -> anyhow::Result<Self> {
+    async fn setup(pool: PgPool, beacon_interval: ChronoDuration) -> anyhow::Result<Self> {
         // setup file sinks
         let (invalid_beacon_client, invalid_beacons) = common::create_file_sink();
         let (invalid_witness_client, invalid_witnesses) = common::create_file_sink();
@@ -88,7 +93,7 @@ impl TestContext {
         // create the runner
         let runner = Runner {
             pool: pool.clone(),
-            beacon_interval: ChronoDuration::seconds(21600),
+            beacon_interval,
             max_witnesses_per_poc: 16,
             beacon_max_retries: 2,
             witness_max_retries: 2,
@@ -125,21 +130,53 @@ impl TestContext {
 
 #[sqlx::test]
 async fn valid_beacon_and_witness(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone()).await?;
+    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let now = ctx.entropy_ts;
 
     // test with a valid beacon and a valid witness
-    //
     let beacon_to_inject = common::create_valid_beacon_report(common::BEACONER1, ctx.entropy_ts);
     let witness_to_inject = common::create_valid_witness_report(common::WITNESS1, ctx.entropy_ts);
     common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
     common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
+
+    // inject last beacons and witness reports into the DB
+    // avoid the reports declared invalid due to reciprocity check
+    // when setting the last time consider the beacon interval setup
+    let mut txn = pool.begin().await?;
+    common::inject_last_beacon(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    common::inject_last_beacon(
+        &mut txn,
+        witness_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        witness_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    txn.commit().await?;
+
     ctx.runner.handle_db_tick().await?;
 
     let valid_poc = ctx.valid_pocs.receive_valid_poc().await;
     assert_eq!(1, valid_poc.selected_witnesses.len());
     assert_eq!(0, valid_poc.unselected_witnesses.len());
     let valid_beacon = valid_poc.beacon_report.unwrap().report.clone().unwrap();
-    let valid_witness = valid_poc.selected_witnesses[0].report.clone().unwrap();
+    let valid_witness_report = valid_poc.selected_witnesses[0].clone();
+    let valid_witness = valid_witness_report.report.unwrap();
     // assert the pubkeys in the outputted reports
     // match those which we injected
     assert_eq!(
@@ -160,17 +197,54 @@ async fn valid_beacon_and_witness(pool: PgPool) -> anyhow::Result<()> {
         valid_witness,
         LoraWitnessReportReqV1::from(witness_to_inject.clone())
     );
-
+    // assert the witness reports status
+    assert_eq!(
+        valid_witness_report.status,
+        VerificationStatus::Valid as i32
+    );
     Ok(())
 }
 
 #[sqlx::test]
 async fn valid_beacon_and_no_witness(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone()).await?;
+    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let now = ctx.entropy_ts;
 
     // test with a valid beacon and no witnesses
     let beacon_to_inject = common::create_valid_beacon_report(common::BEACONER1, ctx.entropy_ts);
     common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
+
+    let mut txn = pool.begin().await?;
+    common::inject_last_beacon(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+
+    // inject last beacons and witness reports into the DB
+    // avoid the reports declared invalid due to reciprocity check
+    // when setting the last time consider the beacon interval setup
+    common::inject_last_beacon(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    txn.commit().await?;
+
     ctx.runner.handle_db_tick().await?;
 
     let valid_poc = ctx.valid_pocs.receive_valid_poc().await;
@@ -193,8 +267,9 @@ async fn valid_beacon_and_no_witness(pool: PgPool) -> anyhow::Result<()> {
 }
 
 #[sqlx::test]
-async fn invalid_beacon_gateway_not_found(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone()).await?;
+async fn valid_beacon_gateway_not_found(pool: PgPool) -> anyhow::Result<()> {
+    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let now = ctx.entropy_ts;
     //
     // test with a valid beacon and an invalid witness
     // witness is invalid due to not found in iot config
@@ -204,6 +279,25 @@ async fn invalid_beacon_gateway_not_found(pool: PgPool) -> anyhow::Result<()> {
         common::create_valid_witness_report(common::UNKNOWN_GATEWAY1, ctx.entropy_ts);
     common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
     common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
+
+    // inject last beacons and witness reports into the DB
+    // avoid the reports declared invalid due to reciprocity check
+    // when setting the last time consider the beacon interval setup
+    let mut txn = pool.begin().await?;
+    common::inject_last_beacon(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    txn.commit().await?;
+
     ctx.runner.handle_db_tick().await?;
 
     let valid_poc = ctx.valid_pocs.receive_valid_poc().await;
@@ -241,13 +335,18 @@ async fn invalid_beacon_gateway_not_found(pool: PgPool) -> anyhow::Result<()> {
         invalid_witness,
         LoraWitnessReportReqV1::from(witness_to_inject.clone())
     );
-
+    // assert the witness reports status
+    assert_eq!(
+        invalid_witness_report.status,
+        VerificationStatus::Invalid as i32
+    );
     Ok(())
 }
 
 #[sqlx::test]
 async fn invalid_witness_no_metadata(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone()).await?;
+    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let now = ctx.entropy_ts;
     //
     // test with a valid beacon and an invalid witness
     // witness is invalid due no metadata in iot config
@@ -257,6 +356,34 @@ async fn invalid_witness_no_metadata(pool: PgPool) -> anyhow::Result<()> {
         common::create_valid_witness_report(common::NO_METADATA_GATEWAY1, ctx.entropy_ts);
     common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
     common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
+
+    let mut txn = pool.begin().await?;
+    common::inject_last_beacon(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    common::inject_last_beacon(
+        &mut txn,
+        witness_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        witness_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    txn.commit().await?;
+
     ctx.runner.handle_db_tick().await?;
 
     let valid_poc = ctx.valid_pocs.receive_valid_poc().await;
@@ -274,6 +401,11 @@ async fn invalid_witness_no_metadata(pool: PgPool) -> anyhow::Result<()> {
     assert_eq!(
         PublicKeyBinary::from(invalid_witness_report.report.unwrap().pub_key.clone()),
         PublicKeyBinary::from_str(common::NO_METADATA_GATEWAY1).unwrap()
+    );
+    // assert the witness reports status
+    assert_eq!(
+        VerificationStatus::Invalid as i32,
+        invalid_witness_report.status
     );
     // assert the invalid details
     assert_eq!(
@@ -300,7 +432,8 @@ async fn invalid_witness_no_metadata(pool: PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn invalid_beacon_no_gateway_found(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone()).await?;
+    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let now = Utc::now();
     //
     // test with an invalid beacon & 1 witness
     // beacon is invalid as GW is unknown
@@ -310,12 +443,28 @@ async fn invalid_beacon_no_gateway_found(pool: PgPool) -> anyhow::Result<()> {
     let witness_to_inject = common::create_valid_witness_report(common::WITNESS1, ctx.entropy_ts);
     common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
     common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
+
+    let mut txn = pool.begin().await?;
+    common::inject_last_beacon(
+        &mut txn,
+        witness_to_inject.report.pub_key.clone(),
+        now - ChronoDuration::hours(1),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        witness_to_inject.report.pub_key.clone(),
+        now - ChronoDuration::hours(1),
+    )
+    .await?;
+    txn.commit().await?;
+
     ctx.runner.handle_db_tick().await?;
 
     let invalid_beacon_report = ctx.invalid_beacons.receive_invalid_beacon().await;
     let invalid_witness_report = ctx.invalid_witnesses.receive_invalid_witness().await;
     let invalid_beacon = invalid_beacon_report.report.clone().unwrap();
-    let invalid_witness = invalid_witness_report.report.clone().unwrap();
+    let invalid_witness = invalid_witness_report.clone().report.unwrap();
     // assert the pubkeys in the outputted reports
     // match those which we injected
     assert_eq!(
@@ -355,7 +504,7 @@ async fn invalid_beacon_no_gateway_found(pool: PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn invalid_beacon_gateway_not_found_no_witnesses(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone()).await?;
+    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
     //
     // test with an invalid beacon, no witnesses
     // beacon is invalid as GW is unknown
@@ -390,7 +539,7 @@ async fn invalid_beacon_gateway_not_found_no_witnesses(pool: PgPool) -> anyhow::
 
 #[sqlx::test]
 async fn invalid_beacon_bad_payload(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone()).await?;
+    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
     //
     // test with an invalid beacon, no witnesses
     // the beacon will have an invalid payload, resulting in an error
@@ -417,5 +566,469 @@ async fn invalid_beacon_bad_payload(pool: PgPool) -> anyhow::Result<()> {
     ctx.invalid_beacons.assert_no_messages();
     ctx.invalid_witnesses.assert_no_messages();
 
+    Ok(())
+}
+
+#[sqlx::test]
+async fn valid_beacon_and_witness_no_beacon_reciprocity(pool: PgPool) -> anyhow::Result<()> {
+    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let now = ctx.entropy_ts;
+
+    // test with a valid beacon and a valid witness
+    let beacon_to_inject = common::create_valid_beacon_report(common::BEACONER1, ctx.entropy_ts);
+    let witness_to_inject = common::create_valid_witness_report(common::WITNESS1, ctx.entropy_ts);
+    common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
+    common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
+
+    // inject last beacons and witness reports into the DB
+    // we will only insert these for the witness
+    // the beaconer will fail the reciprocity check
+    let mut txn = pool.begin().await?;
+    common::inject_last_beacon(
+        &mut txn,
+        witness_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        witness_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    txn.commit().await?;
+
+    ctx.runner.handle_db_tick().await?;
+
+    let invalid_beacon = ctx.invalid_beacons.receive_invalid_beacon().await;
+    let invalid_witness = ctx.invalid_witnesses.receive_invalid_witness().await;
+    // assert the pubkeys in the outputted reports
+    // match those which we injected
+    assert_eq!(
+        PublicKeyBinary::from(invalid_beacon.report.as_ref().unwrap().pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER1).unwrap()
+    );
+    assert_eq!(
+        PublicKeyBinary::from(invalid_witness.report.as_ref().unwrap().pub_key.clone()),
+        PublicKeyBinary::from_str(common::WITNESS1).unwrap()
+    );
+    // assert the invalid details
+    assert_eq!(
+        InvalidReason::GatewayNoValidWitnesses as i32,
+        invalid_beacon.reason
+    );
+    assert_eq!(
+        InvalidReason::GatewayNoValidWitnesses as i32,
+        invalid_witness.reason
+    );
+    assert_eq!(
+        InvalidParticipantSide::Beaconer as i32,
+        invalid_witness.participant_side
+    );
+    // assert the beacon and witness reports outputted to filestore
+    // are unmodified from those submitted
+    assert_eq!(
+        invalid_beacon.report.unwrap(),
+        LoraBeaconReportReqV1::from(beacon_to_inject.clone())
+    );
+    assert_eq!(
+        invalid_witness.report.unwrap(),
+        LoraWitnessReportReqV1::from(witness_to_inject.clone())
+    );
+    Ok(())
+}
+
+#[sqlx::test]
+async fn valid_beacon_and_witness_no_witness_reciprocity(pool: PgPool) -> anyhow::Result<()> {
+    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let now = ctx.entropy_ts;
+
+    // test with a valid beacon and a valid witness
+    let beacon_to_inject = common::create_valid_beacon_report(common::BEACONER1, ctx.entropy_ts);
+    let witness_to_inject = common::create_valid_witness_report(common::WITNESS1, ctx.entropy_ts);
+    common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
+    common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
+
+    // inject last beacons and witness reports into the DB
+    // we will only insert these for the witness
+    // the beaconer will fail the reciprocity check
+    let mut txn = pool.begin().await?;
+    common::inject_last_beacon(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (*BEACON_INTERVAL + ChronoDuration::hours(2)),
+    )
+    .await?;
+    txn.commit().await?;
+
+    ctx.runner.handle_db_tick().await?;
+
+    let valid_poc = ctx.valid_pocs.receive_valid_poc().await;
+    println!("{:?}", valid_poc);
+    assert_eq!(0, valid_poc.selected_witnesses.len());
+    assert_eq!(1, valid_poc.unselected_witnesses.len());
+    let valid_beacon = valid_poc.beacon_report.unwrap().report.clone().unwrap();
+    let invalid_witness_report = valid_poc.unselected_witnesses[0].clone();
+    let invalid_witness = invalid_witness_report.report.clone().unwrap();
+    // assert the pubkeys in the outputted reports
+    // match those which we injected
+    assert_eq!(
+        PublicKeyBinary::from(valid_beacon.pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER1).unwrap()
+    );
+    assert_eq!(
+        PublicKeyBinary::from(invalid_witness_report.report.unwrap().pub_key.clone()),
+        PublicKeyBinary::from_str(common::WITNESS1).unwrap()
+    );
+    // assert the witness reports status
+    assert_eq!(
+        VerificationStatus::Invalid as i32,
+        invalid_witness_report.status
+    );
+    // assert the invalid details
+    assert_eq!(
+        InvalidReason::GatewayNoValidBeacons as i32,
+        invalid_witness_report.invalid_reason
+    );
+    assert_eq!(
+        InvalidParticipantSide::Witness as i32,
+        invalid_witness_report.participant_side
+    );
+    // assert the beacon and witness reports outputted to filestore
+    // are unmodified from those submitted
+    assert_eq!(
+        valid_beacon,
+        LoraBeaconReportReqV1::from(beacon_to_inject.clone())
+    );
+    assert_eq!(
+        invalid_witness,
+        LoraWitnessReportReqV1::from(witness_to_inject.clone())
+    );
+    Ok(())
+}
+
+#[sqlx::test]
+async fn valid_new_gateway_witness_first_reciprocity(pool: PgPool) -> anyhow::Result<()> {
+    let test_beacon_interval = ChronoDuration::seconds(5);
+    let mut ctx = TestContext::setup(pool.clone(), test_beacon_interval).await?;
+    let now = ctx.entropy_ts;
+
+    // simulate a new gateway coming online or a gateway coming online after an extended period offline
+    // the gateway uses beaconer5 pubkey
+    // the gateways first activity will be to submit a witness report for a beacon it sees
+    // this will fail the reciprocity check as there will be no previous/recent beacon from this gateway
+    // whilst the witness will fail reciprocity, its last valid witness timestamp will be updated
+    // as all regular ( ie non reciprocity check ) validations passed
+    // the gateway will then subsequently beacon which will pass ( reciprocity check is ok as previously witnessed )
+    // it will then witness again and this time it will pass  ( reciprocity check is ok as previously beaconed )
+
+    //
+    // step 1 - generate a witness from beaconer5,
+    //          this witness will be valid but will fail reciprocity check as no previous beacon
+    //          last witness timestamp will be updated
+    //
+
+    let beacon_to_inject = common::create_valid_beacon_report(common::BEACONER1, ctx.entropy_ts);
+    let witness_to_inject = common::create_valid_witness_report(common::BEACONER5, ctx.entropy_ts);
+    common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
+    common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
+
+    // inject last beacons and witness reports into the DB for beaconer 1
+    let mut txn = pool.begin().await?;
+    common::inject_last_beacon(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (test_beacon_interval + ChronoDuration::seconds(10)),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (test_beacon_interval + ChronoDuration::seconds(10)),
+    )
+    .await?;
+    txn.commit().await?;
+
+    ctx.runner.handle_db_tick().await?;
+
+    let valid_poc = ctx.valid_pocs.receive_valid_poc().await;
+    println!("{:?}", valid_poc);
+    assert_eq!(0, valid_poc.selected_witnesses.len());
+    assert_eq!(1, valid_poc.unselected_witnesses.len());
+    let valid_beacon = valid_poc.beacon_report.unwrap().report.clone().unwrap();
+    let invalid_witness_report = valid_poc.unselected_witnesses[0].clone();
+    let invalid_witness = invalid_witness_report.report.unwrap();
+    // assert the pubkeys in the outputted reports
+    // match those which we injected
+    assert_eq!(
+        PublicKeyBinary::from(valid_beacon.pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER1).unwrap()
+    );
+    assert_eq!(
+        PublicKeyBinary::from(invalid_witness.pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER5).unwrap()
+    );
+    // assert the witness reports status
+    assert_eq!(
+        VerificationStatus::Invalid as i32,
+        invalid_witness_report.status
+    );
+    // assert the invalid details
+    assert_eq!(
+        InvalidReason::GatewayNoValidBeacons as i32,
+        invalid_witness_report.invalid_reason
+    );
+    assert_eq!(
+        InvalidParticipantSide::Witness as i32,
+        invalid_witness_report.participant_side
+    );
+
+    //
+    // step 2
+    // generate a beacon from beaconer5
+    // as it will now have a previous valid witness, the beacon will pass the reciprocity check
+    // the gateway will then have a valid 'last beacon' and 'last witness' timestamp
+    //
+
+    let beacon_to_inject = common::create_valid_beacon_report(common::BEACONER5, ctx.entropy_ts);
+    let witness_to_inject = common::create_valid_witness_report(common::BEACONER1, ctx.entropy_ts);
+    common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
+    common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
+
+    ctx.runner.handle_db_tick().await?;
+
+    let valid_poc = ctx.valid_pocs.receive_valid_poc().await;
+    println!("{:?}", valid_poc);
+    assert_eq!(1, valid_poc.selected_witnesses.len());
+    assert_eq!(0, valid_poc.unselected_witnesses.len());
+    let valid_beacon = valid_poc.beacon_report.unwrap().report.clone().unwrap();
+    let valid_witness_report = valid_poc.selected_witnesses[0].clone();
+    let valid_witness = valid_witness_report.report.unwrap();
+    // assert the pubkeys in the outputted reports
+    // match those which we injected
+    assert_eq!(
+        PublicKeyBinary::from(valid_beacon.pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER5).unwrap()
+    );
+    assert_eq!(
+        PublicKeyBinary::from(valid_witness.pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER1).unwrap()
+    );
+    // assert the witness reports status
+    assert_eq!(
+        VerificationStatus::Valid as i32,
+        valid_witness_report.status
+    );
+    //
+    // step 3
+    // generate a witness from beaconer5
+    // as the gateway will have both a valid 'last beacon' and 'last witness' timestamp
+    // the reciprocity check will pass
+    //
+
+    let beacon_to_inject = common::create_valid_beacon_report(common::BEACONER2, ctx.entropy_ts);
+    let witness_to_inject = common::create_valid_witness_report(common::BEACONER5, ctx.entropy_ts);
+    common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
+    common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
+
+    // inject last beacons and witness reports into the DB for beaconer 1
+    // avoid the reports declared invalid due to reciprocity check
+    let mut txn = pool.begin().await?;
+    common::inject_last_beacon(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (test_beacon_interval + ChronoDuration::seconds(10)),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (test_beacon_interval + ChronoDuration::seconds(10)),
+    )
+    .await?;
+    txn.commit().await?;
+
+    ctx.runner.handle_db_tick().await?;
+
+    let valid_poc = ctx.valid_pocs.receive_valid_poc().await;
+    println!("{:?}", valid_poc);
+    assert_eq!(1, valid_poc.selected_witnesses.len());
+    assert_eq!(0, valid_poc.unselected_witnesses.len());
+    let valid_beacon = valid_poc.beacon_report.unwrap().report.clone().unwrap();
+    let valid_witness_report = valid_poc.selected_witnesses[0].clone();
+    let valid_witness = valid_witness_report.report.unwrap();
+    // assert the pubkeys in the outputted reports
+    // match those which we injected
+    assert_eq!(
+        PublicKeyBinary::from(valid_beacon.pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER2).unwrap()
+    );
+    assert_eq!(
+        PublicKeyBinary::from(valid_witness.pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER5).unwrap()
+    );
+    // assert the witness reports status
+    assert_eq!(
+        VerificationStatus::Valid as i32,
+        valid_witness_report.status
+    );
+    Ok(())
+}
+
+#[sqlx::test]
+async fn valid_new_gateway_beacon_first_reciprocity(pool: PgPool) -> anyhow::Result<()> {
+    let test_beacon_interval = ChronoDuration::seconds(5);
+    let mut ctx = TestContext::setup(pool.clone(), test_beacon_interval).await?;
+    let now = ctx.entropy_ts;
+
+    // simulate a new gateway coming online or a gateway coming online after an extended period offline
+    // the gateway uses beaconer5 pubkey
+    // the gateways first activity will be to submit a beacon report
+    // this will fail the reciprocity check due to no previous/recent witness from this gateway
+    // whilst the beacon will fail reciprocity, its last valid beacon timestamp will be updated
+    // as all regular ( ie non reciprocity check ) validations passed
+    // the gateway will then subsequently witness which will pass ( reciprocity check is ok as previously beacon )
+    // it will then beacon again and this time it will pass  ( reciprocity check is ok as previously witness )
+
+    //
+    // step 1 - generate a beacon from beaconer5,
+    //          this beacon will be valid but will fail reciprocity check as no previous witness
+    //          last beacon timestamp will be updated
+    //
+    let beacon_to_inject = common::create_valid_beacon_report(common::BEACONER5, ctx.entropy_ts);
+    common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
+
+    ctx.runner.handle_db_tick().await?;
+
+    let invalid_beacon = ctx.invalid_beacons.receive_invalid_beacon().await;
+    let invalid_beacon_report = invalid_beacon.report.clone().unwrap();
+    println!("{:?}", invalid_beacon);
+    // assert the pubkeys in the outputted reports
+    // match those which we injected
+    assert_eq!(
+        PublicKeyBinary::from(invalid_beacon_report.pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER5).unwrap()
+    );
+    // assert the invalid details
+    assert_eq!(
+        InvalidReason::GatewayNoValidWitnesses as i32,
+        invalid_beacon.reason
+    );
+
+    //
+    // step 2
+    // generate a witness from beaconer5
+    // as it will now have a previous valid beacon, the witness will pass the reciprocity check
+    // the gateway will then have a valid 'last beacon' and 'last witness' timestamp
+    //
+
+    let beacon_to_inject = common::create_valid_beacon_report(common::BEACONER1, ctx.entropy_ts);
+    let witness_to_inject = common::create_valid_witness_report(common::BEACONER5, ctx.entropy_ts);
+    common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
+    common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
+
+    // inject last beacons and witness reports into the DB for beaconer 1
+    let mut txn = pool.begin().await?;
+    common::inject_last_beacon(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (test_beacon_interval + ChronoDuration::seconds(10)),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        beacon_to_inject.report.pub_key.clone(),
+        now - (test_beacon_interval + ChronoDuration::seconds(10)),
+    )
+    .await?;
+    txn.commit().await?;
+
+    ctx.runner.handle_db_tick().await?;
+
+    let valid_poc = ctx.valid_pocs.receive_valid_poc().await;
+    println!("{:?}", valid_poc);
+    assert_eq!(1, valid_poc.selected_witnesses.len());
+    assert_eq!(0, valid_poc.unselected_witnesses.len());
+    let valid_beacon = valid_poc.beacon_report.unwrap().report.clone().unwrap();
+    let valid_witness_report = valid_poc.selected_witnesses[0].clone();
+    let valid_witness = valid_witness_report.report.unwrap();
+    // assert the pubkeys in the outputted reports
+    // match those which we injected
+    assert_eq!(
+        PublicKeyBinary::from(valid_beacon.pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER1).unwrap()
+    );
+    assert_eq!(
+        PublicKeyBinary::from(valid_witness.pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER5).unwrap()
+    );
+    // assert the witness reports status
+    assert_eq!(
+        VerificationStatus::Valid as i32,
+        valid_witness_report.status
+    );
+
+    //
+    // step 3
+    // generate a beacon from beaconer5
+    // as the gateway will now have both a valid 'last beacon' and 'last witness' timestamp
+    // the reciprocity check will pass
+    //
+    tokio::time::sleep(Duration::from_secs(6)).await;
+    let beacon_to_inject = common::create_valid_beacon_report(
+        common::BEACONER5,
+        ctx.entropy_ts + ChronoDuration::seconds(5),
+    );
+    let witness_to_inject = common::create_valid_witness_report(common::WITNESS2, ctx.entropy_ts);
+    common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
+    common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
+
+    // inject last beacons and witness reports into the DB for witness 2
+    let mut txn = pool.begin().await?;
+    common::inject_last_beacon(
+        &mut txn,
+        witness_to_inject.report.pub_key.clone(),
+        now - (test_beacon_interval + ChronoDuration::seconds(10)),
+    )
+    .await?;
+    common::inject_last_witness(
+        &mut txn,
+        witness_to_inject.report.pub_key.clone(),
+        now - (test_beacon_interval + ChronoDuration::seconds(10)),
+    )
+    .await?;
+    txn.commit().await?;
+
+    ctx.runner.handle_db_tick().await?;
+
+    let valid_poc = ctx.valid_pocs.receive_valid_poc().await;
+    println!("{:?}", valid_poc);
+    assert_eq!(1, valid_poc.selected_witnesses.len());
+    assert_eq!(0, valid_poc.unselected_witnesses.len());
+    let valid_beacon = valid_poc.beacon_report.unwrap().report.clone().unwrap();
+    let valid_witness_report = valid_poc.selected_witnesses[0].clone();
+    let valid_witness = valid_witness_report.report.unwrap();
+
+    // assert the pubkeys in the outputted reports
+    // match those which we injected
+    assert_eq!(
+        PublicKeyBinary::from(valid_beacon.pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER5).unwrap()
+    );
+    assert_eq!(
+        PublicKeyBinary::from(valid_witness.pub_key.clone()),
+        PublicKeyBinary::from_str(common::WITNESS2).unwrap()
+    );
+    // assert the witness reports status
+    assert_eq!(
+        VerificationStatus::Valid as i32,
+        valid_witness_report.status
+    );
     Ok(())
 }


### PR DESCRIPTION
proto pr: https://github.com/helium/proto/pull/388

This adds a reciprocity or bidirectional  validation to POC validations in order to satisfy https://github.com/helium/HIP/blob/main/0106-hotspot-bidirectional-coverage-requirement.md

The flow is as follows:

1.  Run regular validations on POC ( per beacon and any associated witnesses )

2.  After regular validations update DB to track the 'last beacon' and 'last witness' timestamps per relevant gateway 

- If regular validations declared the  beacon valid then record last valid beacon timestamp ( 1 update per beacon)
- If regular validations declared the  witness valid then record last valid witness timestamp ( 1 update per witness )

3.  After updating the DB then run the reciprocity check:

- For each previously declared valid witness, render the final status of each as invalid where the witnessing gateway does not have a valid beacon within the previous N hours

- Render the beacon invalid if beaconer's gateway does not have a valid witness within the previous N hours

4.  Output POC reports to  S3 as normal

TODO:

- [x] determine perf hit from additional DB access
- [x] ~~add last witness read cache~~
- [x] add batch updates for last witnesses
- [x] ~~mock last witness cache~~




