### PR TITLE
record processing latency for file info streams

### DIFF
--- a/file_store/src/file_info_poller.rs
+++ b/file_store/src/file_info_poller.rs
@@ -60,10 +60,10 @@ where
         T: 'static,
     {
         let latency = Utc::now() - self.file_info.timestamp;
-        metrics::histogram!(
+        metrics::gauge!(
             "file-processing-latency",
             latency.num_seconds() as f64,
-            "file-type" => self.file_info.prefix.clone()
+            "file-type" => self.file_info.prefix.clone(), "process-name" => self.process_name.clone(),
         );
 
         recorder.record(&self.process_name, &self.file_info).await?;


### PR DESCRIPTION
Adds a latency metric to the file info stream recording the amount of time in seconds since a file was created/uploaded to the cloud store to the time it is converted into a stream for processing/ingest by the receiving service.