### PR TITLE
Use protoc action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: ["main"]
   push:
     branches: ["main"]
     tags: ["*"]
@@ -28,8 +28,8 @@ jobs:
       - name: Rust install
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
 
       - name: Cache
         uses: actions/cache@v4
@@ -76,8 +76,8 @@ jobs:
         with:
           components: clippy
       
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
 
       - name: Clippy
         run: cargo clippy --all-targets -- -Dclippy::all -D warnings
@@ -111,8 +111,8 @@ jobs:
       - name: Rust install
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
 
       - name: Cache
         uses: actions/cache@v4
@@ -147,8 +147,8 @@ jobs:
       - name: Rust install
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
 
       - name: Cache
         uses: actions/cache@v4
@@ -176,8 +176,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
 
       - name: Cache
         uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Oracles
+# Oracles [![CI](https://github.com/helium/oracles/actions/workflows/CI.yml/badge.svg)](https://github.com/helium/oracles/actions/workflows/CI.yml)
 
 ## Mobile
 


### PR DESCRIPTION
Using `protoc action` avoid downloading `protoc` with `apt-get` and saves on average 30s on build time.