### PR TITLE
Landtype Boosting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=mj/landtype#d70a0a653ccb5e97cbeec8f9d175a82c487bfa9f"
+source = "git+https://github.com/helium/proto?branch=master#fdb83a38fbe8aead4ff6cb39d1e996f0ad0646b7"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
@@ -1431,7 +1431,7 @@ dependencies = [
  "rand_chacha 0.3.0",
  "rust_decimal",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "thiserror",
 ]
 
@@ -3385,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=mj/landtype#d70a0a653ccb5e97cbeec8f9d175a82c487bfa9f"
+source = "git+https://github.com/helium/proto?branch=master#fdb83a38fbe8aead4ff6cb39d1e996f0ad0646b7"
 dependencies = [
  "bytes",
  "prost",
@@ -3616,7 +3616,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.9",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -8672,7 +8672,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.9.9",
  "thiserror",
  "twox-hash",
  "xorf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown 0.13.1",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "zeroize",
 ]
@@ -492,7 +492,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "digest 0.10.7",
- "itertools 0.10.5",
+ "itertools",
  "num-bigint 0.4.3",
  "num-traits",
  "paste",
@@ -1421,7 +1421,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=mj/landtype#e23e25956f9a75941d6c1fd243e4eb0366cf3075"
+source = "git+https://github.com/helium/proto?branch=mj/landtype#d70a0a653ccb5e97cbeec8f9d175a82c487bfa9f"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
@@ -1431,7 +1431,7 @@ dependencies = [
  "rand_chacha 0.3.0",
  "rust_decimal",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "thiserror",
 ]
 
@@ -3385,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=mj/landtype#e23e25956f9a75941d6c1fd243e4eb0366cf3075"
+source = "git+https://github.com/helium/proto?branch=mj/landtype#d70a0a653ccb5e97cbeec8f9d175a82c487bfa9f"
 dependencies = [
  "bytes",
  "prost",
@@ -3616,7 +3616,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.9",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -3938,7 +3938,7 @@ dependencies = [
  "helium-proto",
  "http-serde",
  "iot-config",
- "itertools 0.12.0",
+ "itertools",
  "lazy_static",
  "metrics",
  "once_cell",
@@ -3978,15 +3978,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]
@@ -5333,7 +5324,7 @@ checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
  "heck 0.4.0",
- "itertools 0.12.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -5353,7 +5344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools 0.12.0",
+ "itertools",
  "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 2.0.38",
@@ -6474,7 +6465,7 @@ dependencies = [
  "futures",
  "helium-anchor-gen",
  "helium-crypto",
- "itertools 0.12.0",
+ "itertools",
  "metrics",
  "serde",
  "sha2 0.10.6",
@@ -6773,7 +6764,7 @@ dependencies = [
  "console_log",
  "curve25519-dalek",
  "getrandom 0.2.10",
- "itertools 0.10.5",
+ "itertools",
  "js-sys",
  "lazy_static",
  "libc",
@@ -6813,7 +6804,7 @@ dependencies = [
  "bincode",
  "eager",
  "enum-iterator",
- "itertools 0.10.5",
+ "itertools",
  "libc",
  "log",
  "num-derive",
@@ -6865,7 +6856,7 @@ dependencies = [
  "async-mutex",
  "async-trait",
  "futures",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "log",
  "quinn",
@@ -6995,7 +6986,7 @@ dependencies = [
  "ed25519-dalek-bip32",
  "generic-array",
  "hmac 0.12.1",
- "itertools 0.10.5",
+ "itertools",
  "js-sys",
  "lazy_static",
  "libsecp256k1",
@@ -7052,7 +7043,7 @@ dependencies = [
  "futures-util",
  "histogram",
  "indexmap 1.9.3",
- "itertools 0.10.5",
+ "itertools",
  "libc",
  "log",
  "nix",
@@ -7205,7 +7196,7 @@ dependencies = [
  "byteorder",
  "curve25519-dalek",
  "getrandom 0.1.16",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "merlin",
  "num-derive",
@@ -7329,7 +7320,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87e292b4291f154971a43c3774364e2cbcaec599d3f5bf6fa9d122885dbc38a"
 dependencies = [
- "itertools 0.10.5",
+ "itertools",
  "nom",
  "unicode_categories",
 ]
@@ -8681,7 +8672,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "thiserror",
  "twox-hash",
  "xorf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#e8d84a8a4a05f069a3ce4f90d67a525aa92b52f9"
+source = "git+https://github.com/helium/proto?branch=mj/landtype#e23e25956f9a75941d6c1fd243e4eb0366cf3075"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
@@ -3385,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#e8d84a8a4a05f069a3ce4f90d67a525aa92b52f9"
+source = "git+https://github.com/helium/proto?branch=mj/landtype#e23e25956f9a75941d6c1fd243e4eb0366cf3075"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,13 +62,13 @@ sqlx = {version = "0", features = [
 helium-anchor-gen = {git = "https://github.com/helium/helium-anchor-gen.git"}
 helium-crypto = {version = "0.8.4", features=["sqlx-postgres", "multisig"]}
 hextree = {git = "https://github.com/jaykickliter/HexTree", branch = "main", features = ["disktree"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "mj/landtype", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
 solana-client = "1.16"
 solana-sdk = "1.16"
 solana-program = "1.16"
 spl-token = "3.5.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
-beacon = { git = "https://github.com/helium/proto", branch = "mj/landtype" }
+beacon = { git = "https://github.com/helium/proto", branch = "master" }
 humantime = "2"
 metrics = "0.21"
 metrics-exporter-prometheus = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,13 +62,13 @@ sqlx = {version = "0", features = [
 helium-anchor-gen = {git = "https://github.com/helium/helium-anchor-gen.git"}
 helium-crypto = {version = "0.8.4", features=["sqlx-postgres", "multisig"]}
 hextree = {git = "https://github.com/jaykickliter/HexTree", branch = "main", features = ["disktree"]}
-helium-proto = {git = "https://github.com/helium/proto", branch = "master", features = ["services"]}
+helium-proto = {git = "https://github.com/helium/proto", branch = "mj/landtype", features = ["services"]}
 solana-client = "1.16"
 solana-sdk = "1.16"
 solana-program = "1.16"
 spl-token = "3.5.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
-beacon = { git = "https://github.com/helium/proto", branch = "master" }
+beacon = { git = "https://github.com/helium/proto", branch = "mj/landtype" }
 humantime = "2"
 metrics = "0.21"
 metrics-exporter-prometheus = "0"

--- a/mobile_verifier/migrations/32_landtype.sql
+++ b/mobile_verifier/migrations/32_landtype.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hexes ADD COLUMN landtype oracle_assignment;

--- a/mobile_verifier/src/boosting_oracles/assignment.rs
+++ b/mobile_verifier/src/boosting_oracles/assignment.rs
@@ -28,6 +28,19 @@ impl From<Assignment> for i32 {
     }
 }
 
+impl TryFrom<i32> for Assignment {
+    type Error = anyhow::Error;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Assignment::A),
+            1 => Ok(Assignment::B),
+            2 => Ok(Assignment::C),
+            other => Err(anyhow::anyhow!("could not make Assignment from {other}")),
+        }
+    }
+}
+
 impl fmt::Display for Assignment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Assignment::*;
@@ -59,7 +72,6 @@ pub fn footfall_and_urbanization_multiplier(
     }
 }
 
-#[allow(dead_code)]
 pub fn boosting_oracles_multiplier(
     footfall: Assignment,
     landtype: Assignment,

--- a/mobile_verifier/src/boosting_oracles/assignment.rs
+++ b/mobile_verifier/src/boosting_oracles/assignment.rs
@@ -3,6 +3,13 @@ use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::fmt;
 
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub struct HexAssignments {
+    pub footfall: Assignment,
+    pub urbanized: Assignment,
+    pub landtype: Assignment,
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, Debug, sqlx::Type)]
 #[sqlx(type_name = "oracle_assignment")]
 #[sqlx(rename_all = "lowercase")]
@@ -53,58 +60,53 @@ impl fmt::Display for Assignment {
     }
 }
 
-pub fn footfall_and_urbanization_multiplier(
-    footfall: Assignment,
-    urbanization: Assignment,
-) -> Decimal {
-    use Assignment::*;
+impl HexAssignments {
+    pub fn boosting_multiplier(&self) -> Decimal {
+        let HexAssignments {
+            footfall,
+            urbanized,
+            landtype,
+        } = self;
 
-    match (footfall, urbanization) {
-        (A, A) => dec!(1.0),
-        (A, B) => dec!(1.0),
-        (B, A) => dec!(0.75),
-        (B, B) => dec!(0.50),
-        (C, A) => dec!(0.40),
-        (C, B) => dec!(0.10),
-        (A, C) => dec!(0.00),
-        (B, C) => dec!(0.00),
-        (C, C) => dec!(0.00),
+        use Assignment::*;
+        match (footfall, landtype, urbanized) {
+            // POI ≥ 1 Urbanized
+            (A, A, A) => dec!(1.00),
+            (A, B, A) => dec!(1.00),
+            (A, C, A) => dec!(1.00),
+            // POI ≥ 1 Not Urbanized
+            (A, A, B) => dec!(1.00),
+            (A, B, B) => dec!(1.00),
+            (A, C, B) => dec!(1.00),
+            // Point of Interest Urbanized
+            (B, A, A) => dec!(0.70),
+            (B, B, A) => dec!(0.70),
+            (B, C, A) => dec!(0.70),
+            // Point of Interest Not Urbanized
+            (B, A, B) => dec!(0.50),
+            (B, B, B) => dec!(0.50),
+            (B, C, B) => dec!(0.50),
+            // No POI Urbanized
+            (C, A, A) => dec!(0.40),
+            (C, B, A) => dec!(0.30),
+            (C, C, A) => dec!(0.05),
+            // No POI Not Urbanized
+            (C, A, B) => dec!(0.20),
+            (C, B, B) => dec!(0.15),
+            (C, C, B) => dec!(0.03),
+            // Outside of USA
+            (_, _, C) => dec!(0.00),
+        }
     }
 }
 
-pub fn boosting_oracles_multiplier(
-    footfall: Assignment,
-    landtype: Assignment,
-    urbanization: Assignment,
-) -> Decimal {
-    use Assignment::*;
-
-    match (footfall, landtype, urbanization) {
-        // POI ≥ 1 Urbanized
-        (A, A, A) => dec!(1.00),
-        (A, B, A) => dec!(1.00),
-        (A, C, A) => dec!(1.00),
-        // POI ≥ 1 Not Urbanized
-        (A, A, B) => dec!(1.00),
-        (A, B, B) => dec!(1.00),
-        (A, C, B) => dec!(1.00),
-        // Point of Interest Urbanized
-        (B, A, A) => dec!(0.70),
-        (B, B, A) => dec!(0.70),
-        (B, C, A) => dec!(0.70),
-        // Point of Interest Not Urbanized
-        (B, A, B) => dec!(0.50),
-        (B, B, B) => dec!(0.50),
-        (B, C, B) => dec!(0.50),
-        // No POI Urbanized
-        (C, A, A) => dec!(0.40),
-        (C, B, A) => dec!(0.30),
-        (C, C, A) => dec!(0.05),
-        // No POI Not Urbanized
-        (C, A, B) => dec!(0.20),
-        (C, B, B) => dec!(0.15),
-        (C, C, B) => dec!(0.03),
-        // Outside of USA
-        (_, _, C) => dec!(0.00),
+#[cfg(test)]
+impl HexAssignments {
+    pub fn test_best() -> Self {
+        Self {
+            footfall: Assignment::A,
+            urbanized: Assignment::A,
+            landtype: Assignment::A,
+        }
     }
 }

--- a/mobile_verifier/src/boosting_oracles/assignment.rs
+++ b/mobile_verifier/src/boosting_oracles/assignment.rs
@@ -6,8 +6,8 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
 pub struct HexAssignments {
     pub footfall: Assignment,
-    pub urbanized: Assignment,
     pub landtype: Assignment,
+    pub urbanized: Assignment,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, sqlx::Type)]

--- a/mobile_verifier/src/boosting_oracles/assignment.rs
+++ b/mobile_verifier/src/boosting_oracles/assignment.rs
@@ -70,31 +70,31 @@ impl HexAssignments {
 
         use Assignment::*;
         match (footfall, landtype, urbanized) {
-            // POI ≥ 1 Urbanized
+            // yellow - POI ≥ 1 Urbanized
             (A, A, A) => dec!(1.00),
             (A, B, A) => dec!(1.00),
             (A, C, A) => dec!(1.00),
-            // POI ≥ 1 Not Urbanized
+            // orange - POI ≥ 1 Not Urbanized
             (A, A, B) => dec!(1.00),
             (A, B, B) => dec!(1.00),
             (A, C, B) => dec!(1.00),
-            // Point of Interest Urbanized
+            // light green - Point of Interest Urbanized
             (B, A, A) => dec!(0.70),
             (B, B, A) => dec!(0.70),
             (B, C, A) => dec!(0.70),
-            // Point of Interest Not Urbanized
+            // dark green - Point of Interest Not Urbanized
             (B, A, B) => dec!(0.50),
             (B, B, B) => dec!(0.50),
             (B, C, B) => dec!(0.50),
-            // No POI Urbanized
+            // light blue - No POI Urbanized
             (C, A, A) => dec!(0.40),
             (C, B, A) => dec!(0.30),
             (C, C, A) => dec!(0.05),
-            // No POI Not Urbanized
+            // dark blue - No POI Not Urbanized
             (C, A, B) => dec!(0.20),
             (C, B, B) => dec!(0.15),
             (C, C, B) => dec!(0.03),
-            // Outside of USA
+            // gray - Outside of USA
             (_, _, C) => dec!(0.00),
         }
     }

--- a/mobile_verifier/src/boosting_oracles/assignment.rs
+++ b/mobile_verifier/src/boosting_oracles/assignment.rs
@@ -1,4 +1,4 @@
-use helium_proto::services::poc_mobile::oracle_boosting_hex_assignment;
+use helium_proto::services::poc_mobile::oracle_boosting_hex_assignment::Assignment as ProtoAssignment;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::fmt;
@@ -19,7 +19,7 @@ pub enum Assignment {
     C,
 }
 
-impl From<Assignment> for oracle_boosting_hex_assignment::Assignment {
+impl From<Assignment> for ProtoAssignment {
     fn from(assignment: Assignment) -> Self {
         match assignment {
             Assignment::A => Self::A,
@@ -31,19 +31,16 @@ impl From<Assignment> for oracle_boosting_hex_assignment::Assignment {
 
 impl From<Assignment> for i32 {
     fn from(assignment: Assignment) -> i32 {
-        oracle_boosting_hex_assignment::Assignment::from(assignment) as i32
+        ProtoAssignment::from(assignment) as i32
     }
 }
 
-impl TryFrom<i32> for Assignment {
-    type Error = anyhow::Error;
-
-    fn try_from(value: i32) -> Result<Self, Self::Error> {
+impl From<ProtoAssignment> for Assignment {
+    fn from(value: ProtoAssignment) -> Self {
         match value {
-            0 => Ok(Assignment::A),
-            1 => Ok(Assignment::B),
-            2 => Ok(Assignment::C),
-            other => Err(anyhow::anyhow!("could not make Assignment from {other}")),
+            ProtoAssignment::A => Assignment::A,
+            ProtoAssignment::B => Assignment::B,
+            ProtoAssignment::C => Assignment::C,
         }
     }
 }

--- a/mobile_verifier/src/boosting_oracles/mod.rs
+++ b/mobile_verifier/src/boosting_oracles/mod.rs
@@ -12,13 +12,16 @@ use hextree::disktree::DiskTreeMap;
 pub fn make_hex_boost_data(
     settings: &Settings,
     usa_geofence: Geofence,
-) -> anyhow::Result<HexBoostData<impl HexAssignment, impl HexAssignment>> {
+) -> anyhow::Result<HexBoostData<impl HexAssignment, impl HexAssignment, impl HexAssignment>> {
     let urban_disktree = DiskTreeMap::open(&settings.urbanization_data_set)?;
     let footfall_disktree = DiskTreeMap::open(&settings.footfall_data_set)?;
+    let landtype_disktree = DiskTreeMap::open(&settings.landtype_data_set)?;
 
     let urbanization = UrbanizationData::new(urban_disktree, usa_geofence);
     let footfall_data = FootfallData::new(footfall_disktree);
-    let hex_boost_data = HexBoostData::new(urbanization, footfall_data);
+    let landtype_data = LandTypeData::new(landtype_disktree);
+
+    let hex_boost_data = HexBoostData::new(urbanization, footfall_data, landtype_data);
 
     Ok(hex_boost_data)
 }
@@ -27,9 +30,10 @@ pub trait HexAssignment: Send + Sync {
     fn assignment(&self, cell: hextree::Cell) -> anyhow::Result<Assignment>;
 }
 
-pub struct HexBoostData<Urban, Foot> {
+pub struct HexBoostData<Urban, Foot, Land> {
     pub urbanization: Urban,
     pub footfall: Foot,
+    pub landtype: Land,
 }
 
 pub struct UrbanizationData<Urban, Geo> {
@@ -41,11 +45,16 @@ pub struct FootfallData<Foot> {
     footfall: Foot,
 }
 
-impl<Urban, Foot> HexBoostData<Urban, Foot> {
-    pub fn new(urbanization: Urban, footfall: Foot) -> Self {
+pub struct LandTypeData<Land> {
+    landtype: Land,
+}
+
+impl<Urban, Foot, Land> HexBoostData<Urban, Foot, Land> {
+    pub fn new(urbanization: Urban, footfall: Foot, landtype: Land) -> Self {
         Self {
             urbanization,
             footfall,
+            landtype,
         }
     }
 }
@@ -62,6 +71,12 @@ impl<Urban, Geo> UrbanizationData<Urban, Geo> {
 impl<Foot> FootfallData<Foot> {
     pub fn new(footfall: Foot) -> Self {
         Self { footfall }
+    }
+}
+
+impl<Land> LandTypeData<Land> {
+    pub fn new(landtype: Land) -> Self {
+        Self { landtype }
     }
 }
 
@@ -113,8 +128,34 @@ where
         match vals {
             &[x] if x >= 1 => Ok(Assignment::A),
             &[0] => Ok(Assignment::B),
-            other => anyhow::bail!("unexpected disktree data: {cell:?} {other:?}"),
+            other => anyhow::bail!("unexpected footfall disktree data: {cell:?} {other:?}"),
         }
+    }
+}
+
+impl<Land> HexAssignment for LandTypeData<Land>
+where
+    Land: DiskTreeLike,
+{
+    fn assignment(&self, cell: hextree::Cell) -> anyhow::Result<Assignment> {
+        let Some((_, vals)) = self.landtype.get(cell)? else {
+            return Ok(Assignment::C);
+        };
+
+        let cover = match vals {
+            &[x] => WorldCover::try_from(x).map_err(|_| {
+                anyhow::anyhow!("unexpected landtype disktree value: {cell:?} {x:?}")
+            })?,
+            other => anyhow::bail!("unexpected landtype disktree data: {cell:?} {other:?}"),
+        };
+
+        Ok(Assignment::from(cover))
+    }
+}
+
+impl HexAssignment for LandTypeData<Assignment> {
+    fn assignment(&self, _cell: hextree::Cell) -> anyhow::Result<Assignment> {
+        Ok(self.landtype)
     }
 }
 
@@ -132,5 +173,95 @@ impl HexAssignment for HashMap<hextree::Cell, bool> {
             None => Assignment::C,
         };
         Ok(assignment)
+    }
+}
+
+impl HexAssignment for HashMap<hextree::Cell, Assignment> {
+    fn assignment(&self, cell: hextree::Cell) -> anyhow::Result<Assignment> {
+        match self.get(&cell) {
+            Some(val) => Ok(*val),
+            None => anyhow::bail!("{cell:?} not found"),
+        }
+    }
+}
+
+impl From<WorldCover> for Assignment {
+    fn from(value: WorldCover) -> Self {
+        match value {
+            WorldCover::Built => Assignment::A,
+            //
+            WorldCover::Tree => Assignment::B,
+            WorldCover::Shrub => Assignment::B,
+            WorldCover::Grass => Assignment::B,
+            //
+            WorldCover::Bare => Assignment::C,
+            WorldCover::Crop => Assignment::C,
+            WorldCover::Frozen => Assignment::C,
+            WorldCover::Water => Assignment::C,
+            WorldCover::Wet => Assignment::C,
+            WorldCover::Mangrove => Assignment::C,
+            WorldCover::Moss => Assignment::C,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorldCover {
+    Tree = 10,
+    Shrub = 20,
+    Grass = 30,
+    Crop = 40,
+    Built = 50,
+    Bare = 60,
+    Frozen = 70,
+    Water = 80,
+    Wet = 90,
+    Mangrove = 95,
+    Moss = 100,
+}
+
+impl std::fmt::Display for WorldCover {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.to_str())
+    }
+}
+
+impl WorldCover {
+    #[allow(dead_code)]
+    pub(crate) fn to_str(self) -> &'static str {
+        match self {
+            WorldCover::Tree => "TreeCover",
+            WorldCover::Shrub => "Shrubland",
+            WorldCover::Grass => "Grassland",
+            WorldCover::Crop => "Cropland",
+            WorldCover::Built => "BuiltUp",
+            WorldCover::Bare => "BareOrSparseVeg",
+            WorldCover::Frozen => "SnowAndIce",
+            WorldCover::Water => "Water",
+            WorldCover::Wet => "HerbaceousWetland",
+            WorldCover::Mangrove => "Mangroves",
+            WorldCover::Moss => "MossAndLichen",
+        }
+    }
+}
+
+impl TryFrom<u8> for WorldCover {
+    type Error = ();
+    fn try_from(other: u8) -> Result<WorldCover, ()> {
+        let val = match other {
+            10 => WorldCover::Tree,
+            20 => WorldCover::Shrub,
+            30 => WorldCover::Grass,
+            40 => WorldCover::Crop,
+            50 => WorldCover::Built,
+            60 => WorldCover::Bare,
+            70 => WorldCover::Frozen,
+            80 => WorldCover::Water,
+            90 => WorldCover::Wet,
+            95 => WorldCover::Mangrove,
+            100 => WorldCover::Moss,
+            _ => return Err(()),
+        };
+        Ok(val)
     }
 }

--- a/mobile_verifier/src/boosting_oracles/mod.rs
+++ b/mobile_verifier/src/boosting_oracles/mod.rs
@@ -220,39 +220,6 @@ mod tests {
         let no_poi_grass_outside_us = hextree::Cell::from_raw(0x8c2681a306525ff)?;
         let no_poi_water_outside_us = hextree::Cell::from_raw(0x8c2681a306527ff)?;
 
-        let all_cells = vec![
-            poi_built_urbanized,
-            poi_grass_urbanized,
-            poi_water_urbanized,
-            poi_built_not_urbanized,
-            poi_grass_not_urbanized,
-            poi_water_not_urbanized,
-            poi_no_data_built_urbanized,
-            poi_no_data_grass_urbanized,
-            poi_no_data_water_urbanized,
-            poi_no_data_built_not_urbanized,
-            poi_no_data_grass_not_urbanized,
-            poi_no_data_water_not_urbanized,
-            no_poi_built_urbanized,
-            no_poi_grass_urbanized,
-            no_poi_water_urbanized,
-            no_poi_built_not_urbanized,
-            no_poi_grass_not_urbanized,
-            no_poi_water_not_urbanized,
-            poi_built_outside_us,
-            poi_grass_outside_us,
-            poi_water_outside_us,
-            poi_no_data_built_outside_us,
-            poi_no_data_grass_outside_us,
-            poi_no_data_water_outside_us,
-            no_poi_built_outside_us,
-            no_poi_grass_outside_us,
-            no_poi_water_outside_us,
-        ];
-        for cell in all_cells {
-            println!("Cell: {cell:?}");
-        }
-
         // Footfall Data
         // POI         - footfalls > 1 for a POI across hexes
         // POI No Data - No footfalls for a POI across any hexes

--- a/mobile_verifier/src/boosting_oracles/mod.rs
+++ b/mobile_verifier/src/boosting_oracles/mod.rs
@@ -167,3 +167,252 @@ impl TryFrom<u8> for Landtype {
         Ok(val)
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use std::io::Cursor;
+
+    use hextree::{HexTreeMap, HexTreeSet};
+
+    use super::*;
+
+    #[test]
+    fn test_hex_boost_data() -> anyhow::Result<()> {
+        // This test will break if any of the logic deriving Assignments from
+        // the underlying DiskTreeMap's changes.
+
+        let unknown_cell = hextree::Cell::from_raw(0x8c2681a3064d9ff)?;
+
+        // Types of Cells
+        // yellow - POI ≥ 1 Urbanized
+        let poi_built_urbanized = hextree::Cell::from_raw(0x8c2681a3064dbff)?;
+        let poi_grass_urbanized = hextree::Cell::from_raw(0x8c2681a3064ddff)?;
+        let poi_water_urbanized = hextree::Cell::from_raw(0x8c2681a3064e1ff)?;
+        // orange - POI ≥ 1 Not Urbanized
+        let poi_built_not_urbanized = hextree::Cell::from_raw(0x8c2681a3064e3ff)?;
+        let poi_grass_not_urbanized = hextree::Cell::from_raw(0x8c2681a3064e5ff)?;
+        let poi_water_not_urbanized = hextree::Cell::from_raw(0x8c2681a3064e7ff)?;
+        // light green - Point of Interest Urbanized
+        let poi_no_data_built_urbanized = hextree::Cell::from_raw(0x8c2681a3064e9ff)?;
+        let poi_no_data_grass_urbanized = hextree::Cell::from_raw(0x8c2681a3064ebff)?;
+        let poi_no_data_water_urbanized = hextree::Cell::from_raw(0x8c2681a3064edff)?;
+        // dark green - Point of Interest Not Urbanized
+        let poi_no_data_built_not_urbanized = hextree::Cell::from_raw(0x8c2681a306501ff)?;
+        let poi_no_data_grass_not_urbanized = hextree::Cell::from_raw(0x8c2681a306503ff)?;
+        let poi_no_data_water_not_urbanized = hextree::Cell::from_raw(0x8c2681a306505ff)?;
+        // light blue - No POI Urbanized
+        let no_poi_built_urbanized = hextree::Cell::from_raw(0x8c2681a306507ff)?;
+        let no_poi_grass_urbanized = hextree::Cell::from_raw(0x8c2681a306509ff)?;
+        let no_poi_water_urbanized = hextree::Cell::from_raw(0x8c2681a30650bff)?;
+        // dark blue - No POI Not Urbanized
+        let no_poi_built_not_urbanized = hextree::Cell::from_raw(0x8c2681a30650dff)?;
+        let no_poi_grass_not_urbanized = hextree::Cell::from_raw(0x8c2681a306511ff)?;
+        let no_poi_water_not_urbanized = hextree::Cell::from_raw(0x8c2681a306513ff)?;
+        // gray - Outside of USA
+        let poi_built_outside_us = hextree::Cell::from_raw(0x8c2681a306515ff)?;
+        let poi_grass_outside_us = hextree::Cell::from_raw(0x8c2681a306517ff)?;
+        let poi_water_outside_us = hextree::Cell::from_raw(0x8c2681a306519ff)?;
+        let poi_no_data_built_outside_us = hextree::Cell::from_raw(0x8c2681a30651bff)?;
+        let poi_no_data_grass_outside_us = hextree::Cell::from_raw(0x8c2681a30651dff)?;
+        let poi_no_data_water_outside_us = hextree::Cell::from_raw(0x8c2681a306521ff)?;
+        let no_poi_built_outside_us = hextree::Cell::from_raw(0x8c2681a306523ff)?;
+        let no_poi_grass_outside_us = hextree::Cell::from_raw(0x8c2681a306525ff)?;
+        let no_poi_water_outside_us = hextree::Cell::from_raw(0x8c2681a306527ff)?;
+
+        let all_cells = vec![
+            poi_built_urbanized,
+            poi_grass_urbanized,
+            poi_water_urbanized,
+            poi_built_not_urbanized,
+            poi_grass_not_urbanized,
+            poi_water_not_urbanized,
+            poi_no_data_built_urbanized,
+            poi_no_data_grass_urbanized,
+            poi_no_data_water_urbanized,
+            poi_no_data_built_not_urbanized,
+            poi_no_data_grass_not_urbanized,
+            poi_no_data_water_not_urbanized,
+            no_poi_built_urbanized,
+            no_poi_grass_urbanized,
+            no_poi_water_urbanized,
+            no_poi_built_not_urbanized,
+            no_poi_grass_not_urbanized,
+            no_poi_water_not_urbanized,
+            poi_built_outside_us,
+            poi_grass_outside_us,
+            poi_water_outside_us,
+            poi_no_data_built_outside_us,
+            poi_no_data_grass_outside_us,
+            poi_no_data_water_outside_us,
+            no_poi_built_outside_us,
+            no_poi_grass_outside_us,
+            no_poi_water_outside_us,
+        ];
+        for cell in all_cells {
+            println!("Cell: {cell:?}");
+        }
+
+        // Footfall Data
+        // POI         - footfalls > 1 for a POI across hexes
+        // POI No Data - No footfalls for a POI across any hexes
+        // NO POI      - Does not exist
+        let mut footfall = HexTreeMap::<u8>::new();
+        footfall.insert(poi_built_urbanized, 42);
+        footfall.insert(poi_grass_urbanized, 42);
+        footfall.insert(poi_water_urbanized, 42);
+        footfall.insert(poi_built_not_urbanized, 42);
+        footfall.insert(poi_grass_not_urbanized, 42);
+        footfall.insert(poi_water_not_urbanized, 42);
+        footfall.insert(poi_no_data_built_urbanized, 0);
+        footfall.insert(poi_no_data_grass_urbanized, 0);
+        footfall.insert(poi_no_data_water_urbanized, 0);
+        footfall.insert(poi_no_data_built_not_urbanized, 0);
+        footfall.insert(poi_no_data_grass_not_urbanized, 0);
+        footfall.insert(poi_no_data_water_not_urbanized, 0);
+        footfall.insert(poi_built_outside_us, 42);
+        footfall.insert(poi_grass_outside_us, 42);
+        footfall.insert(poi_water_outside_us, 42);
+        footfall.insert(poi_no_data_built_outside_us, 0);
+        footfall.insert(poi_no_data_grass_outside_us, 0);
+        footfall.insert(poi_no_data_water_outside_us, 0);
+
+        // Landtype Data
+        // Map to enum values for Landtype
+        // An unknown cell is considered Assignment::C
+        let mut landtype = HexTreeMap::<u8>::new();
+        landtype.insert(poi_built_urbanized, 50);
+        landtype.insert(poi_grass_urbanized, 30);
+        landtype.insert(poi_water_urbanized, 80);
+        landtype.insert(poi_built_not_urbanized, 50);
+        landtype.insert(poi_grass_not_urbanized, 30);
+        landtype.insert(poi_water_not_urbanized, 80);
+        landtype.insert(poi_no_data_built_urbanized, 50);
+        landtype.insert(poi_no_data_grass_urbanized, 30);
+        landtype.insert(poi_no_data_water_urbanized, 80);
+        landtype.insert(poi_no_data_built_not_urbanized, 50);
+        landtype.insert(poi_no_data_grass_not_urbanized, 30);
+        landtype.insert(poi_no_data_water_not_urbanized, 80);
+        landtype.insert(no_poi_built_urbanized, 50);
+        landtype.insert(no_poi_grass_urbanized, 30);
+        landtype.insert(no_poi_water_urbanized, 80);
+        landtype.insert(no_poi_built_not_urbanized, 50);
+        landtype.insert(no_poi_grass_not_urbanized, 30);
+        landtype.insert(no_poi_water_not_urbanized, 80);
+        landtype.insert(poi_built_outside_us, 50);
+        landtype.insert(poi_grass_outside_us, 30);
+        landtype.insert(poi_water_outside_us, 80);
+        landtype.insert(poi_no_data_built_outside_us, 50);
+        landtype.insert(poi_no_data_grass_outside_us, 30);
+        landtype.insert(poi_no_data_water_outside_us, 80);
+        landtype.insert(no_poi_built_outside_us, 50);
+        landtype.insert(no_poi_grass_outside_us, 30);
+        landtype.insert(no_poi_water_outside_us, 80);
+
+        // Urbanized data
+        // Urban     - something in the map, and in the geofence
+        // Not Urban - nothing in the map, but in the geofence
+        // Outside   - not in the geofence, urbanized hex never considered
+        let mut urbanized = HexTreeMap::<u8>::new();
+        urbanized.insert(poi_built_urbanized, 0);
+        urbanized.insert(poi_grass_urbanized, 0);
+        urbanized.insert(poi_water_urbanized, 0);
+        urbanized.insert(poi_no_data_built_urbanized, 0);
+        urbanized.insert(poi_no_data_grass_urbanized, 0);
+        urbanized.insert(poi_no_data_water_urbanized, 0);
+        urbanized.insert(no_poi_built_urbanized, 0);
+        urbanized.insert(no_poi_grass_urbanized, 0);
+        urbanized.insert(no_poi_water_urbanized, 0);
+
+        let inside_usa = [
+            poi_built_urbanized,
+            poi_grass_urbanized,
+            poi_water_urbanized,
+            poi_built_not_urbanized,
+            poi_grass_not_urbanized,
+            poi_water_not_urbanized,
+            poi_no_data_built_urbanized,
+            poi_no_data_grass_urbanized,
+            poi_no_data_water_urbanized,
+            poi_no_data_built_not_urbanized,
+            poi_no_data_grass_not_urbanized,
+            poi_no_data_water_not_urbanized,
+            no_poi_built_urbanized,
+            no_poi_grass_urbanized,
+            no_poi_water_urbanized,
+            no_poi_built_not_urbanized,
+            no_poi_grass_not_urbanized,
+            no_poi_water_not_urbanized,
+        ];
+        let geofence_set: HexTreeSet = inside_usa.iter().collect();
+        let usa_geofence = Geofence::new(geofence_set, h3o::Resolution::Twelve);
+
+        // These vectors are a standin for the file system
+        let mut urbanized_buf = vec![];
+        let mut footfall_buff = vec![];
+        let mut landtype_buf = vec![];
+
+        // Turn the HexTrees into DiskTrees
+        urbanized.to_disktree(Cursor::new(&mut urbanized_buf), |w, v| w.write_all(&[*v]))?;
+        footfall.to_disktree(Cursor::new(&mut footfall_buff), |w, v| w.write_all(&[*v]))?;
+        landtype.to_disktree(Cursor::new(&mut landtype_buf), |w, v| w.write_all(&[*v]))?;
+
+        let urbanized = DiskTreeMap::with_buf(urbanized_buf)?;
+        let footfall = DiskTreeMap::with_buf(footfall_buff)?;
+        let landtype = DiskTreeMap::with_buf(landtype_buf)?;
+
+        // Let the testing commence
+        let data = HexBoostData {
+            urbanized,
+            usa_geofence,
+            footfall,
+            landtype,
+        };
+
+        // NOTE(mj): formatting ignored to make it easier to see the expected change in assignments.
+        // NOTE(mj): The semicolon at the end of the block is there to keep rust from
+        // complaining about attributes on expression being experimental.
+        #[rustfmt::skip]
+        {
+            use Assignment::*;
+            // yellow
+            assert_eq!(HexAssignments { footfall: A, landtype: A, urbanized: A }, data.assignments(poi_built_urbanized)?);
+            assert_eq!(HexAssignments { footfall: A, landtype: B, urbanized: A }, data.assignments(poi_grass_urbanized)?);
+            assert_eq!(HexAssignments { footfall: A, landtype: C, urbanized: A }, data.assignments(poi_water_urbanized)?);
+            // orange
+            assert_eq!(HexAssignments { footfall: A, landtype: A, urbanized: B }, data.assignments(poi_built_not_urbanized)?);
+            assert_eq!(HexAssignments { footfall: A, landtype: B, urbanized: B }, data.assignments(poi_grass_not_urbanized)?);
+            assert_eq!(HexAssignments { footfall: A, landtype: C, urbanized: B }, data.assignments(poi_water_not_urbanized)?);
+            // light green
+            assert_eq!(HexAssignments { footfall: B, landtype: A, urbanized: A }, data.assignments(poi_no_data_built_urbanized)?);
+            assert_eq!(HexAssignments { footfall: B, landtype: B, urbanized: A }, data.assignments(poi_no_data_grass_urbanized)?);
+            assert_eq!(HexAssignments { footfall: B, landtype: C, urbanized: A }, data.assignments(poi_no_data_water_urbanized)?);
+            // green
+            assert_eq!(HexAssignments { footfall: B, landtype: A, urbanized: B }, data.assignments(poi_no_data_built_not_urbanized)?);
+            assert_eq!(HexAssignments { footfall: B, landtype: B, urbanized: B }, data.assignments(poi_no_data_grass_not_urbanized)?);
+            assert_eq!(HexAssignments { footfall: B, landtype: C, urbanized: B }, data.assignments(poi_no_data_water_not_urbanized)?);
+            // light blue
+            assert_eq!(HexAssignments { footfall: C, landtype: A, urbanized: A }, data.assignments(no_poi_built_urbanized)?);
+            assert_eq!(HexAssignments { footfall: C, landtype: B, urbanized: A }, data.assignments(no_poi_grass_urbanized)?);
+            assert_eq!(HexAssignments { footfall: C, landtype: C, urbanized: A }, data.assignments(no_poi_water_urbanized)?);
+            // dark blue
+            assert_eq!(HexAssignments { footfall: C, landtype: A, urbanized: B }, data.assignments(no_poi_built_not_urbanized)?);
+            assert_eq!(HexAssignments { footfall: C, landtype: B, urbanized: B }, data.assignments(no_poi_grass_not_urbanized)?);
+            assert_eq!(HexAssignments { footfall: C, landtype: C, urbanized: B }, data.assignments(no_poi_water_not_urbanized)?);
+            // gray
+            assert_eq!(HexAssignments { footfall: A, landtype: A, urbanized: C }, data.assignments(poi_built_outside_us)?);
+            assert_eq!(HexAssignments { footfall: A, landtype: B, urbanized: C }, data.assignments(poi_grass_outside_us)?);
+            assert_eq!(HexAssignments { footfall: A, landtype: C, urbanized: C }, data.assignments(poi_water_outside_us)?);
+            assert_eq!(HexAssignments { footfall: B, landtype: A, urbanized: C }, data.assignments(poi_no_data_built_outside_us)?);
+            assert_eq!(HexAssignments { footfall: B, landtype: B, urbanized: C }, data.assignments(poi_no_data_grass_outside_us)?);
+            assert_eq!(HexAssignments { footfall: B, landtype: C, urbanized: C }, data.assignments(poi_no_data_water_outside_us)?);
+            assert_eq!(HexAssignments { footfall: C, landtype: A, urbanized: C }, data.assignments(no_poi_built_outside_us)?);
+            assert_eq!(HexAssignments { footfall: C, landtype: B, urbanized: C }, data.assignments(no_poi_grass_outside_us)?);
+            assert_eq!(HexAssignments { footfall: C, landtype: C, urbanized: C }, data.assignments(no_poi_water_outside_us)?);
+            // never inserted
+            assert_eq!(HexAssignments { footfall: C, landtype: C, urbanized: C }, data.assignments(unknown_cell)?);
+        };
+
+        Ok(())
+    }
+}

--- a/mobile_verifier/src/boosting_oracles/mod.rs
+++ b/mobile_verifier/src/boosting_oracles/mod.rs
@@ -88,25 +88,6 @@ impl HexBoostData {
     }
 }
 
-trait DiskTreeLike: Send + Sync {
-    fn get(&self, cell: hextree::Cell) -> hextree::Result<Option<(hextree::Cell, &[u8])>>;
-}
-
-impl DiskTreeLike for DiskTreeMap {
-    fn get(&self, cell: hextree::Cell) -> hextree::Result<Option<(hextree::Cell, &[u8])>> {
-        self.get(cell)
-    }
-}
-
-impl DiskTreeLike for std::collections::HashSet<hextree::Cell> {
-    fn get(&self, cell: hextree::Cell) -> hextree::Result<Option<(hextree::Cell, &[u8])>> {
-        match self.contains(&cell) {
-            true => Ok(Some((cell, &[]))),
-            false => Ok(None),
-        }
-    }
-}
-
 impl From<WorldCover> for Assignment {
     fn from(value: WorldCover) -> Self {
         match value {

--- a/mobile_verifier/src/boosting_oracles/mod.rs
+++ b/mobile_verifier/src/boosting_oracles/mod.rs
@@ -83,33 +83,33 @@ impl HexBoostData {
             "unexpected landtype disktree data: {cell:?} {vals:?}"
         );
 
-        let cover = WorldCover::try_from(vals[0])?;
+        let cover = Landtype::try_from(vals[0])?;
         Ok(cover.into())
     }
 }
 
-impl From<WorldCover> for Assignment {
-    fn from(value: WorldCover) -> Self {
+impl From<Landtype> for Assignment {
+    fn from(value: Landtype) -> Self {
         match value {
-            WorldCover::Built => Assignment::A,
+            Landtype::Built => Assignment::A,
             //
-            WorldCover::Tree => Assignment::B,
-            WorldCover::Shrub => Assignment::B,
-            WorldCover::Grass => Assignment::B,
+            Landtype::Tree => Assignment::B,
+            Landtype::Shrub => Assignment::B,
+            Landtype::Grass => Assignment::B,
             //
-            WorldCover::Bare => Assignment::C,
-            WorldCover::Crop => Assignment::C,
-            WorldCover::Frozen => Assignment::C,
-            WorldCover::Water => Assignment::C,
-            WorldCover::Wet => Assignment::C,
-            WorldCover::Mangrove => Assignment::C,
-            WorldCover::Moss => Assignment::C,
+            Landtype::Bare => Assignment::C,
+            Landtype::Crop => Assignment::C,
+            Landtype::Frozen => Assignment::C,
+            Landtype::Water => Assignment::C,
+            Landtype::Wet => Assignment::C,
+            Landtype::Mangrove => Assignment::C,
+            Landtype::Moss => Assignment::C,
         }
     }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum WorldCover {
+pub enum Landtype {
     Tree = 10,
     Shrub = 20,
     Grass = 30,
@@ -123,45 +123,45 @@ pub enum WorldCover {
     Moss = 100,
 }
 
-impl std::fmt::Display for WorldCover {
+impl std::fmt::Display for Landtype {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.to_str())
     }
 }
 
-impl WorldCover {
+impl Landtype {
     pub(crate) fn to_str(self) -> &'static str {
         match self {
-            WorldCover::Tree => "TreeCover",
-            WorldCover::Shrub => "Shrubland",
-            WorldCover::Grass => "Grassland",
-            WorldCover::Crop => "Cropland",
-            WorldCover::Built => "BuiltUp",
-            WorldCover::Bare => "BareOrSparseVeg",
-            WorldCover::Frozen => "SnowAndIce",
-            WorldCover::Water => "Water",
-            WorldCover::Wet => "HerbaceousWetland",
-            WorldCover::Mangrove => "Mangroves",
-            WorldCover::Moss => "MossAndLichen",
+            Landtype::Tree => "TreeCover",
+            Landtype::Shrub => "Shrubland",
+            Landtype::Grass => "Grassland",
+            Landtype::Crop => "Cropland",
+            Landtype::Built => "BuiltUp",
+            Landtype::Bare => "BareOrSparseVeg",
+            Landtype::Frozen => "SnowAndIce",
+            Landtype::Water => "Water",
+            Landtype::Wet => "HerbaceousWetland",
+            Landtype::Mangrove => "Mangroves",
+            Landtype::Moss => "MossAndLichen",
         }
     }
 }
 
-impl TryFrom<u8> for WorldCover {
+impl TryFrom<u8> for Landtype {
     type Error = anyhow::Error;
-    fn try_from(other: u8) -> anyhow::Result<WorldCover, Self::Error> {
+    fn try_from(other: u8) -> anyhow::Result<Landtype, Self::Error> {
         let val = match other {
-            10 => WorldCover::Tree,
-            20 => WorldCover::Shrub,
-            30 => WorldCover::Grass,
-            40 => WorldCover::Crop,
-            50 => WorldCover::Built,
-            60 => WorldCover::Bare,
-            70 => WorldCover::Frozen,
-            80 => WorldCover::Water,
-            90 => WorldCover::Wet,
-            95 => WorldCover::Mangrove,
-            100 => WorldCover::Moss,
+            10 => Landtype::Tree,
+            20 => Landtype::Shrub,
+            30 => Landtype::Grass,
+            40 => Landtype::Crop,
+            50 => Landtype::Built,
+            60 => Landtype::Bare,
+            70 => Landtype::Frozen,
+            80 => Landtype::Water,
+            90 => Landtype::Wet,
+            95 => Landtype::Mangrove,
+            100 => Landtype::Moss,
             other => anyhow::bail!("unexpected landtype disktree value: {other:?}"),
         };
         Ok(val)

--- a/mobile_verifier/src/boosting_oracles/mod.rs
+++ b/mobile_verifier/src/boosting_oracles/mod.rs
@@ -1,7 +1,5 @@
 pub mod assignment;
 
-use std::collections::HashMap;
-
 use crate::{
     geofence::{Geofence, GeofenceValidator},
     Settings,
@@ -9,41 +7,39 @@ use crate::{
 pub use assignment::{Assignment, HexAssignments};
 use hextree::disktree::DiskTreeMap;
 
-pub fn make_hex_boost_data(
-    settings: &Settings,
-    usa_geofence: Geofence,
-) -> anyhow::Result<impl BoostedHexAssignments> {
-    let urban_disktree = DiskTreeMap::open(&settings.urbanization_data_set)?;
-    let footfall_disktree = DiskTreeMap::open(&settings.footfall_data_set)?;
-    let landtype_disktree = DiskTreeMap::open(&settings.landtype_data_set)?;
-
-    let urbanization = UrbanizationData::new(urban_disktree, usa_geofence);
-    let footfall_data = FootfallData::new(footfall_disktree);
-    let landtype_data = LandTypeData::new(landtype_disktree);
-
-    let hex_boost_data = HexBoostData::new(urbanization, footfall_data, landtype_data);
-
-    Ok(hex_boost_data)
-}
-
 pub trait BoostedHexAssignments: Send + Sync {
     fn assignments(&self, cell: hextree::Cell) -> anyhow::Result<HexAssignments>;
 }
 
-trait HexAssignment: Send + Sync {
-    fn assignment(&self, cell: hextree::Cell) -> anyhow::Result<Assignment>;
+pub struct HexBoostData {
+    urbanized: DiskTreeMap,
+    usa_geofence: Geofence,
+    footfall: DiskTreeMap,
+    landtype: DiskTreeMap,
 }
 
-impl<U, F, L> BoostedHexAssignments for HexBoostData<U, F, L>
-where
-    U: HexAssignment,
-    F: HexAssignment,
-    L: HexAssignment,
-{
+pub fn make_hex_boost_data(
+    settings: &Settings,
+    usa_geofence: Geofence,
+) -> anyhow::Result<HexBoostData> {
+    let urban_disktree = DiskTreeMap::open(&settings.urbanization_data_set)?;
+    let footfall_disktree = DiskTreeMap::open(&settings.footfall_data_set)?;
+    let landtype_disktree = DiskTreeMap::open(&settings.landtype_data_set)?;
+
+    let hex_boost_data = HexBoostData {
+        urbanized: urban_disktree,
+        usa_geofence,
+        footfall: footfall_disktree,
+        landtype: landtype_disktree,
+    };
+
+    Ok(hex_boost_data)
+}
+impl BoostedHexAssignments for HexBoostData {
     fn assignments(&self, cell: hextree::Cell) -> anyhow::Result<HexAssignments> {
-        let footfall = self.footfall.assignment(cell)?;
-        let urbanized = self.urbanization.assignment(cell)?;
-        let landtype = self.landtype.assignment(cell)?;
+        let footfall = self.footfall_assignment(cell)?;
+        let urbanized = self.urbanized_assignment(cell)?;
+        let landtype = self.landtype_assignment(cell)?;
 
         Ok(HexAssignments {
             footfall,
@@ -53,53 +49,42 @@ where
     }
 }
 
-pub struct HexBoostData<Urban, Foot, Land> {
-    pub urbanization: Urban,
-    pub footfall: Foot,
-    pub landtype: Land,
-}
+impl HexBoostData {
+    fn urbanized_assignment(&self, cell: hextree::Cell) -> anyhow::Result<Assignment> {
+        if !self.usa_geofence.in_valid_region(&cell) {
+            return Ok(Assignment::C);
+        }
 
-pub struct UrbanizationData<Urban, Geo> {
-    urbanized: Urban,
-    usa_geofence: Geo,
-}
-
-pub struct FootfallData<Foot> {
-    footfall: Foot,
-}
-
-pub struct LandTypeData<Land> {
-    landtype: Land,
-}
-
-impl<Urban, Foot, Land> HexBoostData<Urban, Foot, Land> {
-    pub fn new(urbanization: Urban, footfall: Foot, landtype: Land) -> Self {
-        Self {
-            urbanization,
-            footfall,
-            landtype,
+        match self.urbanized.get(cell)?.is_some() {
+            true => Ok(Assignment::A),
+            false => Ok(Assignment::B),
         }
     }
-}
 
-impl<Urban, Geo> UrbanizationData<Urban, Geo> {
-    pub fn new(urbanized: Urban, usa_geofence: Geo) -> Self {
-        Self {
-            urbanized,
-            usa_geofence,
+    fn footfall_assignment(&self, cell: hextree::Cell) -> anyhow::Result<Assignment> {
+        let Some((_, vals)) = self.footfall.get(cell)? else {
+            return Ok(Assignment::C);
+        };
+
+        match vals {
+            &[x] if x >= 1 => Ok(Assignment::A),
+            &[0] => Ok(Assignment::B),
+            other => anyhow::bail!("unexpected footfall disktree data: {cell:?} {other:?}"),
         }
     }
-}
 
-impl<Foot> FootfallData<Foot> {
-    pub fn new(footfall: Foot) -> Self {
-        Self { footfall }
-    }
-}
+    fn landtype_assignment(&self, cell: hextree::Cell) -> anyhow::Result<Assignment> {
+        let Some((_, vals)) = self.landtype.get(cell)? else {
+            return Ok(Assignment::C);
+        };
 
-impl<Land> LandTypeData<Land> {
-    pub fn new(landtype: Land) -> Self {
-        Self { landtype }
+        anyhow::ensure!(
+            vals.len() == 1,
+            "unexpected landtype disktree data: {cell:?} {vals:?}"
+        );
+
+        let cover = WorldCover::try_from(vals[0])?;
+        Ok(cover.into())
     }
 }
 
@@ -118,86 +103,6 @@ impl DiskTreeLike for std::collections::HashSet<hextree::Cell> {
         match self.contains(&cell) {
             true => Ok(Some((cell, &[]))),
             false => Ok(None),
-        }
-    }
-}
-
-impl<Urban, Geo> HexAssignment for UrbanizationData<Urban, Geo>
-where
-    Urban: DiskTreeLike,
-    Geo: GeofenceValidator<hextree::Cell>,
-{
-    fn assignment(&self, cell: hextree::Cell) -> anyhow::Result<Assignment> {
-        if !self.usa_geofence.in_valid_region(&cell) {
-            return Ok(Assignment::C);
-        }
-
-        match self.urbanized.get(cell)?.is_some() {
-            true => Ok(Assignment::A),
-            false => Ok(Assignment::B),
-        }
-    }
-}
-
-impl<Foot> HexAssignment for FootfallData<Foot>
-where
-    Foot: DiskTreeLike,
-{
-    fn assignment(&self, cell: hextree::Cell) -> anyhow::Result<Assignment> {
-        let Some((_, vals)) = self.footfall.get(cell)? else {
-            return Ok(Assignment::C);
-        };
-
-        match vals {
-            &[x] if x >= 1 => Ok(Assignment::A),
-            &[0] => Ok(Assignment::B),
-            other => anyhow::bail!("unexpected footfall disktree data: {cell:?} {other:?}"),
-        }
-    }
-}
-
-impl<Land> HexAssignment for LandTypeData<Land>
-where
-    Land: DiskTreeLike,
-{
-    fn assignment(&self, cell: hextree::Cell) -> anyhow::Result<Assignment> {
-        let Some((_, vals)) = self.landtype.get(cell)? else {
-            return Ok(Assignment::C);
-        };
-
-        let cover = match vals {
-            &[x] => WorldCover::try_from(x).map_err(|_| {
-                anyhow::anyhow!("unexpected landtype disktree value: {cell:?} {x:?}")
-            })?,
-            other => anyhow::bail!("unexpected landtype disktree data: {cell:?} {other:?}"),
-        };
-
-        Ok(Assignment::from(cover))
-    }
-}
-
-impl HexAssignment for LandTypeData<Assignment> {
-    fn assignment(&self, _cell: hextree::Cell) -> anyhow::Result<Assignment> {
-        Ok(self.landtype)
-    }
-}
-
-impl HexAssignment for HashMap<hextree::Cell, bool> {
-    fn assignment(&self, cell: hextree::Cell) -> anyhow::Result<Assignment> {
-        let assignment = match self.get(&cell) {
-            Some(true) => Assignment::A,
-            Some(false) => Assignment::B,
-            None => Assignment::C,
-        };
-        Ok(assignment)
-    }
-}
-
-impl HexAssignment for HashMap<hextree::Cell, Assignment> {
-    fn assignment(&self, cell: hextree::Cell) -> anyhow::Result<Assignment> {
-        match self.get(&cell) {
-            Some(val) => Ok(*val),
-            None => anyhow::bail!("{cell:?} not found"),
         }
     }
 }
@@ -244,7 +149,6 @@ impl std::fmt::Display for WorldCover {
 }
 
 impl WorldCover {
-    #[allow(dead_code)]
     pub(crate) fn to_str(self) -> &'static str {
         match self {
             WorldCover::Tree => "TreeCover",
@@ -263,8 +167,8 @@ impl WorldCover {
 }
 
 impl TryFrom<u8> for WorldCover {
-    type Error = ();
-    fn try_from(other: u8) -> Result<WorldCover, ()> {
+    type Error = anyhow::Error;
+    fn try_from(other: u8) -> anyhow::Result<WorldCover, Self::Error> {
         let val = match other {
             10 => WorldCover::Tree,
             20 => WorldCover::Shrub,
@@ -277,7 +181,7 @@ impl TryFrom<u8> for WorldCover {
             90 => WorldCover::Wet,
             95 => WorldCover::Mangrove,
             100 => WorldCover::Moss,
-            _ => return Err(()),
+            other => anyhow::bail!("unexpected landtype disktree value: {other:?}"),
         };
         Ok(val)
     }

--- a/mobile_verifier/src/cli/mod.rs
+++ b/mobile_verifier/src/cli/mod.rs
@@ -1,2 +1,3 @@
 pub mod reward_from_db;
 pub mod server;
+pub mod verify_disktree;

--- a/mobile_verifier/src/cli/server.rs
+++ b/mobile_verifier/src/cli/server.rs
@@ -108,7 +108,8 @@ impl Cmd {
         let usa_region_paths = settings.usa_region_paths()?;
         tracing::info!(?usa_region_paths, "usa_geofence_regions");
 
-        let usa_geofence = Geofence::new(usa_region_paths, settings.usa_fencing_resolution()?)?;
+        let usa_geofence =
+            Geofence::from_paths(usa_region_paths, settings.usa_fencing_resolution()?)?;
 
         let cbrs_heartbeat_daemon = CellHeartbeatDaemon::new(
             pool.clone(),
@@ -128,7 +129,7 @@ impl Cmd {
             "usa_and_mexico_geofence_regions"
         );
 
-        let usa_and_mexico_geofence = Geofence::new(
+        let usa_and_mexico_geofence = Geofence::from_paths(
             usa_and_mexico_region_paths,
             settings.usa_and_mexico_fencing_resolution()?,
         )?;

--- a/mobile_verifier/src/cli/verify_disktree.rs
+++ b/mobile_verifier/src/cli/verify_disktree.rs
@@ -1,0 +1,61 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use hextree::disktree::DiskTreeMap;
+
+use crate::{
+    boosting_oracles::{Assignment, WorldCover},
+    Settings,
+};
+
+#[derive(Debug, clap::Args)]
+pub struct Cmd {
+    /// Path to the unzipped .h3tree file
+    #[clap(long)]
+    path: PathBuf,
+
+    /// Expected type of the .h3tree file
+    #[clap(long)]
+    r#type: DisktreeType,
+}
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+enum DisktreeType {
+    Landtype,
+}
+
+impl Cmd {
+    pub async fn run(self, _settings: &Settings) -> anyhow::Result<()> {
+        let disktree = DiskTreeMap::open(&self.path)?;
+
+        let mut value_counts = HashMap::<u8, usize>::new();
+        let mut idx: u128 = 0;
+        let start = tokio::time::Instant::now();
+
+        println!("Checking {}, this may take a while...", self.path.display());
+        for x in disktree.iter()? {
+            idx += 1;
+            if idx % 100_000_000 == 0 {
+                println!("Processed {} cells after {:?}", idx, start.elapsed());
+            }
+            let (_cell, vals) = x.unwrap();
+            *value_counts.entry(vals[0]).or_insert(0) += 1;
+        }
+
+        println!("REPORT {}", "=".repeat(50));
+        match self.r#type {
+            DisktreeType::Landtype => {
+                for (key, count) in value_counts {
+                    let cover = WorldCover::try_from(key);
+                    let assignment = cover.as_ref().map(|x| Assignment::from(x.clone()));
+                    // cover is formatted twice to allow for padding a result
+                    println!(
+                        "| {key:<4} | {count:<12} | {:<20} | {assignment:?} |",
+                        format!("{cover:?}")
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/mobile_verifier/src/cli/verify_disktree.rs
+++ b/mobile_verifier/src/cli/verify_disktree.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf};
 use hextree::disktree::DiskTreeMap;
 
 use crate::{
-    boosting_oracles::{Assignment, WorldCover},
+    boosting_oracles::{Assignment, Landtype},
     Settings,
 };
 
@@ -45,12 +45,12 @@ impl Cmd {
         match self.r#type {
             DisktreeType::Landtype => {
                 for (key, count) in value_counts {
-                    let cover = WorldCover::try_from(key);
-                    let assignment = cover.as_ref().map(|x| Assignment::from(x.clone()));
+                    let landtype = Landtype::try_from(key);
+                    let assignment = landtype.as_ref().map(|lt| Assignment::from(*lt));
                     // cover is formatted twice to allow for padding a result
                     println!(
                         "| {key:<4} | {count:<12} | {:<20} | {assignment:?} |",
-                        format!("{cover:?}")
+                        format!("{landtype:?}")
                     );
                 }
             }

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -225,7 +225,7 @@ async fn initialize_unassigned_hexes(
     hex_boost_data: &impl BoostedHexAssignments,
     pool: &Pool<Postgres>,
 ) -> Result<HashMap<Uuid, Vec<proto::OracleBoostingHexAssignment>>, anyhow::Error> {
-    const NUMBER_OF_FIELDS_IN_QUERY: u16 = 6;
+    const NUMBER_OF_FIELDS_IN_QUERY: u16 = 7;
     const ASSIGNMENTS_MAX_BATCH_ENTRIES: usize = (u16::MAX / NUMBER_OF_FIELDS_IN_QUERY) as usize;
 
     let mut boost_results = HashMap::<Uuid, Vec<proto::OracleBoostingHexAssignment>>::new();

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -1,5 +1,5 @@
 use crate::{
-    boosting_oracles::{assignment::HexAssignments, BoostedHexAssignments},
+    boosting_oracles::{assignment::HexAssignments, BoostedHexAssignments, HexBoostData},
     heartbeats::{HbType, KeyType, OwnedKeyType},
     IsAuthorized,
 };
@@ -64,24 +64,21 @@ impl From<SignalLevelProto> for SignalLevel {
     }
 }
 
-pub struct CoverageDaemon<Hex> {
+pub struct CoverageDaemon {
     pool: Pool<Postgres>,
     auth_client: AuthorizationClient,
-    hex_boost_data: Hex,
+    hex_boost_data: HexBoostData,
     coverage_objs: Receiver<FileInfoStream<CoverageObjectIngestReport>>,
     initial_boosting_reports: Option<Vec<OracleBoostingReportV1>>,
     coverage_obj_sink: FileSinkClient,
     oracle_boosting_sink: FileSinkClient,
 }
 
-impl<Hex> CoverageDaemon<Hex>
-where
-    Hex: BoostedHexAssignments,
-{
+impl CoverageDaemon {
     pub async fn new(
         pool: PgPool,
         auth_client: AuthorizationClient,
-        hex_boost_data: Hex,
+        hex_boost_data: HexBoostData,
         coverage_objs: Receiver<FileInfoStream<CoverageObjectIngestReport>>,
         coverage_obj_sink: FileSinkClient,
         oracle_boosting_sink: FileSinkClient,
@@ -290,10 +287,7 @@ async fn initialize_unassigned_hexes(
     Ok(boost_results)
 }
 
-impl<Hex> ManagedTask for CoverageDaemon<Hex>
-where
-    Hex: BoostedHexAssignments + 'static,
-{
+impl ManagedTask for CoverageDaemon {
     fn start_task(
         self: Box<Self>,
         shutdown: triggered::Listener,

--- a/mobile_verifier/src/geofence.rs
+++ b/mobile_verifier/src/geofence.rs
@@ -22,11 +22,19 @@ pub struct Geofence {
 }
 
 impl Geofence {
-    pub fn new(paths: Vec<std::path::PathBuf>, resolution: Resolution) -> anyhow::Result<Self> {
-        Ok(Self {
-            regions: Arc::new(valid_mapping_regions(paths)?),
+    pub fn new(hextree: HexTreeSet, resolution: Resolution) -> Self {
+        Self {
+            regions: Arc::new(hextree),
             resolution,
-        })
+        }
+    }
+
+    pub fn from_paths(
+        paths: Vec<std::path::PathBuf>,
+        resolution: Resolution,
+    ) -> anyhow::Result<Self> {
+        let hextree = valid_mapping_regions(paths)?;
+        Ok(Self::new(hextree, resolution))
     }
 }
 

--- a/mobile_verifier/src/main.rs
+++ b/mobile_verifier/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use mobile_verifier::{
-    cli::{reward_from_db, server},
+    cli::{reward_from_db, server, verify_disktree},
     Settings,
 };
 use std::path;
@@ -36,6 +36,11 @@ impl Cli {
 pub enum Cmd {
     Server(server::Cmd),
     RewardFromDb(reward_from_db::Cmd),
+    /// Verify a Disktree file for HexBoosting.
+    ///
+    /// Go through every cell and ensure it's value can be turned into an Assignment.
+    /// NOTE: This can take a very long time. Run with a --release binary.
+    VerifyDisktree(verify_disktree::Cmd),
 }
 
 impl Cmd {
@@ -43,6 +48,7 @@ impl Cmd {
         match self {
             Self::Server(cmd) => cmd.run(&settings).await,
             Self::RewardFromDb(cmd) => cmd.run(&settings).await,
+            Self::VerifyDisktree(cmd) => cmd.run(&settings).await,
         }
     }
 }

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -1006,6 +1006,7 @@ mod test {
             inserted_at: DateTime::<Utc>::MIN_UTC,
             urbanized: Assignment::A,
             footfall: Assignment::C,
+            landtype: Assignment::A,
         }]
     }
 
@@ -1892,6 +1893,7 @@ mod test {
                                 coverage_points: dec!(10.0),
                                 urbanized: Assignment::A,
                                 footfall: Assignment::A,
+                                landtype: Assignment::A,
                                 rank: None,
                             },
                             boosted_hex: BoostedHex {

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -697,11 +697,10 @@ pub fn get_scheduled_tokens_for_oracles(duration: Duration) -> Decimal {
 mod test {
     use super::*;
     use crate::{
-        boosting_oracles::Assignment,
+        boosting_oracles::assignment::HexAssignments,
         cell_type::CellType,
         coverage::{CoveredHexStream, HexCoverage, Seniority},
-        data_session::HotspotDataSession,
-        data_session::{self, HotspotReward},
+        data_session::{self, HotspotDataSession, HotspotReward},
         heartbeats::{HeartbeatReward, KeyType, OwnedKeyType},
         reward_shares,
         speedtests::Speedtest,
@@ -1004,9 +1003,7 @@ mod test {
             signal_power: 0,
             coverage_claim_time: DateTime::<Utc>::MIN_UTC,
             inserted_at: DateTime::<Utc>::MIN_UTC,
-            urbanized: Assignment::A,
-            footfall: Assignment::C,
-            landtype: Assignment::A,
+            assignments: HexAssignments::test_best(),
         }]
     }
 
@@ -1891,9 +1888,7 @@ mod test {
                             coverage_points: CoverageRewardPoints {
                                 boost_multiplier: NonZeroU32::new(1).unwrap(),
                                 coverage_points: dec!(10.0),
-                                urbanized: Assignment::A,
-                                footfall: Assignment::A,
-                                landtype: Assignment::A,
+                                hex_assignments: HexAssignments::test_best(),
                                 rank: None,
                             },
                             boosted_hex: BoostedHex {

--- a/mobile_verifier/src/settings.rs
+++ b/mobile_verifier/src/settings.rs
@@ -44,6 +44,7 @@ pub struct Settings {
     pub usa_fencing_resolution: u8,
     pub urbanization_data_set: PathBuf,
     pub footfall_data_set: PathBuf,
+    pub landtype_data_set: PathBuf,
 }
 
 fn default_fencing_resolution() -> u8 {

--- a/mobile_verifier/tests/boosting_oracles.rs
+++ b/mobile_verifier/tests/boosting_oracles.rs
@@ -146,34 +146,35 @@ async fn test_footfall_and_urbanization_report(pool: PgPool) -> anyhow::Result<(
     }
 
     let hexes = {
+        // NOTE(mj): Cell is mutated in constructor to keep elements aligned for readability
         let mut cell = CellIndex::try_from(0x8c2681a3064d9ff)?;
         use Assignment::*;
         vec![
-            // yellow
+            // yellow - POI ≥ 1 Urbanized
             new_hex_assingment(&mut cell, A, A, A, 1000),
             new_hex_assingment(&mut cell, A, B, A, 1000),
             new_hex_assingment(&mut cell, A, C, A, 1000),
-            // orange
+            // orange - POI ≥ 1 Not Urbanized
             new_hex_assingment(&mut cell, A, A, B, 1000),
             new_hex_assingment(&mut cell, A, B, B, 1000),
             new_hex_assingment(&mut cell, A, C, B, 1000),
-            // light green
+            // light green - Point of Interest Urbanized
             new_hex_assingment(&mut cell, B, A, A, 700),
             new_hex_assingment(&mut cell, B, B, A, 700),
             new_hex_assingment(&mut cell, B, C, A, 700),
-            // green
+            // dark green - Point of Interest Not Urbanized
             new_hex_assingment(&mut cell, B, A, B, 500),
             new_hex_assingment(&mut cell, B, B, B, 500),
             new_hex_assingment(&mut cell, B, C, B, 500),
-            // light blue
+            // light blue - No POI Urbanized
             new_hex_assingment(&mut cell, C, A, A, 400),
             new_hex_assingment(&mut cell, C, B, A, 300),
             new_hex_assingment(&mut cell, C, C, A, 50),
-            // dark blue
+            // dark blue - No POI Not Urbanized
             new_hex_assingment(&mut cell, C, A, B, 200),
             new_hex_assingment(&mut cell, C, B, B, 150),
             new_hex_assingment(&mut cell, C, C, B, 30),
-            // gray
+            // gray - Outside of USA
             new_hex_assingment(&mut cell, A, A, C, 0),
             new_hex_assingment(&mut cell, A, B, C, 0),
             new_hex_assingment(&mut cell, A, C, C, 0),
@@ -264,34 +265,35 @@ async fn test_footfall_and_urbanization_and_landtype(pool: PgPool) -> anyhow::Re
     }
 
     let hexes = {
+        // NOTE(mj): Cell is mutated in constructor to keep elements aligned for readability
         let mut cell = CellIndex::try_from(0x8c2681a3064d9ff)?;
         use Assignment::*;
         vec![
-            // yellow
+            // yellow - POI ≥ 1 Urbanized
             TestHex::new(&mut cell, A, A, A, 400),
             TestHex::new(&mut cell, A, B, A, 400),
             TestHex::new(&mut cell, A, C, A, 400),
-            // orange
+            // orange - POI ≥ 1 Not Urbanized
             TestHex::new(&mut cell, A, A, B, 400),
             TestHex::new(&mut cell, A, B, B, 400),
             TestHex::new(&mut cell, A, C, B, 400),
-            // light green
+            // light green - Point of Interest Urbanized
             TestHex::new(&mut cell, B, A, A, 280),
             TestHex::new(&mut cell, B, B, A, 280),
             TestHex::new(&mut cell, B, C, A, 280),
-            // green
+            // dark green - Point of Interest Not Urbanized
             TestHex::new(&mut cell, B, A, B, 200),
             TestHex::new(&mut cell, B, B, B, 200),
             TestHex::new(&mut cell, B, C, B, 200),
-            // light blue
+            // light blue - No POI Urbanized
             TestHex::new(&mut cell, C, A, A, 160),
             TestHex::new(&mut cell, C, B, A, 120),
             TestHex::new(&mut cell, C, C, A, 20),
-            // dark blue
+            // dark blue - No POI Not Urbanized
             TestHex::new(&mut cell, C, A, B, 80),
             TestHex::new(&mut cell, C, B, B, 60),
             TestHex::new(&mut cell, C, C, B, 12),
-            // gray
+            // gray - Outside of USA
             TestHex::new(&mut cell, A, A, C, 0),
             TestHex::new(&mut cell, A, B, C, 0),
             TestHex::new(&mut cell, A, C, C, 0),
@@ -411,31 +413,31 @@ async fn test_footfall_and_urbanization_and_landtype(pool: PgPool) -> anyhow::Re
     //        (Footfall, Landtype, Urbanized)
     // Hex   | Assignment | Points Equation | Sum
     // -----------------------------------------------
-    // == yellow
+    // == yellow - POI ≥ 1 Urbanized
     // hex1  | A, A, A    | 400 * 1         | 400
     // hex2  | A, B, A    | 400 * 1         | 400
     // hex3  | A, C, A    | 400 * 1         | 400
-    // == orange
+    // == orange - POI ≥ 1 Not Urbanized
     // hex4  | A, A, B    | 400 * 1         | 400
     // hex5  | A, B, B    | 400 * 1         | 400
     // hex6  | A, C, B    | 400 * 1         | 400
-    // == light green
+    // == light green - Point of Interest Urbanized
     // hex7  | B, A, A    | 400 * 0.70      | 280
     // hex8  | B, B, A    | 400 * 0.70      | 280
     // hex9  | B, C, A    | 400 * 0.70      | 280
-    // == green
+    // == dark green - Point of Interest Not Urbanized
     // hex10 | B, A, B    | 400 * 0.50      | 200
     // hex11 | B, B, B    | 400 * 0.50      | 200
     // hex12 | B, C, B    | 400 * 0.50      | 200
-    // == light blue
+    // == light blue - No POI Urbanized
     // hex13 | C, A, A    | 400 * 0.40     | 160
     // hex14 | C, B, A    | 400 * 0.30     | 120
     // hex15 | C, C, A    | 400 * 0.05     | 20
-    // == dark blue
+    // == dark blue - No POI Not Urbanized
     // hex16 | C, A, B    | 400 * 0.20     | 80
     // hex17 | C, B, B    | 400 * 0.15     | 60
     // hex18 | C, C, B    | 400 * 0.03     | 12
-    // == gray
+    // == gray - Outside of USA
     // hex19 | A, A, C    | 400 * 0.00     | 0
     // hex20 | A, B, C    | 400 * 0.00     | 0
     // hex21 | A, C, C    | 400 * 0.00     | 0

--- a/mobile_verifier/tests/boosting_oracles.rs
+++ b/mobile_verifier/tests/boosting_oracles.rs
@@ -205,9 +205,9 @@ async fn test_footfall_and_urbanization_report(pool: PgPool) -> anyhow::Result<(
     let mut urbanized = HashMap::<hextree::Cell, Assignment>::new();
     let mut landtype = HashMap::<hextree::Cell, Assignment>::new();
     for hex in hexes.iter() {
-        urbanized.insert(hex_cell(&hex.location), hex.urbanized.try_into()?);
-        footfall.insert(hex_cell(&hex.location), hex.footfall.try_into()?);
-        landtype.insert(hex_cell(&hex.location), hex.landtype.try_into()?);
+        urbanized.insert(hex_cell(&hex.location), hex.urbanized().into());
+        footfall.insert(hex_cell(&hex.location), hex.footfall().into());
+        landtype.insert(hex_cell(&hex.location), hex.landtype().into());
     }
 
     let mut transaction = pool.begin().await?;

--- a/mobile_verifier/tests/common/mod.rs
+++ b/mobile_verifier/tests/common/mod.rs
@@ -170,14 +170,36 @@ pub fn seconds(s: u64) -> std::time::Duration {
     std::time::Duration::from_secs(s)
 }
 
-pub struct MockHexAssignments;
+type MockAssignmentMap = HashMap<hextree::Cell, Assignment>;
+
+#[derive(Default)]
+pub struct MockHexAssignments {
+    footfall: MockAssignmentMap,
+    urbanized: MockAssignmentMap,
+    landtype: MockAssignmentMap,
+}
+
+impl MockHexAssignments {
+    #[allow(dead_code)]
+    pub fn new(
+        footfall: MockAssignmentMap,
+        urbanized: MockAssignmentMap,
+        landtype: MockAssignmentMap,
+    ) -> Self {
+        Self {
+            footfall,
+            urbanized,
+            landtype,
+        }
+    }
+}
 
 impl BoostedHexAssignments for MockHexAssignments {
-    fn assignments(&self, _cell: hextree::Cell) -> anyhow::Result<HexAssignments> {
+    fn assignments(&self, cell: hextree::Cell) -> anyhow::Result<HexAssignments> {
         Ok(HexAssignments {
-            footfall: Assignment::A,
-            urbanized: Assignment::A,
-            landtype: Assignment::A,
+            footfall: self.footfall.get(&cell).cloned().unwrap_or(Assignment::A),
+            urbanized: self.urbanized.get(&cell).cloned().unwrap_or(Assignment::A),
+            landtype: self.landtype.get(&cell).cloned().unwrap_or(Assignment::A),
         })
     }
 }

--- a/mobile_verifier/tests/common/mod.rs
+++ b/mobile_verifier/tests/common/mod.rs
@@ -174,10 +174,11 @@ pub struct MockHexAssignments;
 
 #[allow(dead_code)]
 impl MockHexAssignments {
-    pub fn best() -> HexBoostData<impl HexAssignment, impl HexAssignment> {
+    pub fn best() -> HexBoostData<impl HexAssignment, impl HexAssignment, impl HexAssignment> {
         HexBoostData {
             urbanization: Assignment::A,
             footfall: Assignment::A,
+            landtype: Assignment::A,
         }
     }
 }

--- a/mobile_verifier/tests/common/mod.rs
+++ b/mobile_verifier/tests/common/mod.rs
@@ -7,7 +7,7 @@ use helium_proto::{
     Message,
 };
 use mobile_config::boosted_hex_info::BoostedHexInfo;
-use mobile_verifier::boosting_oracles::{Assignment, HexAssignment, HexBoostData};
+use mobile_verifier::boosting_oracles::{Assignment, BoostedHexAssignments, HexAssignments};
 use std::collections::HashMap;
 use tokio::{sync::mpsc::error::TryRecvError, time::timeout};
 
@@ -172,13 +172,12 @@ pub fn seconds(s: u64) -> std::time::Duration {
 
 pub struct MockHexAssignments;
 
-#[allow(dead_code)]
-impl MockHexAssignments {
-    pub fn best() -> HexBoostData<impl HexAssignment, impl HexAssignment, impl HexAssignment> {
-        HexBoostData {
-            urbanization: Assignment::A,
+impl BoostedHexAssignments for MockHexAssignments {
+    fn assignments(&self, _cell: hextree::Cell) -> anyhow::Result<HexAssignments> {
+        Ok(HexAssignments {
             footfall: Assignment::A,
+            urbanized: Assignment::A,
             landtype: Assignment::A,
-        }
+        })
     }
 }

--- a/mobile_verifier/tests/hex_boosting.rs
+++ b/mobile_verifier/tests/hex_boosting.rs
@@ -62,8 +62,12 @@ impl HexBoostingInfoResolver for MockHexBoostingClient {
 
 async fn update_assignments(pool: &PgPool) -> anyhow::Result<()> {
     let unassigned_hexes = UnassignedHex::fetch(pool);
-    let _ = set_oracle_boosting_assignments(unassigned_hexes, &common::MockHexAssignments, pool)
-        .await?;
+    let _ = set_oracle_boosting_assignments(
+        unassigned_hexes,
+        &common::MockHexAssignments::default(),
+        pool,
+    )
+    .await?;
     Ok(())
 }
 

--- a/mobile_verifier/tests/hex_boosting.rs
+++ b/mobile_verifier/tests/hex_boosting.rs
@@ -62,12 +62,8 @@ impl HexBoostingInfoResolver for MockHexBoostingClient {
 
 async fn update_assignments(pool: &PgPool) -> anyhow::Result<()> {
     let unassigned_hexes = UnassignedHex::fetch(pool);
-    let _ = set_oracle_boosting_assignments(
-        unassigned_hexes,
-        &common::MockHexAssignments::best(),
-        pool,
-    )
-    .await?;
+    let _ = set_oracle_boosting_assignments(unassigned_hexes, &common::MockHexAssignments, pool)
+        .await?;
     Ok(())
 }
 

--- a/mobile_verifier/tests/modeled_coverage.rs
+++ b/mobile_verifier/tests/modeled_coverage.rs
@@ -413,8 +413,12 @@ async fn process_input(
     transaction.commit().await?;
 
     let unassigned_hexes = UnassignedHex::fetch(pool);
-    let _ = set_oracle_boosting_assignments(unassigned_hexes, &common::MockHexAssignments, pool)
-        .await?;
+    let _ = set_oracle_boosting_assignments(
+        unassigned_hexes,
+        &common::MockHexAssignments::default(),
+        pool,
+    )
+    .await?;
 
     let mut transaction = pool.begin().await?;
     let mut heartbeats = pin!(ValidatedHeartbeat::validate_heartbeats(

--- a/mobile_verifier/tests/modeled_coverage.rs
+++ b/mobile_verifier/tests/modeled_coverage.rs
@@ -413,12 +413,8 @@ async fn process_input(
     transaction.commit().await?;
 
     let unassigned_hexes = UnassignedHex::fetch(pool);
-    let _ = set_oracle_boosting_assignments(
-        unassigned_hexes,
-        &common::MockHexAssignments::best(),
-        pool,
-    )
-    .await?;
+    let _ = set_oracle_boosting_assignments(unassigned_hexes, &common::MockHexAssignments, pool)
+        .await?;
 
     let mut transaction = pool.begin().await?;
     let mut heartbeats = pin!(ValidatedHeartbeat::validate_heartbeats(

--- a/mobile_verifier/tests/rewarder_poc_dc.rs
+++ b/mobile_verifier/tests/rewarder_poc_dc.rs
@@ -305,12 +305,8 @@ async fn seed_heartbeats(
 
 async fn update_assignments(pool: &PgPool) -> anyhow::Result<()> {
     let unassigned_hexes = UnassignedHex::fetch(pool);
-    let _ = set_oracle_boosting_assignments(
-        unassigned_hexes,
-        &common::MockHexAssignments::best(),
-        pool,
-    )
-    .await?;
+    let _ = set_oracle_boosting_assignments(unassigned_hexes, &common::MockHexAssignments, pool)
+        .await?;
     Ok(())
 }
 

--- a/mobile_verifier/tests/rewarder_poc_dc.rs
+++ b/mobile_verifier/tests/rewarder_poc_dc.rs
@@ -305,8 +305,12 @@ async fn seed_heartbeats(
 
 async fn update_assignments(pool: &PgPool) -> anyhow::Result<()> {
     let unassigned_hexes = UnassignedHex::fetch(pool);
-    let _ = set_oracle_boosting_assignments(unassigned_hexes, &common::MockHexAssignments, pool)
-        .await?;
+    let _ = set_oracle_boosting_assignments(
+        unassigned_hexes,
+        &common::MockHexAssignments::default(),
+        pool,
+    )
+    .await?;
     Ok(())
 }
 


### PR DESCRIPTION
https://github.com/helium/proto/pull/398

Add Landtype to Hex Boosting.

---

### `struct HexAssignments`

`Assignments` are never considered individually, nor should they be. This type packs them together, allowing any code that requires specific use of `Assignment` order to attach itself here.

It also allows `boostring_oracles/mod.rs` to reduce it's reliance on traits. There is now a single exported `BoostedHexAssignments` that allows for getting a `HexAssignments`.

---

### `HexBoostData` and `CoverageDaemon`

With only exporting a single trait from `boosting_oracles/mod.rs`, the `CoverageDaemon` now takes the concrete struct `HexBoostData` with no generic arguments.

Downstream from the `CoverageDaemon`, functions will take `impl BoostedHexAssignments` so they can be used in tests.

---

### `verify-disktree --path <PATH> --type <TYPE>` CLI Command

A CLI command was added to `mobile-verifier`.
It verifies a `.h3tree` file by making sure that every cell can be turned into an `Assignment`.

Current only `Landtype` is supported.

NOTE: In release mode, this function took about 8 minutes to run on my 2.3GHz Intel MacBook Pro for a 28gb file.

```sh
cargo run --release --features "file-store/local" -p mobile-verifier -- -c <CONFIG> verify-disktree --help
```

---

#### Other

- Replaced `Geofence::new` with `Geofence::from_paths` so `new` could used without touching the filesystem.