### PR TITLE
Add client_requests timing module to metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
@@ -2970,6 +2970,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3276,7 +3291,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fb938100651db317719f46877a3cd82105920be4ea2ff49d55d1d65fa7bec1"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "auto_ops",
  "either",
  "float_eq",
@@ -3320,7 +3335,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -3328,6 +3343,9 @@ name = "hashbrown"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+dependencies = [
+ "ahash 0.8.11",
+]
 
 [[package]]
 name = "hashlink"
@@ -3401,7 +3419,7 @@ dependencies = [
  "bs58 0.5.0",
  "byteorder",
  "ed25519-compact",
- "getrandom 0.2.10",
+ "getrandom 0.1.16",
  "k256",
  "lazy_static",
  "multihash",
@@ -3726,6 +3744,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.28",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -4353,15 +4384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "mach2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4448,23 +4470,23 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.21.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
 dependencies = [
- "ahash 0.8.7",
- "metrics-macros",
+ "ahash 0.8.11",
  "portable-atomic",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
+checksum = "83a4c4718a371ddfb7806378f23617876eea8b82e5ff1324516bcd283249d9ea"
 dependencies = [
  "base64 0.21.7",
  "hyper 0.14.28",
+ "hyper-tls",
  "indexmap 1.9.3",
  "ipnet",
  "metrics",
@@ -4476,25 +4498,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics-macros"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
-dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
-]
-
-[[package]]
 name = "metrics-util"
-version = "0.15.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
+checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.13.1",
+ "hashbrown 0.14.1",
  "metrics",
  "num_cpus",
  "quanta",
@@ -4740,6 +4751,24 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "nb"
@@ -5013,10 +5042,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -5525,13 +5592,12 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.11.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
 dependencies = [
  "crossbeam-utils",
  "libc",
- "mach2",
  "once_cell",
  "raw-cpuid",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -5689,11 +5755,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "10.7.0"
+version = "11.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -6758,7 +6824,7 @@ version = "1.16.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361cc834e5fbbe1a73f1d904fcb8ab052a665e5be6061bd1ba7ab478d7d17c9c"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "blake3",
  "block-buffer 0.10.4",
  "bs58 0.4.0",
@@ -6860,7 +6926,7 @@ version = "1.16.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4d44a4998ba6d9b37e89399d9ce2812e84489dd4665df619fb23366e1c2ec1b"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "bincode",
  "bv",
  "caps",
@@ -7883,6 +7949,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8325,6 +8401,12 @@ name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5270,12 +5270,16 @@ dependencies = [
 name = "poc-metrics"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "metrics",
  "metrics-exporter-prometheus",
+ "reqwest",
  "serde",
  "thiserror",
+ "tokio",
  "tower",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ reqwest = { version = "0", default-features = false, features = [
 ] }
 beacon = { git = "https://github.com/helium/proto", branch = "master" }
 humantime = "2"
-metrics = "0.21"
+metrics = ">=0.22"
 metrics-exporter-prometheus = "0"
 tracing = "0"
 tracing-subscriber = { version = "0", default-features = false, features = [

--- a/boost_manager/src/telemetry.rs
+++ b/boost_manager/src/telemetry.rs
@@ -16,7 +16,7 @@ pub async fn last_reward_processed_time(
     db: &Pool<Postgres>,
     datetime: DateTime<Utc>,
 ) -> anyhow::Result<()> {
-    metrics::gauge!(LAST_REWARD_PROCESSED_TIME, datetime.timestamp() as f64);
+    metrics::gauge!(LAST_REWARD_PROCESSED_TIME).set(datetime.timestamp() as f64);
     meta::store(db, LAST_REWARD_PROCESSED_TIME, datetime.timestamp()).await?;
 
     Ok(())

--- a/boost_manager/src/updater.rs
+++ b/boost_manager/src/updater.rs
@@ -143,9 +143,9 @@ where
 
     async fn check_failed_activations(&self) -> Result<()> {
         let num_marked_failed = db::update_failed_activations(&self.pool).await?;
-        metrics::counter!("failed_activations", num_marked_failed);
+        metrics::counter!("failed_activations").increment(num_marked_failed);
         let total_failed_count = db::get_failed_activations_count(&self.pool).await?;
-        metrics::gauge!("db_failed_row_count", total_failed_count as f64);
+        metrics::gauge!("db_failed_row_count").set(total_failed_count as f64);
         if total_failed_count > 0 {
             tracing::warn!("{} failed status activations ", total_failed_count);
         };
@@ -159,7 +159,7 @@ where
         summed_activations_count: u64,
     ) -> Result<()> {
         tracing::info!("processed batch of {} activations successfully", batch_size);
-        metrics::counter!("success_activations", summed_activations_count);
+        metrics::counter!("success_activations").increment(summed_activations_count);
         db::update_success_batch(&self.pool, ids).await?;
         Ok(())
     }

--- a/db_store/src/meta.rs
+++ b/db_store/src/meta.rs
@@ -6,11 +6,11 @@ macro_rules! query_exec_timed {
     ( $name:literal, $query:expr, $meth:ident, $exec:expr ) => {{
         match poc_metrics::record_duration!(concat!($name, "_duration"), $query.$meth($exec).await) {
             Ok(x) => {
-                metrics::increment_counter!(concat!($name, "_count"), "status" => "ok");
+                metrics::counter!(concat!($name, "_count"), "status" => "ok").increment(1);
                 Ok(x)
             }
             Err(e) => {
-                metrics::increment_counter!(concat!($name, "_count"), "status" => "error");
+                metrics::counter!(concat!($name, "_count"), "status" => "error").increment(1);
                 Err(Error::SqlError(e))
             }
         }

--- a/db_store/src/metric_tracker.rs
+++ b/db_store/src/metric_tracker.rs
@@ -14,7 +14,7 @@ async fn run(size_name: String, idle_name: String, pool: sqlx::Pool<sqlx::Postgr
     loop {
         trigger.tick().await;
 
-        metrics::gauge!(size_name.clone(), pool.size() as f64);
-        metrics::gauge!(idle_name.clone(), pool.num_idle() as f64);
+        metrics::gauge!(size_name.clone()).set(pool.size() as f64);
+        metrics::gauge!(idle_name.clone()).set(pool.num_idle() as f64);
     }
 }

--- a/file_store/src/file_info_poller.rs
+++ b/file_store/src/file_info_poller.rs
@@ -68,9 +68,8 @@ where
         let latency = Utc::now() - self.file_info.timestamp;
         metrics::gauge!(
             "file-processing-latency",
-            latency.num_seconds() as f64,
             "file-type" => self.file_info.prefix.clone(), "process-name" => self.process_name.clone(),
-        );
+        ).set(latency.num_seconds() as f64);
 
         recorder.record(&self.process_name, &self.file_info).await?;
         Ok(futures::stream::iter(self.data.into_iter()).boxed())

--- a/iot_config/src/telemetry.rs
+++ b/iot_config/src/telemetry.rs
@@ -14,19 +14,19 @@ const GATEWAY_CHAIN_LOOKUP_DURATION_METRIC: &str =
     concat!(env!("CARGO_PKG_NAME"), "-", "gateway-info-lookup-duration");
 
 pub fn initialize() {
-    metrics::gauge!(STREAM_METRIC, 0.0);
+    metrics::gauge!(STREAM_METRIC).set(0.0);
 }
 
 pub fn count_request(service: &'static str, rpc: &'static str) {
-    metrics::increment_counter!(RPC_METRIC, "service" => service, "rpc" => rpc);
+    metrics::counter!(RPC_METRIC, "service" => service, "rpc" => rpc).increment(1);
 }
 
 pub fn count_gateway_info_lookup(result: &'static str) {
-    metrics::increment_counter!(GATEWAY_CHAIN_LOOKUP_METRIC, "result" => result);
+    metrics::counter!(GATEWAY_CHAIN_LOOKUP_METRIC, "result" => result).increment(1);
 }
 
 pub fn gauge_hexes(cells: usize) {
-    metrics::gauge!(REGION_HEX_METRIC, cells as f64);
+    metrics::gauge!(REGION_HEX_METRIC).set(cells as f64);
 }
 
 pub fn count_region_lookup(
@@ -35,37 +35,38 @@ pub fn count_region_lookup(
 ) {
     let reported_region =
         reported_region.map_or_else(|| "LOOKUP_FAILED".to_string(), |region| region.to_string());
-    metrics::increment_counter!(
+    metrics::counter!(
         REGION_LOOKUP_METRIC,
         // per metrics docs, &str should be preferred for performance; should the regions be
         // mapped through a match of region => &'static str of the name?
         "default_region" => default_region.to_string(), "reported_region" => reported_region
-    );
+    )
+    .increment(1);
 }
 
 pub fn duration_gateway_info_lookup(start: std::time::Instant) {
-    metrics::histogram!(GATEWAY_CHAIN_LOOKUP_DURATION_METRIC, start.elapsed());
+    metrics::histogram!(GATEWAY_CHAIN_LOOKUP_DURATION_METRIC).record(start.elapsed());
 }
 
 pub fn count_skf_updates(adds: usize, removes: usize) {
-    metrics::counter!(SKF_ADD_COUNT_METRIC, adds as u64);
-    metrics::counter!(SKF_REMOVE_COUNT_METRIC, removes as u64);
+    metrics::counter!(SKF_ADD_COUNT_METRIC).increment(adds as u64);
+    metrics::counter!(SKF_REMOVE_COUNT_METRIC).increment(removes as u64);
 }
 
 pub fn count_eui_updates(adds: usize, removes: usize) {
-    metrics::counter!(EUI_ADD_COUNT_METRIC, adds as u64);
-    metrics::counter!(EUI_REMOVE_COUNT_METRIC, removes as u64);
+    metrics::counter!(EUI_ADD_COUNT_METRIC).increment(adds as u64);
+    metrics::counter!(EUI_REMOVE_COUNT_METRIC).increment(removes as u64);
 }
 
 pub fn count_devaddr_updates(adds: usize, removes: usize) {
-    metrics::counter!(DEVADDR_ADD_COUNT_METRIC, adds as u64);
-    metrics::counter!(DEVADDR_REMOVE_COUNT_METRIC, removes as u64);
+    metrics::counter!(DEVADDR_ADD_COUNT_METRIC).increment(adds as u64);
+    metrics::counter!(DEVADDR_REMOVE_COUNT_METRIC).increment(removes as u64);
 }
 
 pub fn route_stream_subscribe() {
-    metrics::increment_gauge!(STREAM_METRIC, 1.0);
+    metrics::gauge!(STREAM_METRIC).increment(1.0);
 }
 
 pub fn route_stream_unsubscribe() {
-    metrics::decrement_gauge!(STREAM_METRIC, 1.0);
+    metrics::gauge!(STREAM_METRIC).decrement(1.0);
 }

--- a/iot_packet_verifier/src/burner.rs
+++ b/iot_packet_verifier/src/burner.rs
@@ -131,7 +131,7 @@ where
         payer_account.burned = payer_account.burned.saturating_sub(amount);
         payer_account.balance = payer_account.balance.saturating_sub(amount);
 
-        metrics::counter!("burned", amount, "payer" => payer.to_string());
+        metrics::counter!("burned", "payer" => payer.to_string()).increment(amount);
 
         Ok(())
     }

--- a/iot_verifier/src/entropy_loader.rs
+++ b/iot_verifier/src/entropy_loader.rs
@@ -63,7 +63,7 @@ impl EntropyLoader {
                     report.version as i32,
                 )
                 .await?;
-                metrics::increment_counter!("oracles_iot_verifier_loader_entropy");
+                metrics::counter!("oracles_iot_verifier_loader_entropy").increment(1);
                 Ok(transaction)
             })
             .await?

--- a/iot_verifier/src/gateway_cache.rs
+++ b/iot_verifier/src/gateway_cache.rs
@@ -26,11 +26,11 @@ impl GatewayCache {
     ) -> Result<GatewayInfo, GatewayCacheError> {
         match self.gateway_cache_receiver.borrow().get(address) {
             Some(hit) => {
-                metrics::increment_counter!("oracles_iot_verifier_gateway_cache_hit");
+                metrics::counter!("oracles_iot_verifier_gateway_cache_hit").increment(1);
                 Ok(hit.clone())
             }
             None => {
-                metrics::increment_counter!("oracles_iot_verifier_gateway_cache_miss");
+                metrics::counter!("oracles_iot_verifier_gateway_cache_miss").increment(1);
                 Err(GatewayCacheError::GatewayNotFound(address.clone()))
             }
         }

--- a/iot_verifier/src/region_cache.rs
+++ b/iot_verifier/src/region_cache.rs
@@ -49,12 +49,12 @@ where
     ) -> Result<RegionParamsInfo, RegionCacheError<G::Error>> {
         match self.cache.get(&region).await {
             Some(hit) => {
-                metrics::increment_counter!("oracles_iot_verifier_region_params_cache_hit");
+                metrics::counter!("oracles_iot_verifier_region_params_cache_hit").increment(1);
                 Ok(hit.value().clone())
             }
             _ => match self.gateways.clone().resolve_region_params(region).await {
                 Ok(res) => {
-                    metrics::increment_counter!("oracles_iot_verifier_region_params_cache_miss");
+                    metrics::counter!("oracles_iot_verifier_region_params_cache_miss").increment(1);
                     self.cache
                         .insert(region, res.clone(), self.refresh_interval)
                         .await;

--- a/iot_verifier/src/telemetry.rs
+++ b/iot_verifier/src/telemetry.rs
@@ -26,47 +26,47 @@ pub async fn initialize(db: &Pool<Postgres>) -> anyhow::Result<()> {
 }
 
 pub fn count_packets(count: u64) {
-    metrics::counter!(PACKET_COUNTER, count);
+    metrics::counter!(PACKET_COUNTER).increment(count);
 }
 
 pub fn count_non_rewardable_packets(count: u64) {
-    metrics::counter!(NON_REWARDABLE_PACKET_COUNTER, count);
+    metrics::counter!(NON_REWARDABLE_PACKET_COUNTER).increment(count);
 }
 
 pub fn count_loader_beacons(count: u64) {
-    metrics::counter!(LOADER_BEACON_COUNTER, count);
+    metrics::counter!(LOADER_BEACON_COUNTER).increment(count);
 }
 
 pub fn count_loader_witnesses(count: u64) {
-    metrics::counter!(LOADER_WITNESS_COUNTER, count);
+    metrics::counter!(LOADER_WITNESS_COUNTER).increment(count);
 }
 
 pub fn count_loader_dropped_beacons(count: u64, labels: &[(&'static str, &'static str)]) {
-    metrics::counter!(LOADER_DROPPED_BEACON_COUNTER, count, labels);
+    metrics::counter!(LOADER_DROPPED_BEACON_COUNTER, labels).increment(count);
 }
 
 pub fn count_loader_dropped_witnesses(count: u64, labels: &[(&'static str, &'static str)]) {
-    metrics::counter!(LOADER_DROPPED_WITNESS_COUNTER, count, labels);
+    metrics::counter!(LOADER_DROPPED_WITNESS_COUNTER, labels).increment(count);
 }
 
 pub fn num_beacons(count: u64) {
-    metrics::gauge!(BEACON_GUAGE, count as f64);
+    metrics::gauge!(BEACON_GUAGE).set(count as f64);
 }
 
 pub fn increment_num_beacons_by(count: u64) {
-    metrics::increment_gauge!(BEACON_GUAGE, count as f64);
+    metrics::gauge!(BEACON_GUAGE).increment(count as f64);
 }
 
 pub fn decrement_num_beacons() {
-    metrics::decrement_gauge!(BEACON_GUAGE, 1.0)
+    metrics::gauge!(BEACON_GUAGE).decrement(1.0)
 }
 
 pub fn increment_invalid_witnesses(labels: &[(&'static str, &'static str)]) {
-    metrics::increment_counter!(INVALID_WITNESS_COUNTER, labels);
+    metrics::counter!(INVALID_WITNESS_COUNTER, labels).increment(1);
 }
 
 pub fn last_rewarded_end_time(datetime: DateTime<Utc>) {
-    metrics::gauge!(LAST_REWARDED_END_TIME, datetime.timestamp() as f64);
+    metrics::gauge!(LAST_REWARDED_END_TIME).set(datetime.timestamp() as f64);
 }
 
 #[derive(Default)]

--- a/iot_verifier/src/witness_updater.rs
+++ b/iot_verifier/src/witness_updater.rs
@@ -24,7 +24,7 @@ struct Telemetry {
 
 impl Telemetry {
     fn new() -> Self {
-        let gauge = metrics::register_gauge!("iot_verifier_witness_updater_queue");
+        let gauge = metrics::gauge!("iot_verifier_witness_updater_queue");
         gauge.set(0.0);
         Self { queue_gauge: gauge }
     }

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -11,5 +11,11 @@ tower = "0.4"
 thiserror = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
+futures = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+reqwest = { workspace = true }

--- a/metrics/src/client_requests.rs
+++ b/metrics/src/client_requests.rs
@@ -1,0 +1,195 @@
+//! Add a timing span to anything that can be instrumented and returns a Result.
+//!
+//! Example:
+//! ```ignore
+//! use poc_metrics::client_requests::ClientMetricTiming;
+//!
+//! async fn time_function() {
+//!     let x: Result<i32, ()> = async { Ok(42) }
+//!         .with_timing("iot_fetch_info")
+//!         .await;
+//!     assert_eq!(42, x.unwrap());
+//! }
+//! ```
+//!
+//! This will result in a prometheus metric
+//! >> client_request_duration_seconds{name = "iot_fetch_info", quantile="xxx"}
+//!
+//! Install the `ApiTimingLayer`.
+//!
+//! Adding `.with_span_events(FmtSpan::CLOSE)` to a regular format layer will
+//! print the timing spans to stdout as well.
+//!
+//! Example:
+//! ```ignore
+//! use poc_metrics::client_requests;
+//! use tracing_subscriber::fmt::format::FmtSpan;
+//! use tracing_subscriber::layer::SubscriberExt;
+//! use tracing_subscriber::util::SubscriberInitExt;
+//!
+//! tracing_subscriber::registry()
+//!   .with(tracing_subscriber::fmt::layer().with_span_events(FmtSpan::CLOSE))
+//!   .with(client_requests::client_request_timing_layer("histogram_name"))
+//!   .init();
+//! ```
+use futures::{future::Inspect, Future, FutureExt};
+use std::time::Instant;
+use tracing::{field::Visit, instrument::Instrumented, span, Instrument, Subscriber};
+use tracing_subscriber::{filter, layer, registry::LookupSpan, Layer};
+
+const SPAN_NAME: &str = "metrics::timing";
+
+pub fn client_request_timing_layer<S>(histogram_name: &'static str) -> impl layer::Layer<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    ApiTimingLayer::new(histogram_name).with_filter(filter::filter_fn(|m| m.name() == SPAN_NAME))
+}
+
+pub trait ClientMetricTiming<A, B>: Sized + Instrument + FutureExt {
+    fn with_timing(
+        self,
+        name: &'static str,
+    ) -> Instrumented<Inspect<Self, impl FnOnce(&Result<A, B>)>>
+    where
+        Self: Future<Output = Result<A, B>> + Sized;
+}
+
+// Impl ClientMetricTiming for all futures that return a Result
+impl<F, A, B> ClientMetricTiming<A, B> for F
+where
+    F: Future<Output = Result<A, B>> + Sized,
+{
+    fn with_timing(
+        self,
+        name: &'static str,
+    ) -> Instrumented<Inspect<Self, impl FnOnce(&Result<A, B>)>> {
+        let span = tracing::info_span!(SPAN_NAME, name, result = tracing::field::Empty);
+        let inner_span = span.clone();
+        self.inspect(move |res| {
+            inner_span.record("result", res.as_ref().ok().map_or("error", |_| "ok"));
+        })
+        .instrument(span)
+    }
+}
+
+struct Timing {
+    name: Option<String>,
+    start: Instant,
+    // ok | error | unknown
+    result: String,
+}
+
+impl Timing {
+    fn new() -> Self {
+        Self {
+            name: None,
+            start: Instant::now(),
+            result: "unknown".to_string(),
+        }
+    }
+
+    fn record(self, histogram_name: &'static str) {
+        if let Some(name) = self.name {
+            metrics::histogram!(
+                histogram_name,
+                self.start.elapsed().as_secs_f64(),
+                "name" => name,
+                "result" => self.result
+            )
+        }
+    }
+}
+
+impl Visit for Timing {
+    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        match field.name() {
+            "name" => self.name = Some(value.to_string()),
+            "result" => self.result = value.to_string(),
+            _ => (),
+        }
+    }
+}
+
+struct ApiTimingLayer {
+    histogram_name: &'static str,
+}
+
+impl ApiTimingLayer {
+    fn new(histogram_name: &'static str) -> Self {
+        Self { histogram_name }
+    }
+}
+
+impl<S> tracing_subscriber::Layer<S> for ApiTimingLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: layer::Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+
+        let mut timing = Timing::new();
+        attrs.values().record(&mut timing);
+        span.extensions_mut().insert(timing);
+    }
+
+    fn on_record(&self, id: &span::Id, values: &span::Record<'_>, ctx: layer::Context<'_, S>) {
+        let span = ctx.span(id).unwrap();
+
+        if let Some(timing) = span.extensions_mut().get_mut::<Timing>() {
+            values.record(timing);
+        };
+    }
+
+    fn on_close(&self, id: tracing::Id, ctx: layer::Context<S>) {
+        let span = ctx.span(&id).unwrap();
+
+        if let Some(timing) = span.extensions_mut().remove::<Timing>() {
+            timing.record(self.histogram_name);
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ClientMetricTiming;
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    #[tokio::test]
+    async fn test_telemetry() -> Result<(), Box<dyn std::error::Error>> {
+        tracing_subscriber::registry()
+            // Uncomment to view traces and Spans closing
+            // .with(
+            //     tracing_subscriber::fmt::layer()
+            //         .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE),
+            // )
+            .with(super::client_request_timing_layer("histogram_name"))
+            .init();
+
+        // Let the OS assign a port
+        let addr = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr()?
+        };
+        tracing::info!("listening on {addr}");
+        super::super::install(addr)?;
+
+        let success = async { Ok("nothing went wrong") };
+        let failure = async { Err("something went wrong") };
+        let _: Result<&str, &str> = success.with_timing("success").await;
+        let _: Result<&str, &str> = failure.with_timing("failing").await;
+
+        // .with_timing() can only be added to futures that return Results.
+        // let will_not_compile = async { 1 + 2 }.with_timing("not a result");
+
+        let res = reqwest::get(format!("http://{addr}")).await?;
+        let body = res.text().await?;
+
+        tracing::info!("response: \n{body}");
+        assert!(body.contains(r#"histogram_name_count{name="success",result="ok"} 1"#));
+        assert!(body.contains(r#"histogram_name_count{name="failing",result="error"} 1"#));
+
+        Ok(())
+    }
+}

--- a/metrics/src/client_requests.rs
+++ b/metrics/src/client_requests.rs
@@ -93,10 +93,10 @@ impl Timing {
         if let Some(name) = self.name {
             metrics::histogram!(
                 histogram_name,
-                self.start.elapsed().as_secs_f64(),
                 "name" => name,
                 "result" => self.result
             )
+            .record(self.start.elapsed().as_secs_f64())
         }
     }
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -12,32 +12,26 @@ use std::{
 };
 use tower::{Layer, Service};
 
+pub mod client_requests;
 mod error;
 pub mod settings;
 
 pub fn start_metrics(settings: &Settings) -> Result {
     let socket: SocketAddr = settings.endpoint.parse()?;
-    PrometheusBuilder::new()
-        .with_http_listener(socket)
-        .install()?;
-    Ok(())
+    install(socket)
 }
 
-/// Install the Prometheus export gateway
-pub fn install_metrics() {
-    let endpoint =
-        std::env::var("METRICS_SCRAPE_ENDPOINT").unwrap_or_else(|_| String::from("0.0.0.0:9000"));
-    let socket: SocketAddr = endpoint
-        .parse()
-        .expect("Invalid METRICS_SCRAPE_ENDPOINT value");
+fn install(socket_addr: SocketAddr) -> Result {
     if let Err(e) = PrometheusBuilder::new()
-        .with_http_listener(socket)
+        .with_http_listener(socket_addr)
         .install()
     {
         tracing::error!(target: "poc", "Failed to install Prometheus scrape endpoint: {e}");
     } else {
-        tracing::info!(target: "poc", "Metrics scrape endpoint listening on {endpoint}");
+        tracing::info!(target: "poc", "Metrics scrape endpoint listening on {socket_addr}");
     }
+
+    Ok(())
 }
 
 /// Measure the duration of a block and record it

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -43,7 +43,7 @@ macro_rules! record_duration {
     ( $metric_name:expr, $e:expr ) => {{
         let timer = std::time::Instant::now();
         let res = $e;
-        ::metrics::histogram!($metric_name, timer.elapsed());
+        ::metrics::histogram!($metric_name).record(timer.elapsed());
         res
     }};
 }
@@ -120,7 +120,7 @@ where
         let metric_name_time = self.metric_name_time;
 
         let timer = std::time::Instant::now();
-        metrics::increment_gauge!(metric_name_count, 1.0);
+        metrics::gauge!(metric_name_count).increment(1.0);
 
         let clone = self.inner.clone();
         // take the service that was ready
@@ -128,11 +128,11 @@ where
 
         Box::pin(async move {
             let res = inner.call(req).await;
-            metrics::decrement_gauge!(metric_name_count, 1.0);
+            metrics::gauge!(metric_name_count).decrement(1.0);
             let elapsed_time = timer.elapsed();
             tracing::debug!("request processed in {elapsed_time:?}");
             // TODO What units to use? Is f64 seconds appropriate?
-            ::metrics::histogram!(metric_name_time, elapsed_time.as_secs_f64());
+            metrics::histogram!(metric_name_time).record(elapsed_time.as_secs_f64());
             res
         })
     }

--- a/mobile_config/src/telemetry.rs
+++ b/mobile_config/src/telemetry.rs
@@ -3,9 +3,9 @@ const GATEWAY_CHAIN_LOOKUP_METRIC: &str =
     concat!(env!("CARGO_PKG_NAME"), "-", "gateway-chain-lookup");
 
 pub fn count_request(service: &'static str, rpc: &'static str) {
-    metrics::increment_counter!(RPC_METRIC, "service" => service, "rpc" => rpc);
+    metrics::counter!(RPC_METRIC, "service" => service, "rpc" => rpc).increment(1);
 }
 
 pub fn count_gateway_chain_lookup(result: &'static str) {
-    metrics::increment_counter!(GATEWAY_CHAIN_LOOKUP_METRIC, "result" => result);
+    metrics::counter!(GATEWAY_CHAIN_LOOKUP_METRIC, "result" => result).increment(1);
 }

--- a/mobile_packet_verifier/src/burner.rs
+++ b/mobile_packet_verifier/src/burner.rs
@@ -96,13 +96,15 @@ where
             tracing::info!(%total_dcs, %payer, "Burning DC");
             if self.burn_data_credits(&payer, total_dcs).await.is_err() {
                 // We have failed to burn data credits:
-                metrics::counter!("burned", total_dcs, "payer" => payer.to_string(), "success" => "false");
+                metrics::counter!("burned", "payer" => payer.to_string(), "success" => "false")
+                    .increment(total_dcs);
                 continue;
             }
 
             // We succesfully managed to burn data credits:
 
-            metrics::counter!("burned", total_dcs, "payer" => payer.to_string(), "success" => "true");
+            metrics::counter!("burned", "payer" => payer.to_string(), "success" => "true")
+                .increment(total_dcs);
 
             // Delete from the data transfer session and write out to S3
 

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -178,16 +178,16 @@ impl CoverageDaemon {
         self.oracle_boosting_sink.commit().await?;
 
         loop {
-            #[rustfmt::skip]
             tokio::select! {
                 _ = shutdown.clone() => {
                     tracing::info!("CoverageDaemon shutting down");
                     break;
                 }
                 Some(file) = self.coverage_objs.recv() => {
-		    let start = Instant::now();
-		    self.process_file(file).await?;
-		    metrics::histogram!("coverage_object_processing_time", start.elapsed());
+                    let start = Instant::now();
+                    self.process_file(file).await?;
+                    metrics::histogram!("coverage_object_processing_time")
+                        .record(start.elapsed());
                 }
             }
         }

--- a/mobile_verifier/src/heartbeats/cbrs.rs
+++ b/mobile_verifier/src/heartbeats/cbrs.rs
@@ -122,7 +122,6 @@ where
         let location_cache = LocationCache::new(&self.pool);
 
         loop {
-            #[rustfmt::skip]
             tokio::select! {
                 biased;
                 _ = shutdown.clone() => {
@@ -130,15 +129,16 @@ where
                     break;
                 }
                 Some(file) = self.heartbeats.recv() => {
-		    let start = Instant::now();
-		    self.process_file(
+                    let start = Instant::now();
+                    self.process_file(
                         file,
                         &heartbeat_cache,
                         &coverage_claim_time_cache,
                         &coverage_object_cache,
                         &location_cache,
-		    ).await?;
-		    metrics::histogram!("cbrs_heartbeat_processing_time", start.elapsed());
+                    ).await?;
+                    metrics::histogram!("cbrs_heartbeat_processing_time")
+                        .record(start.elapsed());
                 }
             }
         }

--- a/mobile_verifier/src/heartbeats/wifi.rs
+++ b/mobile_verifier/src/heartbeats/wifi.rs
@@ -119,7 +119,6 @@ where
         let location_cache = LocationCache::new(&self.pool);
 
         loop {
-            #[rustfmt::skip]
             tokio::select! {
                 biased;
                 _ = shutdown.clone() => {
@@ -127,15 +126,16 @@ where
                     break;
                 }
                 Some(file) = self.heartbeats.recv() => {
-		    let start = Instant::now();
-		    self.process_file(
+                    let start = Instant::now();
+                    self.process_file(
                         file,
                         &heartbeat_cache,
                         &coverage_claim_time_cache,
                         &coverage_object_cache,
                         &location_cache
-		    ).await?;
-		    metrics::histogram!("wifi_heartbeat_processing_time", start.elapsed());
+                    ).await?;
+                    metrics::histogram!("wifi_heartbeat_processing_time")
+                        .record(start.elapsed());
                 }
             }
         }

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -123,7 +123,6 @@ where
 
     pub async fn run(mut self, shutdown: triggered::Listener) -> anyhow::Result<()> {
         loop {
-            #[rustfmt::skip]
             tokio::select! {
                 biased;
                 _ = shutdown.clone() => {
@@ -131,9 +130,10 @@ where
                     break;
                 }
                 Some(file) = self.speedtests.recv() => {
-		    let start = Instant::now();
-		    self.process_file(file).await?;
-		    metrics::histogram!("speedtest_processing_time", start.elapsed());
+                    let start = Instant::now();
+                    self.process_file(file).await?;
+                    metrics::histogram!("speedtest_processing_time")
+                        .record(start.elapsed());
                 }
             }
         }

--- a/mobile_verifier/src/subscriber_location.rs
+++ b/mobile_verifier/src/subscriber_location.rs
@@ -105,17 +105,14 @@ where
 
     async fn run(mut self, shutdown: triggered::Listener) -> anyhow::Result<()> {
         loop {
-            #[rustfmt::skip]
             tokio::select! {
                 biased;
                 _ = shutdown.clone() => break,
                 Some(file) = self.reports_receiver.recv() => {
-		    let start = Instant::now();
+                    let start = Instant::now();
                     self.process_file(file).await?;
-		    metrics::histogram!(
-			"subscriber_location_processing_time",
-			start.elapsed()
-		    );
+                    metrics::histogram!("subscriber_location_processing_time")
+                        .record(start.elapsed());
                 }
             }
         }

--- a/mobile_verifier/src/telemetry.rs
+++ b/mobile_verifier/src/telemetry.rs
@@ -13,9 +13,9 @@ pub async fn initialize(db: &Pool<Postgres>) -> anyhow::Result<()> {
 }
 
 pub fn last_rewarded_end_time(timestamp: DateTime<Utc>) {
-    metrics::gauge!(LAST_REWARDED_END_TIME, timestamp.timestamp() as f64);
+    metrics::gauge!(LAST_REWARDED_END_TIME).set(timestamp.timestamp() as f64);
 }
 
 pub fn data_transfer_rewards_scale(scale: f64) {
-    metrics::gauge!(DATA_TRANSFER_REWARDS_SCALE, scale);
+    metrics::gauge!(DATA_TRANSFER_REWARDS_SCALE).set(scale);
 }

--- a/poc_entropy/src/server.rs
+++ b/poc_entropy/src/server.rs
@@ -18,7 +18,7 @@ impl PocEntropy for EntropyServer {
         _request: tonic::Request<EntropyReqV1>,
     ) -> Result<tonic::Response<EntropyReportV1>, tonic::Status> {
         let entropy = &*self.entropy_watch.borrow();
-        metrics::increment_counter!("entropy_server_get_count");
+        metrics::counter!("entropy_server_get_count").increment(1);
         Ok(tonic::Response::new(entropy.into()))
     }
 }

--- a/price/src/metrics.rs
+++ b/price/src/metrics.rs
@@ -12,9 +12,9 @@ impl Metrics {
 }
 
 fn increment_counter(counter: String, token_type: BlockchainTokenTypeV1) {
-    metrics::increment_counter!(counter, "token_type" => token_type.as_str_name());
+    metrics::counter!(counter, "token_type" => token_type.as_str_name()).increment(1);
 }
 
 fn set_gauge(token_type: BlockchainTokenTypeV1, value: f64) {
-    metrics::gauge!(PRICE_GAUGE, value, "token_type" => token_type.as_str_name());
+    metrics::gauge!(PRICE_GAUGE, "token_type" => token_type.as_str_name()).set(value);
 }

--- a/reward_index/src/telemetry.rs
+++ b/reward_index/src/telemetry.rs
@@ -16,7 +16,7 @@ pub async fn last_reward_processed_time(
     db: &Pool<Postgres>,
     datetime: DateTime<Utc>,
 ) -> anyhow::Result<()> {
-    metrics::gauge!(LAST_REWARD_PROCESSED_TIME, datetime.timestamp() as f64);
+    metrics::gauge!(LAST_REWARD_PROCESSED_TIME).set(datetime.timestamp() as f64);
     meta::store(db, LAST_REWARD_PROCESSED_TIME, datetime.timestamp()).await?;
 
     Ok(())

--- a/solana/src/burn.rs
+++ b/solana/src/burn.rs
@@ -141,9 +141,9 @@ impl SolanaNetwork for SolanaRpc {
         if self.payers_to_monitor.contains(payer) {
             metrics::gauge!(
                 "balance",
-                account_layout.amount as f64,
                 "payer" => payer.to_string()
-            );
+            )
+            .set(account_layout.amount as f64);
         }
 
         Ok(account_layout.amount)


### PR DESCRIPTION
**Questions:**

- Is there a way we can handle repos that take this as a dependency having a different `metrics` crate version than oracles?
  - Ended up updating `metrics` to latest api style and putting a `>=0.22` on the dep.

----


- Add a timing span to anything that can be instrumented and returns a Result.

  Example: ```ignore let client = GatewayClient::new(channel);

  client.info(req) .with_timing("iot_fetch_info") .await?; ```

  This will result in a prometheus metric
  >> client_request_duration_seconds{name = "iot_fetch_info", quantile="xxx"}

- Install the `ApiTimingLayer`.

  Adding `.with_span_events(FmtSpan::CLOSE)` to a regular format layer will print the timing spans to stdout as well.

  Example: ```ignore tracing_subscriber::registry() .with(tracing_subscriber::fmt::layer().with_span_events(FmtSpan::CLOSE)) .with(metrics::client_requests::client_request_timing_layer("histogram_name")) .init(); ```

- Remove unused `install_metrics` function, replace with nested `install` function that `start_metrics` delegates to. This allows us to start metrics in tests without needing to make a `Settings` struct.