### PR TITLE
Refactor FileSinkBuilder

### DIFF
--- a/boost_manager/src/main.rs
+++ b/boost_manager/src/main.rs
@@ -102,9 +102,9 @@ impl Server {
         let (updated_hexes_sink, updated_hexes_sink_server) = file_sink::FileSinkBuilder::new(
             FileType::BoostedHexUpdate,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_boosted_hex_update"),
         )
-        .file_upload(Some(file_upload.clone()))
         .roll_time(Duration::minutes(5))
         .create()
         .await?;

--- a/ingest/src/server_iot.rs
+++ b/ingest/src/server_iot.rs
@@ -356,9 +356,9 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
     let (beacon_report_sink, beacon_report_sink_server) = file_sink::FileSinkBuilder::new(
         FileType::IotBeaconIngestReport,
         store_base_path,
+        file_upload.clone(),
         concat!(env!("CARGO_PKG_NAME"), "_beacon_report"),
     )
-    .file_upload(Some(file_upload.clone()))
     .roll_time(Duration::minutes(5))
     .create()
     .await?;
@@ -367,9 +367,9 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
     let (witness_report_sink, witness_report_sink_server) = file_sink::FileSinkBuilder::new(
         FileType::IotWitnessIngestReport,
         store_base_path,
+        file_upload.clone(),
         concat!(env!("CARGO_PKG_NAME"), "_witness_report"),
     )
-    .file_upload(Some(file_upload.clone()))
     .roll_time(Duration::minutes(5))
     .create()
     .await?;

--- a/ingest/src/server_mobile.rs
+++ b/ingest/src/server_mobile.rs
@@ -326,9 +326,9 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
     let (heartbeat_report_sink, heartbeat_report_sink_server) = file_sink::FileSinkBuilder::new(
         FileType::CbrsHeartbeatIngestReport,
         store_base_path,
+        file_upload.clone(),
         concat!(env!("CARGO_PKG_NAME"), "_heartbeat_report"),
     )
-    .file_upload(Some(file_upload.clone()))
     .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))
     .create()
     .await?;
@@ -337,9 +337,9 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
         file_sink::FileSinkBuilder::new(
             FileType::WifiHeartbeatIngestReport,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_wifi_heartbeat_report"),
         )
-        .file_upload(Some(file_upload.clone()))
         .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))
         .create()
         .await?;
@@ -348,9 +348,9 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
     let (speedtest_report_sink, speedtest_report_sink_server) = file_sink::FileSinkBuilder::new(
         FileType::CellSpeedtestIngestReport,
         store_base_path,
+        file_upload.clone(),
         concat!(env!("CARGO_PKG_NAME"), "_speedtest_report"),
     )
-    .file_upload(Some(file_upload.clone()))
     .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))
     .create()
     .await?;
@@ -359,12 +359,12 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
         file_sink::FileSinkBuilder::new(
             FileType::DataTransferSessionIngestReport,
             store_base_path,
+            file_upload.clone(),
             concat!(
                 env!("CARGO_PKG_NAME"),
                 "_mobile_data_transfer_session_report"
             ),
         )
-        .file_upload(Some(file_upload.clone()))
         .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))
         .create()
         .await?;
@@ -373,9 +373,9 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
         file_sink::FileSinkBuilder::new(
             FileType::SubscriberLocationIngestReport,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_subscriber_location_report"),
         )
-        .file_upload(Some(file_upload.clone()))
         .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))
         .create()
         .await?;
@@ -384,9 +384,9 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
         file_sink::FileSinkBuilder::new(
             FileType::RadioThresholdIngestReport,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_radio_threshold_ingest_report"),
         )
-        .file_upload(Some(file_upload.clone()))
         .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))
         .create()
         .await?;
@@ -395,12 +395,12 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
         file_sink::FileSinkBuilder::new(
             FileType::InvalidatedRadioThresholdIngestReport,
             store_base_path,
+            file_upload.clone(),
             concat!(
                 env!("CARGO_PKG_NAME"),
                 "_invalidated_radio_threshold_ingest_report"
             ),
         )
-        .file_upload(Some(file_upload.clone()))
         .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))
         .create()
         .await?;
@@ -409,9 +409,9 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
         file_sink::FileSinkBuilder::new(
             FileType::CoverageObjectIngestReport,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_coverage_object_report"),
         )
-        .file_upload(Some(file_upload.clone()))
         .roll_time(Duration::minutes(INGEST_WAIT_DURATION_MINUTES))
         .create()
         .await?;

--- a/iot_packet_verifier/src/daemon.rs
+++ b/iot_packet_verifier/src/daemon.rs
@@ -140,9 +140,9 @@ impl Cmd {
         let (valid_packets, valid_packets_server) = FileSinkBuilder::new(
             FileType::IotValidPacket,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_valid_packets"),
         )
-        .file_upload(Some(file_upload.clone()))
         .auto_commit(false)
         .create()
         .await?;
@@ -150,9 +150,9 @@ impl Cmd {
         let (invalid_packets, invalid_packets_server) = FileSinkBuilder::new(
             FileType::InvalidPacket,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_invalid_packets"),
         )
-        .file_upload(Some(file_upload.clone()))
         .auto_commit(false)
         .create()
         .await?;

--- a/iot_verifier/src/main.rs
+++ b/iot_verifier/src/main.rs
@@ -120,9 +120,9 @@ impl Server {
         let (rewards_sink, gateway_rewards_sink_server) = file_sink::FileSinkBuilder::new(
             FileType::IotRewardShare,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_gateway_reward_shares"),
         )
-        .file_upload(Some(file_upload.clone()))
         .auto_commit(false)
         .create()
         .await?;
@@ -132,9 +132,9 @@ impl Server {
             file_sink::FileSinkBuilder::new(
                 FileType::RewardManifest,
                 store_base_path,
+                file_upload.clone(),
                 concat!(env!("CARGO_PKG_NAME"), "_iot_reward_manifest"),
             )
-            .file_upload(Some(file_upload.clone()))
             .auto_commit(false)
             .create()
             .await?;
@@ -178,9 +178,9 @@ impl Server {
             file_sink::FileSinkBuilder::new(
                 FileType::NonRewardablePacket,
                 store_base_path,
+                file_upload.clone(),
                 concat!(env!("CARGO_PKG_NAME"), "_non_rewardable_packet"),
             )
-            .file_upload(Some(file_upload.clone()))
             .roll_time(ChronoDuration::minutes(5))
             .create()
             .await?;
@@ -214,9 +214,9 @@ impl Server {
             file_sink::FileSinkBuilder::new(
                 FileType::IotInvalidBeaconReport,
                 store_base_path,
+                file_upload.clone(),
                 concat!(env!("CARGO_PKG_NAME"), "_invalid_beacon"),
             )
-            .file_upload(Some(file_upload.clone()))
             .auto_commit(false)
             .create()
             .await?;
@@ -225,9 +225,9 @@ impl Server {
             file_sink::FileSinkBuilder::new(
                 FileType::IotInvalidWitnessReport,
                 store_base_path,
+                file_upload.clone(),
                 concat!(env!("CARGO_PKG_NAME"), "_invalid_witness_report"),
             )
-            .file_upload(Some(file_upload.clone()))
             .auto_commit(false)
             .create()
             .await?;
@@ -255,9 +255,9 @@ impl Server {
             file_sink::FileSinkBuilder::new(
                 FileType::IotInvalidBeaconReport,
                 store_base_path,
+                file_upload.clone(),
                 concat!(env!("CARGO_PKG_NAME"), "_invalid_beacon_report"),
             )
-            .file_upload(Some(file_upload.clone()))
             .roll_time(ChronoDuration::minutes(5))
             .create()
             .await?;
@@ -266,9 +266,9 @@ impl Server {
             file_sink::FileSinkBuilder::new(
                 FileType::IotInvalidWitnessReport,
                 store_base_path,
+                file_upload.clone(),
                 concat!(env!("CARGO_PKG_NAME"), "_invalid_witness_report"),
             )
-            .file_upload(Some(file_upload.clone()))
             .roll_time(ChronoDuration::minutes(5))
             .create()
             .await?;
@@ -276,9 +276,9 @@ impl Server {
         let (runner_poc_sink, runner_poc_sink_server) = file_sink::FileSinkBuilder::new(
             FileType::IotPoc,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_valid_poc"),
         )
-        .file_upload(Some(file_upload.clone()))
         .roll_time(ChronoDuration::minutes(2))
         .create()
         .await?;

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -131,9 +131,9 @@ impl Cmd {
         let (valid_sessions, valid_sessions_server) = FileSinkBuilder::new(
             FileType::ValidDataTransferSession,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_valid_data_transfer_session"),
         )
-        .file_upload(Some(file_upload.clone()))
         .auto_commit(true)
         .create()
         .await?;
@@ -141,9 +141,9 @@ impl Cmd {
         let (invalid_sessions, invalid_sessions_server) = FileSinkBuilder::new(
             FileType::InvalidDataTransferSessionIngestReport,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_invalid_data_transfer_session"),
         )
-        .file_upload(Some(file_upload.clone()))
         .auto_commit(false)
         .create()
         .await?;

--- a/mobile_verifier/src/cli/server.rs
+++ b/mobile_verifier/src/cli/server.rs
@@ -86,9 +86,9 @@ impl Cmd {
         let (valid_heartbeats, valid_heartbeats_server) = file_sink::FileSinkBuilder::new(
             FileType::ValidatedHeartbeat,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_heartbeat"),
         )
-        .file_upload(Some(file_upload.clone()))
         .auto_commit(false)
         .roll_time(Duration::minutes(15))
         .create()
@@ -98,9 +98,9 @@ impl Cmd {
         let (seniority_updates, seniority_updates_server) = file_sink::FileSinkBuilder::new(
             FileType::SeniorityUpdate,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_seniority_update"),
         )
-        .file_upload(Some(file_upload.clone()))
         .auto_commit(false)
         .roll_time(Duration::minutes(15))
         .create()
@@ -159,9 +159,9 @@ impl Cmd {
         let (speedtests_avg, speedtests_avg_server) = file_sink::FileSinkBuilder::new(
             FileType::SpeedtestAvg,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_speedtest_average"),
         )
-        .file_upload(Some(file_upload.clone()))
         .auto_commit(false)
         .roll_time(Duration::minutes(15))
         .create()
@@ -170,9 +170,9 @@ impl Cmd {
         let (speedtests_validity, speedtests_validity_server) = file_sink::FileSinkBuilder::new(
             FileType::VerifiedSpeedtest,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_verified_speedtest"),
         )
-        .file_upload(Some(file_upload.clone()))
         .auto_commit(false)
         .roll_time(Duration::minutes(15))
         .create()
@@ -199,9 +199,9 @@ impl Cmd {
         let (valid_coverage_objs, valid_coverage_objs_server) = file_sink::FileSinkBuilder::new(
             FileType::CoverageObject,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_coverage_object"),
         )
-        .file_upload(Some(file_upload.clone()))
         .auto_commit(false)
         .roll_time(Duration::minutes(15))
         .create()
@@ -212,9 +212,9 @@ impl Cmd {
             file_sink::FileSinkBuilder::new(
                 FileType::OracleBoostingReport,
                 store_base_path,
+                file_upload.clone(),
                 concat!(env!("CARGO_PKG_NAME"), "_oracle_boosting_report"),
             )
-            .file_upload(Some(file_upload.clone()))
             .auto_commit(false)
             .roll_time(Duration::minutes(15))
             .create()
@@ -236,9 +236,9 @@ impl Cmd {
         let (mobile_rewards, mobile_rewards_server) = file_sink::FileSinkBuilder::new(
             FileType::MobileRewardShare,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_radio_reward_shares"),
         )
-        .file_upload(Some(file_upload.clone()))
         .auto_commit(false)
         .create()
         .await?;
@@ -246,9 +246,9 @@ impl Cmd {
         let (reward_manifests, reward_manifests_server) = file_sink::FileSinkBuilder::new(
             FileType::RewardManifest,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_reward_manifest"),
         )
-        .file_upload(Some(file_upload.clone()))
         .auto_commit(false)
         .create()
         .await?;
@@ -279,9 +279,9 @@ impl Cmd {
             file_sink::FileSinkBuilder::new(
                 FileType::VerifiedSubscriberLocationIngestReport,
                 store_base_path,
+                file_upload.clone(),
                 concat!(env!("CARGO_PKG_NAME"), "_verified_subscriber_location"),
             )
-            .file_upload(Some(file_upload.clone()))
             .auto_commit(false)
             .create()
             .await?;
@@ -308,9 +308,9 @@ impl Cmd {
             file_sink::FileSinkBuilder::new(
                 FileType::VerifiedRadioThresholdIngestReport,
                 store_base_path,
+                file_upload.clone(),
                 concat!(env!("CARGO_PKG_NAME"), "_verified_radio_threshold"),
             )
-            .file_upload(Some(file_upload.clone()))
             .auto_commit(false)
             .create()
             .await?;
@@ -336,12 +336,12 @@ impl Cmd {
             file_sink::FileSinkBuilder::new(
                 FileType::VerifiedInvalidatedRadioThresholdIngestReport,
                 store_base_path,
+                file_upload.clone(),
                 concat!(
                     env!("CARGO_PKG_NAME"),
                     "_verified_invalidated_radio_threshold"
                 ),
             )
-            .file_upload(Some(file_upload.clone()))
             .auto_commit(false)
             .create()
             .await?;

--- a/price/src/main.rs
+++ b/price/src/main.rs
@@ -88,9 +88,9 @@ impl Server {
         let (price_sink, price_sink_server) = file_sink::FileSinkBuilder::new(
             FileType::PriceReport,
             store_base_path,
+            file_upload.clone(),
             concat!(env!("CARGO_PKG_NAME"), "_report_submission"),
         )
-        .file_upload(Some(file_upload.clone()))
         .roll_time(Duration::minutes(PRICE_SINK_ROLL_MINS))
         .create()
         .await?;


### PR DESCRIPTION
`FileSink.file_upload` was added as an alternative `FileSink.deposits`. 

They behave in a mutually exclusive manner, and no production code was constructing a `FileSink` without providing a `FileUpload`. (There was one test that made a FileSink without a destination channel).

This PR removes the ability to use `FileSinkBuilder.deposits` and the corresponding `FileSink.deposits`;
and requires a `FileUpload` when constructing a `FileSinkBuilder`.

