### PR TITLE
use beacon recip table rather than last beacon table for active beaconing gateways

### DIFF
--- a/iot_verifier/src/last_beacon_reciprocity.rs
+++ b/iot_verifier/src/last_beacon_reciprocity.rs
@@ -31,6 +31,23 @@ impl LastBeaconReciprocity {
         .await?)
     }
 
+    pub async fn get_all_since<'c, E>(
+        executor: E,
+        timestamp: DateTime<Utc>,
+    ) -> anyhow::Result<Vec<Self>>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres> + 'c,
+    {
+        Ok(
+            sqlx::query_as::<_, Self>(
+                r#" select * from last_beacon_recip where timestamp >= $1; "#,
+            )
+            .bind(timestamp)
+            .fetch_all(executor)
+            .await?,
+        )
+    }
+
     pub async fn update_last_timestamp(
         txn: &mut Transaction<'_, Postgres>,
         id: &PublicKeyBinary,

--- a/iot_verifier/src/tx_scaler.rs
+++ b/iot_verifier/src/tx_scaler.rs
@@ -1,7 +1,7 @@
 use crate::{
     gateway_updater::MessageReceiver,
     hex_density::{compute_hex_density_map, GlobalHexMap, HexDensityMap},
-    last_beacon::LastBeacon,
+    last_beacon_reciprocity::LastBeaconReciprocity,
 };
 use chrono::{DateTime, Duration, Utc};
 use futures::future::LocalBoxFuture;
@@ -103,7 +103,7 @@ impl Server {
     ) -> anyhow::Result<HashMap<PublicKeyBinary, DateTime<Utc>>> {
         let interactivity_deadline = now - Duration::minutes(HIP_17_INTERACTIVITY_LIMIT);
         Ok(
-            LastBeacon::get_all_since(&self.pool, interactivity_deadline)
+            LastBeaconReciprocity::get_all_since(&self.pool, interactivity_deadline)
                 .await?
                 .into_iter()
                 .map(|beacon| (beacon.id, beacon.timestamp))


### PR DESCRIPTION
Fix for issue https://github.com/helium/oracles/issues/793

This changes the hex density scaler to use the last_beacon_recip table as its source data rather than the `last_beacon` table.  As per #784 the last_beacon_recip table is updated only when a beacon is valid whereas the last_beacon table is updated upon receipt of the last beacon whether than beacon is valid or invalid.  

As such since #784 the hex density scaler has been using incorrect data