### PR TITLE
Separate out cbrs and wifi geofence regions

### DIFF
--- a/mobile_verifier/src/cli/server.rs
+++ b/mobile_verifier/src/cli/server.rs
@@ -93,7 +93,10 @@ impl Cmd {
         .create()
         .await?;
 
-        let geofence = Geofence::from_settings(settings)?;
+        let cbrs_region_paths = settings.cbrs_region_paths()?;
+        tracing::info!(?cbrs_region_paths, "cbrs_geofence_regions");
+
+        let cbrs_geofence = Geofence::new(cbrs_region_paths, settings.cbrs_fencing_resolution()?)?;
 
         let cbrs_heartbeat_daemon = CellHeartbeatDaemon::new(
             pool.clone(),
@@ -104,8 +107,13 @@ impl Cmd {
             settings.max_distance_from_coverage,
             valid_heartbeats.clone(),
             seniority_updates.clone(),
-            geofence.clone(),
+            cbrs_geofence,
         );
+
+        let wifi_region_paths = settings.wifi_region_paths()?;
+        tracing::info!(?wifi_region_paths, "wifi_geofence_regions");
+
+        let wifi_geofence = Geofence::new(wifi_region_paths, settings.wifi_fencing_resolution()?)?;
 
         let wifi_heartbeat_daemon = WifiHeartbeatDaemon::new(
             pool.clone(),
@@ -116,7 +124,7 @@ impl Cmd {
             settings.max_distance_from_coverage,
             valid_heartbeats,
             seniority_updates,
-            geofence,
+            wifi_geofence,
         );
 
         // Speedtests

--- a/mobile_verifier/src/geofence.rs
+++ b/mobile_verifier/src/geofence.rs
@@ -3,7 +3,7 @@ use h3o::{LatLng, Resolution};
 use hextree::{Cell, HexTreeSet};
 use std::{fs, io::Read, path, sync::Arc};
 
-use crate::{heartbeats::Heartbeat, Settings};
+use crate::heartbeats::Heartbeat;
 
 pub trait GeofenceValidator: Clone + Send + Sync + 'static {
     fn in_valid_region(&self, heartbeat: &Heartbeat) -> bool;
@@ -16,12 +16,10 @@ pub struct Geofence {
 }
 
 impl Geofence {
-    pub fn from_settings(settings: &Settings) -> anyhow::Result<Self> {
-        let paths = settings.region_paths()?;
-        tracing::info!(?paths, "geofence_regions");
+    pub fn new(paths: Vec<std::path::PathBuf>, resolution: Resolution) -> anyhow::Result<Self> {
         Ok(Self {
             regions: Arc::new(valid_mapping_regions(paths)?),
-            resolution: settings.fencing_resolution()?,
+            resolution,
         })
     }
 }

--- a/mobile_verifier/src/settings.rs
+++ b/mobile_verifier/src/settings.rs
@@ -42,7 +42,6 @@ pub struct Settings {
     pub cbrs_geofence_regions: String,
     #[serde(default = "default_fencing_resolution")]
     pub cbrs_fencing_resolution: u8,
-
 }
 
 fn default_fencing_resolution() -> u8 {

--- a/mobile_verifier/src/settings.rs
+++ b/mobile_verifier/src/settings.rs
@@ -36,9 +36,13 @@ pub struct Settings {
     #[serde(default = "default_max_asserted_distance_deviation")]
     pub max_asserted_distance_deviation: u32,
     // Geofencing settings
-    pub geofence_regions: String,
+    pub wifi_geofence_regions: String,
     #[serde(default = "default_fencing_resolution")]
-    pub fencing_resolution: u8,
+    pub wifi_fencing_resolution: u8,
+    pub cbrs_geofence_regions: String,
+    #[serde(default = "default_fencing_resolution")]
+    pub cbrs_fencing_resolution: u8,
+
 }
 
 fn default_fencing_resolution() -> u8 {
@@ -105,8 +109,8 @@ impl Settings {
             .unwrap()
     }
 
-    pub fn region_paths(&self) -> anyhow::Result<Vec<std::path::PathBuf>> {
-        let paths = std::fs::read_dir(&self.geofence_regions)?;
+    pub fn wifi_region_paths(&self) -> anyhow::Result<Vec<std::path::PathBuf>> {
+        let paths = std::fs::read_dir(&self.wifi_geofence_regions)?;
         Ok(paths
             .into_iter()
             .collect::<Result<Vec<std::fs::DirEntry>, std::io::Error>>()?
@@ -115,7 +119,21 @@ impl Settings {
             .collect())
     }
 
-    pub fn fencing_resolution(&self) -> anyhow::Result<h3o::Resolution> {
-        Ok(h3o::Resolution::try_from(self.fencing_resolution)?)
+    pub fn wifi_fencing_resolution(&self) -> anyhow::Result<h3o::Resolution> {
+        Ok(h3o::Resolution::try_from(self.wifi_fencing_resolution)?)
+    }
+
+    pub fn cbrs_region_paths(&self) -> anyhow::Result<Vec<std::path::PathBuf>> {
+        let paths = std::fs::read_dir(&self.cbrs_geofence_regions)?;
+        Ok(paths
+            .into_iter()
+            .collect::<Result<Vec<std::fs::DirEntry>, std::io::Error>>()?
+            .into_iter()
+            .map(|path| path.path())
+            .collect())
+    }
+
+    pub fn cbrs_fencing_resolution(&self) -> anyhow::Result<h3o::Resolution> {
+        Ok(h3o::Resolution::try_from(self.cbrs_fencing_resolution)?)
     }
 }


### PR DESCRIPTION
I thought about other programmatic ways to do this that shared the same geofence objects but that seemed more complicated than necessary