### PR TITLE
settings shenans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4590,6 +4590,7 @@ dependencies = [
  "hextree",
  "http 0.2.11",
  "http-serde",
+ "humantime-serde",
  "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",

--- a/boost_manager/src/settings.rs
+++ b/boost_manager/src/settings.rs
@@ -56,11 +56,11 @@ fn default_activation_check_interval() -> Duration {
     humantime::parse_duration("15 minutes").unwrap()
 }
 
-pub fn default_start_after() -> DateTime<Utc> {
+fn default_start_after() -> DateTime<Utc> {
     DateTime::UNIX_EPOCH
 }
 
-pub fn default_log() -> String {
+fn default_log() -> String {
     "boost_manager=info".to_string()
 }
 

--- a/denylist/src/settings.rs
+++ b/denylist/src/settings.rs
@@ -23,11 +23,11 @@ pub struct Settings {
     pub sign_keys: Vec<String>,
 }
 
-pub fn default_log() -> String {
+fn default_log() -> String {
     "denylist=debug".to_string()
 }
 
-pub fn default_denylist_url() -> String {
+fn default_denylist_url() -> String {
     "https://api.github.com/repos/helium/denylist/releases/latest".to_string()
 }
 

--- a/ingest/src/settings.rs
+++ b/ingest/src/settings.rs
@@ -61,10 +61,6 @@ fn default_tracing_cfg_file() -> String {
     "tracing.cfg".to_string()
 }
 
-pub fn default_sink() -> String {
-    "/var/data/ingest".to_string()
-}
-
 /// Mode to deploy the ingest engine in. Each mode exposes different submission
 /// grpc methods
 #[derive(Debug, Deserialize)]

--- a/ingest/src/settings.rs
+++ b/ingest/src/settings.rs
@@ -41,23 +41,23 @@ pub struct Settings {
     pub metrics: poc_metrics::Settings,
 }
 
-pub fn default_session_key_timeout() -> Duration {
+fn default_session_key_timeout() -> Duration {
     humantime::parse_duration("30 minutes").unwrap()
 }
 
-pub fn default_session_key_offer_timeout() -> Duration {
+fn default_session_key_offer_timeout() -> Duration {
     humantime::parse_duration("5 seconds").unwrap()
 }
 
-pub fn default_listen_addr() -> SocketAddr {
+fn default_listen_addr() -> SocketAddr {
     "0.0.0.0:9081".parse().unwrap()
 }
 
-pub fn default_log() -> String {
+fn default_log() -> String {
     "ingest=debug,poc_store=info".to_string()
 }
 
-pub fn default_tracing_cfg_file() -> String {
+fn default_tracing_cfg_file() -> String {
     "tracing.cfg".to_string()
 }
 

--- a/iot_config/src/client/settings.rs
+++ b/iot_config/src/client/settings.rs
@@ -21,15 +21,15 @@ pub struct Settings {
     pub batch_size: u32,
 }
 
-pub fn default_connect_timeout() -> u64 {
+fn default_connect_timeout() -> u64 {
     5
 }
 
-pub fn default_rpc_timeout() -> u64 {
+fn default_rpc_timeout() -> u64 {
     5
 }
 
-pub fn default_batch_size() -> u32 {
+fn default_batch_size() -> u32 {
     1000
 }
 

--- a/iot_config/src/settings.rs
+++ b/iot_config/src/settings.rs
@@ -25,15 +25,15 @@ pub struct Settings {
     pub metrics: poc_metrics::Settings,
 }
 
-pub fn default_log() -> String {
+fn default_log() -> String {
     "iot_config=debug".to_string()
 }
 
-pub fn default_listen_addr() -> SocketAddr {
+fn default_listen_addr() -> SocketAddr {
     "0.0.0.0:8080".parse().unwrap()
 }
 
-pub fn default_deleted_entry_retention() -> Duration {
+fn default_deleted_entry_retention() -> Duration {
     humantime::parse_duration("48 hours").unwrap()
 }
 

--- a/iot_packet_verifier/src/settings.rs
+++ b/iot_packet_verifier/src/settings.rs
@@ -34,23 +34,23 @@ pub struct Settings {
     pub monitor_funds_period: Duration,
 }
 
-pub fn default_start_after() -> DateTime<Utc> {
+fn default_start_after() -> DateTime<Utc> {
     DateTime::UNIX_EPOCH
 }
 
-pub fn default_burn_period() -> Duration {
+fn default_burn_period() -> Duration {
     humantime::parse_duration("1 minute").unwrap()
 }
 
-pub fn default_log() -> String {
+fn default_log() -> String {
     "iot_packet_verifier=debug".to_string()
 }
 
-pub fn default_minimum_allowed_balance() -> u64 {
+fn default_minimum_allowed_balance() -> u64 {
     3_500_000
 }
 
-pub fn default_monitor_funds_period() -> Duration {
+fn default_monitor_funds_period() -> Duration {
     humantime::parse_duration("30 minutes").unwrap()
 }
 

--- a/iot_verifier/src/settings.rs
+++ b/iot_verifier/src/settings.rs
@@ -51,10 +51,6 @@ pub struct Settings {
     /// beaconing bucket sizes
     #[serde(with = "humantime_serde", default = "default_beacon_interval")]
     pub beacon_interval: Duration,
-    // FIXME: unused
-    /// Trigger interval for generating a transmit scaling map
-    #[serde(with = "humantime_serde", default = "default_transmit_scale_interval")]
-    pub transmit_scale_interval: Duration,
     // roll up time defined in the ingestors ( in seconds )
     // ie the time after which they will write out files to s3
     // this will be used when padding out the witness
@@ -70,10 +66,6 @@ pub struct Settings {
     /// cadence for how often to look for poc reports from s3 buckets
     #[serde(with = "humantime_serde", default = "default_poc_loader_poll_time")]
     pub poc_loader_poll_time: Duration,
-    // FIXME: unused
-    /// the lifespan of a piece of entropy
-    #[serde(with = "humantime_serde", default = "default_entropy_lifespan ")]
-    pub entropy_lifespan: Duration,
     /// max window age for the poc report loader ( in seconds )
     /// the starting point of the window will never be older than now - max age
     #[serde(
@@ -123,10 +115,6 @@ fn default_entropy_interval() -> Duration {
     humantime::parse_duration("5 minutes").unwrap()
 }
 
-fn default_entropy_lifespan() -> Duration {
-    humantime::parse_duration("5 minutes").unwrap()
-}
-
 fn default_poc_loader_window_width() -> Duration {
     humantime::parse_duration("5 minutes").unwrap()
 }
@@ -147,10 +135,6 @@ fn default_poc_loader_poll_time() -> Duration {
 
 fn default_beacon_interval() -> Duration {
     humantime::parse_duration("6 hours").unwrap()
-}
-
-fn default_transmit_scale_interval() -> Duration {
-    humantime::parse_duration("30 minutes").unwrap()
 }
 
 fn default_log() -> String {
@@ -228,7 +212,6 @@ impl Settings {
     }
 
     pub fn beacon_interval(&self) -> anyhow::Result<Duration> {
-        // FIXME:
         // validate the beacon_interval value is a factor of 24, if not bail out
         if (24 * 60 * 60) % self.beacon_interval.as_secs() != 0 {
             bail!("beacon interval is not a factor of 24")

--- a/mobile_config/Cargo.toml
+++ b/mobile_config/Cargo.toml
@@ -43,6 +43,7 @@ tracing-subscriber = {workspace = true}
 triggered = {workspace = true}
 task-manager = { path = "../task_manager" }
 solana-sdk = {workspace = true}
+humantime-serde = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/mobile_config/src/client/authorization_client.rs
+++ b/mobile_config/src/client/authorization_client.rs
@@ -43,7 +43,7 @@ impl AuthorizationClient {
             client: settings.connect_authorization_client(),
             signing_key: settings.signing_keypair()?,
             config_pubkey: settings.config_pubkey()?,
-            cache_ttl: settings.cache_ttl(),
+            cache_ttl: settings.cache_ttl,
             cache,
         })
     }

--- a/mobile_config/src/client/carrier_service_client.rs
+++ b/mobile_config/src/client/carrier_service_client.rs
@@ -77,7 +77,7 @@ impl CarrierServiceClient {
             client: settings.connect_carrier_service_client(),
             signing_key: settings.signing_keypair()?,
             config_pubkey: settings.config_pubkey()?,
-            cache_ttl: settings.cache_ttl(),
+            cache_ttl: settings.cache_ttl,
             cache,
         })
     }

--- a/mobile_config/src/client/entity_client.rs
+++ b/mobile_config/src/client/entity_client.rs
@@ -74,7 +74,7 @@ impl EntityClient {
             client: settings.connect_entity_client(),
             signing_key: settings.signing_keypair()?,
             config_pubkey: settings.config_pubkey()?,
-            cache_ttl: settings.cache_ttl(),
+            cache_ttl: settings.cache_ttl,
             cache,
         })
     }

--- a/mobile_config/src/client/gateway_client.rs
+++ b/mobile_config/src/client/gateway_client.rs
@@ -35,7 +35,7 @@ impl GatewayClient {
             signing_key: settings.signing_keypair()?,
             config_pubkey: settings.config_pubkey()?,
             batch_size: settings.batch_size,
-            cache_ttl: settings.cache_ttl(),
+            cache_ttl: settings.cache_ttl,
             cache,
         })
     }

--- a/mobile_config/src/client/settings.rs
+++ b/mobile_config/src/client/settings.rs
@@ -28,23 +28,23 @@ pub struct Settings {
     pub cache_ttl: Duration,
 }
 
-pub fn default_connect_timeout() -> Duration {
+fn default_connect_timeout() -> Duration {
     humantime::parse_duration("5 seconds").unwrap()
 }
 
-pub fn default_rpc_timeout() -> Duration {
+fn default_rpc_timeout() -> Duration {
     humantime::parse_duration("5 seconds").unwrap()
 }
 
-pub fn default_batch_size() -> u32 {
+fn default_batch_size() -> u32 {
     100
 }
 
-pub fn default_hex_boosting_batch_size() -> u32 {
+fn default_hex_boosting_batch_size() -> u32 {
     100
 }
 
-pub fn default_cache_ttl_in_secs() -> Duration {
+fn default_cache_ttl_in_secs() -> Duration {
     humantime::parse_duration("1 hour").unwrap()
 }
 

--- a/mobile_config/src/client/settings.rs
+++ b/mobile_config/src/client/settings.rs
@@ -1,4 +1,5 @@
 use helium_proto::services::{mobile_config, Channel, Endpoint};
+use humantime_serde::re::humantime;
 use serde::Deserialize;
 use std::{str::FromStr, sync::Arc, time::Duration};
 
@@ -12,27 +13,27 @@ pub struct Settings {
     /// B58 encoded public key of the mobile config server for verification
     pub config_pubkey: String,
     /// Connect timeout for the mobile config client in seconds. Default 5
-    #[serde(default = "default_connect_timeout")]
-    pub connect_timeout: u64,
+    #[serde(with = "humantime_serde", default = "default_connect_timeout")]
+    pub connect_timeout: Duration,
     /// RPC timeout for mobile config client in seconds. Default 5
-    #[serde(default = "default_rpc_timeout")]
-    pub rpc_timeout: u64,
+    #[serde(with = "humantime_serde", default = "default_rpc_timeout")]
+    pub rpc_timeout: Duration,
     /// Batch size for hotspot metadata stream results. Default 100
     #[serde(default = "default_batch_size")]
     pub batch_size: u32,
     /// Batch size for hex boosting stream results. Default 100
     #[serde(default = "default_hex_boosting_batch_size")]
     pub hex_boosting_batch_size: u32,
-    #[serde(default = "default_cache_ttl_in_secs")]
-    pub cache_ttl_in_secs: u64,
+    #[serde(with = "humantime_serde", default = "default_cache_ttl_in_secs")]
+    pub cache_ttl: Duration,
 }
 
-pub fn default_connect_timeout() -> u64 {
-    5
+pub fn default_connect_timeout() -> Duration {
+    humantime::parse_duration("5 seconds").unwrap()
 }
 
-pub fn default_rpc_timeout() -> u64 {
-    5
+pub fn default_rpc_timeout() -> Duration {
+    humantime::parse_duration("5 seconds").unwrap()
 }
 
 pub fn default_batch_size() -> u32 {
@@ -43,8 +44,8 @@ pub fn default_hex_boosting_batch_size() -> u32 {
     100
 }
 
-pub fn default_cache_ttl_in_secs() -> u64 {
-    60 * 60
+pub fn default_cache_ttl_in_secs() -> Duration {
+    humantime::parse_duration("1 hour").unwrap()
 }
 
 impl Settings {
@@ -83,15 +84,11 @@ impl Settings {
     pub fn config_pubkey(&self) -> Result<helium_crypto::PublicKey, helium_crypto::Error> {
         helium_crypto::PublicKey::from_str(&self.config_pubkey)
     }
-
-    pub fn cache_ttl(&self) -> std::time::Duration {
-        std::time::Duration::from_secs(self.cache_ttl_in_secs)
-    }
 }
 
 fn connect_channel(settings: &Settings) -> Channel {
     Endpoint::from(settings.url.clone())
-        .connect_timeout(Duration::from_secs(settings.connect_timeout))
-        .timeout(Duration::from_secs(settings.rpc_timeout))
+        .connect_timeout(settings.connect_timeout)
+        .timeout(settings.rpc_timeout)
         .connect_lazy()
 }

--- a/mobile_config/src/settings.rs
+++ b/mobile_config/src/settings.rs
@@ -25,11 +25,11 @@ pub struct Settings {
     pub metrics: poc_metrics::Settings,
 }
 
-pub fn default_log() -> String {
+fn default_log() -> String {
     "mobile_config=debug".to_string()
 }
 
-pub fn default_listen_addr() -> SocketAddr {
+fn default_listen_addr() -> SocketAddr {
     "0.0.0.0:8080".parse().unwrap()
 }
 

--- a/poc_entropy/src/settings.rs
+++ b/poc_entropy/src/settings.rs
@@ -22,15 +22,15 @@ pub struct Settings {
     pub metrics: poc_metrics::Settings,
 }
 
-pub fn default_log() -> String {
+fn default_log() -> String {
     "poc_entropy=debug,poc_store=info".to_string()
 }
 
-pub fn default_cache() -> String {
+fn default_cache() -> String {
     "/var/data/entropy".to_string()
 }
 
-pub fn default_listen_addr() -> String {
+fn default_listen_addr() -> String {
     "0.0.0.0:8080".to_string()
 }
 

--- a/price/src/settings.rs
+++ b/price/src/settings.rs
@@ -81,7 +81,7 @@ fn default_stale_price_duration() -> Duration {
     humantime::parse_duration("12 hours").unwrap()
 }
 
-pub fn default_cache() -> String {
+fn default_cache() -> String {
     "/var/data/price".to_string()
 }
 


### PR DESCRIPTION
- `humantime_serde` the missed mobile-config client settings
- default functions for serde do not need to be exported
  - file_store default region is a special case because it's used
- remove some unused settings

