### PR TITLE
Add `coverage_map` crate to provide `CoverageMapBuilder` and `CoverageMap` data structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,7 +2131,6 @@ dependencies = [
  "helium-proto",
  "hex-assignments",
  "hextree",
- "mobile-config",
  "uuid",
 ]
 
@@ -4616,6 +4615,7 @@ dependencies = [
  "chrono",
  "clap 4.4.8",
  "config",
+ "coverage_map",
  "custom-tracing",
  "db-store",
  "file-store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,6 +2122,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "coverage_map"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "h3o",
+ "helium-crypto",
+ "helium-proto",
+ "hex-assignments",
+ "hextree",
+ "mobile-config",
+ "uuid",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "coverage_map"
+name = "coverage-map"
 version = "0.1.0"
 dependencies = [
  "chrono",
@@ -4615,7 +4615,7 @@ dependencies = [
  "chrono",
  "clap 4.4.8",
  "config",
- "coverage_map",
+ "coverage-map",
  "custom-tracing",
  "db-store",
  "file-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ debug = true
 [workspace]
 members = [
   "boost_manager",
+  "coverage_map",
   "custom_tracing",
   "db_store",
   "denylist",

--- a/coverage_map/Cargo.toml
+++ b/coverage_map/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "coverage_map"
+name = "coverage-map"
 version = "0.1.0"
 authors.workspace = true
 license.workspace = true
@@ -14,5 +14,4 @@ helium-crypto = { workspace = true }
 helium-proto = { workspace = true }
 hex-assignments = { path = "../hex_assignments" }
 hextree = { workspace = true }
-mobile-config = { path = "../mobile_config" }
 uuid = { workspace = true }

--- a/coverage_map/Cargo.toml
+++ b/coverage_map/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "coverage_map"
+version = "0.1.0"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+chrono = { workspace = true }
+h3o = { workspace = true }
+helium-crypto = { workspace = true }
+helium-proto = { workspace = true }
+hex-assignments = { path = "../hex_assignments" }
+hextree = { workspace = true }
+mobile-config = { path = "../mobile_config" }
+uuid = { workspace = true }

--- a/coverage_map/src/indoor.rs
+++ b/coverage_map/src/indoor.rs
@@ -97,7 +97,6 @@ pub fn into_indoor_coverage_map(
             let boosted = boosted_hexes.get_current_multiplier(hex, epoch_start);
             radios
                 .into_values()
-                .rev()
                 .flat_map(move |radios| radios.into_sorted_vec().into_iter())
                 .map(move |cov| (hex, boosted, cov))
         })
@@ -105,7 +104,6 @@ pub fn into_indoor_coverage_map(
         .map(move |(rank, (hex, boosted, cov))| RankedCoverage {
             hex,
             rank: rank + 1,
-            indoor: true,
             hotspot_key: cov.hotspot_key,
             cbsd_id: cov.cbsd_id,
             assignments: cov.assignments,

--- a/coverage_map/src/indoor.rs
+++ b/coverage_map/src/indoor.rs
@@ -7,9 +7,8 @@ use chrono::{DateTime, Utc};
 use helium_crypto::PublicKeyBinary;
 use hex_assignments::assignment::HexAssignments;
 use hextree::Cell;
-use mobile_config::boosted_hex_info::BoostedHexes;
 
-use crate::{CoverageObject, RankedCoverage, SignalLevel, UnrankedCoverage};
+use crate::{BoostedHexMap, CoverageObject, RankedCoverage, SignalLevel, UnrankedCoverage};
 
 pub type IndoorCellTree = HashMap<Cell, BTreeMap<SignalLevel, BinaryHeap<IndoorCoverageLevel>>>;
 
@@ -89,7 +88,7 @@ pub fn clone_indoor_coverage_into_submap(
 
 pub fn into_indoor_coverage_map(
     indoor: IndoorCellTree,
-    boosted_hexes: &BoostedHexes,
+    boosted_hexes: &impl BoostedHexMap,
     epoch_start: DateTime<Utc>,
 ) -> impl Iterator<Item = RankedCoverage> + '_ {
     indoor
@@ -138,7 +137,7 @@ mod test {
             insert_indoor_coverage_object(&mut indoor_coverage, cov_obj);
         }
         let ranked: HashMap<_, _> =
-            into_indoor_coverage_map(indoor_coverage, &BoostedHexes::default(), Utc::now())
+            into_indoor_coverage_map(indoor_coverage, &NoBoostedHexes, Utc::now())
                 .map(|x| (x.cbsd_id.clone().unwrap(), x))
                 .collect();
         assert_eq!(ranked.get("3").unwrap().rank, 1);
@@ -180,7 +179,7 @@ mod test {
             insert_indoor_coverage_object(&mut indoor_coverage, cov_obj);
         }
         let ranked: HashMap<_, _> =
-            into_indoor_coverage_map(indoor_coverage, &BoostedHexes::default(), Utc::now())
+            into_indoor_coverage_map(indoor_coverage, &NoBoostedHexes, Utc::now())
                 .map(|x| (x.cbsd_id.clone().unwrap(), x))
                 .collect();
         assert_eq!(ranked.get("1").unwrap().rank, 9);

--- a/coverage_map/src/indoor.rs
+++ b/coverage_map/src/indoor.rs
@@ -94,7 +94,7 @@ pub fn into_indoor_coverage_map(
     indoor: IndoorCellTree,
     boosted_hexes: &BoostedHexes,
     epoch_start: DateTime<Utc>,
-) -> impl Iterator<Item = (PublicKeyBinary, RankedCoverage)> + '_ {
+) -> impl Iterator<Item = RankedCoverage> + '_ {
     indoor
         .into_iter()
         .flat_map(move |(hex, mut radios)| {
@@ -106,17 +106,14 @@ pub fn into_indoor_coverage_map(
                     .take(MAX_INDOOR_RADIOS_PER_RES12_HEX)
                     .enumerate()
                     .flat_map(move |(rank, cov)| {
-                        Rank::from_indoor_index(rank).map(move |rank| {
-                            let key = cov.hotspot_key;
-                            let cov = RankedCoverage {
-                                hex,
-                                rank,
-                                cbsd_id: cov.cbsd_id,
-                                assignments: cov.assignments,
-                                boosted,
-                                signal_level: cov.signal_level,
-                            };
-                            (key, cov)
+                        Rank::from_indoor_index(rank).map(move |rank| RankedCoverage {
+                            hex,
+                            rank,
+                            hotspot_key: cov.hotspot_key,
+                            cbsd_id: cov.cbsd_id,
+                            assignments: cov.assignments,
+                            boosted,
+                            signal_level: cov.signal_level,
                         })
                     })
             })

--- a/coverage_map/src/indoor.rs
+++ b/coverage_map/src/indoor.rs
@@ -1,0 +1,125 @@
+use std::{
+    cmp::Ordering,
+    collections::{hash_map::Entry, BTreeMap, BinaryHeap, HashMap},
+};
+
+use chrono::{DateTime, Utc};
+use helium_crypto::PublicKeyBinary;
+use hex_assignments::assignment::HexAssignments;
+use hextree::Cell;
+use mobile_config::boosted_hex_info::BoostedHexes;
+
+use crate::{
+    CoverageObject, Rank, RankedCoverage, SignalLevel, UnrankedCoverage,
+    MAX_INDOOR_RADIOS_PER_RES12_HEX,
+};
+
+pub type IndoorCellTree = HashMap<Cell, BTreeMap<SignalLevel, BinaryHeap<IndoorCoverageLevel>>>;
+
+#[derive(Eq, Debug, Clone)]
+pub struct IndoorCoverageLevel {
+    hotspot_key: PublicKeyBinary,
+    cbsd_id: Option<String>,
+    seniority_timestamp: DateTime<Utc>,
+    signal_level: SignalLevel,
+    assignments: HexAssignments,
+}
+
+impl PartialEq for IndoorCoverageLevel {
+    fn eq(&self, other: &Self) -> bool {
+        self.seniority_timestamp == other.seniority_timestamp
+    }
+}
+
+impl PartialOrd for IndoorCoverageLevel {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for IndoorCoverageLevel {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.seniority_timestamp.cmp(&other.seniority_timestamp)
+    }
+}
+
+pub fn insert_indoor_coverage_object(indoor: &mut IndoorCellTree, coverage_object: CoverageObject) {
+    for hex_coverage in coverage_object.coverage.into_iter() {
+        insert_indoor_coverage(
+            indoor,
+            &coverage_object.hotspot_key,
+            &coverage_object.cbsd_id,
+            coverage_object.seniority_timestamp,
+            hex_coverage,
+        );
+    }
+}
+
+pub fn insert_indoor_coverage(
+    indoor: &mut IndoorCellTree,
+    hotspot: &PublicKeyBinary,
+    cbsd_id: &Option<String>,
+    seniority_timestamp: DateTime<Utc>,
+    hex_coverage: UnrankedCoverage,
+) {
+    indoor
+        .entry(hex_coverage.location)
+        .or_default()
+        .entry(hex_coverage.signal_level)
+        .or_default()
+        .push(IndoorCoverageLevel {
+            hotspot_key: hotspot.clone(),
+            cbsd_id: cbsd_id.clone(),
+            seniority_timestamp,
+            signal_level: hex_coverage.signal_level,
+            assignments: hex_coverage.assignments,
+        })
+}
+
+pub fn clone_indoor_coverage_into_submap(
+    submap: &mut IndoorCellTree,
+    from: &IndoorCellTree,
+    coverage_obj: &CoverageObject,
+) {
+    for coverage in &coverage_obj.coverage {
+        if let Entry::Vacant(e) = submap.entry(coverage.location) {
+            if let Some(old_coverage_data) = from.get(&coverage.location) {
+                e.insert(old_coverage_data.clone());
+            }
+        }
+    }
+}
+
+pub fn into_indoor_coverage_map(
+    indoor: IndoorCellTree,
+    boosted_hexes: &BoostedHexes,
+    epoch_start: DateTime<Utc>,
+) -> impl Iterator<Item = (PublicKeyBinary, RankedCoverage)> + '_ {
+    indoor
+        .into_iter()
+        .flat_map(move |(hex, mut radios)| {
+            let boosted = boosted_hexes.get_current_multiplier(hex, epoch_start);
+            radios.pop_last().map(move |(_, radios)| {
+                radios
+                    .into_sorted_vec()
+                    .into_iter()
+                    .take(MAX_INDOOR_RADIOS_PER_RES12_HEX)
+                    .enumerate()
+                    .flat_map(move |(rank, cov)| {
+                        Rank::from_indoor_index(rank).map(move |rank| {
+                            let key = cov.hotspot_key;
+                            let cov = RankedCoverage {
+                                hex,
+                                rank,
+                                cbsd_id: cov.cbsd_id,
+                                assignments: cov.assignments,
+                                boosted,
+                                signal_level: cov.signal_level,
+                            };
+                            (key, cov)
+                        })
+                    })
+            })
+        })
+        .flatten()
+}

--- a/coverage_map/src/lib.rs
+++ b/coverage_map/src/lib.rs
@@ -4,7 +4,6 @@ use chrono::{DateTime, Utc};
 use helium_crypto::PublicKeyBinary;
 use hex_assignments::assignment::HexAssignments;
 use hextree::Cell;
-use mobile_config::boosted_hex_info::BoostedHexes;
 
 mod indoor;
 mod outdoor;
@@ -78,7 +77,7 @@ impl CoverageMapBuilder {
     }
 
     /// Constructs a [CoverageMap] from the current `CoverageMapBuilder`
-    pub fn build(self, boosted_hexes: &BoostedHexes, epoch_start: DateTime<Utc>) -> CoverageMap {
+    pub fn build(self, boosted_hexes: &impl BoostedHexMap, epoch_start: DateTime<Utc>) -> CoverageMap {
         let mut wifi_hotspots = HashMap::<_, Vec<RankedCoverage>>::new();
         let mut cbrs_radios = HashMap::<_, Vec<RankedCoverage>>::new();
         for coverage in into_indoor_coverage_map(self.indoor_cbrs, boosted_hexes, epoch_start)
@@ -183,4 +182,18 @@ pub enum SignalLevel {
     Low,
     Medium,
     High,
+}
+
+pub trait BoostedHexMap {
+    fn get_current_multiplier(&self, cell: Cell, ts: DateTime<Utc>) -> Option<NonZeroU32>;
+}
+
+#[cfg(test)]
+pub(crate) struct NoBoostedHexes;
+
+#[cfg(test)]
+impl BoostedHexMap for NoBoostedHexes {
+    fn get_current_multiplier(&self, _cell: Cell, _ts: DateTime<Utc>) -> Option<NonZeroU32> {
+        None
+    }
 }

--- a/coverage_map/src/lib.rs
+++ b/coverage_map/src/lib.rs
@@ -1,0 +1,175 @@
+use std::{collections::HashMap, num::NonZeroU32};
+
+use chrono::{DateTime, Utc};
+use helium_crypto::PublicKeyBinary;
+use hex_assignments::assignment::HexAssignments;
+use hextree::Cell;
+use mobile_config::boosted_hex_info::BoostedHexes;
+
+mod indoor;
+mod outdoor;
+
+use indoor::*;
+use outdoor::*;
+
+/// Data structure for keeping track of the ranking the coverage in each hex cell for indoor
+/// and outdoor CBRS and WiFi radios.
+#[derive(Default)]
+pub struct CoverageMapBuilder {
+    indoor_cbrs: IndoorCellTree,
+    indoor_wifi: IndoorCellTree,
+    outdoor_cbrs: OutdoorCellTree,
+    outdoor_wifi: OutdoorCellTree,
+}
+
+impl CoverageMapBuilder {
+    /// Inserts a new coverage object into the builder.
+    pub fn insert_coverage_object(&mut self, coverage_obj: CoverageObject) {
+        match (coverage_obj.indoor, coverage_obj.cbsd_id.is_some()) {
+            (true, true) => insert_indoor_coverage_object(&mut self.indoor_cbrs, coverage_obj),
+            (true, false) => insert_indoor_coverage_object(&mut self.indoor_wifi, coverage_obj),
+            (false, true) => insert_outdoor_coverage_object(&mut self.outdoor_cbrs, coverage_obj),
+            (false, false) => insert_outdoor_coverage_object(&mut self.outdoor_wifi, coverage_obj),
+        }
+    }
+
+    /// Creates a submap from the current `CoverageMapBuilder` and the provided `coverage_objs`.
+    ///
+    /// A submap only contains the hexes that exist in the provided `coverage_objs` arguments. This
+    /// allows for one to determine the potential ranking of new coverage objects without having
+    /// to clone the entire CoverageMapBuilder.
+    pub fn submap(&self, coverage_objs: Vec<CoverageObject>) -> Self {
+        // A different way to implement this function would be to insert all of the coverage_objs into
+        // the submap, and then reconstruct the coverage objs from only the relevant hexes and then
+        // insert them into the new coverage object builder.
+        let mut new_submap = Self::default();
+        for coverage_obj in coverage_objs {
+            // Clone each of the hexes in the current coverage from the old map into the new submap:
+            match (coverage_obj.indoor, coverage_obj.cbsd_id.is_some()) {
+                (true, true) => clone_indoor_coverage_into_submap(
+                    &mut new_submap.indoor_cbrs,
+                    &self.indoor_cbrs,
+                    &coverage_obj,
+                ),
+                (true, false) => clone_indoor_coverage_into_submap(
+                    &mut new_submap.indoor_wifi,
+                    &self.indoor_wifi,
+                    &coverage_obj,
+                ),
+                (false, true) => clone_outdoor_coverage_into_submap(
+                    &mut new_submap.outdoor_cbrs,
+                    &self.outdoor_cbrs,
+                    &coverage_obj,
+                ),
+                (false, false) => clone_outdoor_coverage_into_submap(
+                    &mut new_submap.outdoor_wifi,
+                    &self.outdoor_wifi,
+                    &coverage_obj,
+                ),
+            }
+            // Now that we are sure that each of the hexes in this coverage object are in the new
+            // submap, we can insert the new coverage obj.
+            new_submap.insert_coverage_object(coverage_obj);
+        }
+        new_submap
+    }
+
+    /// Constructs a [CoverageMap] from the current `CoverageMapBuilder`
+    pub fn build(self, boosted_hexes: &BoostedHexes, epoch_start: DateTime<Utc>) -> CoverageMap {
+        let mut hotspots = HashMap::<_, Vec<RankedCoverage>>::new();
+        for (radio, coverage) in
+            into_indoor_coverage_map(self.indoor_cbrs, boosted_hexes, epoch_start)
+                .chain(into_indoor_coverage_map(
+                    self.indoor_wifi,
+                    boosted_hexes,
+                    epoch_start,
+                ))
+                .chain(into_outdoor_coverage_map(
+                    self.outdoor_cbrs,
+                    boosted_hexes,
+                    epoch_start,
+                ))
+                .chain(into_outdoor_coverage_map(
+                    self.outdoor_wifi,
+                    boosted_hexes,
+                    epoch_start,
+                ))
+        {
+            hotspots.entry(radio).or_default().push(coverage);
+        }
+        CoverageMap { hotspots }
+    }
+}
+
+/// Data structure from mapping hotspots to their ranked hex coverage
+pub struct CoverageMap {
+    hotspots: HashMap<PublicKeyBinary, Vec<RankedCoverage>>,
+}
+
+impl CoverageMap {
+    /// Returns the hexes covered by the hotspot. The returned slice can be empty, indicating that
+    /// the hotspot did not meet the criteria to be ranked in any hex.
+    pub fn get_coverage(&self, hotspot: &PublicKeyBinary) -> &[RankedCoverage] {
+        self.hotspots.get(hotspot).map(Vec::as_slice).unwrap_or(&[])
+    }
+}
+
+/// Coverage data given as input to the [CoverageMapBuilder]
+pub struct CoverageObject {
+    pub indoor: bool,
+    pub hotspot_key: PublicKeyBinary,
+    pub cbsd_id: Option<String>,
+    pub seniority_timestamp: DateTime<Utc>,
+    pub coverage: Vec<UnrankedCoverage>,
+}
+
+/// Unranked hex coverage data given as input to the [CoverageMapBuilder]
+pub struct UnrankedCoverage {
+    pub location: Cell,
+    pub signal_power: i32,
+    pub signal_level: SignalLevel,
+    pub assignments: HexAssignments,
+}
+
+/// Ranked hex coverage given as output from the [CoverageMap]
+pub struct RankedCoverage {
+    pub hex: Cell,
+    pub rank: Rank,
+    pub cbsd_id: Option<String>,
+    pub assignments: HexAssignments,
+    pub boosted: Option<NonZeroU32>,
+    pub signal_level: SignalLevel,
+}
+
+/// Rank of the hex coverage.
+pub enum Rank {
+    First,
+    Second,
+    Third,
+}
+
+#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
+pub enum SignalLevel {
+    None,
+    Low,
+    Medium,
+    High,
+}
+
+pub const MAX_INDOOR_RADIOS_PER_RES12_HEX: usize = 1;
+pub const MAX_OUTDOOR_RADIOS_PER_RES12_HEX: usize = 3;
+
+impl Rank {
+    pub(crate) fn from_outdoor_index(idx: usize) -> Option<Self> {
+        match idx {
+            0 => Some(Self::First),
+            1 => Some(Self::Second),
+            2 => Some(Self::Third),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn from_indoor_index(idx: usize) -> Option<Self> {
+        (idx == 0).then_some(Self::First)
+    }
+}

--- a/coverage_map/src/lib.rs
+++ b/coverage_map/src/lib.rs
@@ -169,10 +169,8 @@ pub struct UnrankedCoverage {
 /// Ranked hex coverage given as output from the [CoverageMap]
 #[derive(Clone, Debug)]
 pub struct RankedCoverage {
-    // TODO(map): Does this need to indicate whether the coverage is indoor or outdoor?
     pub hex: Cell,
     pub rank: usize,
-    pub indoor: bool,
     pub hotspot_key: PublicKeyBinary,
     pub cbsd_id: Option<String>,
     pub assignments: HexAssignments,
@@ -182,10 +180,10 @@ pub struct RankedCoverage {
 
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub enum SignalLevel {
-    None,
-    Low,
-    Medium,
     High,
+    Medium,
+    Low,
+    None,
 }
 
 pub trait BoostedHexMap {

--- a/coverage_map/src/lib.rs
+++ b/coverage_map/src/lib.rs
@@ -77,7 +77,11 @@ impl CoverageMapBuilder {
     }
 
     /// Constructs a [CoverageMap] from the current `CoverageMapBuilder`
-    pub fn build(self, boosted_hexes: &impl BoostedHexMap, epoch_start: DateTime<Utc>) -> CoverageMap {
+    pub fn build(
+        self,
+        boosted_hexes: &impl BoostedHexMap,
+        epoch_start: DateTime<Utc>,
+    ) -> CoverageMap {
         let mut wifi_hotspots = HashMap::<_, Vec<RankedCoverage>>::new();
         let mut cbrs_radios = HashMap::<_, Vec<RankedCoverage>>::new();
         for coverage in into_indoor_coverage_map(self.indoor_cbrs, boosted_hexes, epoch_start)

--- a/coverage_map/src/lib.rs
+++ b/coverage_map/src/lib.rs
@@ -38,6 +38,9 @@ impl CoverageMapBuilder {
     /// A submap only contains the hexes that exist in the provided `coverage_objs` arguments. This
     /// allows for one to determine the potential ranking of new coverage objects without having
     /// to clone the entire CoverageMapBuilder.
+    // TODO(map): Should this return a `CoverageMap` instead? I don't really see the purpose of
+    // having this return a `CoverageMapBuilder` since it will probably always be converted instantly
+    // to a `CoverageMap`.
     pub fn submap(&self, coverage_objs: Vec<CoverageObject>) -> Self {
         // A different way to implement this function would be to insert all of the coverage_objs into
         // the submap, and then reconstruct the coverage objs from only the relevant hexes and then
@@ -75,6 +78,7 @@ impl CoverageMapBuilder {
     }
 
     /// Constructs a [CoverageMap] from the current `CoverageMapBuilder`
+    // TODO(map): Should this take &self and clone the data?
     pub fn build(self, boosted_hexes: &BoostedHexes, epoch_start: DateTime<Utc>) -> CoverageMap {
         let mut hotspots = HashMap::<_, Vec<RankedCoverage>>::new();
         for (radio, coverage) in

--- a/coverage_map/src/lib.rs
+++ b/coverage_map/src/lib.rs
@@ -175,6 +175,7 @@ pub struct RankedCoverage {
 
 /// Rank of the hex coverage.
 // TODO(map): Should this be split into Indoor and OutdoorRank?
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Rank {
     First,
     Second,

--- a/coverage_map/src/lib.rs
+++ b/coverage_map/src/lib.rs
@@ -37,9 +37,6 @@ impl CoverageMapBuilder {
     /// A submap only contains the hexes that exist in the provided `coverage_objs` arguments. This
     /// allows for one to determine the potential ranking of new coverage objects without having
     /// to clone the entire CoverageMapBuilder.
-    // TODO(map): Should this return a `CoverageMap` instead? I don't really see the purpose of
-    // having this return a `CoverageMapBuilder` since it will probably always be converted instantly
-    // to a `CoverageMap`.
     pub fn submap(&self, coverage_objs: Vec<CoverageObject>) -> Self {
         // A different way to implement this function would be to insert all of the coverage_objs into
         // the submap, and then reconstruct the coverage objs from only the relevant hexes and then

--- a/coverage_map/src/lib.rs
+++ b/coverage_map/src/lib.rs
@@ -137,6 +137,7 @@ pub struct UnrankedCoverage {
 
 /// Ranked hex coverage given as output from the [CoverageMap]
 pub struct RankedCoverage {
+    // TODO(map): Does this need to indicate whether the coverage is indoor or outdoor?
     pub hex: Cell,
     pub rank: Rank,
     pub cbsd_id: Option<String>,
@@ -146,22 +147,12 @@ pub struct RankedCoverage {
 }
 
 /// Rank of the hex coverage.
+// TODO(map): Should this be split into Indoor and OutdoorRank?
 pub enum Rank {
     First,
     Second,
     Third,
 }
-
-#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
-pub enum SignalLevel {
-    None,
-    Low,
-    Medium,
-    High,
-}
-
-pub const MAX_INDOOR_RADIOS_PER_RES12_HEX: usize = 1;
-pub const MAX_OUTDOOR_RADIOS_PER_RES12_HEX: usize = 3;
 
 impl Rank {
     pub(crate) fn from_outdoor_index(idx: usize) -> Option<Self> {
@@ -177,3 +168,14 @@ impl Rank {
         (idx == 0).then_some(Self::First)
     }
 }
+
+#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
+pub enum SignalLevel {
+    None,
+    Low,
+    Medium,
+    High,
+}
+
+pub const MAX_INDOOR_RADIOS_PER_RES12_HEX: usize = 1;
+pub const MAX_OUTDOOR_RADIOS_PER_RES12_HEX: usize = 3;

--- a/coverage_map/src/lib.rs
+++ b/coverage_map/src/lib.rs
@@ -199,3 +199,222 @@ impl BoostedHexMap for NoBoostedHexes {
         None
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use hex_assignments::Assignment;
+
+    #[test]
+    fn test_indoor_cbrs_submap() {
+        let mut coverage_map_builder = CoverageMapBuilder::default();
+        coverage_map_builder.insert_coverage_object(indoor_cbrs_coverage(
+            "1",
+            0x8a1fb46622dffff,
+            SignalLevel::High,
+        ));
+        coverage_map_builder.insert_coverage_object(indoor_cbrs_coverage(
+            "2",
+            0x8c2681a3064d9ff,
+            SignalLevel::Low,
+        ));
+        let submap_builder = coverage_map_builder.submap(vec![indoor_cbrs_coverage(
+            "3",
+            0x8c2681a3064d9ff,
+            SignalLevel::High,
+        )]);
+        let submap = submap_builder.build(&NoBoostedHexes, Utc::now());
+        let cov_1 = submap.get_cbrs_coverage("1");
+        assert_eq!(cov_1.len(), 0);
+        let cov_2 = submap.get_cbrs_coverage("2");
+        assert_eq!(cov_2.len(), 1);
+        assert_eq!(cov_2[0].rank, 2);
+        let cov_3 = submap.get_cbrs_coverage("3");
+        assert_eq!(cov_3.len(), 1);
+        assert_eq!(cov_3[0].rank, 1);
+    }
+
+    #[test]
+    fn test_indoor_wifi_submap() {
+        let mut coverage_map_builder = CoverageMapBuilder::default();
+        coverage_map_builder.insert_coverage_object(indoor_wifi_coverage(
+            "11xtYwQYnvkFYnJ9iZ8kmnetYKwhdi87Mcr36e1pVLrhBMPLjV9",
+            0x8a1fb46622dffff,
+            SignalLevel::High,
+        ));
+        coverage_map_builder.insert_coverage_object(indoor_wifi_coverage(
+            "11PGVtgW9aM9ynfvns5USUsynYQ7EsMpxVqWuDKqFogKQX7etkR",
+            0x8c2681a3064d9ff,
+            SignalLevel::Low,
+        ));
+        let submap_builder = coverage_map_builder.submap(vec![indoor_wifi_coverage(
+            "11ibmJmQXTL6qMh4cq9pJ7tUtrpafWaVjjT6qhY7CNvjyvY9g1",
+            0x8c2681a3064d9ff,
+            SignalLevel::High,
+        )]);
+        let submap = submap_builder.build(&NoBoostedHexes, Utc::now());
+        let cov_1 = submap.get_wifi_coverage(
+            &"11xtYwQYnvkFYnJ9iZ8kmnetYKwhdi87Mcr36e1pVLrhBMPLjV9"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(cov_1.len(), 0);
+        let cov_2 = submap.get_wifi_coverage(
+            &"11PGVtgW9aM9ynfvns5USUsynYQ7EsMpxVqWuDKqFogKQX7etkR"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(cov_2.len(), 1);
+        assert_eq!(cov_2[0].rank, 2);
+        let cov_3 = submap.get_wifi_coverage(
+            &"11ibmJmQXTL6qMh4cq9pJ7tUtrpafWaVjjT6qhY7CNvjyvY9g1"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(cov_3.len(), 1);
+        assert_eq!(cov_3[0].rank, 1);
+    }
+
+    #[test]
+    fn test_outdoor_cbrs_submap() {
+        let mut coverage_map_builder = CoverageMapBuilder::default();
+        coverage_map_builder.insert_coverage_object(outdoor_cbrs_coverage(
+            "1",
+            0x8a1fb46622dffff,
+            3,
+        ));
+        coverage_map_builder.insert_coverage_object(outdoor_cbrs_coverage(
+            "2",
+            0x8c2681a3064d9ff,
+            1,
+        ));
+        let submap_builder =
+            coverage_map_builder.submap(vec![outdoor_cbrs_coverage("3", 0x8c2681a3064d9ff, 2)]);
+        let submap = submap_builder.build(&NoBoostedHexes, Utc::now());
+        let cov_1 = submap.get_cbrs_coverage("1");
+        assert_eq!(cov_1.len(), 0);
+        let cov_2 = submap.get_cbrs_coverage("2");
+        assert_eq!(cov_2.len(), 1);
+        assert_eq!(cov_2[0].rank, 2);
+        let cov_3 = submap.get_cbrs_coverage("3");
+        assert_eq!(cov_3.len(), 1);
+        assert_eq!(cov_3[0].rank, 1);
+    }
+
+    #[test]
+    fn test_outdoor_wifi_submap() {
+        let mut coverage_map_builder = CoverageMapBuilder::default();
+        coverage_map_builder.insert_coverage_object(outdoor_wifi_coverage(
+            "11xtYwQYnvkFYnJ9iZ8kmnetYKwhdi87Mcr36e1pVLrhBMPLjV9",
+            0x8a1fb46622dffff,
+            3,
+        ));
+        coverage_map_builder.insert_coverage_object(outdoor_wifi_coverage(
+            "11PGVtgW9aM9ynfvns5USUsynYQ7EsMpxVqWuDKqFogKQX7etkR",
+            0x8c2681a3064d9ff,
+            1,
+        ));
+        let submap_builder = coverage_map_builder.submap(vec![outdoor_wifi_coverage(
+            "11ibmJmQXTL6qMh4cq9pJ7tUtrpafWaVjjT6qhY7CNvjyvY9g1",
+            0x8c2681a3064d9ff,
+            2,
+        )]);
+        let submap = submap_builder.build(&NoBoostedHexes, Utc::now());
+        let cov_1 = submap.get_wifi_coverage(
+            &"11xtYwQYnvkFYnJ9iZ8kmnetYKwhdi87Mcr36e1pVLrhBMPLjV9"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(cov_1.len(), 0);
+        let cov_2 = submap.get_wifi_coverage(
+            &"11PGVtgW9aM9ynfvns5USUsynYQ7EsMpxVqWuDKqFogKQX7etkR"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(cov_2.len(), 1);
+        assert_eq!(cov_2[0].rank, 2);
+        let cov_3 = submap.get_wifi_coverage(
+            &"11ibmJmQXTL6qMh4cq9pJ7tUtrpafWaVjjT6qhY7CNvjyvY9g1"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(cov_3.len(), 1);
+        assert_eq!(cov_3[0].rank, 1);
+    }
+
+    fn hex_assignments_mock() -> HexAssignments {
+        HexAssignments {
+            footfall: Assignment::A,
+            urbanized: Assignment::A,
+            landtype: Assignment::A,
+        }
+    }
+
+    fn indoor_cbrs_coverage(cbsd_id: &str, hex: u64, signal_level: SignalLevel) -> CoverageObject {
+        let owner: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
+            .parse()
+            .expect("failed owner parse");
+        CoverageObject {
+            indoor: true,
+            hotspot_key: owner,
+            seniority_timestamp: Utc::now(),
+            cbsd_id: Some(cbsd_id.to_string()),
+            coverage: vec![UnrankedCoverage {
+                location: Cell::from_raw(hex).expect("valid h3 cell"),
+                signal_power: 0,
+                signal_level,
+                assignments: hex_assignments_mock(),
+            }],
+        }
+    }
+
+    fn indoor_wifi_coverage(owner: &str, hex: u64, signal_level: SignalLevel) -> CoverageObject {
+        let owner: PublicKeyBinary = owner.parse().expect("failed owner parse");
+        CoverageObject {
+            indoor: true,
+            hotspot_key: owner,
+            seniority_timestamp: Utc::now(),
+            cbsd_id: None,
+            coverage: vec![UnrankedCoverage {
+                location: Cell::from_raw(hex).expect("valid h3 cell"),
+                signal_power: 0,
+                signal_level,
+                assignments: hex_assignments_mock(),
+            }],
+        }
+    }
+
+    fn outdoor_cbrs_coverage(cbsd_id: &str, hex: u64, signal_power: i32) -> CoverageObject {
+        let owner: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
+            .parse()
+            .expect("failed owner parse");
+        CoverageObject {
+            indoor: false,
+            hotspot_key: owner,
+            seniority_timestamp: Utc::now(),
+            cbsd_id: Some(cbsd_id.to_string()),
+            coverage: vec![UnrankedCoverage {
+                location: Cell::from_raw(hex).expect("valid h3 cell"),
+                signal_power,
+                signal_level: SignalLevel::None,
+                assignments: hex_assignments_mock(),
+            }],
+        }
+    }
+
+    fn outdoor_wifi_coverage(owner: &str, hex: u64, signal_power: i32) -> CoverageObject {
+        let owner: PublicKeyBinary = owner.parse().expect("failed owner parse");
+        CoverageObject {
+            indoor: false,
+            hotspot_key: owner,
+            seniority_timestamp: Utc::now(),
+            cbsd_id: None,
+            coverage: vec![UnrankedCoverage {
+                location: Cell::from_raw(hex).expect("valid h3 cell"),
+                signal_power,
+                signal_level: SignalLevel::None,
+                assignments: hex_assignments_mock(),
+            }],
+        }
+    }
+}

--- a/coverage_map/src/outdoor.rs
+++ b/coverage_map/src/outdoor.rs
@@ -1,0 +1,128 @@
+use std::{
+    cmp::Ordering,
+    collections::{hash_map::Entry, BinaryHeap, HashMap},
+};
+
+use chrono::{DateTime, Utc};
+use helium_crypto::PublicKeyBinary;
+use hex_assignments::assignment::HexAssignments;
+use hextree::Cell;
+use mobile_config::boosted_hex_info::BoostedHexes;
+
+use crate::{
+    CoverageObject, Rank, RankedCoverage, SignalLevel, UnrankedCoverage,
+    MAX_OUTDOOR_RADIOS_PER_RES12_HEX,
+};
+
+/// Data structure for storing outdoor radios ranked by their coverage level
+pub type OutdoorCellTree = HashMap<Cell, BinaryHeap<OutdoorCoverageLevel>>;
+
+#[derive(Eq, Debug, Clone)]
+pub struct OutdoorCoverageLevel {
+    hotspot_key: PublicKeyBinary,
+    cbsd_id: Option<String>,
+    seniority_timestamp: DateTime<Utc>,
+    signal_power: i32,
+    signal_level: SignalLevel,
+    assignments: HexAssignments,
+}
+
+impl PartialEq for OutdoorCoverageLevel {
+    fn eq(&self, other: &Self) -> bool {
+        self.signal_power == other.signal_power
+            && self.seniority_timestamp == other.seniority_timestamp
+    }
+}
+
+impl PartialOrd for OutdoorCoverageLevel {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OutdoorCoverageLevel {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.signal_power
+            .cmp(&other.signal_power)
+            .reverse()
+            .then_with(|| self.seniority_timestamp.cmp(&other.seniority_timestamp))
+    }
+}
+
+pub fn insert_outdoor_coverage_object(
+    indoor: &mut OutdoorCellTree,
+    coverage_object: CoverageObject,
+) {
+    for hex_coverage in coverage_object.coverage.into_iter() {
+        insert_outdoor_coverage(
+            indoor,
+            &coverage_object.hotspot_key,
+            &coverage_object.cbsd_id,
+            coverage_object.seniority_timestamp,
+            hex_coverage,
+        );
+    }
+}
+
+pub fn insert_outdoor_coverage(
+    outdoor: &mut OutdoorCellTree,
+    hotspot: &PublicKeyBinary,
+    cbsd_id: &Option<String>,
+    seniority_timestamp: DateTime<Utc>,
+    hex_coverage: UnrankedCoverage,
+) {
+    outdoor
+        .entry(hex_coverage.location)
+        .or_default()
+        .push(OutdoorCoverageLevel {
+            hotspot_key: hotspot.clone(),
+            cbsd_id: cbsd_id.clone(),
+            seniority_timestamp,
+            signal_level: hex_coverage.signal_level,
+            signal_power: hex_coverage.signal_power,
+            assignments: hex_coverage.assignments,
+        });
+}
+
+pub fn clone_outdoor_coverage_into_submap(
+    submap: &mut OutdoorCellTree,
+    from: &OutdoorCellTree,
+    coverage_obj: &CoverageObject,
+) {
+    for coverage in &coverage_obj.coverage {
+        if let Entry::Vacant(e) = submap.entry(coverage.location) {
+            if let Some(old_coverage_data) = from.get(&coverage.location) {
+                e.insert(old_coverage_data.clone());
+            }
+        }
+    }
+}
+
+pub fn into_outdoor_coverage_map(
+    outdoor: OutdoorCellTree,
+    boosted_hexes: &BoostedHexes,
+    epoch_start: DateTime<Utc>,
+) -> impl Iterator<Item = (PublicKeyBinary, RankedCoverage)> + '_ {
+    outdoor.into_iter().flat_map(move |(hex, radios)| {
+        let boosted = boosted_hexes.get_current_multiplier(hex, epoch_start);
+        radios
+            .into_sorted_vec()
+            .into_iter()
+            .take(MAX_OUTDOOR_RADIOS_PER_RES12_HEX)
+            .enumerate()
+            .flat_map(move |(rank, cov)| {
+                Rank::from_outdoor_index(rank).map(move |rank| {
+                    let key = cov.hotspot_key;
+                    let cov = RankedCoverage {
+                        rank,
+                        hex,
+                        cbsd_id: cov.cbsd_id,
+                        assignments: cov.assignments,
+                        boosted,
+                        signal_level: cov.signal_level,
+                    };
+                    (key, cov)
+                })
+            })
+    })
+}

--- a/coverage_map/src/outdoor.rs
+++ b/coverage_map/src/outdoor.rs
@@ -102,7 +102,7 @@ pub fn into_outdoor_coverage_map(
     outdoor: OutdoorCellTree,
     boosted_hexes: &BoostedHexes,
     epoch_start: DateTime<Utc>,
-) -> impl Iterator<Item = (PublicKeyBinary, RankedCoverage)> + '_ {
+) -> impl Iterator<Item = RankedCoverage> + '_ {
     outdoor.into_iter().flat_map(move |(hex, radios)| {
         let boosted = boosted_hexes.get_current_multiplier(hex, epoch_start);
         radios
@@ -111,17 +111,14 @@ pub fn into_outdoor_coverage_map(
             .take(MAX_OUTDOOR_RADIOS_PER_RES12_HEX)
             .enumerate()
             .flat_map(move |(rank, cov)| {
-                Rank::from_outdoor_index(rank).map(move |rank| {
-                    let key = cov.hotspot_key;
-                    let cov = RankedCoverage {
-                        rank,
-                        hex,
-                        cbsd_id: cov.cbsd_id,
-                        assignments: cov.assignments,
-                        boosted,
-                        signal_level: cov.signal_level,
-                    };
-                    (key, cov)
+                Rank::from_outdoor_index(rank).map(move |rank| RankedCoverage {
+                    rank,
+                    hex,
+                    hotspot_key: cov.hotspot_key,
+                    cbsd_id: cov.cbsd_id,
+                    assignments: cov.assignments,
+                    boosted,
+                    signal_level: cov.signal_level,
                 })
             })
     })

--- a/coverage_map/src/outdoor.rs
+++ b/coverage_map/src/outdoor.rs
@@ -7,9 +7,8 @@ use chrono::{DateTime, Utc};
 use helium_crypto::PublicKeyBinary;
 use hex_assignments::assignment::HexAssignments;
 use hextree::Cell;
-use mobile_config::boosted_hex_info::BoostedHexes;
 
-use crate::{CoverageObject, RankedCoverage, SignalLevel, UnrankedCoverage};
+use crate::{BoostedHexMap, CoverageObject, RankedCoverage, SignalLevel, UnrankedCoverage};
 
 /// Data structure for storing outdoor radios ranked by their coverage level
 pub type OutdoorCellTree = HashMap<Cell, BinaryHeap<OutdoorCoverageLevel>>;
@@ -97,7 +96,7 @@ pub fn clone_outdoor_coverage_into_submap(
 
 pub fn into_outdoor_coverage_map(
     outdoor: OutdoorCellTree,
-    boosted_hexes: &BoostedHexes,
+    boosted_hexes: &impl BoostedHexMap,
     epoch_start: DateTime<Utc>,
 ) -> impl Iterator<Item = RankedCoverage> + '_ {
     outdoor.into_iter().flat_map(move |(hex, radios)| {
@@ -142,7 +141,7 @@ mod test {
             insert_outdoor_coverage_object(&mut outdoor_coverage, cov_obj);
         }
         let ranked: HashMap<_, _> =
-            into_outdoor_coverage_map(outdoor_coverage, &BoostedHexes::default(), Utc::now())
+            into_outdoor_coverage_map(outdoor_coverage, &NoBoostedHexes, Utc::now())
                 .map(|x| (x.cbsd_id.clone().unwrap(), x))
                 .collect();
         assert_eq!(ranked.get("5").unwrap().rank, 1);

--- a/coverage_map/src/outdoor.rs
+++ b/coverage_map/src/outdoor.rs
@@ -50,12 +50,12 @@ impl Ord for OutdoorCoverageLevel {
 }
 
 pub fn insert_outdoor_coverage_object(
-    indoor: &mut OutdoorCellTree,
+    outdoor: &mut OutdoorCellTree,
     coverage_object: CoverageObject,
 ) {
     for hex_coverage in coverage_object.coverage.into_iter() {
         insert_outdoor_coverage(
-            indoor,
+            outdoor,
             &coverage_object.hotspot_key,
             &coverage_object.cbsd_id,
             coverage_object.seniority_timestamp,
@@ -122,4 +122,76 @@ pub fn into_outdoor_coverage_map(
                 })
             })
     })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::*;
+    use chrono::NaiveDate;
+    use hex_assignments::Assignment;
+    use hextree::Cell;
+
+    #[test]
+    fn ensure_outdoor_radios_ranked_by_power() {
+        let mut outdoor_coverage = OutdoorCellTree::default();
+        for cov_obj in vec![
+            outdoor_cbrs_coverage("1", -946, date(2022, 8, 1)),
+            outdoor_cbrs_coverage("2", -936, date(2022, 12, 5)),
+            outdoor_cbrs_coverage("3", -887, date(2022, 12, 2)),
+            outdoor_cbrs_coverage("4", -887, date(2022, 12, 1)),
+            outdoor_cbrs_coverage("5", -773, date(2023, 5, 1)),
+        ]
+        .into_iter()
+        {
+            insert_outdoor_coverage_object(&mut outdoor_coverage, cov_obj);
+        }
+        let ranked: HashMap<_, _> =
+            into_outdoor_coverage_map(outdoor_coverage, &BoostedHexes::default(), Utc::now())
+                .map(|x| (x.cbsd_id.clone().unwrap(), x))
+                .collect();
+        assert_eq!(ranked.get("5").unwrap().rank, Rank::First);
+        assert_eq!(ranked.get("4").unwrap().rank, Rank::Second);
+        assert_eq!(ranked.get("3").unwrap().rank, Rank::Third);
+        assert!(ranked.get("1").is_none());
+        assert!(ranked.get("2").is_none());
+    }
+
+    fn hex_assignments_mock() -> HexAssignments {
+        HexAssignments {
+            footfall: Assignment::A,
+            urbanized: Assignment::A,
+            landtype: Assignment::A,
+        }
+    }
+
+    fn date(year: i32, month: u32, day: u32) -> DateTime<Utc> {
+        NaiveDate::from_ymd_opt(year, month, day)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc()
+    }
+
+    fn outdoor_cbrs_coverage(
+        cbsd_id: &str,
+        signal_power: i32,
+        seniority_timestamp: DateTime<Utc>,
+    ) -> CoverageObject {
+        let owner: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
+            .parse()
+            .expect("failed owner parse");
+        CoverageObject {
+            indoor: false,
+            hotspot_key: owner,
+            seniority_timestamp,
+            cbsd_id: Some(cbsd_id.to_string()),
+            coverage: vec![UnrankedCoverage {
+                location: Cell::from_raw(0x8a1fb46622dffff).expect("valid h3 cell"),
+                signal_power,
+                signal_level: SignalLevel::High,
+                assignments: hex_assignments_mock(),
+            }],
+        }
+    }
 }

--- a/coverage_map/src/outdoor.rs
+++ b/coverage_map/src/outdoor.rs
@@ -108,7 +108,6 @@ pub fn into_outdoor_coverage_map(
             .map(move |(rank, cov)| RankedCoverage {
                 hex,
                 rank: rank + 1,
-                indoor: false,
                 hotspot_key: cov.hotspot_key,
                 cbsd_id: cov.cbsd_id,
                 assignments: cov.assignments,

--- a/mobile_config/Cargo.toml
+++ b/mobile_config/Cargo.toml
@@ -45,6 +45,7 @@ task-manager = { path = "../task_manager" }
 solana-sdk = { workspace = true }
 custom-tracing = { path = "../custom_tracing", features = ["grpc"] }
 humantime-serde = { workspace = true }
+coverage-map = { path = "../coverage_map" }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/mobile_config/src/boosted_hex_info.rs
+++ b/mobile_config/src/boosted_hex_info.rs
@@ -177,6 +177,12 @@ impl BoostedHexes {
     }
 }
 
+impl coverage_map::BoostedHexMap for BoostedHexes {
+    fn get_current_multiplier(&self, location: Cell, ts: DateTime<Utc>) -> Option<NonZeroU32> {
+        self.get_current_multiplier(location, ts)
+    }
+}
+
 pub(crate) mod db {
     use super::{to_end_ts, to_start_ts, BoostedHexInfo};
     use chrono::{DateTime, Duration, Utc};


### PR DESCRIPTION
## What does this new crate provide?

- `CoverageMapBuilder`: A data structure for keeping track of the current rank of all of the radios providing coverage to a given set of hexes. This data structure does not allow you to map radios to their ranked hex coverage, but allows you to build the `CoverageMap` data structure which does. Additionally, you can create a "submap" from a `CoverageMapBuilder` and a collection of `CoverageObject`s, which allows for inserting ranking only those hexes which are relevant to the set of `CoverageObject`s provided.
- `CoverageMap`: A data structure that maps hotspots to all of their ranked hex coverage.

## What work is left to do in this crate?

This crate is basically complete, but the following work remains:

- [x] Port over the old coverage tests from the mobile verifier.
- [x] Add new tests for the `submap` method.