### PR TITLE
serialize last witness DB writes

### DIFF
--- a/iot_verifier/src/lib.rs
+++ b/iot_verifier/src/lib.rs
@@ -18,4 +18,5 @@ pub mod runner;
 mod settings;
 pub mod telemetry;
 pub mod tx_scaler;
+pub mod witness_updater;
 pub use settings::Settings;

--- a/iot_verifier/src/poc.rs
+++ b/iot_verifier/src/poc.rs
@@ -1,7 +1,11 @@
 use crate::{
-    entropy::ENTROPY_LIFESPAN, gateway_cache::GatewayCache, gateway_cache::GatewayCacheError,
-    hex_density::HexDensityMap, last_beacon::LastBeacon, last_witness::LastWitness,
+    entropy::ENTROPY_LIFESPAN,
+    gateway_cache::{GatewayCache, GatewayCacheError},
+    hex_density::HexDensityMap,
+    last_beacon::LastBeacon,
+    last_witness::LastWitness,
     region_cache::RegionCache,
+    witness_updater::WitnessUpdater,
 };
 use beacon;
 use chrono::{DateTime, Duration, DurationRound, Utc};
@@ -28,7 +32,7 @@ use rust_decimal::Decimal;
 use sqlx::PgPool;
 use std::f64::consts::PI;
 
-pub type GenericVerifyResult<T = ()> = std::result::Result<T, InvalidResponse>;
+pub type GenericVerifyResult<T = ()> = Result<T, InvalidResponse>;
 
 /// C is the speed of light in air in meters per second
 pub const C: f64 = 2.998e8;
@@ -114,6 +118,7 @@ impl Poc {
         gateway_cache: &GatewayCache,
         region_cache: &RegionCache<G>,
         deny_list: &DenyList,
+        witness_updater: &WitnessUpdater,
     ) -> anyhow::Result<VerifyBeaconResult>
     where
         G: Gateways,
@@ -146,7 +151,7 @@ impl Poc {
             Err(err) => return Err(anyhow::Error::from(err)),
         };
         // we have beaconer info, proceed to verifications
-        let last_beacon = LastBeacon::get(&self.pool, beaconer_pub_key.as_ref()).await?;
+        let last_beacon = LastBeacon::get(&self.pool, &beaconer_pub_key).await?;
         match do_beacon_verifications(
             deny_list,
             self.entropy_start,
@@ -168,15 +173,16 @@ impl Poc {
                 if !self.witness_reports.is_empty() {
                     LastBeacon::update_last_timestamp(
                         &self.pool,
-                        beaconer_pub_key.as_ref(),
+                        &beaconer_pub_key,
                         self.beacon_report.received_timestamp,
                     )
                     .await?;
                 }
+
                 // post regular validations, check for beacon reciprocity
                 // if this check fails we will invalidate the beacon
                 // even tho it has passed all regular validations
-                if !self.verify_beacon_reciprocity().await? {
+                if !self.verify_beacon_reciprocity(witness_updater).await? {
                     Ok(VerifyBeaconResult::invalid(
                         InvalidReason::GatewayNoValidWitnesses,
                         None,
@@ -200,8 +206,9 @@ impl Poc {
         hex_density_map: &HexDensityMap,
         gateway_cache: &GatewayCache,
         deny_list: &DenyList,
+        witness_updater: &WitnessUpdater,
     ) -> anyhow::Result<VerifyWitnessesResult> {
-        let mut witnesses_to_update: Vec<(PublicKeyBinary, DateTime<Utc>)> = Vec::new();
+        let mut witnesses_to_update: Vec<LastWitness> = Vec::new();
         let mut verified_witnesses: Vec<IotVerifiedWitnessReport> = Vec::new();
         let mut failed_witnesses: Vec<IotWitnessIngestReport> = Vec::new();
         let mut existing_gateways: Vec<PublicKeyBinary> = Vec::new();
@@ -231,17 +238,15 @@ impl Poc {
                             existing_gateways.push(verified_witness.report.pub_key.clone());
                             if verified_witness.status == VerificationStatus::Valid {
                                 // add to list of witness to update last timestamp off
-                                witnesses_to_update.push((
-                                    witness_report.report.pub_key.clone(),
-                                    verified_witness.received_timestamp,
-                                ));
+                                witnesses_to_update.push(LastWitness {
+                                    id: witness_report.report.pub_key.clone(),
+                                    timestamp: verified_witness.received_timestamp,
+                                });
+
                                 // post regular validations, check for witness reciprocity
                                 // if this check fails we will invalidate the witness
                                 // even tho it has passed all regular validations
-                                if !self
-                                    .verify_witness_reciprocity(&witness_report.report.pub_key)
-                                    .await?
-                                {
+                                if !self.verify_witness_reciprocity(&witness_report).await? {
                                     verified_witness.status = VerificationStatus::Invalid;
                                     verified_witness.invalid_reason =
                                         InvalidReason::GatewayNoValidBeacons;
@@ -271,10 +276,8 @@ impl Poc {
             }
         }
 
-        // update the last witness timestamp for any witness which has successfully passed regular validations
-        if !witnesses_to_update.is_empty() {
-            LastWitness::bulk_update_last_timestamps(&self.pool, witnesses_to_update).await?
-        };
+        // save a list of gateways which require their last witness timestamp to be updated
+        witness_updater.update(witnesses_to_update).await?;
 
         let resp = VerifyWitnessesResult {
             verified_witnesses,
@@ -381,28 +384,29 @@ impl Poc {
         }
     }
 
-    async fn verify_beacon_reciprocity(&self) -> anyhow::Result<bool> {
+    async fn verify_beacon_reciprocity(
+        &self,
+        witness_updater: &WitnessUpdater,
+    ) -> anyhow::Result<bool> {
         if !self.witness_reports.is_empty() {
-            let last_witness =
-                LastWitness::get(&self.pool, self.beacon_report.report.pub_key.as_ref()).await?;
-            if let Some(last_witness) = last_witness {
-                return Ok(
-                    self.beacon_report.received_timestamp - last_witness.timestamp
-                        < *RECIPROCITY_WINDOW,
-                );
-            }
+            let last_witness = witness_updater
+                .get_last_witness(&self.beacon_report.report.pub_key)
+                .await?;
+            return Ok(last_witness.map_or(false, |lw| {
+                self.beacon_report.received_timestamp - lw.timestamp < *RECIPROCITY_WINDOW
+            }));
         }
         Ok(false)
     }
 
-    async fn verify_witness_reciprocity(&self, pubkey: &PublicKeyBinary) -> anyhow::Result<bool> {
-        let last_beacon = LastBeacon::get(&self.pool, pubkey.as_ref()).await?;
-        if let Some(last_beacon) = last_beacon {
-            if self.beacon_report.received_timestamp - last_beacon.timestamp < *RECIPROCITY_WINDOW {
-                return Ok(true);
-            }
-        };
-        Ok(false)
+    async fn verify_witness_reciprocity(
+        &self,
+        report: &IotWitnessIngestReport,
+    ) -> anyhow::Result<bool> {
+        let last_beacon = LastBeacon::get(&self.pool, &report.report.pub_key).await?;
+        Ok(last_beacon.map_or(false, |lw| {
+            report.received_timestamp - lw.timestamp < *RECIPROCITY_WINDOW
+        }))
     }
 }
 
@@ -1217,14 +1221,13 @@ mod tests {
 
     #[test]
     fn test_verify_beacon_schedule() {
-        let id: &str = "test_id";
         let beacon_interval = Duration::seconds(21600); // 6 hours
         let last_beacon_ts: DateTime<Utc> =
             DateTime::parse_from_str("2023 Jan 02 00:00:01 +0000", "%Y %b %d %H:%M:%S %z")
                 .unwrap()
                 .into();
         let last_beacon = Some(LastBeacon {
-            id: id.as_bytes().to_vec(),
+            id: PublicKeyBinary::from_str(PUBKEY1).unwrap(),
             timestamp: last_beacon_ts,
         });
         // beacon is in a later bucket ( by one hour) after last beacon, expectation pass
@@ -1653,7 +1656,7 @@ mod tests {
         // test schedule verification is active in the beacon validation list
         let beacon_report3 = valid_beacon_report(PUBKEY1, entropy_start + Duration::minutes(2));
         let last_beacon3 = LastBeacon {
-            id: vec![],
+            id: PublicKeyBinary::from_str(PUBKEY1).unwrap(),
             timestamp: Utc::now() - Duration::hours(5),
         };
         let resp3 = do_beacon_verifications(

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -5,7 +5,9 @@ use crate::{
     poc_report::Report,
     region_cache::RegionCache,
     reward_share::GatewayPocShare,
-    telemetry, Settings,
+    telemetry,
+    witness_updater::WitnessUpdater,
+    Settings,
 };
 use chrono::{Duration as ChronoDuration, Utc};
 use denylist::DenyList;
@@ -54,6 +56,7 @@ pub struct Runner<G> {
     pub invalid_witness_sink: FileSinkClient,
     pub poc_sink: FileSinkClient,
     pub hex_density_map: HexDensityMap,
+    pub witness_updater: WitnessUpdater,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -98,6 +101,7 @@ where
         invalid_witness_sink: FileSinkClient,
         poc_sink: FileSinkClient,
         hex_density_map: HexDensityMap,
+        witness_updater: WitnessUpdater,
     ) -> anyhow::Result<Self> {
         let beacon_interval = settings.beacon_interval()?;
         let max_witnesses_per_poc = settings.max_witnesses_per_poc;
@@ -134,6 +138,7 @@ where
             invalid_witness_sink,
             poc_sink,
             hex_density_map,
+            witness_updater,
         })
     }
 
@@ -268,6 +273,7 @@ where
                 &self.gateway_cache,
                 &self.region_cache,
                 &self.deny_list,
+                &self.witness_updater,
             )
             .await?;
         match beacon_verify_result.result {
@@ -280,6 +286,7 @@ where
                             &self.hex_density_map,
                             &self.gateway_cache,
                             &self.deny_list,
+                            &self.witness_updater,
                         )
                         .await?;
 

--- a/iot_verifier/src/witness_updater.rs
+++ b/iot_verifier/src/witness_updater.rs
@@ -1,0 +1,151 @@
+use crate::last_witness::LastWitness;
+use futures::future::LocalBoxFuture;
+use futures_util::TryFutureExt;
+use helium_crypto::PublicKeyBinary;
+use metrics::Gauge;
+use sqlx::PgPool;
+use std::{collections::HashMap, sync::Arc};
+use task_manager::ManagedTask;
+use tokio::{
+    sync::{mpsc, RwLock},
+    time::{self, MissedTickBehavior},
+};
+
+const WRITE_INTERVAL: time::Duration = time::Duration::from_secs(60);
+
+pub type WitnessMap = HashMap<PublicKeyBinary, LastWitness>;
+pub type MessageSender = mpsc::Sender<Vec<LastWitness>>;
+pub type MessageReceiver = mpsc::Receiver<Vec<LastWitness>>;
+
+#[derive(Clone)]
+struct Telemetry {
+    queue_gauge: Gauge,
+}
+
+impl Telemetry {
+    fn new() -> Self {
+        let gauge = metrics::register_gauge!("iot_verifier_witness_updater_queue");
+        gauge.set(0.0);
+        Self { queue_gauge: gauge }
+    }
+
+    fn increment_queue(&self) {
+        self.queue_gauge.increment(1.0);
+    }
+
+    fn decrement_queue(&self) {
+        self.queue_gauge.decrement(1.0);
+    }
+}
+
+pub struct WitnessUpdater {
+    pool: PgPool,
+    cache: Arc<RwLock<WitnessMap>>,
+    sender: MessageSender,
+    telemetry: Telemetry,
+}
+
+pub struct WitnessUpdaterServer {
+    pool: PgPool,
+    cache: Arc<RwLock<WitnessMap>>,
+    receiver: MessageReceiver,
+    telemetry: Telemetry,
+}
+
+impl ManagedTask for WitnessUpdaterServer {
+    fn start_task(
+        self: Box<Self>,
+        shutdown: triggered::Listener,
+    ) -> LocalBoxFuture<'static, anyhow::Result<()>> {
+        let handle = tokio::spawn(self.run(shutdown));
+        Box::pin(
+            handle
+                .map_err(anyhow::Error::from)
+                .and_then(|result| async move { result.map_err(anyhow::Error::from) }),
+        )
+    }
+}
+
+impl WitnessUpdater {
+    pub async fn new(pool: PgPool) -> anyhow::Result<(Self, WitnessUpdaterServer)> {
+        let cache = Arc::new(RwLock::new(WitnessMap::new()));
+        let (sender, receiver) = mpsc::channel(500);
+        let telemetry = Telemetry::new();
+        Ok((
+            Self {
+                pool: pool.clone(),
+                cache: cache.clone(),
+                sender,
+                telemetry: telemetry.clone(),
+            },
+            WitnessUpdaterServer {
+                pool,
+                cache,
+                receiver,
+                telemetry,
+            },
+        ))
+    }
+
+    pub async fn get_last_witness(
+        &self,
+        pubkey: &PublicKeyBinary,
+    ) -> anyhow::Result<Option<LastWitness>> {
+        match self.cache.read().await.get(pubkey) {
+            Some(witness) => Ok(Some(witness.clone())),
+            None => LastWitness::get(&self.pool, pubkey).await,
+        }
+    }
+
+    pub async fn update(&self, witnesses: Vec<LastWitness>) -> anyhow::Result<()> {
+        self.telemetry.increment_queue();
+        self.sender
+            .send(witnesses)
+            .await
+            .map_err(anyhow::Error::from)
+    }
+}
+
+impl WitnessUpdaterServer {
+    pub async fn run(mut self, shutdown: triggered::Listener) -> anyhow::Result<()> {
+        tracing::info!("starting witness updater process");
+        let mut write_timer = time::interval(WRITE_INTERVAL);
+        write_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown.clone() => break,
+                _ = write_timer.tick() => {
+                    self.write_cache().await?;
+                }
+                message = self.receiver.recv() => {
+                    if let Some(updates) = message {
+                        self.telemetry.decrement_queue();
+                        self.update_cache(updates).await;
+                    }
+                }
+            }
+        }
+        tracing::info!("stopping witness updater process");
+        Ok(())
+    }
+
+    pub async fn write_cache(&mut self) -> anyhow::Result<()> {
+        let mut cache = self.cache.write().await;
+        if !cache.is_empty() {
+            let updates = cache.values().collect::<Vec<_>>();
+            tracing::info!("writing {} updates to db", updates.len());
+            LastWitness::bulk_update_last_timestamps(&self.pool, updates).await?;
+            cache.clear();
+        }
+        Ok(())
+    }
+
+    pub async fn update_cache(&mut self, updates: Vec<LastWitness>) {
+        tracing::debug!("updating cache with {} entries", updates.len());
+        let mut cache = self.cache.write().await;
+        updates.into_iter().for_each(|update| {
+            cache.insert(update.id.clone(), update);
+        });
+    }
+}

--- a/iot_verifier/tests/common/mod.rs
+++ b/iot_verifier/tests/common/mod.rs
@@ -311,7 +311,7 @@ pub async fn inject_last_beacon(
     gateway: PublicKeyBinary,
     ts: DateTime<Utc>,
 ) -> anyhow::Result<()> {
-    LastBeacon::update_last_timestamp(&mut *txn, gateway.as_ref(), ts).await
+    LastBeacon::update_last_timestamp(&mut *txn, &gateway, ts).await
 }
 
 #[allow(dead_code)]
@@ -320,7 +320,7 @@ pub async fn inject_last_witness(
     gateway: PublicKeyBinary,
     ts: DateTime<Utc>,
 ) -> anyhow::Result<()> {
-    LastWitness::update_last_timestamp(&mut *txn, gateway.as_ref(), ts).await
+    LastWitness::update_last_timestamp(&mut *txn, &gateway, ts).await
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
This addresses DB deadlock errors encountered as a result of the recent reciprocity check implementation.   

The core of the deadlock issue is as follows:

1. we spawn up to 100 concurrent POCs
2. each poc process attempts to bulk update the last witness table to record the timestamp of each gateway's last witness event
3. if across multiple POCs there are one or more reports from the same gateway, then it is possible for those concurrent processes to attempt to update the same record of the last witness table at the same time, thus triggering the deadlock

NOTE: the deadlock did not result in any loss of data or a drop in POCs being processed. Any POC which hit the deadlock would be re-queued and retried next tick ( up to a max of 10 times )

The fix is to serialize all writes to the last witness table via the new witness_updater process.  The POC processes use a channel to send list of updates to the witness_updater, those get pushed to a map and periodically the map is dumped to the DB.  

In order to ensure the POC processes always have access to the latest data ( and before it hits the DB ) the witness_updater also exposes its map to act as a cache. 

There is no observable drop in performance.

I also applied some minor refactoring.  I plan to follow up with another PR to apply further refactoring including the use of transactions within the context of each poc