### PR TITLE
Refactor: Hex location use `hextree::Cell` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "hextree"
 version = "0.3.1"
-source = "git+https://github.com/jaykickliter/HexTree?branch=main#bbc9fcf5b0cdfe0b6e99cec8d798d338819e985b"
+source = "git+https://github.com/jaykickliter/HexTree?branch=main#f3ac30814f15bf1c98714a40c3b094429dc8b1b2"
 dependencies = [
  "byteorder",
  "memmap",

--- a/boost_manager/tests/activator_tests.rs
+++ b/boost_manager/tests/activator_tests.rs
@@ -1,8 +1,7 @@
 mod common;
 use boost_manager::{activator, db, OnChainStatus};
 use chrono::{DateTime, Duration as ChronoDuration, Duration, Timelike, Utc};
-use helium_proto::services::poc_mobile::BoostedHex as BoostedHexProto;
-use mobile_config::boosted_hex_info::{BoostedHexInfo, BoostedHexes};
+use mobile_config::boosted_hex_info::{BoostedHex, BoostedHexInfo, BoostedHexes};
 use solana_sdk::pubkey::Pubkey;
 use sqlx::PgPool;
 use std::{collections::HashMap, num::NonZeroU32, str::FromStr};
@@ -44,7 +43,7 @@ impl TestContext {
 
         let boosts = vec![
             BoostedHexInfo {
-                location: 0x8a1fb466d2dffff_u64,
+                location: 0x8a1fb466d2dffff_u64.try_into().expect("valid h3 cell"),
                 start_ts: Some(start_ts_1),
                 end_ts: Some(end_ts_1),
                 period_length: boost_period_length,
@@ -54,7 +53,7 @@ impl TestContext {
                 version: 0,
             },
             BoostedHexInfo {
-                location: 0x8a1fb49642dffff_u64,
+                location: 0x8a1fb49642dffff_u64.try_into().expect("valid h3 cell"),
                 start_ts: Some(start_ts_2),
                 end_ts: Some(end_ts_2),
                 period_length: boost_period_length,
@@ -65,7 +64,7 @@ impl TestContext {
             },
             BoostedHexInfo {
                 // hotspot 3's location
-                location: 0x8c2681a306607ff_u64,
+                location: 0x8c2681a306607ff_u64.try_into().expect("valid h3 cell"),
                 start_ts: None,
                 end_ts: None,
                 period_length: boost_period_length,
@@ -101,9 +100,9 @@ async fn test_activated_hex_insert(pool: PgPool) -> anyhow::Result<()> {
         &mut txn,
         now,
         &boosted_hexes,
-        &BoostedHexProto {
-            location: 0x8c2681a306607ff_u64,
-            multiplier: 10,
+        &BoostedHex {
+            location: 0x8c2681a306607ff_u64.try_into().expect("valid h3 cell"),
+            multiplier: NonZeroU32::new(10).unwrap(),
         },
     )
     .await?;
@@ -138,9 +137,9 @@ async fn test_activated_hex_no_insert(pool: PgPool) -> anyhow::Result<()> {
         &mut txn,
         now,
         &boosted_hexes,
-        &BoostedHexProto {
-            location: 0x8a1fb49642dffff_u64,
-            multiplier: 10,
+        &BoostedHex {
+            location: 0x8a1fb49642dffff_u64.try_into().expect("valid h3 cell"),
+            multiplier: NonZeroU32::new(10).unwrap(),
         },
     )
     .await?;
@@ -172,9 +171,9 @@ async fn test_activated_dup_hex_insert(pool: PgPool) -> anyhow::Result<()> {
         &mut txn,
         now,
         &boosted_hexes,
-        &BoostedHexProto {
-            location: 0x8c2681a306607ff_u64,
-            multiplier: 10,
+        &BoostedHex {
+            location: 0x8c2681a306607ff_u64.try_into().expect("valid h3 cell"),
+            multiplier: NonZeroU32::new(10).unwrap(),
         },
     )
     .await?;
@@ -183,9 +182,9 @@ async fn test_activated_dup_hex_insert(pool: PgPool) -> anyhow::Result<()> {
         &mut txn,
         now - ChronoDuration::days(1),
         &boosted_hexes,
-        &BoostedHexProto {
-            location: 0x8c2681a306607ff_u64,
-            multiplier: 5,
+        &BoostedHex {
+            location: 0x8c2681a306607ff_u64.try_into().expect("valid h3 cell"),
+            multiplier: NonZeroU32::new(5).unwrap(),
         },
     )
     .await?;

--- a/boost_manager/tests/watcher_tests.rs
+++ b/boost_manager/tests/watcher_tests.rs
@@ -65,7 +65,7 @@ async fn test_boosted_hex_updates_to_filestore(pool: PgPool) -> anyhow::Result<(
 
     let boosted_hexes = vec![
         BoostedHexInfo {
-            location: 0x8a1fb466d2dffff_u64,
+            location: 0x8a1fb466d2dffff_u64.try_into().expect("valid h3 cell"),
             start_ts: Some(start_ts_1),
             end_ts: Some(end_ts_1),
             period_length: boost_period_length,
@@ -75,7 +75,7 @@ async fn test_boosted_hex_updates_to_filestore(pool: PgPool) -> anyhow::Result<(
             version: 0,
         },
         BoostedHexInfo {
-            location: 0x8a1fb49642dffff_u64,
+            location: 0x8a1fb49642dffff_u64.try_into().expect("valid h3 cell"),
             start_ts: Some(start_ts_2),
             end_ts: Some(end_ts_2),
             period_length: boost_period_length,

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -26,6 +26,7 @@ use helium_proto::services::{
         SignalLevel as SignalLevelProto,
     },
 };
+use hextree::Cell;
 use mobile_config::{
     boosted_hex_info::{BoostedHex, BoostedHexes},
     client::AuthorizationClient,
@@ -501,7 +502,8 @@ impl CoverageObject {
 #[derive(Clone, FromRow)]
 pub struct HexCoverage {
     pub uuid: Uuid,
-    pub hex: i64,
+    #[sqlx(try_from = "i64")]
+    pub hex: Cell,
     pub indoor: bool,
     pub radio_key: OwnedKeyType,
     pub signal_level: SignalLevel,
@@ -755,12 +757,15 @@ pub async fn clear_coverage_objects(
     Ok(())
 }
 
+type IndoorCellTree = HashMap<Cell, BTreeMap<SignalLevel, BinaryHeap<IndoorCoverageLevel>>>;
+type OutdoorCellTree = HashMap<Cell, BinaryHeap<OutdoorCoverageLevel>>;
+
 #[derive(Default, Debug)]
 pub struct CoveredHexes {
-    indoor_cbrs: HashMap<CellIndex, BTreeMap<SignalLevel, BinaryHeap<IndoorCoverageLevel>>>,
-    indoor_wifi: HashMap<CellIndex, BTreeMap<SignalLevel, BinaryHeap<IndoorCoverageLevel>>>,
-    outdoor_cbrs: HashMap<CellIndex, BinaryHeap<OutdoorCoverageLevel>>,
-    outdoor_wifi: HashMap<CellIndex, BinaryHeap<OutdoorCoverageLevel>>,
+    indoor_cbrs: IndoorCellTree,
+    indoor_wifi: IndoorCellTree,
+    outdoor_cbrs: OutdoorCellTree,
+    outdoor_wifi: OutdoorCellTree,
 }
 
 pub const MAX_INDOOR_RADIOS_PER_RES12_HEX: usize = 1;
@@ -779,7 +784,7 @@ impl CoveredHexes {
         let mut boosted = false;
 
         while let Some(hex_coverage) = covered_hexes.next().await.transpose()? {
-            boosted |= boosted_hexes.is_boosted(&(hex_coverage.hex as u64));
+            boosted |= boosted_hexes.is_boosted(&hex_coverage.hex);
             match (hex_coverage.indoor, &hex_coverage.radio_key) {
                 (true, OwnedKeyType::Cbrs(_)) => {
                     insert_indoor_coverage(&mut self.indoor_cbrs, hotspot, hex_coverage);
@@ -823,12 +828,12 @@ impl CoveredHexes {
 }
 
 fn insert_indoor_coverage(
-    indoor: &mut HashMap<CellIndex, BTreeMap<SignalLevel, BinaryHeap<IndoorCoverageLevel>>>,
+    indoor: &mut IndoorCellTree,
     hotspot: &PublicKeyBinary,
     hex_coverage: HexCoverage,
 ) {
     indoor
-        .entry(CellIndex::try_from(hex_coverage.hex as u64).unwrap())
+        .entry(hex_coverage.hex)
         .or_default()
         .entry(hex_coverage.signal_level)
         .or_default()
@@ -842,12 +847,12 @@ fn insert_indoor_coverage(
 }
 
 fn insert_outdoor_coverage(
-    outdoor: &mut HashMap<CellIndex, BinaryHeap<OutdoorCoverageLevel>>,
+    outdoor: &mut OutdoorCellTree,
     hotspot: &PublicKeyBinary,
     hex_coverage: HexCoverage,
 ) {
     outdoor
-        .entry(CellIndex::try_from(hex_coverage.hex as u64).unwrap())
+        .entry(hex_coverage.hex)
         .or_default()
         .push(OutdoorCoverageLevel {
             radio_key: hex_coverage.radio_key,
@@ -860,7 +865,7 @@ fn insert_outdoor_coverage(
 }
 
 fn into_outdoor_rewards(
-    outdoor: HashMap<CellIndex, BinaryHeap<OutdoorCoverageLevel>>,
+    outdoor: OutdoorCellTree,
     boosted_hexes: &BoostedHexes,
     epoch_start: DateTime<Utc>,
 ) -> impl Iterator<Item = CoverageReward> + '_ {
@@ -872,7 +877,7 @@ fn into_outdoor_rewards(
             .zip(OUTDOOR_REWARD_WEIGHTS)
             .map(move |(cl, rank)| {
                 let boost_multiplier = boosted_hexes
-                    .get_current_multiplier(hex.into(), epoch_start)
+                    .get_current_multiplier(hex, epoch_start)
                     .unwrap_or(NonZeroU32::new(1).unwrap());
 
                 CoverageReward {
@@ -885,7 +890,7 @@ fn into_outdoor_rewards(
                     hotspot: cl.hotspot,
                     radio_key: cl.radio_key,
                     boosted_hex_info: BoostedHex {
-                        location: hex.into(),
+                        location: hex,
                         multiplier: boost_multiplier,
                     },
                 }
@@ -894,7 +899,7 @@ fn into_outdoor_rewards(
 }
 
 fn into_indoor_rewards(
-    indoor: HashMap<CellIndex, BTreeMap<SignalLevel, BinaryHeap<IndoorCoverageLevel>>>,
+    indoor: IndoorCellTree,
     boosted_hexes: &BoostedHexes,
     epoch_start: DateTime<Utc>,
 ) -> impl Iterator<Item = CoverageReward> + '_ {
@@ -908,7 +913,7 @@ fn into_indoor_rewards(
                     .take(MAX_INDOOR_RADIOS_PER_RES12_HEX)
                     .map(move |cl| {
                         let boost_multiplier = boosted_hexes
-                            .get_current_multiplier(hex.into(), epoch_start)
+                            .get_current_multiplier(hex, epoch_start)
                             .unwrap_or(NonZeroU32::new(1).unwrap());
 
                         CoverageReward {
@@ -921,7 +926,7 @@ fn into_indoor_rewards(
                             hotspot: cl.hotspot,
                             radio_key: cl.radio_key,
                             boosted_hex_info: BoostedHex {
-                                location: hex.into(),
+                                location: hex,
                                 multiplier: boost_multiplier,
                             },
                         }
@@ -1093,6 +1098,7 @@ mod test {
     use super::*;
     use chrono::NaiveDate;
     use futures::stream::iter;
+    use hextree::Cell;
 
     /// Test to ensure that if there are multiple radios with different signal levels
     /// in a given hex, that the one with the highest signal level is chosen.
@@ -1131,7 +1137,7 @@ mod test {
                     rank: None
                 },
                 boosted_hex_info: BoostedHex {
-                    location: 0x8a1fb46622dffff_u64,
+                    location: Cell::from_raw(0x8a1fb46622dffff).expect("valid h3 cell"),
                     multiplier: NonZeroU32::new(1).unwrap(),
                 },
             }]
@@ -1153,7 +1159,7 @@ mod test {
     ) -> HexCoverage {
         HexCoverage {
             uuid: Uuid::new_v4(),
-            hex: 0x8a1fb46622dffff_u64 as i64,
+            hex: Cell::from_raw(0x8a1fb46622dffff).expect("valid h3 cell"),
             indoor: true,
             radio_key: OwnedKeyType::Cbrs(cbsd_id.to_string()),
             signal_level,
@@ -1247,7 +1253,7 @@ mod test {
                     rank: None
                 },
                 boosted_hex_info: BoostedHex {
-                    location: 0x8a1fb46622dffff_u64,
+                    location: Cell::from_raw(0x8a1fb46622dffff).expect("valid h3 cell"),
                     multiplier: NonZeroU32::new(1).unwrap(),
                 },
             }]
@@ -1290,7 +1296,7 @@ mod test {
                         hex_assignments: HexAssignments::test_best(),
                     },
                     boosted_hex_info: BoostedHex {
-                        location: 0x8a1fb46622dffff_u64,
+                        location: Cell::from_raw(0x8a1fb46622dffff).expect("valid h3 cell"),
                         multiplier: NonZeroU32::new(1).unwrap(),
                     },
                 },
@@ -1304,7 +1310,7 @@ mod test {
                         hex_assignments: HexAssignments::test_best(),
                     },
                     boosted_hex_info: BoostedHex {
-                        location: 0x8a1fb46622dffff_u64,
+                        location: Cell::from_raw(0x8a1fb46622dffff).expect("valid h3 cell"),
                         multiplier: NonZeroU32::new(1).unwrap(),
                     },
                 },
@@ -1318,7 +1324,7 @@ mod test {
                         hex_assignments: HexAssignments::test_best(),
                     },
                     boosted_hex_info: BoostedHex {
-                        location: 0x8a1fb46622dffff_u64,
+                        location: Cell::from_raw(0x8a1fb46622dffff).expect("valid h3 cell"),
                         multiplier: NonZeroU32::new(1).unwrap(),
                     },
                 }
@@ -1578,7 +1584,7 @@ mod test {
     ) -> HexCoverage {
         HexCoverage {
             uuid: Uuid::new_v4(),
-            hex: 0x8a1fb46622dffff_u64 as i64,
+            hex: Cell::from_raw(0x8a1fb46622dffff).expect("valid h3 cell"),
             indoor: true,
             radio_key: OwnedKeyType::Cbrs(cbsd_id.to_string()),
             signal_level,
@@ -1597,7 +1603,7 @@ mod test {
     ) -> HexCoverage {
         HexCoverage {
             uuid: Uuid::new_v4(),
-            hex: 0x8a1fb46622dffff_u64 as i64,
+            hex: Cell::from_raw(0x8a1fb46622dffff).expect("valid h3 cell"),
             indoor: false,
             radio_key: OwnedKeyType::Cbrs(cbsd_id.to_string()),
             signal_power,
@@ -1615,7 +1621,7 @@ mod test {
     ) -> HexCoverage {
         HexCoverage {
             uuid: Uuid::new_v4(),
-            hex: 0x8a1fb46622dffff_u64 as i64,
+            hex: Cell::from_raw(0x8a1fb46622dffff).expect("valid h3 cell"),
             indoor: false,
             radio_key: OwnedKeyType::Wifi(hotspot_key.clone()),
             signal_power,
@@ -1633,7 +1639,7 @@ mod test {
     ) -> HexCoverage {
         HexCoverage {
             uuid: Uuid::new_v4(),
-            hex: 0x8a1fb46622dffff_u64 as i64,
+            hex: Cell::from_raw(0x8a1fb46622dffff).expect("valid h3 cell"),
             indoor: true,
             radio_key: OwnedKeyType::Wifi(hotspot_key.clone()),
             signal_power: 0,

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -640,7 +640,7 @@ fn new_radio_reward(
         .iter()
         .filter(|radio_points| radio_points.boosted_hex.multiplier > NonZeroU32::new(1).unwrap())
         .map(|radio_points| proto::BoostedHex {
-            location: radio_points.boosted_hex.location,
+            location: radio_points.boosted_hex.location.into_raw(),
             multiplier: radio_points.boosted_hex.multiplier.get(),
         })
         .collect();
@@ -713,6 +713,7 @@ mod test {
     use helium_proto::{
         services::poc_mobile::mobile_reward_share::Reward as MobileReward, ServiceProvider,
     };
+    use hextree::Cell;
     use prost::Message;
     use std::collections::HashMap;
     use uuid::Uuid;
@@ -994,9 +995,11 @@ mod test {
     fn simple_hex_coverage<'a>(key: impl Into<KeyType<'a>>, hex: u64) -> Vec<HexCoverage> {
         let key = key.into();
         let radio_key = key.to_owned();
+        let hex = hex.try_into().expect("valid h3 cell");
+
         vec![HexCoverage {
             uuid: Uuid::new_v4(),
-            hex: hex as i64,
+            hex,
             indoor: true,
             radio_key,
             signal_level: crate::coverage::SignalLevel::Low,
@@ -1892,7 +1895,7 @@ mod test {
                                 rank: None,
                             },
                             boosted_hex: BoostedHex {
-                                location: 0,
+                                location: Cell::from_raw(0x8a1fb46622dffff).expect("valid h3 cell"),
                                 multiplier: NonZeroU32::new(1).unwrap(),
                             },
                         }],

--- a/mobile_verifier/tests/hex_boosting.rs
+++ b/mobile_verifier/tests/hex_boosting.rs
@@ -13,6 +13,7 @@ use helium_proto::services::poc_mobile::{
     CoverageObjectValidity, HeartbeatValidity, RadioReward, SeniorityUpdateReason, SignalLevel,
     UnallocatedReward,
 };
+use hextree::Cell;
 use mobile_config::{
     boosted_hex_info::{BoostedHexInfo, BoostedHexInfoStream},
     client::{hex_boosting_client::HexBoostingInfoResolver, ClientError},
@@ -123,7 +124,7 @@ async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
     let boosted_hexes = vec![
         BoostedHexInfo {
             // hotspot 1's location
-            location: 0x8a1fb466d2dffff_u64,
+            location: Cell::from_raw(0x8a1fb466d2dffff_u64)?,
             start_ts: Some(start_ts_1),
             end_ts: Some(end_ts_1),
             period_length: boost_period_length,
@@ -134,7 +135,7 @@ async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
         },
         BoostedHexInfo {
             // hotspot 2's location
-            location: 0x8a1fb49642dffff_u64,
+            location: Cell::from_raw(0x8a1fb49642dffff_u64)?,
             start_ts: Some(start_ts_2),
             end_ts: Some(end_ts_2),
             period_length: boost_period_length,
@@ -145,7 +146,7 @@ async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
         },
         BoostedHexInfo {
             // hotspot 3's location
-            location: 0x8c2681a306607ff_u64,
+            location: Cell::from_raw(0x8c2681a306607ff_u64)?,
             start_ts: None,
             end_ts: None,
             period_length: boost_period_length,
@@ -291,7 +292,7 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
     let boosted_hexes = vec![
         BoostedHexInfo {
             // hotspot 1's location
-            location: 0x8a1fb466d2dffff_u64,
+            location: Cell::from_raw(0x8a1fb466d2dffff_u64)?,
             start_ts: Some(start_ts_1),
             end_ts: Some(end_ts_1),
             period_length: boost_period_length,
@@ -302,7 +303,7 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
         },
         BoostedHexInfo {
             // hotspot 2's location
-            location: 0x8a1fb49642dffff_u64,
+            location: Cell::from_raw(0x8a1fb49642dffff_u64)?,
             start_ts: Some(start_ts_2),
             end_ts: Some(end_ts_2),
             period_length: boost_period_length,
@@ -313,7 +314,7 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
         },
         BoostedHexInfo {
             // hotspot 3's location
-            location: 0x8c2681a306607ff_u64,
+            location: Cell::from_raw(0x8c2681a306607ff_u64)?,
             start_ts: None,
             end_ts: None,
             period_length: boost_period_length,
@@ -439,7 +440,7 @@ async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Res
     let boosted_hexes = vec![
         BoostedHexInfo {
             // hotspot 1's first covered location
-            location: 0x8a1fb46622dffff_u64,
+            location: Cell::from_raw(0x8a1fb46622dffff_u64)?,
             start_ts: Some(start_ts_1),
             end_ts: Some(end_ts_1),
             period_length: boost_period_length,
@@ -450,7 +451,7 @@ async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Res
         },
         BoostedHexInfo {
             // hotspot 1's second covered location
-            location: 0x8a1fb46622d7fff_u64,
+            location: Cell::from_raw(0x8a1fb46622d7fff_u64)?,
             start_ts: Some(start_ts_1),
             end_ts: Some(end_ts_1),
             period_length: boost_period_length,
@@ -461,7 +462,7 @@ async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Res
         },
         BoostedHexInfo {
             // hotspot 2's location
-            location: 0x8a1fb49642dffff_u64,
+            location: Cell::from_raw(0x8a1fb49642dffff_u64)?,
             start_ts: Some(start_ts_2),
             end_ts: Some(end_ts_2),
             period_length: boost_period_length,
@@ -472,7 +473,7 @@ async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Res
         },
         BoostedHexInfo {
             // hotspot 3's location
-            location: 0x8c2681a306607ff_u64,
+            location: Cell::from_raw(0x8c2681a306607ff_u64)?,
             start_ts: Some(start_ts_3),
             end_ts: Some(end_ts_3),
             period_length: boost_period_length,
@@ -610,7 +611,7 @@ async fn test_expired_boosted_hex(pool: PgPool) -> anyhow::Result<()> {
 
     let boosted_hexes = vec![
         BoostedHexInfo {
-            location: 0x8a1fb466d2dffff_u64,
+            location: Cell::from_raw(0x8a1fb466d2dffff_u64)?,
             start_ts: Some(start_ts_1),
             end_ts: Some(end_ts_1),
             period_length: boost_period_length,
@@ -620,7 +621,7 @@ async fn test_expired_boosted_hex(pool: PgPool) -> anyhow::Result<()> {
             version: 0,
         },
         BoostedHexInfo {
-            location: 0x8a1fb49642dffff_u64,
+            location: Cell::from_raw(0x8a1fb49642dffff_u64)?,
             start_ts: Some(start_ts_2),
             end_ts: Some(end_ts_2),
             period_length: boost_period_length,
@@ -721,7 +722,7 @@ async fn test_reduced_location_score_with_boosted_hexes(pool: PgPool) -> anyhow:
     let boosted_hexes = vec![
         BoostedHexInfo {
             // hotspot 1's location
-            location: 0x8a1fb466d2dffff_u64,
+            location: Cell::from_raw(0x8a1fb466d2dffff_u64)?,
             start_ts: Some(start_ts_1),
             end_ts: Some(end_ts_1),
             period_length: boost_period_length,
@@ -732,7 +733,7 @@ async fn test_reduced_location_score_with_boosted_hexes(pool: PgPool) -> anyhow:
         },
         BoostedHexInfo {
             // hotspot 3's location
-            location: 0x8c2681a306607ff_u64,
+            location: Cell::from_raw(0x8c2681a306607ff_u64)?,
             start_ts: None,
             end_ts: None,
             period_length: boost_period_length,
@@ -885,7 +886,7 @@ async fn test_poc_with_cbrs_and_multi_coverage_boosted_hexes(pool: PgPool) -> an
     let boosted_hexes = vec![
         BoostedHexInfo {
             // hotspot 1's first covered location
-            location: 0x8a1fb46622dffff_u64,
+            location: Cell::from_raw(0x8a1fb46622dffff_u64)?,
             start_ts: Some(start_ts_1),
             end_ts: Some(end_ts_1),
             period_length: boost_period_length,
@@ -896,7 +897,7 @@ async fn test_poc_with_cbrs_and_multi_coverage_boosted_hexes(pool: PgPool) -> an
         },
         BoostedHexInfo {
             // hotspot 1's second covered location
-            location: 0x8a1fb46622d7fff_u64,
+            location: Cell::from_raw(0x8a1fb46622d7fff_u64)?,
             start_ts: Some(start_ts_1),
             end_ts: Some(end_ts_1),
             period_length: boost_period_length,
@@ -907,7 +908,7 @@ async fn test_poc_with_cbrs_and_multi_coverage_boosted_hexes(pool: PgPool) -> an
         },
         BoostedHexInfo {
             // hotspot 2's location
-            location: 0x8a1fb49642dffff_u64,
+            location: Cell::from_raw(0x8a1fb49642dffff_u64)?,
             start_ts: Some(start_ts_2),
             end_ts: Some(end_ts_2),
             period_length: boost_period_length,
@@ -918,7 +919,7 @@ async fn test_poc_with_cbrs_and_multi_coverage_boosted_hexes(pool: PgPool) -> an
         },
         BoostedHexInfo {
             // hotspot 3's location
-            location: 0x8c2681a306607ff_u64,
+            location: Cell::from_raw(0x8c2681a306607ff_u64)?,
             start_ts: Some(start_ts_3),
             end_ts: Some(end_ts_3),
             period_length: boost_period_length,

--- a/mobile_verifier/tests/modeled_coverage.rs
+++ b/mobile_verifier/tests/modeled_coverage.rs
@@ -12,6 +12,7 @@ use helium_proto::services::{
     mobile_config::NetworkKeyRole,
     poc_mobile::{CoverageObjectValidity, SignalLevel},
 };
+use hextree::Cell;
 use mobile_config::boosted_hex_info::{BoostedHexInfo, BoostedHexes};
 
 use mobile_verifier::{
@@ -845,9 +846,9 @@ async fn scenario_three(pool: PgPool) -> anyhow::Result<()> {
 
     let mut boosted_hexes = BoostedHexes::default();
     boosted_hexes.hexes.insert(
-        0x8a1fb466d2dffff_u64,
+        Cell::from_raw(0x8a1fb466d2dffff)?,
         BoostedHexInfo {
-            location: 0x8a1fb466d2dffff_u64,
+            location: Cell::from_raw(0x8a1fb466d2dffff)?,
             start_ts: None,
             end_ts: None,
             period_length: Duration::hours(1),
@@ -858,9 +859,9 @@ async fn scenario_three(pool: PgPool) -> anyhow::Result<()> {
         },
     );
     boosted_hexes.hexes.insert(
-        0x8a1fb49642dffff_u64,
+        Cell::from_raw(0x8a1fb49642dffff)?,
         BoostedHexInfo {
-            location: 0x8a1fb49642dffff_u64,
+            location: Cell::from_raw(0x8a1fb49642dffff)?,
             start_ts: None,
             end_ts: None,
             period_length: Duration::hours(1),
@@ -871,10 +872,10 @@ async fn scenario_three(pool: PgPool) -> anyhow::Result<()> {
         },
     );
     boosted_hexes.hexes.insert(
-        0x8c2681a306607ff_u64,
+        Cell::from_raw(0x8c2681a306607ff)?,
         BoostedHexInfo {
             // hotspot 1's location
-            location: 0x8c2681a306607ff_u64,
+            location: Cell::from_raw(0x8c2681a306607ff)?,
             start_ts: None,
             end_ts: None,
             period_length: Duration::hours(1),


### PR DESCRIPTION
This is something that I was planning on doing as part of HIP-109 changes I was going to be making. 
So I thought I'd push it early to make it easier to review.

---
Got some advice from Jay to only use a `h3o::CellIndex` when you need to
convert to/from a LatLng. So we went with `hextree::Cell` for the type.

`hextree::Cell` is a loose wrapper around a u64. Parsing the value as
early as possible tightens the gaurantee that we can make valid types
that need use `Cell`s.

It is also an attempt to remove discrepancies where some types carry a
`i64` hex straight from a database, and other types carry a `u64` that
were converted out of a database, even though they're goal is the same.

(see previous commit where `#[sqlx(try_from = "i64")]` was enabled by
the update to hextree).