### PR TITLE
handle blockhash-not-found errors for mobile packet verifier

### DIFF
--- a/boost_manager/src/db.rs
+++ b/boost_manager/src/db.rs
@@ -117,7 +117,7 @@ pub async fn save_batch_txn_id(
     .map(|_| ())?)
 }
 
-pub async fn revert_saved_batch(db: &Pool<Postgres>, hexes: &[u64]) -> anyhow::Result<()> {
+pub async fn revert_saved_batch_txn_id(db: &Pool<Postgres>, hexes: &[u64]) -> anyhow::Result<()> {
     let hexes = hexes.iter().map(|x| *x as i64).collect::<Vec<i64>>();
     Ok(sqlx::query(
         r#"

--- a/boost_manager/src/main.rs
+++ b/boost_manager/src/main.rs
@@ -125,7 +125,7 @@ impl Server {
             settings.activation_check_interval,
             settings.txn_batch_size(),
             solana,
-            settings.txn_retry_delay(),
+            settings.txn_retry_delay,
         )?;
 
         let purger = Purger::new(pool.clone(), settings.retention_period);

--- a/boost_manager/src/main.rs
+++ b/boost_manager/src/main.rs
@@ -125,6 +125,7 @@ impl Server {
             settings.activation_check_interval,
             settings.txn_batch_size(),
             solana,
+            settings.txn_retry_delay(),
         )?;
 
         let purger = Purger::new(pool.clone(), settings.retention_period);

--- a/boost_manager/src/settings.rs
+++ b/boost_manager/src/settings.rs
@@ -41,7 +41,7 @@ pub struct Settings {
     #[serde(with = "humantime_serde", default = "default_retention_period")]
     pub retention_period: Duration,
     #[serde(with = "humantime_serde", default = "default_txn_retry_delay")]
-    txn_retry_delay: Duration,
+    pub txn_retry_delay: Duration,
 }
 
 fn default_txn_retry_delay() -> Duration {

--- a/boost_manager/src/settings.rs
+++ b/boost_manager/src/settings.rs
@@ -40,6 +40,12 @@ pub struct Settings {
     // default retention period in seconds
     #[serde(with = "humantime_serde", default = "default_retention_period")]
     pub retention_period: Duration,
+    #[serde(with = "humantime_serde", default = "default_txn_retry_delay")]
+    txn_retry_delay: Duration,
+}
+
+fn default_txn_retry_delay() -> Duration {
+    humantime::parse_duration("1 second").unwrap()
 }
 
 fn default_retention_period() -> Duration {

--- a/boost_manager/src/updater.rs
+++ b/boost_manager/src/updater.rs
@@ -122,8 +122,8 @@ where
             let txn = self.solana.make_start_boost_transaction(batch).await?;
             let mut signed_txn = self.sign_and_prep_txn(&txn, &ids).await?;
 
-            // retry the sign and submit if we encounter a blockhash not found error
-            // all other errors will be returned and exit the retry loop
+            // handle retries, if we encounter a blockhash not found error
+            // resign the txn with the latest blockhash before next retry attempt
             let mut attempt: u32 = 1;
             const MAX_ATTEMPTS: u32 = 10;
             loop {

--- a/boost_manager/tests/integrations/updater_tests.rs
+++ b/boost_manager/tests/integrations/updater_tests.rs
@@ -100,6 +100,7 @@ async fn test_process_activations_success(pool: PgPool) -> anyhow::Result<()> {
         Duration::from_secs(10),
         10,
         solana_connection,
+        Duration::from_millis(10),
     )?;
 
     let mut txn = pool.begin().await?;
@@ -129,14 +130,16 @@ async fn test_process_activations_failure(pool: PgPool) -> anyhow::Result<()> {
         Duration::from_secs(10),
         10,
         solana_connection,
+        Duration::from_millis(10),
     )?;
 
     let mut txn = pool.begin().await?;
     seed_activations(&mut txn, now).await?;
     txn.commit().await?;
 
-    // ensure the activations are processed at least 10 times
+    // process the activations
     // submit_txn will bork each time
+    // a failing txn will by default be retried 10 times
     // pushing the retries value to exceed max and
     // thus forcing it to FAILED status
     for _ in 1..=11 {

--- a/boost_manager/tests/integrations/updater_tests.rs
+++ b/boost_manager/tests/integrations/updater_tests.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use boost_manager::{db, updater::Updater, OnChainStatus};
 use chrono::{DateTime, Utc};
 use file_store::hex_boost::BoostedHexActivation;
-use solana::{start_boost::SolanaNetwork, GetSignature};
+use solana::{start_boost::SolanaNetwork, GetSignature, IsErrorBlockhashNotFound};
 use solana_sdk::signature::Signature;
 use sqlx::{PgPool, Postgres, Transaction};
 use std::{string::ToString, sync::Mutex, time::Duration};
@@ -45,6 +45,12 @@ impl MockSolanaConnection {
     }
 }
 
+impl IsErrorBlockhashNotFound for Error {
+    fn is_error_blockhash_not_found(&self) -> bool {
+        false
+    }
+}
+
 #[async_trait]
 impl SolanaNetwork for MockSolanaConnection {
     type Error = Error;
@@ -77,10 +83,6 @@ impl SolanaNetwork for MockSolanaConnection {
         transaction: &Self::Transaction,
     ) -> Result<Self::Transaction, Self::Error> {
         Ok(transaction.clone())
-    }
-
-    async fn check_for_blockhash_not_found_error(&self, _err: &Self::Error) -> bool {
-        false
     }
 }
 

--- a/boost_manager/tests/integrations/updater_tests.rs
+++ b/boost_manager/tests/integrations/updater_tests.rs
@@ -71,6 +71,17 @@ impl SolanaNetwork for MockSolanaConnection {
     async fn confirm_transaction(&self, _id: &str) -> Result<bool, Self::Error> {
         Ok(true)
     }
+
+    async fn sign_transaction(
+        &self,
+        transaction: &Self::Transaction,
+    ) -> Result<Self::Transaction, Self::Error> {
+        Ok(transaction.clone())
+    }
+
+    async fn check_for_blockhash_not_found_error(&self, _err: &Self::Error) -> bool {
+        false
+    }
 }
 
 impl GetSignature for MockTransaction {

--- a/iot_packet_verifier/src/burner.rs
+++ b/iot_packet_verifier/src/burner.rs
@@ -114,8 +114,8 @@ where
             .map_err(BurnError::SolanaError)?;
         let mut signed_txn = self.sign_and_prep_txn(&txn, &payer, amount).await?;
 
-        // retry the sign and submit if we encounter a blockhash not found error
-        // all other errors will be returned and exit the retry loop
+        // handle retries, if we encounter a blockhash not found error
+        // resign the txn with the latest blockhash before next retry attempt
         let mut attempt = 1;
         const MAX_ATTEMPTS: u64 = 10;
         loop {

--- a/iot_packet_verifier/src/burner.rs
+++ b/iot_packet_verifier/src/burner.rs
@@ -5,6 +5,7 @@ use crate::{
     },
 };
 use futures::{future::LocalBoxFuture, TryFutureExt};
+use helium_crypto::PublicKeyBinary;
 use solana::{burn::SolanaNetwork, GetSignature};
 use std::time::Duration;
 use task_manager::ManagedTask;
@@ -46,6 +47,8 @@ pub enum BurnError<S> {
     SolanaError(S),
     #[error("Confirm pending transaction error: {0}")]
     ConfirmPendingError(#[from] ConfirmPendingError<S>),
+    #[error("Custom error: {0}")]
+    CustomError(#[from] anyhow::Error),
 }
 
 impl<P, S> Burner<P, S> {
@@ -109,14 +112,54 @@ where
             .make_burn_transaction(&payer, amount)
             .await
             .map_err(BurnError::SolanaError)?;
-        self.pending_tables
-            .add_pending_transaction(&payer, amount, txn.get_signature())
-            .await?;
-        self.solana
-            .submit_transaction(&txn)
-            .await
-            .map_err(BurnError::SolanaError)?;
 
+        // retry the sign and submit if we encounter a blockhash not found error
+        // all other errors will be returned and exit the retry loop
+        // if we dont have a successful burn by the end of the loop, return an error
+        let mut attempt = 1;
+        const MAX_ATTEMPTS: u64 = 10;
+        loop {
+            let signed_txn = self
+                .solana
+                .sign_transaction(&txn)
+                .await
+                .map_err(BurnError::SolanaError)?;
+            self.pending_tables
+                .add_pending_transaction(&payer, amount, signed_txn.get_signature())
+                .await?;
+            match self.solana.submit_transaction(&signed_txn).await {
+                Ok(_) => {
+                    tracing::info!(%payer, %amount, "Burned DC");
+                    self.handle_burn_success(signed_txn, &payer, amount).await?;
+                    break;
+                }
+                Err(err)
+                    if self.solana.check_for_blockhash_not_found_error(&err).await
+                        && attempt < MAX_ATTEMPTS =>
+                {
+                    tracing::error!(%payer, %amount, "block hash not found..possibly stale block hash, resigning txn and retrying");
+                    let mut pending_tables_txn = self.pending_tables.begin().await?;
+                    pending_tables_txn
+                        .remove_pending_transaction(txn.get_signature())
+                        .await?;
+                    pending_tables_txn.commit().await?;
+                    attempt += 1;
+                    continue;
+                }
+                Err(err) => {
+                    Err(BurnError::SolanaError(err))?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_burn_success(
+        &self,
+        txn: S::Transaction,
+        payer: &PublicKeyBinary,
+        amount: u64,
+    ) -> Result<(), BurnError<S::Error>> {
         // Removing the pending transaction and subtract the burn amount
         // now that we have confirmation that the burn transaction is confirmed
         // on chain:
@@ -125,12 +168,12 @@ where
             .remove_pending_transaction(txn.get_signature())
             .await?;
         pending_tables_txn
-            .subtract_burned_amount(&payer, amount)
+            .subtract_burned_amount(payer, amount)
             .await?;
         pending_tables_txn.commit().await?;
 
         let mut balance_lock = self.balances.lock().await;
-        let payer_account = balance_lock.get_mut(&payer).unwrap();
+        let payer_account = balance_lock.get_mut(payer).unwrap();
         // Reduce the pending burn amount and the payer's balance by the amount
         // we've burned.
         payer_account.burned = payer_account.burned.saturating_sub(amount);

--- a/iot_packet_verifier/src/daemon.rs
+++ b/iot_packet_verifier/src/daemon.rs
@@ -129,6 +129,7 @@ impl Cmd {
             &balances,
             settings.burn_period,
             solana.clone(),
+            settings.txn_retry_delay,
         );
 
         let (file_upload, file_upload_server) =

--- a/iot_packet_verifier/src/pending.rs
+++ b/iot_packet_verifier/src/pending.rs
@@ -431,10 +431,6 @@ mod test {
         ) -> Result<Self::Transaction, Self::Error> {
             unreachable!()
         }
-
-        async fn check_for_blockhash_not_found_error(&self, _err: &Self::Error) -> bool {
-            false
-        }
     }
 
     #[tokio::test]

--- a/iot_packet_verifier/src/pending.rs
+++ b/iot_packet_verifier/src/pending.rs
@@ -424,6 +424,17 @@ mod test {
         async fn confirm_transaction(&self, txn: &Signature) -> Result<bool, Self::Error> {
             Ok(self.0.contains(txn))
         }
+
+        async fn sign_transaction(
+            &self,
+            _transaction: &Self::Transaction,
+        ) -> Result<Self::Transaction, Self::Error> {
+            unreachable!()
+        }
+
+        async fn check_for_blockhash_not_found_error(&self, _err: &Self::Error) -> bool {
+            false
+        }
     }
 
     #[tokio::test]

--- a/iot_packet_verifier/src/settings.rs
+++ b/iot_packet_verifier/src/settings.rs
@@ -34,6 +34,13 @@ pub struct Settings {
     /// any disabled orgs.
     #[serde(default = "default_monitor_funds_period")]
     pub monitor_funds_period: Duration,
+    // default delay between retry attempts at submitting solana txns
+    #[serde(default = "default_txn_retry_delay")]
+    pub txn_retry_delay: Duration,
+}
+
+pub fn default_txn_retry_delay() -> Duration {
+    humantime::parse_duration("1 seconds").unwrap()
 }
 
 fn default_start_after() -> DateTime<Utc> {

--- a/iot_packet_verifier/tests/integration_tests.rs
+++ b/iot_packet_verifier/tests/integration_tests.rs
@@ -615,6 +615,17 @@ impl SolanaNetwork for MockSolanaNetwork {
     async fn confirm_transaction(&self, txn: &Signature) -> Result<bool, Self::Error> {
         Ok(self.confirmed.lock().await.contains(txn))
     }
+
+    async fn sign_transaction(
+        &self,
+        transaction: &Self::Transaction,
+    ) -> Result<Self::Transaction, Self::Error> {
+        self.ledger.sign_transaction(transaction).await
+    }
+
+    async fn check_for_blockhash_not_found_error(&self, _err: &Self::Error) -> bool {
+        false
+    }
 }
 
 #[sqlx::test]

--- a/iot_packet_verifier/tests/integration_tests.rs
+++ b/iot_packet_verifier/tests/integration_tests.rs
@@ -454,6 +454,7 @@ async fn test_end_to_end() {
         &balance_cache,
         Duration::default(), // Burn period does not matter, we manually burn
         solana_network.clone(),
+        Duration::from_secs(1),
     );
 
     // Orgs:

--- a/iot_packet_verifier/tests/integration_tests.rs
+++ b/iot_packet_verifier/tests/integration_tests.rs
@@ -622,10 +622,6 @@ impl SolanaNetwork for MockSolanaNetwork {
     ) -> Result<Self::Transaction, Self::Error> {
         self.ledger.sign_transaction(transaction).await
     }
-
-    async fn check_for_blockhash_not_found_error(&self, _err: &Self::Error) -> bool {
-        false
-    }
 }
 
 #[sqlx::test]

--- a/iot_packet_verifier/tests/integration_tests.rs
+++ b/iot_packet_verifier/tests/integration_tests.rs
@@ -629,7 +629,6 @@ impl SolanaNetwork for MockSolanaNetwork {
 }
 
 #[sqlx::test]
-#[ignore]
 async fn test_pending_txns(pool: PgPool) -> anyhow::Result<()> {
     const CONFIRMED_BURN_AMOUNT: u64 = 7;
     const UNCONFIRMED_BURN_AMOUNT: u64 = 11;
@@ -667,10 +666,11 @@ async fn test_pending_txns(pool: PgPool) -> anyhow::Result<()> {
             .make_burn_transaction(&payer, CONFIRMED_BURN_AMOUNT)
             .await
             .unwrap();
-        pool.add_pending_transaction(&payer, CONFIRMED_BURN_AMOUNT, txn.get_signature())
+        let signed_txn = mock_network.sign_transaction(&txn).await.unwrap();
+        pool.add_pending_transaction(&payer, CONFIRMED_BURN_AMOUNT, signed_txn.get_signature())
             .await
             .unwrap();
-        mock_network.submit_transaction(&txn).await.unwrap();
+        mock_network.submit_transaction(&signed_txn).await.unwrap();
     }
 
     // Second is unconfirmed
@@ -679,7 +679,8 @@ async fn test_pending_txns(pool: PgPool) -> anyhow::Result<()> {
             .make_burn_transaction(&payer, UNCONFIRMED_BURN_AMOUNT)
             .await
             .unwrap();
-        pool.add_pending_transaction(&payer, UNCONFIRMED_BURN_AMOUNT, txn.get_signature())
+        let signed_txn = mock_network.sign_transaction(&txn).await.unwrap();
+        pool.add_pending_transaction(&payer, UNCONFIRMED_BURN_AMOUNT, signed_txn.get_signature())
             .await
             .unwrap();
     }

--- a/mobile_packet_verifier/src/burner.rs
+++ b/mobile_packet_verifier/src/burner.rs
@@ -4,7 +4,7 @@ use helium_crypto::PublicKeyBinary;
 use helium_proto::services::packet_verifier::ValidDataTransferSession;
 use solana::burn::SolanaNetwork;
 use sqlx::{FromRow, Pool, Postgres};
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 #[derive(FromRow)]
 pub struct DataTransferSession {
@@ -176,6 +176,7 @@ where
                 }
                 Err(_) if attempt < MAX_ATTEMPTS => {
                     attempt += 1;
+                    tokio::time::sleep(Duration::from_secs(attempt)).await;
                     continue;
                 }
                 Err(err) => {

--- a/mobile_packet_verifier/src/burner.rs
+++ b/mobile_packet_verifier/src/burner.rs
@@ -150,8 +150,8 @@ where
             .sign_transaction(&txn)
             .await
             .map_err(BurnError::SolanaError)?;
-        // retry the sign and submit if we encounter a blockhash not found error
-        // all other errors will be returned and exit the retry loop
+        // handle retries, if we encounter a blockhash not found error
+        // resign the txn with the latest blockhash before next retry attempt
         let mut attempt = 1;
         const MAX_ATTEMPTS: u64 = 10;
         loop {

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -157,7 +157,7 @@ impl Cmd {
         .create()
         .await?;
 
-        let burner = Burner::new(valid_sessions, solana);
+        let burner = Burner::new(valid_sessions, solana, settings.txn_retry_delay);
 
         let file_store = FileStore::from_settings(&settings.ingest).await?;
 

--- a/mobile_packet_verifier/src/settings.rs
+++ b/mobile_packet_verifier/src/settings.rs
@@ -34,6 +34,13 @@ pub struct Settings {
     pub purger_interval: Duration,
     #[serde(with = "humantime_serde", default = "default_purger_max_age")]
     pub purger_max_age: Duration,
+    // default delay between retry attempts at submitting solana txns, in seconds
+    #[serde(default = "default_txn_retry_delay")]
+    pub txn_retry_delay: Duration,
+}
+
+pub fn default_txn_retry_delay() -> Duration {
+    humantime::parse_duration("1 seconds").unwrap()
 }
 
 fn default_purger_interval() -> Duration {

--- a/solana/src/burn.rs
+++ b/solana/src/burn.rs
@@ -557,7 +557,7 @@ impl SolanaNetwork for Arc<Mutex<HashMap<PublicKeyBinary, u64>>> {
         amount: u64,
     ) -> Result<MockTransaction, Self::Error> {
         Ok(MockTransaction {
-            signature: Signature::new_unique(),
+            signature: Signature::default(),
             payer: payer.clone(),
             amount,
         })

--- a/solana/src/burn.rs
+++ b/solana/src/burn.rs
@@ -25,10 +25,7 @@ use solana_sdk::{
 };
 use std::convert::Infallible;
 use std::{collections::HashMap, str::FromStr};
-use std::{
-    sync::Arc,
-    time::{Duration, SystemTime},
-};
+use std::{sync::Arc, time::SystemTime};
 use tokio::sync::Mutex;
 
 #[async_trait]
@@ -276,13 +273,15 @@ impl SolanaNetwork for SolanaRpc {
             skip_preflight: true,
             ..Default::default()
         };
-        match send_with_retry!(self
+        match self
             .provider
             .send_and_confirm_transaction_with_spinner_and_config(
                 tx,
                 CommitmentConfig::confirmed(),
                 config,
-            )) {
+            )
+            .await
+        {
             Ok(signature) => {
                 tracing::info!(
                     transaction = %signature,

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -41,7 +41,6 @@ pub trait IsErrorBlockhashNotFound {
 
 impl IsErrorBlockhashNotFound for SolanaRpcError {
     fn is_error_blockhash_not_found(&self) -> bool {
-        // matches!(self, SolanaRpcError::RpcClientError(ClientError::BlockhashNotFound))
         matches!(
             self,
             SolanaRpcError::RpcClientError(ClientError {

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -35,6 +35,25 @@ impl From<helium_anchor_gen::anchor_lang::error::Error> for SolanaRpcError {
     }
 }
 
+pub trait IsErrorBlockhashNotFound {
+    fn is_error_blockhash_not_found(&self) -> bool;
+}
+
+impl IsErrorBlockhashNotFound for SolanaRpcError {
+    fn is_error_blockhash_not_found(&self) -> bool {
+        // matches!(self, SolanaRpcError::RpcClientError(ClientError::BlockhashNotFound))
+        matches!(
+            self,
+            SolanaRpcError::RpcClientError(ClientError {
+                kind: solana_client::client_error::ClientErrorKind::TransactionError(
+                    solana_sdk::transaction::TransactionError::BlockhashNotFound,
+                ),
+                ..
+            })
+        )
+    }
+}
+
 pub trait GetSignature {
     fn get_signature(&self) -> &Signature;
 }

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -7,34 +7,6 @@ use std::time::SystemTimeError;
 pub mod burn;
 pub mod start_boost;
 
-macro_rules! send_with_retry {
-    ($rpc:expr) => {{
-        let mut attempt = 1;
-        loop {
-            match $rpc.await {
-                Ok(resp) => break Ok(resp),
-                Err(
-                    err @ ClientError {
-                        kind:
-                            solana_client::client_error::ClientErrorKind::TransactionError(
-                                solana_sdk::transaction::TransactionError::BlockhashNotFound,
-                            ),
-                        ..
-                    },
-                ) => break Err(err),
-                Err(_err) if attempt < 5 => {
-                    attempt += 1;
-                    tokio::time::sleep(Duration::from_secs(attempt)).await;
-                    continue;
-                }
-                Err(err) => break Err(err),
-            }
-        }
-    }};
-}
-
-pub(crate) use send_with_retry;
-
 #[derive(thiserror::Error, Debug)]
 pub enum SolanaRpcError {
     #[error("Solana rpc error: {0}")]

--- a/solana/src/start_boost.rs
+++ b/solana/src/start_boost.rs
@@ -16,7 +16,7 @@ use solana_sdk::{
     signer::Signer,
     transaction::Transaction,
 };
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 #[async_trait]
 pub trait SolanaNetwork: Send + Sync + 'static {
@@ -132,7 +132,7 @@ impl SolanaNetwork for SolanaRpc {
     }
 
     async fn submit_transaction(&self, tx: &Self::Transaction) -> Result<(), Self::Error> {
-        match send_with_retry!(self.provider.send_and_confirm_transaction(tx)) {
+        match self.provider.send_and_confirm_transaction(tx).await {
             Ok(signature) => {
                 tracing::info!(
                     transaction = %signature,

--- a/solana/src/start_boost.rs
+++ b/solana/src/start_boost.rs
@@ -7,7 +7,7 @@ use helium_anchor_gen::{
     hexboosting::{self, accounts, instruction},
 };
 use serde::Deserialize;
-use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_client::{client_error::ClientError, nonblocking::rpc_client::RpcClient};
 use solana_program::instruction::Instruction;
 use solana_sdk::{
     commitment_config::CommitmentConfig,


### PR DESCRIPTION
When submitting a txn via solana, if we hit a blockhash not found error it likely means the blockhash included in the txn is stale...older than 150 blocks.  In this scenario we will now re-sign the txn ( including specifying a current blockhash ) and resubmit immediately.

As the current setup of the calling applications need to take actions when a blockhash not found error is encountered ( such as updating a DB as part of a 2 stage commit ) this retry logic is handled at the application level.  Further then, so as to avoid having retry logic existing at both the application side and then again at the solana lib side, I have dropped the solana lib retry logic and centralised the logic for all retries within each application.

The intention is to revisit this and attempt to centralise the retries within solana but that will require more comprehensive changes.  This interim solution permits the resigning of the stale txns to be deployed and hopefully help to increase the number of successful txn submit attempts during periods of chain congestion.
