### PR TITLE
Socket Addrs

### DIFF
--- a/ingest/src/server_iot.rs
+++ b/ingest/src/server_iot.rs
@@ -344,8 +344,6 @@ impl poc_lora::PocLora for GrpcServer {
 }
 
 pub async fn grpc_server(settings: &Settings) -> Result<()> {
-    let grpc_addr = settings.listen_addr()?;
-
     // Initialize uploader
     let (file_upload, file_upload_server) =
         file_upload::FileUpload::from_settings_tm(&settings.output).await?;
@@ -374,6 +372,7 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
     .create()
     .await?;
 
+    let grpc_addr = settings.listen;
     let grpc_server = GrpcServer {
         beacon_report_sink,
         witness_report_sink,

--- a/ingest/src/server_mobile.rs
+++ b/ingest/src/server_mobile.rs
@@ -342,8 +342,6 @@ impl poc_mobile::PocMobile for GrpcServer {
 }
 
 pub async fn grpc_server(settings: &Settings) -> Result<()> {
-    let grpc_addr = settings.listen_addr()?;
-
     // Initialize uploader
     let (file_upload, file_upload_server) =
         file_upload::FileUpload::from_settings_tm(&settings.output).await?;
@@ -451,6 +449,7 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
         bail!("expected valid api token in settings");
     };
 
+    let grpc_addr = settings.listen;
     let grpc_server = GrpcServer {
         heartbeat_report_sink,
         wifi_heartbeat_report_sink,

--- a/ingest/src/settings.rs
+++ b/ingest/src/settings.rs
@@ -1,11 +1,7 @@
 use config::{Config, Environment, File};
 use helium_crypto::Network;
 use serde::Deserialize;
-use std::{
-    net::{AddrParseError, SocketAddr},
-    path::Path,
-    str::FromStr,
-};
+use std::{net::SocketAddr, path::Path};
 
 #[derive(Debug, Deserialize)]
 pub struct Settings {
@@ -20,7 +16,7 @@ pub struct Settings {
     pub mode: Mode,
     /// Listen address. Required. Default is 0.0.0.0:9081
     #[serde(default = "default_listen_addr")]
-    pub listen: String,
+    pub listen: SocketAddr,
     /// Local folder for storing intermediate files
     pub cache: String,
     /// Network required in all public keys:  mainnet | testnet
@@ -49,8 +45,8 @@ pub fn default_session_key_offer_timeout() -> u64 {
     5
 }
 
-pub fn default_listen_addr() -> String {
-    "0.0.0.0:9081".to_string()
+pub fn default_listen_addr() -> SocketAddr {
+    "0.0.0.0:9081".parse().unwrap()
 }
 
 pub fn default_log() -> String {
@@ -95,10 +91,6 @@ impl Settings {
             .add_source(Environment::with_prefix("INGEST").separator("_"))
             .build()
             .and_then(|config| config.try_deserialize())
-    }
-
-    pub fn listen_addr(&self) -> Result<SocketAddr, AddrParseError> {
-        SocketAddr::from_str(&self.listen)
     }
 
     pub fn session_key_offer_timeout(&self) -> std::time::Duration {

--- a/iot_config/src/main.rs
+++ b/iot_config/src/main.rs
@@ -68,8 +68,6 @@ impl Daemon {
         // Create on-chain metadata pool
         let metadata_pool = settings.metadata.connect("iot-config-metadata").await?;
 
-        let listen_addr = settings.listen_addr()?;
-
         let (auth_updater, auth_cache) = AuthCache::new(settings.admin_pubkey()?, &pool).await?;
         let (region_updater, region_map) = RegionMapReader::new(&pool).await?;
         let (delegate_key_updater, delegate_key_cache) = org::delegate_keys_cache(&pool).await?;
@@ -104,6 +102,7 @@ impl Daemon {
             region_updater,
         )?;
 
+        let listen_addr = settings.listen;
         let pubkey = settings
             .signing_keypair()
             .map(|keypair| keypair.public_key().to_string())?;

--- a/iot_config/src/settings.rs
+++ b/iot_config/src/settings.rs
@@ -1,11 +1,7 @@
 use chrono::Duration;
 use config::{Config, Environment, File};
 use serde::Deserialize;
-use std::{
-    net::{AddrParseError, SocketAddr},
-    path::Path,
-    str::FromStr,
-};
+use std::{net::SocketAddr, path::Path, str::FromStr};
 
 #[derive(Debug, Deserialize)]
 pub struct Settings {
@@ -15,7 +11,7 @@ pub struct Settings {
     pub log: String,
     /// Listen address. Required. Default is 0.0.0.0:8080
     #[serde(default = "default_listen_addr")]
-    pub listen: String,
+    pub listen: SocketAddr,
     /// File from which to load config server signing keypair
     pub keypair: String,
     /// B58 encoded public key of the admin keypair
@@ -33,8 +29,8 @@ pub fn default_log() -> String {
     "iot_config=debug".to_string()
 }
 
-pub fn default_listen_addr() -> String {
-    "0.0.0.0:8080".to_string()
+pub fn default_listen_addr() -> SocketAddr {
+    "0.0.0.0:8080".parse().unwrap()
 }
 
 pub fn default_deleted_entry_retention() -> u64 {
@@ -64,10 +60,6 @@ impl Settings {
             .add_source(Environment::with_prefix("CFG").separator("__"))
             .build()
             .and_then(|config| config.try_deserialize())
-    }
-
-    pub fn listen_addr(&self) -> Result<SocketAddr, AddrParseError> {
-        SocketAddr::from_str(&self.listen)
     }
 
     pub fn signing_keypair(&self) -> Result<helium_crypto::Keypair, Box<helium_crypto::Error>> {

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -17,8 +17,7 @@ mod error;
 pub mod settings;
 
 pub fn start_metrics(settings: &Settings) -> Result {
-    let socket: SocketAddr = settings.endpoint.parse()?;
-    install(socket)
+    install(settings.endpoint)
 }
 
 fn install(socket_addr: SocketAddr) -> Result {

--- a/metrics/src/settings.rs
+++ b/metrics/src/settings.rs
@@ -1,12 +1,14 @@
+use std::net::SocketAddr;
+
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Settings {
     /// Scrape endpoint for metrics
     #[serde(default = "default_metrics_endpoint")]
-    pub endpoint: String,
+    pub endpoint: SocketAddr,
 }
 
-pub fn default_metrics_endpoint() -> String {
-    "127.0.0.1:19000".to_string()
+fn default_metrics_endpoint() -> SocketAddr {
+    "127.0.0.1:19000".parse().unwrap()
 }

--- a/mobile_config/src/main.rs
+++ b/mobile_config/src/main.rs
@@ -71,8 +71,6 @@ impl Daemon {
         // Create on-chain metadata pool
         let metadata_pool = settings.metadata.connect("mobile-config-metadata").await?;
 
-        let listen_addr = settings.listen_addr()?;
-
         let (key_cache_updater, key_cache) = KeyCache::from_settings(settings, &pool).await?;
 
         let admin_svc =
@@ -97,6 +95,7 @@ impl Daemon {
             settings.signing_keypair()?,
         );
 
+        let listen_addr = settings.listen;
         let grpc_server = GrpcServer {
             listen_addr,
             admin_svc,

--- a/mobile_config/src/settings.rs
+++ b/mobile_config/src/settings.rs
@@ -1,11 +1,7 @@
 use anyhow::Context;
 use config::{Config, Environment, File};
 use serde::Deserialize;
-use std::{
-    net::{AddrParseError, SocketAddr},
-    path::Path,
-    str::FromStr,
-};
+use std::{net::SocketAddr, path::Path, str::FromStr};
 
 #[derive(Debug, Deserialize)]
 pub struct Settings {
@@ -15,7 +11,7 @@ pub struct Settings {
     pub log: String,
     /// Listen address. Required. Default to 0.0.0.0::8080
     #[serde(default = "default_listen_addr")]
-    pub listen: String,
+    pub listen: SocketAddr,
     /// File from which to load config server signing keypair
     pub signing_keypair: String,
     /// B58 encoded public key of the default admin keypair
@@ -33,8 +29,8 @@ pub fn default_log() -> String {
     "mobile_config=debug".to_string()
 }
 
-pub fn default_listen_addr() -> String {
-    "0.0.0.0:8080".to_string()
+pub fn default_listen_addr() -> SocketAddr {
+    "0.0.0.0:8080".parse().unwrap()
 }
 
 impl Settings {
@@ -59,10 +55,6 @@ impl Settings {
             .add_source(Environment::with_prefix("CFG").separator("__"))
             .build()
             .and_then(|config| config.try_deserialize())
-    }
-
-    pub fn listen_addr(&self) -> Result<SocketAddr, AddrParseError> {
-        SocketAddr::from_str(&self.listen)
     }
 
     pub fn signing_keypair(&self) -> anyhow::Result<helium_crypto::Keypair> {


### PR DESCRIPTION
- `SocketAddr` can be parsed directly from a config file. This moves potential errors even earlier in the bootup process.
- During tests, get an assigned open port from the OS. This removes the small chance you get a conflicting port when running tests locally.