### PR TITLE
add ExternalError variant to file_store::error::Error

### DIFF
--- a/file_store/src/error.rs
+++ b/file_store/src/error.rs
@@ -37,6 +37,8 @@ pub enum Error {
     DbError(#[from] sqlx::Error),
     #[error("channel send error")]
     SendError(#[from] tokio::sync::mpsc::error::SendError<()>),
+    #[error("External Error")]
+    ExternalError(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
 #[derive(Error, Debug)]

--- a/file_store/src/error.rs
+++ b/file_store/src/error.rs
@@ -37,7 +37,7 @@ pub enum Error {
     DbError(#[from] sqlx::Error),
     #[error("channel send error")]
     SendError(#[from] tokio::sync::mpsc::error::SendError<()>),
-    //Generic error wrapper for external (out of that repository) traits implementations. 
+    //Generic error wrapper for external (out of that repository) traits implementations.
     //Not recommended for internal use!
     #[error("external error")]
     ExternalError(#[from] Box<dyn std::error::Error + Send + Sync>),

--- a/file_store/src/error.rs
+++ b/file_store/src/error.rs
@@ -37,7 +37,9 @@ pub enum Error {
     DbError(#[from] sqlx::Error),
     #[error("channel send error")]
     SendError(#[from] tokio::sync::mpsc::error::SendError<()>),
-    #[error("External Error")]
+    //Generic error wrapper for external (out of that repository) traits implementations. 
+    //Not recommended for internal use!
+    #[error("external error")]
     ExternalError(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 


### PR DESCRIPTION
Add ExternalError variant to file_store::error::Error. It will simplify external implementation of MsgDecode, StateRecord and State traits. 