### PR TITLE
Fix compilation error for projects that use oracles as dependency 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ spl-token = "3.5.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
 beacon = { git = "https://github.com/helium/proto", branch = "master" }
 humantime = "2"
-metrics = "0"
+metrics = "0.21"
 metrics-exporter-prometheus = "0"
 tracing = "0"
 tracing-subscriber = { version = "0", default-features=false, features = ["env-filter", "registry", "fmt"] }


### PR DESCRIPTION
Metrics dependency announced v0.22 with breaking changes that aren't supported by `oracles`
https://github.com/metrics-rs/metrics/blob/a143ef60b5354770fb292d29acc1f7bdef2c4aed/metrics/RELEASES.md#0220---2023-12-24

When I use the `file_store` as a dependency it doesn't compile until I add a patch fix to my project
![image](https://github.com/helium/oracles/assets/20345096/4f2ba407-4de9-438e-9b93-d4811848e8da)

```
[patch.crates-io]
metrics = { git = "https://github.com/metrics-rs/metrics", tag = "metrics-v0.21.1"}
```

Use `metrics = 0.21` to let use `oracles` crates as a dependency without hack 