### PR TITLE
Update seniority update to include new field that is seniority timestamp in milliseconds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=bbalser/seniority-milliseconds#c042b93087ee2c96121401ed552df44f0c0be938"
+source = "git+https://github.com/helium/proto?branch=master#009aeadc1fcd3028cb5b52676a44d7920f1d162b"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
@@ -3556,7 +3556,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=bbalser/seniority-milliseconds#c042b93087ee2c96121401ed552df44f0c0be938"
+source = "git+https://github.com/helium/proto?branch=master#009aeadc1fcd3028cb5b52676a44d7920f1d162b"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#7011d31e39af8d548466c820a7c1409288a7f48e"
+source = "git+https://github.com/helium/proto?branch=bbalser/seniority-milliseconds#c042b93087ee2c96121401ed552df44f0c0be938"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
@@ -3556,7 +3556,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#7011d31e39af8d548466c820a7c1409288a7f48e"
+source = "git+https://github.com/helium/proto?branch=bbalser/seniority-milliseconds#c042b93087ee2c96121401ed552df44f0c0be938"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,13 +63,13 @@ sqlx = {version = "0", features = [
 helium-anchor-gen = {git = "https://github.com/helium/helium-anchor-gen.git"}
 helium-crypto = {version = "0.8.1", features=["sqlx-postgres", "multisig"]}
 hextree = {git = "https://github.com/jaykickliter/HexTree", branch = "main", features = ["disktree"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "bbalser/seniority-milliseconds", features = ["services"]}
 solana-client = "1.16"
 solana-sdk = "1.16"
 solana-program = "1.16"
 spl-token = "3.5.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
-beacon = { git = "https://github.com/helium/proto", branch = "master" }
+beacon = { git = "https://github.com/helium/proto", branch = "bbalser/seniority-milliseconds" }
 humantime = "2"
 metrics = "0"
 metrics-exporter-prometheus = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,13 +63,13 @@ sqlx = {version = "0", features = [
 helium-anchor-gen = {git = "https://github.com/helium/helium-anchor-gen.git"}
 helium-crypto = {version = "0.8.1", features=["sqlx-postgres", "multisig"]}
 hextree = {git = "https://github.com/jaykickliter/HexTree", branch = "main", features = ["disktree"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "bbalser/seniority-milliseconds", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
 solana-client = "1.16"
 solana-sdk = "1.16"
 solana-program = "1.16"
 spl-token = "3.5.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
-beacon = { git = "https://github.com/helium/proto", branch = "bbalser/seniority-milliseconds" }
+beacon = { git = "https://github.com/helium/proto", branch = "master" }
 humantime = "2"
 metrics = "0"
 metrics-exporter-prometheus = "0"

--- a/mobile_verifier/src/heartbeats/mod.rs
+++ b/mobile_verifier/src/heartbeats/mod.rs
@@ -827,6 +827,7 @@ impl<'a> SeniorityUpdate<'a> {
 }
 
 impl SeniorityUpdate<'_> {
+    #[allow(deprecated)]
     pub async fn write(&self, seniorities: &FileSinkClient) -> anyhow::Result<()> {
         if let SeniorityUpdateAction::Insert {
             new_seniority,
@@ -839,6 +840,7 @@ impl SeniorityUpdate<'_> {
                         key_type: Some(self.heartbeat.heartbeat.key().into()),
                         new_seniority_timestamp: new_seniority.timestamp() as u64,
                         reason: update_reason as i32,
+                        new_seniority_timestamp_ms: new_seniority.timestamp_millis() as u64,
                     },
                     [],
                 )


### PR DESCRIPTION
Had feedback from community that multiple radios have same signal power and seniority timestamp.  Upon investigation the issue that we only output the seniority timestamp in seconds and that the seniority timestamps in this example are not equals but have only millisecond difference.  

This PR deprecates the current second on timestamp and adds a new seniority timestamp in milliseconds to the seniority update protobuf.

Proto PR: https://github.com/helium/proto/pull/396