### PR TITLE
apply reciprocity checks post beacon & witness verification

### DIFF
--- a/iot_verifier/tests/runner_tests.rs
+++ b/iot_verifier/tests/runner_tests.rs
@@ -981,24 +981,18 @@ async fn valid_new_gateway_beacon_first_reciprocity(pool: PgPool) -> anyhow::Res
 }
 
 #[sqlx::test]
-async fn valid_beacon_and_no_witnesses(pool: PgPool) -> anyhow::Result<()> {
+async fn valid_lone_wolf_beacon(pool: PgPool) -> anyhow::Result<()> {
     let test_beacon_interval = ChronoDuration::seconds(5);
     let mut ctx = TestContext::setup(pool.clone(), test_beacon_interval).await?;
     let now = ctx.entropy_ts;
 
-    // simulate a gateway submitting a beacon which is not witnessed by other gateways
-    // this replicates a scenario whereby a gateway cannot broadcast due to a hardware failure
-    // but yet continues to submit beacon reports to the oracle
-    // also simulates a lone wolf gateway, broadcasting and no one around to hear it
+    // simulate a lone wolf gateway, broadcasting and no one around to hear it
     // the gateway uses beaconer1 pubkey
-    // the gateway will not be able to successfully witness other gateways due to reciprocity
-    // until it has successfully had a beacon witnessed by another gateway
 
     //
     // step 1 - generate a beacon from beaconer1,
-    //          this beacon will be valid but will fail reciprocity check as there are no witnesses
-    //          from other gateways for the beacon
-    //          last beacon timestamp will NOT as there are no witnesses
+    //          this beacon will be valid but will fail reciprocity check as the gateway has not previously witnessed
+    //          last beacon timestamp will NOT be updated as there are no witnesses to the beacon
     //
     let beacon_to_inject = common::create_valid_beacon_report(common::BEACONER1, ctx.entropy_ts);
     common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
@@ -1022,9 +1016,13 @@ async fn valid_beacon_and_no_witnesses(pool: PgPool) -> anyhow::Result<()> {
 
     //
     // step 2
+    // confirm beaconer1's last beacon timestamp was not updated
+    // the gateway should not be able to witness a beacon and will fail reciprocity check
+
     // generate a beacon from beaconer5 and have it witnessed by beaconer1
-    // the witness will fail reciprocity check as beaconer1 does not have
-    // a current last beacon timestamp
+    // the beacon will be successful but the witness will fail reciprocity check
+    // as beaconer1 does not have a current last beacon timestamp
+    // beaconer1's last witness timestamp will be updated ( as its witness was structurally valid )
     //
 
     let beacon_to_inject = common::create_valid_beacon_report(common::BEACONER5, ctx.entropy_ts);
@@ -1032,7 +1030,8 @@ async fn valid_beacon_and_no_witnesses(pool: PgPool) -> anyhow::Result<()> {
     common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
     common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
 
-    // inject last beacon & witness timestamps into the DB for beaconer 5 - allow it to pass reciprocity checks
+    // inject last beacon & witness timestamps into the DB for beaconer 5
+    // allow it to pass reciprocity checks
     let mut txn = pool.begin().await?;
     common::inject_last_beacon(
         &mut txn,
@@ -1080,44 +1079,101 @@ async fn valid_beacon_and_no_witnesses(pool: PgPool) -> anyhow::Result<()> {
         InvalidParticipantSide::Witness as i32,
         invalid_witness_report.participant_side
     );
+    Ok(())
+}
+
+#[sqlx::test]
+async fn valid_two_isolated_gateways_beaconing_and_witnessing(pool: PgPool) -> anyhow::Result<()> {
+    let test_beacon_interval = ChronoDuration::seconds(5);
+    let mut ctx = TestContext::setup(pool.clone(), test_beacon_interval).await?;
+
+    // simulate two gateways with no recent activity coming online and
+    // witnessing each others beacons
 
     //
-    // step 3
-    // generate a second beacon attempt from beaconer1
-    // and witness the beacon from another gateway
-    // this beacon will pass the reciprocity check now that it has an associated witness
-    // the witness itself will also pass the reciprocity check as we pre seed necessary timestamps
+    // step 1
+    // generate a beacon from gateway1 with gateway 2 as witness
+    // this beacon will be valid but will fail reciprocity check as no previous witness
+    // gateway 1's last beacon timestamp will be updated
+    // gateway 2's last witness timestamp will be updated
     //
-
-    // sleep to ensure the second beacon fits with the beaconing interval
-    tokio::time::sleep(Duration::from_secs(5)).await;
-
-    let beacon_to_inject = common::create_valid_beacon_report(
-        common::BEACONER1,
-        ctx.entropy_ts + test_beacon_interval,
-    );
-    let witness_to_inject = common::create_valid_witness_report(
-        common::WITNESS1,
-        ctx.entropy_ts + test_beacon_interval,
-    );
+    let beacon_to_inject = common::create_valid_beacon_report(common::BEACONER1, ctx.entropy_ts);
+    let witness_to_inject = common::create_valid_witness_report(common::WITNESS1, ctx.entropy_ts);
     common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
     common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
 
-    // seed last beacons and witness reports into the DB for witnesser
-    let mut txn = pool.begin().await?;
-    common::inject_last_beacon(
-        &mut txn,
-        witness_to_inject.report.pub_key.clone(),
-        now - (test_beacon_interval + ChronoDuration::seconds(10)),
-    )
-    .await?;
-    common::inject_last_witness(
-        &mut txn,
-        witness_to_inject.report.pub_key.clone(),
-        now - (test_beacon_interval + ChronoDuration::seconds(10)),
-    )
-    .await?;
-    txn.commit().await?;
+    ctx.runner.handle_db_tick().await?;
+
+    let invalid_beacon = ctx.invalid_beacons.receive_invalid_beacon().await;
+    let invalid_beacon_report = invalid_beacon.report.clone().unwrap();
+    println!("{:?}", invalid_beacon);
+    // assert the pubkeys in the outputted reports
+    // match those which we injected
+    assert_eq!(
+        PublicKeyBinary::from(invalid_beacon_report.pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER1).unwrap()
+    );
+    // assert the invalid details
+    assert_eq!(
+        InvalidReason::GatewayNoValidWitnesses as i32,
+        invalid_beacon.reason
+    );
+
+    //
+    // step 2
+    // generate a beacon from gateway2 with gateway 1 as witness,
+    // this beacon will be valid and will pass reciprocity check as the gateway 2 witnessed previously
+    // gateway 2's last beacon timestamp will be updated
+    // gateway 1's last witness timestamp will be updated
+    //
+
+    let beacon_to_inject = common::create_valid_beacon_report(common::WITNESS1, ctx.entropy_ts);
+    let witness_to_inject = common::create_valid_witness_report(common::BEACONER1, ctx.entropy_ts);
+    common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
+    common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
+
+    ctx.runner.handle_db_tick().await?;
+
+    let valid_poc = ctx.valid_pocs.receive_valid_poc().await;
+    println!("{:?}", valid_poc);
+    assert_eq!(1, valid_poc.selected_witnesses.len());
+    assert_eq!(0, valid_poc.unselected_witnesses.len());
+    let valid_beacon = valid_poc.beacon_report.unwrap().report.clone().unwrap();
+    let valid_witness_report = valid_poc.selected_witnesses[0].clone();
+    let valid_witness = valid_witness_report.report.unwrap();
+    // assert the pubkeys in the outputted reports
+    // match those which we injected
+    assert_eq!(
+        PublicKeyBinary::from(valid_beacon.pub_key.clone()),
+        PublicKeyBinary::from_str(common::WITNESS1).unwrap()
+    );
+    assert_eq!(
+        PublicKeyBinary::from(valid_witness.pub_key.clone()),
+        PublicKeyBinary::from_str(common::BEACONER1).unwrap()
+    );
+    // assert the witness reports status
+    assert_eq!(
+        VerificationStatus::Valid as i32,
+        valid_witness_report.status
+    );
+
+    //
+    // step 3
+    // generate a beacon from gateway1 with gateway 2 as witness,
+    // this beacon will be valid and pass reciprocity check as gateway 1 previously witnessed
+    // gateway 2 has previously beaconed and so its witness will also be valid
+    //
+
+    let beacon_to_inject = common::create_valid_beacon_report(
+        common::BEACONER1,
+        ctx.entropy_ts + ChronoDuration::seconds(5),
+    );
+    let witness_to_inject = common::create_valid_witness_report(
+        common::WITNESS1,
+        ctx.entropy_ts + ChronoDuration::seconds(5),
+    );
+    common::inject_beacon_report(pool.clone(), beacon_to_inject.clone()).await?;
+    common::inject_witness_report(pool.clone(), witness_to_inject.clone()).await?;
 
     ctx.runner.handle_db_tick().await?;
 
@@ -1143,5 +1199,6 @@ async fn valid_beacon_and_no_witnesses(pool: PgPool) -> anyhow::Result<()> {
         VerificationStatus::Valid as i32,
         valid_witness_report.status
     );
+
     Ok(())
 }


### PR DESCRIPTION
Refactor the reciprocity checks.  As part of this refactor, some furniture has been moved around and some obvious poor code updated in order to make the functional changes clearer to follow.  There remains a lot of opportunity for additional refactor but it goes beyond the scope of this PR and including any additional refactor makes it difficult to determine the scope of actual functional changes.   

NOTE: regular verifications = all report verifications excluding reciprocity checks

The reciprocity checks have been moved out of the `poc` beacon and witness verification flows and into the `runner` where they are applied post regular verifications of the beacon and witnesses .  Reciprocity checks are applied to the witnesses only if the beacon itself is valid ( ie all regular verifications render the beacon valid ).

During regular verifications of a beacon and witness report the last_beacon and last_witness timestamps are always updated if the reports pass regular verifications.

This addresses the scenario where there are two gateways in isolation with no prior recent activity and which are witnessing each others beacons.  Prior to this fix these beacons would always have been declared invalid as neither gateway would have a valid last_witness timestamp.  The last witness timestamp would never get updated as the witnesses for the beacon reports would never be verified due to the beacons themselves being invalidated due to failing reciprocity check.

Now, witnesses will always be verified when a beacon passes regular verifications and the last witness timestamps will be updated for any witness passing regular verification.  Reciprocity checks will then be applied to any valid beacon and any valid witnesses

In addition, when a beacon is submitted with no witnesses it will not longer be failed on the reciprocity checks.  Instead if it passes regular verifications, it will be rendered valid.  However the last beacon timestamp will not be updated in this scenario and thus a beacon without witnesses will not be counted against reciprocity
