### PR TITLE
fail beacons with no witnesses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#c2b1dfa06e6f726ab19cd50444b2a90dd6c841e0"
+source = "git+https://github.com/helium/proto?branch=andymck/add-invalid-reason-beacon-no-witnesses#e1d7be930639cb41d60676905cb0f3acaa7a72d5"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
@@ -1600,7 +1600,7 @@ dependencies = [
  "rand_chacha 0.3.0",
  "rust_decimal",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "thiserror",
 ]
 
@@ -3556,7 +3556,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#c2b1dfa06e6f726ab19cd50444b2a90dd6c841e0"
+source = "git+https://github.com/helium/proto?branch=andymck/add-invalid-reason-beacon-no-witnesses#e1d7be930639cb41d60676905cb0f3acaa7a72d5"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,14 +62,14 @@ sqlx = {version = "0", features = [
 ]}
 helium-anchor-gen = {git = "https://github.com/helium/helium-anchor-gen.git"}
 helium-crypto = {version = "0.8.1", features=["sqlx-postgres", "multisig"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "andymck/add-invalid-reason-beacon-no-witnesses", features = ["services"]}
 hextree = "*"
 solana-client = "1.16"
 solana-sdk = "1.16"
 solana-program = "1.16"
 spl-token = "3.5.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
-beacon = { git = "https://github.com/helium/proto", branch = "master" }
+beacon = { git = "https://github.com/helium/proto", branch = "andymck/add-invalid-reason-beacon-no-witnesses" }
 humantime = "2"
 metrics = "0"
 metrics-exporter-prometheus = "0"


### PR DESCRIPTION
This adds a new beacon verification which requires beacons to have at least one witness.  Any beacon reports which fail this verification will be declared invalid with a newly added invalid reason: `BeaconNoWitnesses`

This is to address the current scenario whereby a gateway which is submitting beacon reports but does not have any witnesses ( be that due to being a lone wolf or it has faulty hardware preventing it from being able to transmit) from being able to receive witnessing rewards.  

Prior to this change the gateways beacon reports would pass regular verifications and then subsequently fail reciprocity as the beacon reciprocity check would return invalid as the beacon had no witnesses.  As the last_beacon timestamp is updated should the beacon pass regular verifications it resulted in a gap whereby the gateway was able to witness and earn rewards for those witnesses, despite it never having a successful beacon ( ie passing both regular verifications + reciprocity ).

With this change the rule that the last beacon timestamp is updated should the beacon pass regular verifications is maintained but the check to enforce at least one witness is moved out of the beacon reciprocity check and into a regular standalone verification.  This results in the gateways described being prevented from being able to earn beaconing or witnessing rewards.