### PR TITLE
Fix clippy

### DIFF
--- a/boost_manager/tests/common/mod.rs
+++ b/boost_manager/tests/common/mod.rs
@@ -2,13 +2,7 @@ use file_store::file_sink::{FileSinkClient, Message as SinkMessage};
 use helium_proto::BoostedHexInfoV1 as BoostedHexInfoProto;
 use helium_proto::BoostedHexUpdateV1 as BoostedHexUpdateProto;
 use helium_proto::Message;
-use mobile_config::boosted_hex_info::BoostedHexInfo;
 use tokio::{sync::mpsc::error::TryRecvError, time::timeout};
-
-#[derive(Debug, Clone)]
-pub struct MockHexBoostingClient {
-    pub boosted_hexes: Vec<BoostedHexInfo>,
-}
 
 pub struct MockFileSinkReceiver {
     pub receiver: tokio::sync::mpsc::Receiver<SinkMessage>,

--- a/boost_manager/tests/watcher_tests.rs
+++ b/boost_manager/tests/watcher_tests.rs
@@ -1,5 +1,5 @@
 mod common;
-use crate::common::{MockFileSinkReceiver, MockHexBoostingClient};
+use crate::common::MockFileSinkReceiver;
 use async_trait::async_trait;
 use boost_manager::watcher::{self, Watcher};
 use chrono::{DateTime, Duration as ChronoDuration, Duration, Utc};
@@ -16,9 +16,12 @@ use std::{num::NonZeroU32, str::FromStr};
 const BOOST_HEX_PUBKEY: &str = "J9JiLTpjaShxL8eMvUs8txVw6TZ36E38SiJ89NxnMbLU";
 const BOOST_CONFIG_PUBKEY: &str = "BZM1QTud72B2cpTW7PhEnFmRX7ZWzvY7DpPpNJJuDrWG";
 
+#[derive(Debug, Clone)]
+pub struct MockHexBoostingClient(pub Vec<BoostedHexInfo>);
+
 impl MockHexBoostingClient {
-    fn new(boosted_hexes: Vec<BoostedHexInfo>) -> Self {
-        Self { boosted_hexes }
+    pub fn new(boosted_hexes: Vec<BoostedHexInfo>) -> Self {
+        Self(boosted_hexes)
     }
 }
 
@@ -27,14 +30,14 @@ impl HexBoostingInfoResolver for MockHexBoostingClient {
     type Error = ClientError;
 
     async fn stream_boosted_hexes_info(&mut self) -> Result<BoostedHexInfoStream, ClientError> {
-        Ok(stream::iter(self.boosted_hexes.clone()).boxed())
+        Ok(stream::iter(self.0.clone()).boxed())
     }
 
     async fn stream_modified_boosted_hexes_info(
         &mut self,
         _timestamp: DateTime<Utc>,
     ) -> Result<BoostedHexInfoStream, ClientError> {
-        Ok(stream::iter(self.boosted_hexes.clone()).boxed())
+        Ok(stream::iter(self.0.clone()).boxed())
     }
 }
 

--- a/boost_manager/tests/watcher_tests.rs
+++ b/boost_manager/tests/watcher_tests.rs
@@ -17,11 +17,13 @@ const BOOST_HEX_PUBKEY: &str = "J9JiLTpjaShxL8eMvUs8txVw6TZ36E38SiJ89NxnMbLU";
 const BOOST_CONFIG_PUBKEY: &str = "BZM1QTud72B2cpTW7PhEnFmRX7ZWzvY7DpPpNJJuDrWG";
 
 #[derive(Debug, Clone)]
-pub struct MockHexBoostingClient(pub Vec<BoostedHexInfo>);
+pub struct MockHexBoostingClient {
+    pub boosted_hexes: Vec<BoostedHexInfo>,
+}
 
 impl MockHexBoostingClient {
-    pub fn new(boosted_hexes: Vec<BoostedHexInfo>) -> Self {
-        Self(boosted_hexes)
+    fn new(boosted_hexes: Vec<BoostedHexInfo>) -> Self {
+        Self { boosted_hexes }
     }
 }
 
@@ -30,14 +32,14 @@ impl HexBoostingInfoResolver for MockHexBoostingClient {
     type Error = ClientError;
 
     async fn stream_boosted_hexes_info(&mut self) -> Result<BoostedHexInfoStream, ClientError> {
-        Ok(stream::iter(self.0.clone()).boxed())
+        Ok(stream::iter(self.boosted_hexes.clone()).boxed())
     }
 
     async fn stream_modified_boosted_hexes_info(
         &mut self,
         _timestamp: DateTime<Utc>,
     ) -> Result<BoostedHexInfoStream, ClientError> {
-        Ok(stream::iter(self.0.clone()).boxed())
+        Ok(stream::iter(self.boosted_hexes.clone()).boxed())
     }
 }
 

--- a/mobile_verifier/tests/common/mod.rs
+++ b/mobile_verifier/tests/common/mod.rs
@@ -6,22 +6,9 @@ use helium_proto::{
     },
     Message,
 };
-use mobile_config::boosted_hex_info::BoostedHexInfo;
 use mobile_verifier::boosting_oracles::{Assignment, BoostedHexAssignments, HexAssignments};
 use std::collections::HashMap;
 use tokio::{sync::mpsc::error::TryRecvError, time::timeout};
-
-pub type ValidSpMap = HashMap<String, String>;
-
-#[derive(Debug, Clone)]
-pub struct MockCarrierServiceClient {
-    pub valid_sps: ValidSpMap,
-}
-
-#[derive(Debug, Clone)]
-pub struct MockHexBoostingClient {
-    pub boosted_hexes: Vec<BoostedHexInfo>,
-}
 
 pub struct MockFileSinkReceiver {
     pub receiver: tokio::sync::mpsc::Receiver<SinkMessage>,

--- a/mobile_verifier/tests/hex_boosting.rs
+++ b/mobile_verifier/tests/hex_boosting.rs
@@ -1,5 +1,5 @@
 mod common;
-use crate::common::{MockFileSinkReceiver, MockHexBoostingClient};
+use crate::common::MockFileSinkReceiver;
 use async_trait::async_trait;
 use chrono::{DateTime, Duration as ChronoDuration, Duration, Utc};
 use file_store::{
@@ -38,6 +38,11 @@ const HOTSPOT_4: &str = "11fEisW6J38vnS6qL65QyxnnNV5jfukFhuFiD4uteo4eUgDSShK";
 const CARRIER_HOTSPOT_KEY: &str = "11hd7HoicRgBPjBGcqcT2Y9hRQovdZeff5eKFMbCSuDYQmuCiF1";
 const BOOST_HEX_PUBKEY: &str = "J9JiLTpjaShxL8eMvUs8txVw6TZ36E38SiJ89NxnMbLU";
 const BOOST_CONFIG_PUBKEY: &str = "BZM1QTud72B2cpTW7PhEnFmRX7ZWzvY7DpPpNJJuDrWG";
+
+#[derive(Debug, Clone)]
+pub struct MockHexBoostingClient {
+    pub boosted_hexes: Vec<BoostedHexInfo>,
+}
 
 impl MockHexBoostingClient {
     fn new(boosted_hexes: Vec<BoostedHexInfo>) -> Self {

--- a/mobile_verifier/tests/rewarder_poc_dc.rs
+++ b/mobile_verifier/tests/rewarder_poc_dc.rs
@@ -1,5 +1,5 @@
 mod common;
-use crate::common::{MockFileSinkReceiver, MockHexBoostingClient};
+use crate::common::MockFileSinkReceiver;
 use async_trait::async_trait;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use file_store::{
@@ -20,7 +20,6 @@ use mobile_verifier::{
     cell_type::CellType,
     coverage::{set_oracle_boosting_assignments, CoverageObject, UnassignedHex},
     data_session,
-    geofence::GeofenceValidator,
     heartbeats::{HbType, Heartbeat, ValidatedHeartbeat},
     reward_shares, rewarder, speedtests,
 };
@@ -33,6 +32,11 @@ const HOTSPOT_1: &str = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6";
 const HOTSPOT_2: &str = "11uJHS2YaEWJqgqC7yza9uvSmpv5FWoMQXiP8WbxBGgNUmifUJf";
 const HOTSPOT_3: &str = "112E7TxoNHV46M6tiPA8N1MkeMeQxc9ztb4JQLXBVAAUfq1kJLoF";
 const PAYER_1: &str = "11eX55faMbqZB7jzN4p67m6w7ScPMH6ubnvCjCPLh72J49PaJEL";
+
+#[derive(Debug, Clone)]
+pub struct MockHexBoostingClient {
+    pub boosted_hexes: Vec<BoostedHexInfo>,
+}
 
 impl MockHexBoostingClient {
     fn new(boosted_hexes: Vec<BoostedHexInfo>) -> Self {
@@ -53,15 +57,6 @@ impl HexBoostingInfoResolver for MockHexBoostingClient {
         _timestamp: DateTime<Utc>,
     ) -> Result<BoostedHexInfoStream, ClientError> {
         Ok(stream::iter(self.boosted_hexes.clone()).boxed())
-    }
-}
-
-#[derive(Clone)]
-struct MockGeofence;
-
-impl GeofenceValidator<hextree::Cell> for MockGeofence {
-    fn in_valid_region(&self, _cell: &hextree::Cell) -> bool {
-        true
     }
 }
 

--- a/mobile_verifier/tests/rewarder_sp_rewards.rs
+++ b/mobile_verifier/tests/rewarder_sp_rewards.rs
@@ -11,8 +11,6 @@ use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
 use sqlx::{PgPool, Postgres, Transaction};
 
-use common::MockCarrierServiceClient;
-use common::ValidSpMap;
 use mobile_config::client::{carrier_service_client::CarrierServiceVerifier, ClientError};
 use mobile_verifier::{data_session, reward_shares, rewarder};
 
@@ -25,6 +23,13 @@ const HOTSPOT_2: &str = "11eX55faMbqZB7jzN4p67m6w7ScPMH6ubnvCjCPLh72J49PaJEL";
 const PAYER_1: &str = "11uJHS2YaEWJqgqC7yza9uvSmpv5FWoMQXiP8WbxBGgNUmifUJf";
 const PAYER_2: &str = "11sctWiP9r5wDJVuDe1Th4XSL2vaawaLLSQF8f8iokAoMAJHxqp";
 const SP_1: &str = "Helium Mobile";
+
+pub type ValidSpMap = HashMap<String, String>;
+
+#[derive(Debug, Clone)]
+pub struct MockCarrierServiceClient {
+    pub valid_sps: ValidSpMap,
+}
 
 impl MockCarrierServiceClient {
     fn new(valid_sps: ValidSpMap) -> Self {


### PR DESCRIPTION
It seems like this version of Rust does not like to have `struct` and `impl` in different files.