### PR TITLE
Mobile Coverage points calculator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,6 +2134,7 @@ dependencies = [
 name = "coverage-point-calculator"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "coverage-map",
  "helium-crypto",
  "hex-assignments",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,6 +2139,7 @@ dependencies = [
  "helium-crypto",
  "hex-assignments",
  "hextree",
+ "rstest",
  "rust_decimal",
  "rust_decimal_macros",
  "thiserror",
@@ -3253,6 +3254,12 @@ name = "gimli"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "goblin"
@@ -5955,6 +5962,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6187,6 +6200,33 @@ dependencies = [
  "heapless",
  "num-traits",
  "smallvec",
+]
+
+[[package]]
+name = "rstest"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afd55a67069d6e434a95161415f5beeada95a01c7b815508a82dcb0e1593682"
+dependencies = [
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4165dfae59a39dd41d8dec720d3cbfbc71f69744efb480a3920f5d4e0cc6798d"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "regex",
+ "relative-path",
+ "rustc_version 0.4.0",
+ "syn 2.0.38",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/coverage_point_calculator/Cargo.toml
+++ b/coverage_point_calculator/Cargo.toml
@@ -17,3 +17,4 @@ coverage-map = { path = "../coverage_map" }
 
 [dev-dependencies]
 helium-crypto = { workspace = true }
+rstest = { version = "0.21.0", default-features = false }

--- a/coverage_point_calculator/Cargo.toml
+++ b/coverage_point_calculator/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
+chrono = { workspace = true }
 hextree = { workspace = true }
 rust_decimal = { workspace = true }
 rust_decimal_macros = { workspace = true }

--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -13,16 +13,18 @@ pub struct CoveredHexes {
 #[derive(Debug, Clone)]
 pub struct CoveredHex {
     pub hex: hextree::Cell,
-    // --
+    /// Default points received from (RadioType, SignalLevel) pair.
     pub base_coverage_points: Decimal,
+    /// Coverage points including assignment, rank, and boosted hex multipliers.
     pub calculated_coverage_points: Decimal,
-    // oracle boosted
+    /// Oracle boosted Assignments
     pub assignments: HexAssignments,
     pub assignment_multiplier: Decimal,
-    // --
+    /// [RankedCoverage::rank] 1-based
     pub rank: usize,
     pub rank_multiplier: Decimal,
-    // provider boosted
+    /// Provider boosted multiplier. Will be None if the Radio does not qualify
+    /// for boosted rewards.
     pub boosted_multiplier: Option<Decimal>,
 }
 

--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -46,8 +46,15 @@ pub(crate) fn clean_covered_hexes(
         .map(|ranked| {
             let base_coverage_points = radio_type.base_coverage_points(&ranked.signal_level)?;
             let rank_multiplier = radio_type.rank_multiplier(ranked.rank);
-            let assignment_multiplier = ranked.assignments.boosting_multiplier();
             let boosted_multiplier = ranked.boosted.map(|boost| boost.get()).map(Decimal::from);
+
+            // hip-103: if a hex is boosted by a service provider >1x, the oracle
+            // multiplier will automatically be 1x, regardless of boosted_hex_status.
+            let assignment_multiplier = if ranked.boosted.is_some() {
+                dec!(1)
+            } else {
+                ranked.assignments.boosting_multiplier()
+            };
 
             let calculated_coverage_points = base_coverage_points
                 * assignment_multiplier
@@ -75,4 +82,62 @@ pub(crate) fn calculated_coverage_points(covered_hexes: &[CoveredHex]) -> Decima
         .iter()
         .map(|hex| hex.calculated_coverage_points)
         .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use coverage_map::SignalLevel;
+    use hex_assignments::Assignment;
+
+    use super::*;
+
+    #[test]
+    fn hip_103_provider_boosted_hex_receives_maximum_oracle_boost() {
+        let unboosted_coverage = RankedCoverage {
+            hotspot_key: vec![1],
+            cbsd_id: None,
+            hex: hextree::Cell::from_raw(0x8c2681a3064edff).unwrap(),
+            rank: 1,
+            signal_level: SignalLevel::High,
+            assignments: HexAssignments {
+                footfall: Assignment::C,
+                landtype: Assignment::C,
+                urbanized: Assignment::C,
+            },
+            boosted: NonZeroU32::new(0),
+        };
+        let boosted_coverage = RankedCoverage {
+            boosted: NonZeroU32::new(5),
+            ..unboosted_coverage.clone()
+        };
+
+        let covered_hexes = clean_covered_hexes(
+            RadioType::IndoorWifi,
+            vec![unboosted_coverage.clone(), boosted_coverage],
+            BoostedHexStatus::Eligible,
+        )
+        .unwrap();
+
+        let unboosted = &covered_hexes[0];
+        let boosted = &covered_hexes[1];
+
+        // unboosted receives original multiplier
+        assert_eq!(dec!(0), unboosted.calculated_coverage_points);
+        assert_eq!(
+            unboosted_coverage.assignments.boosting_multiplier(),
+            unboosted.assignment_multiplier
+        );
+
+        // provider boosted gets oracle assignment bumped to 1x
+        assert_eq!(dec!(1), boosted.assignment_multiplier);
+        assert_eq!(
+            RadioType::IndoorWifi
+                .base_coverage_points(&SignalLevel::High)
+                .unwrap_or_default()
+                * dec!(5),
+            boosted.calculated_coverage_points
+        );
+    }
 }

--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -49,12 +49,8 @@ impl CoveredHexes {
             .into_iter()
             .map(|ranked| {
                 let coverage_points = radio_type.base_coverage_points(&ranked.signal_level)?;
+                let rank_multiplier = radio_type.rank_multiplier(ranked.rank);
                 let assignment_multiplier = ranked.assignments.boosting_multiplier();
-                let rank_multiplier = rank_multipliers
-                    .get(ranked.rank - 1)
-                    .cloned()
-                    .unwrap_or(dec!(0));
-
                 let boosted_multiplier = ranked.boosted.map(|boost| boost.get()).map(Decimal::from);
 
                 let calculated_coverage_points = coverage_points

--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -1,0 +1,90 @@
+use coverage_map::RankedCoverage;
+use hex_assignments::assignment::HexAssignments;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+use crate::{RadioType, Result};
+
+#[derive(Debug, Clone)]
+pub struct CoveredHexes {
+    pub hexes: Vec<CoveredHex>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CoveredHex {
+    pub hex: hextree::Cell,
+    // --
+    pub base_coverage_points: Decimal,
+    pub calculated_coverage_points: Decimal,
+    // oracle boosted
+    pub assignments: HexAssignments,
+    pub assignment_multiplier: Decimal,
+    // --
+    pub rank: usize,
+    pub rank_multiplier: Decimal,
+    // provider boosted
+    pub boosted_multiplier: Option<Decimal>,
+}
+
+impl CoveredHexes {
+    pub fn new_without_boosts(
+        radio_type: &RadioType,
+        ranked_coverage: Vec<RankedCoverage>,
+    ) -> Result<Self> {
+        let ranked_coverage: Vec<_> = ranked_coverage
+            .into_iter()
+            .map(|ranked| RankedCoverage {
+                boosted: None,
+                ..ranked
+            })
+            .collect();
+
+        Self::new(radio_type, ranked_coverage)
+    }
+
+    pub fn new(radio_type: &RadioType, ranked_coverage: Vec<RankedCoverage>) -> Result<Self> {
+        let rank_multipliers = radio_type.rank_multipliers();
+
+        // verify all hexes can obtain a base coverage point
+        let covered_hexes = ranked_coverage
+            .into_iter()
+            .map(|ranked| {
+                let coverage_points = radio_type.base_coverage_points(&ranked.signal_level)?;
+                let assignment_multiplier = ranked.assignments.boosting_multiplier();
+                let rank_multiplier = rank_multipliers
+                    .get(ranked.rank - 1)
+                    .cloned()
+                    .unwrap_or(dec!(0));
+
+                let boosted_multiplier = ranked.boosted.map(|boost| boost.get()).map(Decimal::from);
+
+                let calculated_coverage_points = coverage_points
+                    * assignment_multiplier
+                    * rank_multiplier
+                    * boosted_multiplier.unwrap_or(dec!(1));
+
+                Ok(CoveredHex {
+                    hex: ranked.hex,
+                    base_coverage_points: coverage_points,
+                    calculated_coverage_points,
+                    assignments: ranked.assignments,
+                    assignment_multiplier,
+                    rank: ranked.rank,
+                    rank_multiplier,
+                    boosted_multiplier,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self {
+            hexes: covered_hexes,
+        })
+    }
+
+    pub fn accumulate_calculated_coverage_points(&self) -> Decimal {
+        self.hexes
+            .iter()
+            .map(|hex| hex.calculated_coverage_points)
+            .sum()
+    }
+}

--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -3,7 +3,7 @@ use hex_assignments::assignment::HexAssignments;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 
-use crate::{RadioType, Result};
+use crate::{BoostedHexStatus, RadioType, Result};
 
 #[derive(Debug, Clone)]
 pub struct CoveredHexes {
@@ -27,23 +27,22 @@ pub struct CoveredHex {
 }
 
 impl CoveredHexes {
-    pub fn new_without_boosts(
-        radio_type: &RadioType,
+    pub fn new(
+        radio_type: RadioType,
         ranked_coverage: Vec<RankedCoverage>,
+        boosted_hex_status: BoostedHexStatus,
     ) -> Result<Self> {
-        let ranked_coverage: Vec<_> = ranked_coverage
-            .into_iter()
-            .map(|ranked| RankedCoverage {
-                boosted: None,
-                ..ranked
-            })
-            .collect();
-
-        Self::new(radio_type, ranked_coverage)
-    }
-
-    pub fn new(radio_type: &RadioType, ranked_coverage: Vec<RankedCoverage>) -> Result<Self> {
-        let rank_multipliers = radio_type.rank_multipliers();
+        let ranked_coverage = if !boosted_hex_status.is_eligible() {
+            ranked_coverage
+                .into_iter()
+                .map(|ranked| RankedCoverage {
+                    boosted: None,
+                    ..ranked
+                })
+                .collect()
+        } else {
+            ranked_coverage
+        };
 
         // verify all hexes can obtain a base coverage point
         let covered_hexes = ranked_coverage

--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -50,19 +50,19 @@ impl CoveredHexes {
         let covered_hexes = ranked_coverage
             .into_iter()
             .map(|ranked| {
-                let coverage_points = radio_type.base_coverage_points(&ranked.signal_level)?;
+                let base_coverage_points = radio_type.base_coverage_points(&ranked.signal_level)?;
                 let rank_multiplier = radio_type.rank_multiplier(ranked.rank);
                 let assignment_multiplier = ranked.assignments.boosting_multiplier();
                 let boosted_multiplier = ranked.boosted.map(|boost| boost.get()).map(Decimal::from);
 
-                let calculated_coverage_points = coverage_points
+                let calculated_coverage_points = base_coverage_points
                     * assignment_multiplier
                     * rank_multiplier
                     * boosted_multiplier.unwrap_or(dec!(1));
 
                 Ok(CoveredHex {
                     hex: ranked.hex,
-                    base_coverage_points: coverage_points,
+                    base_coverage_points,
                     calculated_coverage_points,
                     assignments: ranked.assignments,
                     assignment_multiplier,

--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -25,8 +25,8 @@ pub struct CoveredHex {
 
 pub(crate) fn clean_covered_hexes(
     radio_type: RadioType,
-    ranked_coverage: Vec<RankedCoverage>,
     boosted_hex_status: BoostedHexStatus,
+    ranked_coverage: Vec<RankedCoverage>,
 ) -> Result<Vec<CoveredHex>> {
     // verify all hexes can obtain a base coverage point
     let covered_hexes = ranked_coverage
@@ -116,8 +116,8 @@ mod tests {
 
         let covered_hexes = clean_covered_hexes(
             RadioType::IndoorWifi,
-            vec![unboosted_coverage, boosted_coverage],
             boost_status,
+            vec![unboosted_coverage, boosted_coverage],
         )
         .unwrap();
 

--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -81,7 +81,7 @@ impl CoveredHexes {
         })
     }
 
-    pub fn accumulate_calculated_coverage_points(&self) -> Decimal {
+    pub fn calculated_coverage_points(&self) -> Decimal {
         self.hexes
             .iter()
             .map(|hex| hex.calculated_coverage_points)

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -853,10 +853,7 @@ mod tests {
             .collect()
     }
 
-    fn pubkey() -> helium_crypto::PublicKeyBinary {
-        helium_crypto::PublicKeyBinary::from_str(
-            "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6",
-        )
-        .expect("failed owner parse")
+    fn pubkey() -> Vec<u8> {
+        vec![1]
     }
 }

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -68,7 +68,6 @@ pub mod location;
 pub mod speedtest;
 
 pub type Result<T = ()> = std::result::Result<T, Error>;
-pub type MaxOneMultplier = Decimal;
 
 /// Necessary checks for calculating coverage points is done during [RewardableRadio::new].
 #[derive(Debug, Clone)]

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -182,10 +182,6 @@ impl RewardableRadio {
             boosted_hex_eligibility: boosted_hex_status,
         })
     }
-
-    pub fn radio_type(&self) -> RadioType {
-        self.radio_type
-    }
 }
 
 impl CoveragePoints {

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -67,11 +67,11 @@ pub type MaxOneMultplier = Decimal;
 /// Input Radio to calculation
 #[derive(Debug, Clone)]
 pub struct RewardableRadio {
-    pub radio_type: RadioType,
-    pub speedtests: Speedtests,
-    pub location_trust_scores: LocationTrustScores,
-    pub radio_threshold: RadioThreshold,
-    pub covered_hexes: CoveredHexes,
+    radio_type: RadioType,
+    speedtests: Speedtests,
+    location_trust_scores: LocationTrustScores,
+    radio_threshold: RadioThreshold,
+    covered_hexes: CoveredHexes,
 }
 
 #[derive(Debug)]
@@ -175,6 +175,10 @@ impl RewardableRadio {
                 covered_hexes,
             )?,
         })
+    }
+
+    pub fn radio_type(&self) -> RadioType {
+        self.radio_type
     }
 
     // These points need to be reported in the proto pre-(location, speedtest) multipliers

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -92,10 +92,10 @@ pub struct RewardableRadio {
 /// - If more than the allowed speedtests were provided, only the speedtests
 ///   considered are included here.
 ///
-/// - When a radio covers boosted hexes, [location_trust_scores] will contain a
+/// - When a radio covers boosted hexes, [CoveragePoints::location_trust_scores] will contain a
 ///   trust score _after_ the boosted hex restriction has been applied.
 ///
-/// - When a radio is not eligible for boosted hex rewards, [covered_hexes] will
+/// - When a radio is not eligible for boosted hex rewards, [CoveragePoints::covered_hexes] will
 ///   have no boosted_multiplier values.
 ///
 #[derive(Debug)]

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -21,7 +21,8 @@
 ///
 /// - location_trust_score_multiplier
 ///   - [HIP-98][qos-score]
-///   - increase Boosted hex restriction, 30m -> 50m [HIP-93][boosted-hex-restriction]
+///   - states 30m requirement for boosted hexes [HIP-107][prevent-gaming]
+///   - increase Boosted hex restriction, 30m -> 50m [Pull Request][boosted-hex-restriction]
 ///
 /// - speedtest_multiplier
 ///   - [HIP-74][modeled-coverage]
@@ -30,19 +31,18 @@
 ///
 /// ## References:
 /// [modeled-coverage]:        https://github.com/helium/HIP/blob/main/0074-mobile-poc-modeled-coverage-rewards.md#outdoor-radios
-/// [cbrs-experimental]:       https://github.com/helium/HIP/blob/main/0113-reward-cbrs-as-experimental.md
+/// [provider-boosting]:       https://github.com/helium/HIP/blob/main/0084-service-provider-hex-boosting.md
+/// [wifi-aps]:                https://github.com/helium/HIP/blob/main/0093-addition-of-wifi-aps-to-mobile-subdao.md
+/// [qos-score]:               https://github.com/helium/HIP/blob/main/0098-mobile-subdao-quality-of-service-requirements.md
 /// [oracle-boosting]:         https://github.com/helium/HIP/blob/main/0103-oracle-hex-boosting.md
 /// [hex-limits]:              https://github.com/helium/HIP/blob/main/0105-modification-of-mobile-subdao-hex-limits.md
-/// [provider-boosting]:       https://github.com/helium/HIP/blob/main/0084-service-provider-hex-boosting.md
-/// [qos-score]:               https://github.com/helium/HIP/blob/main/0098-mobile-subdao-quality-of-service-requirements.md
-/// [wifi-aps]:                https://github.com/helium/HIP/blob/main/0093-addition-of-wifi-aps-to-mobile-subdao.md
+/// [prevent-gaming]:          https://github.com/helium/HIP/blob/main/0107-preventing-gaming-within-the-mobile-network.md
+/// [cbrs-experimental]:       https://github.com/helium/HIP/blob/main/0113-reward-cbrs-as-experimental.md
 /// [mobile-poc-blog]:         https://docs.helium.com/mobile/proof-of-coverage
 /// [boosted-hex-restriction]: https://github.com/helium/oracles/pull/808
 ///
 /// To Integrate in Docs:
 ///
-/// Some verbiage about ranks.
-/// https://github.com/helium/HIP/blob/main/0105-modification-of-mobile-subdao-hex-limits.md
 ///
 /// Has something to say about 30meters from asserted location wrt poc rewards
 /// for boosted hexes.

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -175,18 +175,6 @@ impl RewardableRadio {
     }
 }
 
-impl CoveragePoints {
-    pub fn iter_boosted_hexes(&self) -> impl Iterator<Item = CoveredHex> {
-        let eligible = self.boosted_hex_eligibility.is_eligible();
-
-        self.covered_hexes
-            .clone()
-            .into_iter()
-            .filter(move |_| eligible)
-            .filter(|hex| hex.boosted_multiplier.is_some())
-    }
-}
-
 #[derive(Debug, Clone)]
 pub enum BoostedHexStatus {
     Eligible,

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -272,7 +272,7 @@ mod tests {
 
     use std::num::NonZeroU32;
 
-    use crate::{location::Meters, speedtest::BytesPs};
+    use crate::speedtest::BytesPs;
 
     use super::*;
     use chrono::Utc;
@@ -834,7 +834,7 @@ mod tests {
 
     fn location_trust_maximum() -> Vec<LocationTrust> {
         vec![LocationTrust {
-            distance_to_asserted: Meters::new(1),
+            meters_to_asserted: 1,
             trust_score: dec!(1.0),
         }]
     }
@@ -845,7 +845,7 @@ mod tests {
             .iter()
             .copied()
             .map(|trust_score| LocationTrust {
-                distance_to_asserted: Meters::new(1),
+                meters_to_asserted: 1,
                 trust_score,
             })
             .collect()

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -813,13 +813,13 @@ mod tests {
             Speedtest {
                 upload_speed: BytesPs::mbps(15),
                 download_speed: BytesPs::mbps(150),
-                latency: Millis::new(15),
+                latency_millis: 15,
                 timestamp: Utc::now(),
             },
             Speedtest {
                 upload_speed: BytesPs::mbps(15),
                 download_speed: BytesPs::mbps(150),
-                latency: Millis::new(15),
+                latency_millis: 15,
                 timestamp: Utc::now(),
             },
         ]
@@ -829,7 +829,7 @@ mod tests {
         Speedtest {
             upload_speed: BytesPs::mbps(15),
             download_speed: download,
-            latency: Millis::new(15),
+            latency_millis: 15,
             timestamp: Utc::now(),
         }
     }

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -309,7 +309,7 @@ mod tests {
         let verified_wifi = make_wifi(RadioThreshold::Verified);
         assert_eq!(
             base_points * dec!(5),
-            calculate_coverage_points(verified_wifi.clone()).total_coverage_points
+            calculate_coverage_points(&verified_wifi).total_coverage_points
         );
 
         // Radio not meeting the threshold is not eligible for boosted hexes.
@@ -317,7 +317,7 @@ mod tests {
         let unverified_wifi = make_wifi(RadioThreshold::Unverified);
         assert_eq!(
             base_points,
-            calculate_coverage_points(unverified_wifi).total_coverage_points
+            calculate_coverage_points(&unverified_wifi).total_coverage_points
         );
     }
 
@@ -350,15 +350,13 @@ mod tests {
         // Boosted hex provides radio with more than base_points.
         let trusted_wifi = make_wifi(location_trust_with_scores(&[dec!(1), dec!(1)]));
         assert!(trusted_wifi.location_trust_scores.multiplier > dec!(0.75));
-        assert!(
-            calculate_coverage_points(trusted_wifi.clone()).total_coverage_points > base_points
-        );
+        assert!(calculate_coverage_points(&trusted_wifi).total_coverage_points > base_points);
 
         // Radio with poor trust score is not eligible for boosted hexes.
         // Boost from hex is not applied, and points are further lowered by poor trust score.
         let untrusted_wifi = make_wifi(location_trust_with_scores(&[dec!(0.1), dec!(0.2)]));
         assert!(untrusted_wifi.location_trust_scores.multiplier < dec!(0.75));
-        assert!(calculate_coverage_points(untrusted_wifi).total_coverage_points < base_points);
+        assert!(calculate_coverage_points(&untrusted_wifi).total_coverage_points < base_points);
     }
 
     #[test]
@@ -389,7 +387,7 @@ mod tests {
         let indoor_cbrs = make_indoor_cbrs(speedtest_maximum());
         assert_eq!(
             base_coverage_points * SpeedtestTier::Good.multiplier(),
-            calculate_coverage_points(indoor_cbrs).total_coverage_points
+            calculate_coverage_points(&indoor_cbrs).total_coverage_points
         );
 
         let indoor_cbrs = make_indoor_cbrs(vec![
@@ -398,7 +396,7 @@ mod tests {
         ]);
         assert_eq!(
             base_coverage_points * SpeedtestTier::Acceptable.multiplier(),
-            calculate_coverage_points(indoor_cbrs.clone()).total_coverage_points
+            calculate_coverage_points(&indoor_cbrs).total_coverage_points
         );
 
         let indoor_cbrs = make_indoor_cbrs(vec![
@@ -407,7 +405,7 @@ mod tests {
         ]);
         assert_eq!(
             base_coverage_points * SpeedtestTier::Degraded.multiplier(),
-            calculate_coverage_points(indoor_cbrs).total_coverage_points
+            calculate_coverage_points(&indoor_cbrs).total_coverage_points
         );
 
         let indoor_cbrs = make_indoor_cbrs(vec![
@@ -416,7 +414,7 @@ mod tests {
         ]);
         assert_eq!(
             base_coverage_points * SpeedtestTier::Poor.multiplier(),
-            calculate_coverage_points(indoor_cbrs).total_coverage_points
+            calculate_coverage_points(&indoor_cbrs).total_coverage_points
         );
 
         let indoor_cbrs = make_indoor_cbrs(vec![
@@ -425,7 +423,7 @@ mod tests {
         ]);
         assert_eq!(
             base_coverage_points * SpeedtestTier::Fail.multiplier(),
-            calculate_coverage_points(indoor_cbrs).total_coverage_points
+            calculate_coverage_points(&indoor_cbrs).total_coverage_points
         );
     }
 
@@ -498,7 +496,7 @@ mod tests {
 
         assert_eq!(
             dec!(1073),
-            calculate_coverage_points(indoor_cbrs).total_coverage_points
+            calculate_coverage_points(&indoor_cbrs).total_coverage_points
         );
     }
 
@@ -556,7 +554,7 @@ mod tests {
         // rank 42 :: 0.00 * 16 == 0
         assert_eq!(
             dec!(28),
-            calculate_coverage_points(outdoor_wifi).total_coverage_points
+            calculate_coverage_points(&outdoor_wifi).total_coverage_points
         );
     }
 
@@ -601,7 +599,7 @@ mod tests {
 
         assert_eq!(
             dec!(400),
-            calculate_coverage_points(indoor_wifi).total_coverage_points
+            calculate_coverage_points(&indoor_wifi).total_coverage_points
         );
     }
 
@@ -629,7 +627,7 @@ mod tests {
         // (0.1 + 0.2 + 0.3 + 0.4) / 4
         assert_eq!(
             dec!(100),
-            calculate_coverage_points(indoor_wifi).total_coverage_points
+            calculate_coverage_points(&indoor_wifi).total_coverage_points
         );
     }
 
@@ -668,7 +666,7 @@ mod tests {
         // signal_level of High.
         assert_eq!(
             dec!(800),
-            calculate_coverage_points(indoor_wifi.clone()).total_coverage_points
+            calculate_coverage_points(&indoor_wifi).total_coverage_points
         );
     }
 
@@ -700,7 +698,7 @@ mod tests {
 
         assert_eq!(
             expected,
-            calculate_coverage_points(outdoor_cbrs).total_coverage_points
+            calculate_coverage_points(&outdoor_cbrs).total_coverage_points
         );
     }
 
@@ -730,7 +728,7 @@ mod tests {
 
         assert_eq!(
             expected,
-            calculate_coverage_points(indoor_cbrs).total_coverage_points
+            calculate_coverage_points(&indoor_cbrs).total_coverage_points
         );
     }
 
@@ -762,7 +760,7 @@ mod tests {
 
         assert_eq!(
             expected,
-            calculate_coverage_points(outdoor_wifi).total_coverage_points
+            calculate_coverage_points(&outdoor_wifi).total_coverage_points
         );
     }
 
@@ -792,7 +790,7 @@ mod tests {
 
         assert_eq!(
             expected,
-            calculate_coverage_points(indoor_wifi).total_coverage_points
+            calculate_coverage_points(&indoor_wifi).total_coverage_points
         );
     }
 

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -4,44 +4,43 @@
 //! thorough explanation of many of them. It is not exhaustive, but a great
 //! place to start.
 //!
-//! ## Fields:
-//! - modeled_coverage_points
+//! ## Important Fields
+//! - [CoveredHex::base_coverage_points]
 //!   - [HIP-74][modeled-coverage]
 //!   - reduced cbrs radio coverage points [HIP-113][cbrs-experimental]
 //!
-//! - assignment_multiplier
+//! - [CoveredHex::assignment_multiplier]
 //!   - [HIP-103][oracle-boosting]
 //!
-//! - rank
+//! - [CoveredHex::rank]
 //!   - [HIP-105][hex-limits]
 //!
-//! - hex_boost_multiplier  
+//! - [CoveredHex::boosted_multiplier]
 //!   - must meet minimum subscriber thresholds [HIP-84][provider-boosting]
 //!   - Wifi Location trust score >0.75 for boosted hex eligibility [HIP-93][wifi-aps]
 //!
-//! - location_trust_score_multiplier
+//! - [CoveragePoints::location_trust_multiplier]
 //!   - [HIP-98][qos-score]
 //!   - states 30m requirement for boosted hexes [HIP-107][prevent-gaming]
 //!   - increase Boosted hex restriction, 30m -> 50m [Pull Request][boosted-hex-restriction]
 //!
-//! - speedtest_multiplier
+//! - [CoveragePoints::speedtest_multiplier]
 //!   - [HIP-74][modeled-coverage]
 //!   - added "Good" speedtest tier [HIP-98][qos-score]
 //!     - latency is explicitly under limit in HIP <https://github.com/helium/oracles/pull/737>
 //!
 //! ## Notable Conditions:
-//! - Location
+//! - [LocationTrust]
 //!   - If a Radio covers any boosted hexes, [LocationTrust] scores must meet distance requirements, or be degraded.
 //!   - CBRS Radio's location is always trusted because of GPS.
 //!
-//! - Speedtests
+//! - [Speedtest]
 //!   - The latest 6 speedtests will be used.
 //!   - There must be more than 2 speedtests.
 //!
-//! - Covered Hexes
-//!   - If a Radio is not [BoostedHexStatus::Eligible], boost values are removed before calculations. [CoveredHexes::new]
+//! - [CoveredHex]
+//!   - If a Radio is not [BoostedHexStatus::Eligible], boost values are removed before calculations.
 //!
-//! ## References:
 //! [modeled-coverage]:        https://github.com/helium/HIP/blob/main/0074-mobile-poc-modeled-coverage-rewards.md#outdoor-radios
 //! [provider-boosting]:       https://github.com/helium/HIP/blob/main/0084-service-provider-hex-boosting.md
 //! [wifi-aps]:                https://github.com/helium/HIP/blob/main/0093-addition-of-wifi-aps-to-mobile-subdao.md

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -242,12 +242,21 @@ impl RadioType {
         Ok(mult)
     }
 
-    fn rank_multipliers(&self) -> Vec<Decimal> {
-        match self {
-            RadioType::IndoorWifi => vec![dec!(1)],
-            RadioType::IndoorCbrs => vec![dec!(1)],
-            RadioType::OutdoorWifi => vec![dec!(1), dec!(0.5), dec!(0.25)],
-            RadioType::OutdoorCbrs => vec![dec!(1), dec!(0.5), dec!(0.25)],
+    fn rank_multiplier(&self, rank: usize) -> Decimal {
+        match (self, rank) {
+            // Indoors Radios
+            (RadioType::IndoorWifi, 1) => dec!(1),
+            (RadioType::IndoorCbrs, 1) => dec!(1),
+            // Outdoor Wifi
+            (RadioType::OutdoorWifi, 1) => dec!(1),
+            (RadioType::OutdoorWifi, 2) => dec!(0.5),
+            (RadioType::OutdoorWifi, 3) => dec!(0.25),
+            // Outdoor Cbrs
+            (RadioType::OutdoorCbrs, 1) => dec!(1),
+            (RadioType::OutdoorCbrs, 2) => dec!(0.5),
+            (RadioType::OutdoorCbrs, 3) => dec!(0.25),
+            // Radios outside acceptable rank in a hex do not get points for that hex.
+            _ => dec!(0),
         }
     }
 

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -107,7 +107,7 @@ pub enum Error {
 }
 
 pub fn calculate_coverage_points(radio: RewardableRadio) -> CoveragePoints {
-    let hex_coverage_points = radio.covered_hexes.accumulate_calculated_coverage_points();
+    let hex_coverage_points = radio.covered_hexes.calculated_coverage_points();
     let location_trust_multiplier = radio.location_trust_scores.multiplier;
     let speedtest_multiplier = radio.speedtests.multiplier;
 

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -69,6 +69,11 @@ pub mod speedtest;
 
 pub type Result<T = ()> = std::result::Result<T, Error>;
 
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("signal level {0:?} not allowed for {1:?}")]
+    InvalidSignalLevel(SignalLevel, RadioType),
+}
 /// Necessary checks for calculating coverage points is done during [RewardableRadio::new].
 #[derive(Debug, Clone)]
 pub struct RewardableRadio {
@@ -110,12 +115,6 @@ pub struct CoveragePoints {
     pub location_trust_scores: Vec<LocationTrust>,
     pub covered_hexes: Vec<CoveredHex>,
     pub boosted_hex_eligibility: BoostedHexStatus,
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error("signal level {0:?} not allowed for {1:?}")]
-    InvalidSignalLevel(SignalLevel, RadioType),
 }
 
 pub fn calculate_coverage_points(radio: RewardableRadio) -> CoveragePoints {

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -267,12 +267,12 @@ impl RadioThreshold {
 #[cfg(test)]
 mod tests {
 
-    use std::{num::NonZeroU32, str::FromStr};
+    use rstest::rstest;
+    use speedtest::SpeedtestTier;
 
-    use crate::{
-        location::Meters,
-        speedtest::{BytesPs, Millis},
-    };
+    use std::num::NonZeroU32;
+
+    use crate::{location::Meters, speedtest::BytesPs};
 
     use super::*;
     use chrono::Utc;
@@ -672,172 +672,126 @@ mod tests {
         );
     }
 
-    #[test]
-    fn base_radio_coverage_points() {
+    #[rstest]
+    #[case(SignalLevel::High, dec!(4))]
+    #[case(SignalLevel::Medium, dec!(2))]
+    #[case(SignalLevel::Low, dec!(1))]
+    #[case(SignalLevel::None, dec!(0))]
+    fn outdoor_cbrs_base_coverage_points(
+        #[case] signal_level: SignalLevel,
+        #[case] expected: Decimal,
+    ) {
         let outdoor_cbrs = RewardableRadio::new(
             RadioType::OutdoorCbrs,
             speedtest_maximum(),
             location_trust_maximum(),
             RadioThreshold::Verified,
-            vec![
-                RankedCoverage {
-                    hotspot_key: pubkey(),
-                    cbsd_id: Some("serial".to_string()),
-                    hex: hex_location(),
-                    rank: 1,
-                    signal_level: SignalLevel::High,
-                    assignments: assignments_maximum(),
-                    boosted: None,
-                },
-                RankedCoverage {
-                    hotspot_key: pubkey(),
-                    cbsd_id: Some("serial".to_string()),
-                    hex: hex_location(),
-                    rank: 1,
-                    signal_level: SignalLevel::Medium,
-                    assignments: assignments_maximum(),
-                    boosted: None,
-                },
-                RankedCoverage {
-                    hotspot_key: pubkey(),
-                    cbsd_id: Some("serial".to_string()),
-                    hex: hex_location(),
-                    rank: 1,
-                    signal_level: SignalLevel::Low,
-                    assignments: assignments_maximum(),
-                    boosted: None,
-                },
-                RankedCoverage {
-                    hotspot_key: pubkey(),
-                    cbsd_id: Some("serial".to_string()),
-                    hex: hex_location(),
-                    rank: 1,
-                    signal_level: SignalLevel::None,
-                    assignments: assignments_maximum(),
-                    boosted: None,
-                },
-            ],
+            vec![RankedCoverage {
+                hotspot_key: pubkey(),
+                cbsd_id: Some("serial".to_string()),
+                hex: hex_location(),
+                rank: 1,
+                signal_level,
+                assignments: assignments_maximum(),
+                boosted: None,
+            }],
         )
         .expect("outdoor cbrs");
 
+        assert_eq!(
+            expected,
+            calculate_coverage_points(outdoor_cbrs).total_coverage_points
+        );
+    }
+
+    #[rstest]
+    #[case(SignalLevel::High, dec!(100))]
+    #[case(SignalLevel::Low, dec!(25))]
+    fn indoor_cbrs_base_coverage_points(
+        #[case] signal_level: SignalLevel,
+        #[case] expected: Decimal,
+    ) {
         let indoor_cbrs = RewardableRadio::new(
             RadioType::IndoorCbrs,
             speedtest_maximum(),
             location_trust_maximum(),
             RadioThreshold::Verified,
-            vec![
-                RankedCoverage {
-                    hotspot_key: pubkey(),
-                    cbsd_id: Some("serial".to_string()),
-                    hex: hex_location(),
-                    rank: 1,
-                    signal_level: SignalLevel::High,
-                    assignments: assignments_maximum(),
-                    boosted: None,
-                },
-                RankedCoverage {
-                    hotspot_key: pubkey(),
-                    cbsd_id: Some("serial".to_string()),
-                    hex: hex_location(),
-                    rank: 1,
-                    signal_level: SignalLevel::Low,
-                    assignments: assignments_maximum(),
-                    boosted: None,
-                },
-            ],
+            vec![RankedCoverage {
+                hotspot_key: pubkey(),
+                cbsd_id: Some("serial".to_string()),
+                hex: hex_location(),
+                rank: 1,
+                signal_level,
+                assignments: assignments_maximum(),
+                boosted: None,
+            }],
         )
         .expect("indoor cbrs");
 
+        assert_eq!(
+            expected,
+            calculate_coverage_points(indoor_cbrs).total_coverage_points
+        );
+    }
+
+    #[rstest]
+    #[case(SignalLevel::High, dec!(16))]
+    #[case(SignalLevel::Medium, dec!(8))]
+    #[case(SignalLevel::Low, dec!(4))]
+    #[case(SignalLevel::None, dec!(0))]
+    fn outdoor_wifi_base_coverage_points(
+        #[case] signal_level: SignalLevel,
+        #[case] expected: Decimal,
+    ) {
         let outdoor_wifi = RewardableRadio::new(
-            RadioType::OutdoorWifi,
+            RadioType::IndoorCbrs,
             speedtest_maximum(),
             location_trust_maximum(),
             RadioThreshold::Verified,
-            vec![
-                RankedCoverage {
-                    hotspot_key: pubkey(),
-                    cbsd_id: None,
-                    hex: hex_location(),
-                    rank: 1,
-                    signal_level: SignalLevel::High,
-                    assignments: assignments_maximum(),
-                    boosted: None,
-                },
-                RankedCoverage {
-                    hotspot_key: pubkey(),
-                    cbsd_id: None,
-                    hex: hex_location(),
-                    rank: 1,
-                    signal_level: SignalLevel::Medium,
-                    assignments: assignments_maximum(),
-                    boosted: None,
-                },
-                RankedCoverage {
-                    hotspot_key: pubkey(),
-                    cbsd_id: None,
-                    hex: hex_location(),
-                    rank: 1,
-                    signal_level: SignalLevel::Low,
-                    assignments: assignments_maximum(),
-                    boosted: None,
-                },
-                RankedCoverage {
-                    hotspot_key: pubkey(),
-                    cbsd_id: None,
-                    hex: hex_location(),
-                    rank: 1,
-                    signal_level: SignalLevel::None,
-                    assignments: assignments_maximum(),
-                    boosted: None,
-                },
-            ],
+            vec![RankedCoverage {
+                hotspot_key: pubkey(),
+                cbsd_id: Some("serial".to_string()),
+                hex: hex_location(),
+                rank: 1,
+                signal_level,
+                assignments: assignments_maximum(),
+                boosted: None,
+            }],
         )
-        .expect("outdoor wifi");
+        .expect("indoor cbrs");
 
+        assert_eq!(
+            expected,
+            calculate_coverage_points(outdoor_wifi).total_coverage_points
+        );
+    }
+
+    #[rstest]
+    #[case(SignalLevel::High, dec!(400))]
+    #[case(SignalLevel::Low, dec!(100))]
+    fn indoor_wifi_base_coverage_points(
+        #[case] signal_level: SignalLevel,
+        #[case] expected: Decimal,
+    ) {
         let indoor_wifi = RewardableRadio::new(
             RadioType::IndoorWifi,
             speedtest_maximum(),
             location_trust_maximum(),
             RadioThreshold::Verified,
-            vec![
-                RankedCoverage {
-                    hotspot_key: pubkey(),
-                    cbsd_id: None,
-                    hex: hex_location(),
-                    rank: 1,
-                    signal_level: SignalLevel::High,
-                    assignments: assignments_maximum(),
-                    boosted: None,
-                },
-                RankedCoverage {
-                    hotspot_key: pubkey(),
-                    cbsd_id: None,
-                    hex: hex_location(),
-                    rank: 1,
-                    signal_level: SignalLevel::Low,
-                    assignments: assignments_maximum(),
-                    boosted: None,
-                },
-            ],
+            vec![RankedCoverage {
+                hotspot_key: pubkey(),
+                cbsd_id: None,
+                hex: hex_location(),
+                rank: 1,
+                signal_level,
+                assignments: assignments_maximum(),
+                boosted: None,
+            }],
         )
         .expect("indoor wifi");
 
-        // When each radio contains a hex of every applicable signal_level, and
-        // multipliers are break even. These are the accumulated coverage points.
         assert_eq!(
-            dec!(7),
-            calculate_coverage_points(outdoor_cbrs).total_coverage_points
-        );
-        assert_eq!(
-            dec!(125),
-            calculate_coverage_points(indoor_cbrs).total_coverage_points
-        );
-        assert_eq!(
-            dec!(28),
-            calculate_coverage_points(outdoor_wifi).total_coverage_points
-        );
-        assert_eq!(
-            dec!(500),
+            expected,
             calculate_coverage_points(indoor_wifi).total_coverage_points
         );
     }

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -189,7 +189,7 @@ impl BoostedHexStatus {
         }
 
         // hip84: if radio has not met minimum data and subscriber thresholds, no boosting
-        if !radio_threshold.threshold_met() {
+        if !radio_threshold.is_met() {
             return Self::RadioThresholdNotMet;
         }
 
@@ -272,7 +272,7 @@ pub enum RadioThreshold {
 }
 
 impl RadioThreshold {
-    fn threshold_met(&self) -> bool {
+    fn is_met(&self) -> bool {
         matches!(self, Self::Verified)
     }
 }

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -272,7 +272,7 @@ impl RadioType {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RadioThreshold {
     Verified,
-    UnVerified,
+    Unverified,
 }
 
 impl RadioThreshold {
@@ -331,7 +331,7 @@ mod tests {
 
         // Radio not meeting the threshold is not eligible for boosted hexes.
         // Boost from hex is not applied, radio receives base points.
-        let unverified_wifi = make_wifi(RadioThreshold::UnVerified);
+        let unverified_wifi = make_wifi(RadioThreshold::Unverified);
         assert_eq!(
             base_points,
             calculate_coverage_points(unverified_wifi).total_coverage_points

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -29,6 +29,18 @@
 ///   - added "Good" speedtest tier [HIP-98][qos-score]
 ///     - latency is explicitly under limit in HIP https://github.com/helium/oracles/pull/737
 ///
+/// ## Notable Conditions:
+/// - Location
+///   - If a Radio covers any boosted hexes, [LocationTrust] scores must meet distance requirements, or be degraded.
+///   - CBRS Radio's location is always trusted because of GPS.
+///
+/// - Speedtests
+///   - The latest 6 speedtests will be used.
+///   - There must be more than 2 speedtests.
+///
+/// - Covered Hexes
+///   - If a Radio is not [eligible_for_boosted_hexes], boost values are removed before calculations. [CoveredHexes::new_without_boosts]
+///
 /// ## References:
 /// [modeled-coverage]:        https://github.com/helium/HIP/blob/main/0074-mobile-poc-modeled-coverage-rewards.md#outdoor-radios
 /// [provider-boosting]:       https://github.com/helium/HIP/blob/main/0084-service-provider-hex-boosting.md
@@ -40,13 +52,6 @@
 /// [cbrs-experimental]:       https://github.com/helium/HIP/blob/main/0113-reward-cbrs-as-experimental.md
 /// [mobile-poc-blog]:         https://docs.helium.com/mobile/proof-of-coverage
 /// [boosted-hex-restriction]: https://github.com/helium/oracles/pull/808
-///
-/// To Integrate in Docs:
-///
-///
-/// Has something to say about 30meters from asserted location wrt poc rewards
-/// for boosted hexes.
-/// https://github.com/helium/HIP/blob/8b1e814afa61a714b5ba63d3265e5897ab4c5116/0107-preventing-gaming-within-the-mobile-network.md
 ///
 use crate::{
     hexes::{CoveredHex, CoveredHexes},

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -148,10 +148,6 @@ impl RewardableRadio {
         radio_threshold: RadioThreshold,
         ranked_coverage: Vec<RankedCoverage>,
     ) -> Result<Self> {
-        // QUESTION: we need to know about boosted hexes to determine location multiplier.
-        // The location multiplier is then used to determine if they are eligible for boosted hexes.
-        // In the case where they cannot use boosted hexes, should the location mulitiplier be restored?
-
         let location_trust_scores =
             LocationTrustScores::new(radio_type, location_trust_scores, &ranked_coverage);
 

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -59,6 +59,7 @@ use crate::{
     speedtest::Speedtest,
 };
 use coverage_map::{RankedCoverage, SignalLevel};
+use hexes::CoveredHex;
 use rust_decimal::{Decimal, RoundingStrategy};
 use rust_decimal_macros::dec;
 use speedtest::Speedtests;
@@ -110,6 +111,18 @@ pub struct CoveragePoints {
     pub location_trust_multiplier: Decimal,
     /// Speedtest Mulitplier, maximum of 1
     pub speedtest_multiplier: Decimal,
+    /// Input Radio Type
+    pub radio_type: RadioType,
+    /// Input RadioThreshold
+    pub radio_threshold: RadioThreshold,
+    /// Derived Eligibility for Boosted Hex Rewards
+    pub boosted_hex_eligibility: BoostedHexStatus,
+    /// Speedtests used in calculcation
+    pub speedtests: Vec<Speedtest>,
+    /// Locaiton Trust Scores used in calculations
+    pub location_trust_scores: Vec<LocationTrust>,
+    /// Covered Hexes used in calculations
+    pub covered_hexes: Vec<CoveredHex>,
 }
 
 /// Entry point into the Coverage Point Calculator.
@@ -159,6 +172,27 @@ pub fn calculate_coverage_points(radio: &RewardableRadio) -> CoveragePoints {
         hex_coverage_points,
         location_trust_multiplier,
         speedtest_multiplier,
+        radio_type: radio.radio_type,
+        radio_threshold: radio.radio_threshold,
+        boosted_hex_eligibility: radio.boosted_hex_eligibility,
+        speedtests: radio
+            .speedtests
+            .speedtests
+            .iter()
+            .map(|s| s.clone())
+            .collect(),
+        location_trust_scores: radio
+            .location_trust_scores
+            .trust_scores
+            .iter()
+            .map(|s| s.clone())
+            .collect(),
+        covered_hexes: radio
+            .covered_hexes
+            .hexes
+            .iter()
+            .map(|h| h.clone())
+            .collect(),
     }
 }
 

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -109,16 +109,9 @@ pub struct CoveragePoints {
     pub location_trust_multiplier: Decimal,
     /// Speedtest Mulitplier, maximum of 1
     pub speedtest_multiplier: Decimal,
-    // ---
-    pub radio_type: RadioType,
-    pub radio_threshold: RadioThreshold,
-    pub speedtests: Vec<Speedtest>,
-    pub location_trust_scores: Vec<LocationTrust>,
-    pub covered_hexes: Vec<CoveredHex>,
-    pub boosted_hex_eligibility: BoostedHexStatus,
 }
 
-pub fn calculate_coverage_points(radio: RewardableRadio) -> CoveragePoints {
+pub fn calculate_coverage_points(radio: &RewardableRadio) -> CoveragePoints {
     let hex_coverage_points = radio.covered_hexes.calculated_coverage_points();
     let location_trust_multiplier = radio.location_trust_scores.multiplier;
     let speedtest_multiplier = radio.speedtests.multiplier;
@@ -131,13 +124,6 @@ pub fn calculate_coverage_points(radio: RewardableRadio) -> CoveragePoints {
         hex_coverage_points,
         location_trust_multiplier,
         speedtest_multiplier,
-        // Radio information
-        radio_type: radio.radio_type,
-        radio_threshold: radio.radio_threshold,
-        speedtests: radio.speedtests.speedtests,
-        location_trust_scores: radio.location_trust_scores.trust_scores,
-        covered_hexes: radio.covered_hexes.hexes,
-        boosted_hex_eligibility: radio.boosted_hex_eligibility,
     }
 }
 

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -382,9 +382,13 @@ mod tests {
             .expect("indoor cbrs with speedtests")
         };
 
+        let base_coverage_points = RadioType::IndoorCbrs
+            .base_coverage_points(&SignalLevel::High)
+            .unwrap();
+
         let indoor_cbrs = make_indoor_cbrs(speedtest_maximum());
         assert_eq!(
-            dec!(100),
+            base_coverage_points * SpeedtestTier::Good.multiplier(),
             calculate_coverage_points(indoor_cbrs).total_coverage_points
         );
 
@@ -393,7 +397,7 @@ mod tests {
             speedtest_with_download(BytesPs::mbps(88)),
         ]);
         assert_eq!(
-            dec!(75),
+            base_coverage_points * SpeedtestTier::Acceptable.multiplier(),
             calculate_coverage_points(indoor_cbrs.clone()).total_coverage_points
         );
 
@@ -402,7 +406,7 @@ mod tests {
             speedtest_with_download(BytesPs::mbps(62)),
         ]);
         assert_eq!(
-            dec!(50),
+            base_coverage_points * SpeedtestTier::Degraded.multiplier(),
             calculate_coverage_points(indoor_cbrs).total_coverage_points
         );
 
@@ -411,7 +415,7 @@ mod tests {
             speedtest_with_download(BytesPs::mbps(42)),
         ]);
         assert_eq!(
-            dec!(25),
+            base_coverage_points * SpeedtestTier::Poor.multiplier(),
             calculate_coverage_points(indoor_cbrs).total_coverage_points
         );
 
@@ -420,7 +424,7 @@ mod tests {
             speedtest_with_download(BytesPs::mbps(25)),
         ]);
         assert_eq!(
-            dec!(0),
+            base_coverage_points * SpeedtestTier::Fail.multiplier(),
             calculate_coverage_points(indoor_cbrs).total_coverage_points
         );
     }

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -1,58 +1,58 @@
-///
-/// Many changes to the rewards algorithm are contained in and across many HIPs.
-/// The blog post [MOBILE Proof of Coverage][mobile-poc-blog] contains a more
-/// thorough explanation of many of them. It is not exhaustive, but a great
-/// place to start.
-///
-/// ## Fields:
-/// - modeled_coverage_points
-///   - [HIP-74][modeled-coverage]
-///   - reduced cbrs radio coverage points [HIP-113][cbrs-experimental]
-///
-/// - assignment_multiplier
-///   - [HIP-103][oracle-boosting]
-///
-/// - rank
-///   - [HIP-105][hex-limits]
-///
-/// - hex_boost_multiplier  
-///   - must meet minimum subscriber thresholds [HIP-84][provider-boosting]
-///   - Wifi Location trust score >0.75 for boosted hex eligibility [HIP-93][wifi-aps]
-///
-/// - location_trust_score_multiplier
-///   - [HIP-98][qos-score]
-///   - states 30m requirement for boosted hexes [HIP-107][prevent-gaming]
-///   - increase Boosted hex restriction, 30m -> 50m [Pull Request][boosted-hex-restriction]
-///
-/// - speedtest_multiplier
-///   - [HIP-74][modeled-coverage]
-///   - added "Good" speedtest tier [HIP-98][qos-score]
-///     - latency is explicitly under limit in HIP https://github.com/helium/oracles/pull/737
-///
-/// ## Notable Conditions:
-/// - Location
-///   - If a Radio covers any boosted hexes, [LocationTrust] scores must meet distance requirements, or be degraded.
-///   - CBRS Radio's location is always trusted because of GPS.
-///
-/// - Speedtests
-///   - The latest 6 speedtests will be used.
-///   - There must be more than 2 speedtests.
-///
-/// - Covered Hexes
-///   - If a Radio is not [eligible_for_boosted_hexes], boost values are removed before calculations. [CoveredHexes::new_without_boosts]
-///
-/// ## References:
-/// [modeled-coverage]:        https://github.com/helium/HIP/blob/main/0074-mobile-poc-modeled-coverage-rewards.md#outdoor-radios
-/// [provider-boosting]:       https://github.com/helium/HIP/blob/main/0084-service-provider-hex-boosting.md
-/// [wifi-aps]:                https://github.com/helium/HIP/blob/main/0093-addition-of-wifi-aps-to-mobile-subdao.md
-/// [qos-score]:               https://github.com/helium/HIP/blob/main/0098-mobile-subdao-quality-of-service-requirements.md
-/// [oracle-boosting]:         https://github.com/helium/HIP/blob/main/0103-oracle-hex-boosting.md
-/// [hex-limits]:              https://github.com/helium/HIP/blob/main/0105-modification-of-mobile-subdao-hex-limits.md
-/// [prevent-gaming]:          https://github.com/helium/HIP/blob/main/0107-preventing-gaming-within-the-mobile-network.md
-/// [cbrs-experimental]:       https://github.com/helium/HIP/blob/main/0113-reward-cbrs-as-experimental.md
-/// [mobile-poc-blog]:         https://docs.helium.com/mobile/proof-of-coverage
-/// [boosted-hex-restriction]: https://github.com/helium/oracles/pull/808
-///
+//!
+//! Many changes to the rewards algorithm are contained in and across many HIPs.
+//! The blog post [MOBILE Proof of Coverage][mobile-poc-blog] contains a more
+//! thorough explanation of many of them. It is not exhaustive, but a great
+//! place to start.
+//!
+//! ## Fields:
+//! - modeled_coverage_points
+//!   - [HIP-74][modeled-coverage]
+//!   - reduced cbrs radio coverage points [HIP-113][cbrs-experimental]
+//!
+//! - assignment_multiplier
+//!   - [HIP-103][oracle-boosting]
+//!
+//! - rank
+//!   - [HIP-105][hex-limits]
+//!
+//! - hex_boost_multiplier  
+//!   - must meet minimum subscriber thresholds [HIP-84][provider-boosting]
+//!   - Wifi Location trust score >0.75 for boosted hex eligibility [HIP-93][wifi-aps]
+//!
+//! - location_trust_score_multiplier
+//!   - [HIP-98][qos-score]
+//!   - states 30m requirement for boosted hexes [HIP-107][prevent-gaming]
+//!   - increase Boosted hex restriction, 30m -> 50m [Pull Request][boosted-hex-restriction]
+//!
+//! - speedtest_multiplier
+//!   - [HIP-74][modeled-coverage]
+//!   - added "Good" speedtest tier [HIP-98][qos-score]
+//!     - latency is explicitly under limit in HIP <https://github.com/helium/oracles/pull/737>
+//!
+//! ## Notable Conditions:
+//! - Location
+//!   - If a Radio covers any boosted hexes, [LocationTrust] scores must meet distance requirements, or be degraded.
+//!   - CBRS Radio's location is always trusted because of GPS.
+//!
+//! - Speedtests
+//!   - The latest 6 speedtests will be used.
+//!   - There must be more than 2 speedtests.
+//!
+//! - Covered Hexes
+//!   - If a Radio is not [CoveragePoints::boosted_hex_eligibility], boost values are removed before calculations. [CoveredHexes::new_without_boosts]
+//!
+//! ## References:
+//! [modeled-coverage]:        https://github.com/helium/HIP/blob/main/0074-mobile-poc-modeled-coverage-rewards.md#outdoor-radios
+//! [provider-boosting]:       https://github.com/helium/HIP/blob/main/0084-service-provider-hex-boosting.md
+//! [wifi-aps]:                https://github.com/helium/HIP/blob/main/0093-addition-of-wifi-aps-to-mobile-subdao.md
+//! [qos-score]:               https://github.com/helium/HIP/blob/main/0098-mobile-subdao-quality-of-service-requirements.md
+//! [oracle-boosting]:         https://github.com/helium/HIP/blob/main/0103-oracle-hex-boosting.md
+//! [hex-limits]:              https://github.com/helium/HIP/blob/main/0105-modification-of-mobile-subdao-hex-limits.md
+//! [prevent-gaming]:          https://github.com/helium/HIP/blob/main/0107-preventing-gaming-within-the-mobile-network.md
+//! [cbrs-experimental]:       https://github.com/helium/HIP/blob/main/0113-reward-cbrs-as-experimental.md
+//! [mobile-poc-blog]:         https://docs.helium.com/mobile/proof-of-coverage
+//! [boosted-hex-restriction]: https://github.com/helium/oracles/pull/808
+//!
 use crate::{
     hexes::{CoveredHex, CoveredHexes},
     location::{LocationTrust, LocationTrustScores},

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -148,18 +148,6 @@ impl CoveragePoints {
         let reward_shares = hex_coverage_points * location_trust_multiplier * speedtest_multiplier;
         let total_coverage_points = hex_coverage_points * location_trust_multiplier;
 
-        // Values to be used directly are truncated here.
-        // The values that make them up, go forward untruncated.
-        // let reward_shares = reward_shares.to_u64().unwrap_or_default();
-        // let total_coverage_points = total_coverage_points.to_u64().unwrap_or_default();
-
-        // TODO: poc_reward calculations are done with fractional shares,
-        // truncating shares and points here breaks calculations
-        let reward_shares =
-            reward_shares.round_dp_with_strategy(2, rust_decimal::RoundingStrategy::ToZero);
-        let total_coverage_points =
-            total_coverage_points.round_dp_with_strategy(2, rust_decimal::RoundingStrategy::ToZero);
-
         Ok(CoveragePoints {
             reward_shares,
             total_coverage_points,

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -119,9 +119,9 @@ pub struct CoveragePoints {
 /// [calculate_coverage_points].
 pub fn make_rewardable_radio(
     radio_type: RadioType,
+    radio_threshold: RadioThreshold,
     speedtests: Vec<Speedtest>,
     location_trust_scores: Vec<LocationTrust>,
-    radio_threshold: RadioThreshold,
     ranked_coverage: Vec<RankedCoverage>,
 ) -> Result<RewardableRadio> {
     let location_trust_scores =
@@ -289,9 +289,9 @@ mod tests {
         let make_wifi = |radio_verified: RadioThreshold| {
             make_rewardable_radio(
                 RadioType::IndoorWifi,
+                radio_verified,
                 speedtest_maximum(),
                 location_trust_maximum(),
-                radio_verified,
                 vec![RankedCoverage {
                     hotspot_key: pubkey(),
                     cbsd_id: None,
@@ -331,9 +331,9 @@ mod tests {
         let make_wifi = |location_trust_scores: Vec<LocationTrust>| {
             make_rewardable_radio(
                 RadioType::IndoorWifi,
+                RadioThreshold::Verified,
                 speedtest_maximum(),
                 location_trust_scores,
-                RadioThreshold::Verified,
                 vec![RankedCoverage {
                     hotspot_key: pubkey(),
                     cbsd_id: None,
@@ -369,9 +369,9 @@ mod tests {
         let make_indoor_cbrs = |speedtests: Vec<Speedtest>| {
             make_rewardable_radio(
                 RadioType::IndoorCbrs,
+                RadioThreshold::Verified,
                 speedtests,
                 location_trust_maximum(),
-                RadioThreshold::Verified,
                 vec![RankedCoverage {
                     hotspot_key: pubkey(),
                     cbsd_id: Some("serial".to_string()),
@@ -457,9 +457,9 @@ mod tests {
         use Assignment::*;
         let indoor_cbrs = make_rewardable_radio(
             RadioType::IndoorCbrs,
+            RadioThreshold::Verified,
             speedtest_maximum(),
             location_trust_maximum(),
-            RadioThreshold::Verified,
             vec![
                 // yellow - POI ≥ 1 Urbanized
                 ranked_coverage(A, A, A), // 100
@@ -517,9 +517,9 @@ mod tests {
     ) {
         let outdoor_wifi = make_rewardable_radio(
             radio_type,
+            RadioThreshold::Verified,
             speedtest_maximum(),
             location_trust_maximum(),
-            RadioThreshold::Verified,
             vec![RankedCoverage {
                 hotspot_key: pubkey(),
                 cbsd_id: None,
@@ -549,9 +549,9 @@ mod tests {
     ) {
         let indoor_wifi = make_rewardable_radio(
             radio_type,
+            RadioThreshold::Verified,
             speedtest_maximum(),
             location_trust_maximum(),
-            RadioThreshold::Verified,
             vec![
                 RankedCoverage {
                     hotspot_key: pubkey(),
@@ -595,9 +595,9 @@ mod tests {
         // Location scores are averaged together
         let indoor_wifi = make_rewardable_radio(
             RadioType::IndoorWifi,
+            RadioThreshold::Verified,
             speedtest_maximum(),
             location_trust_with_scores(&[dec!(0.1), dec!(0.2), dec!(0.3), dec!(0.4)]),
-            RadioThreshold::Verified,
             vec![RankedCoverage {
                 hotspot_key: pubkey(),
                 cbsd_id: None,
@@ -642,9 +642,9 @@ mod tests {
         ];
         let indoor_wifi = make_rewardable_radio(
             RadioType::IndoorWifi,
+            RadioThreshold::Verified,
             speedtest_maximum(),
             location_trust_maximum(),
-            RadioThreshold::Verified,
             covered_hexes.clone(),
         )
         .expect("indoor wifi");
@@ -668,9 +668,9 @@ mod tests {
     ) {
         let outdoor_cbrs = make_rewardable_radio(
             RadioType::OutdoorCbrs,
+            RadioThreshold::Verified,
             speedtest_maximum(),
             location_trust_maximum(),
-            RadioThreshold::Verified,
             vec![RankedCoverage {
                 hotspot_key: pubkey(),
                 cbsd_id: Some("serial".to_string()),
@@ -698,9 +698,9 @@ mod tests {
     ) {
         let indoor_cbrs = make_rewardable_radio(
             RadioType::IndoorCbrs,
+            RadioThreshold::Verified,
             speedtest_maximum(),
             location_trust_maximum(),
-            RadioThreshold::Verified,
             vec![RankedCoverage {
                 hotspot_key: pubkey(),
                 cbsd_id: Some("serial".to_string()),
@@ -730,9 +730,9 @@ mod tests {
     ) {
         let outdoor_wifi = make_rewardable_radio(
             RadioType::OutdoorWifi,
+            RadioThreshold::Verified,
             speedtest_maximum(),
             location_trust_maximum(),
-            RadioThreshold::Verified,
             vec![RankedCoverage {
                 hotspot_key: pubkey(),
                 cbsd_id: Some("serial".to_string()),
@@ -760,9 +760,9 @@ mod tests {
     ) {
         let indoor_wifi = make_rewardable_radio(
             RadioType::IndoorWifi,
+            RadioThreshold::Verified,
             speedtest_maximum(),
             location_trust_maximum(),
-            RadioThreshold::Verified,
             vec![RankedCoverage {
                 hotspot_key: pubkey(),
                 cbsd_id: None,

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -129,18 +129,6 @@ pub fn calculate_coverage_points(radio: RewardableRadio) -> CoveragePoints {
     }
 }
 
-impl CoveragePoints {
-    pub fn iter_boosted_hexes(&self) -> impl Iterator<Item = CoveredHex> {
-        let eligible = self.boosted_hex_eligibility.is_eligible();
-
-        self.covered_hexes
-            .clone()
-            .into_iter()
-            .filter(move |_| eligible)
-            .filter(|hex| hex.boosted_multiplier.is_some())
-    }
-}
-
 impl RewardableRadio {
     pub fn new(
         radio_type: RadioType,
@@ -184,6 +172,18 @@ impl RewardableRadio {
 
     pub fn radio_type(&self) -> RadioType {
         self.radio_type
+    }
+}
+
+impl CoveragePoints {
+    pub fn iter_boosted_hexes(&self) -> impl Iterator<Item = CoveredHex> {
+        let eligible = self.boosted_hex_eligibility.is_eligible();
+
+        self.covered_hexes
+            .clone()
+            .into_iter()
+            .filter(move |_| eligible)
+            .filter(|hex| hex.boosted_multiplier.is_some())
     }
 }
 

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -141,7 +141,7 @@ impl CoveragePoints {
             BoostedHexStatus::new(&radio_type, location_trust_multiplier, &radio_threshold);
 
         let covered_hexes =
-            hexes::clean_covered_hexes(radio_type, ranked_coverage, boost_eligibility)?;
+            hexes::clean_covered_hexes(radio_type, boost_eligibility, ranked_coverage)?;
         let hex_coverage_points = hexes::calculated_coverage_points(&covered_hexes);
 
         let speedtests = speedtest::clean_speedtests(speedtests);

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -39,7 +39,7 @@
 //!   - There must be more than 2 speedtests.
 //!
 //! - Covered Hexes
-//!   - If a Radio is not [CoveragePoints::boosted_hex_eligibility], boost values are removed before calculations. [CoveredHexes::new_without_boosts]
+//!   - If a Radio is not [BoostedHexStatus::Eligible], boost values are removed before calculations. [CoveredHexes::new]
 //!
 //! ## References:
 //! [modeled-coverage]:        https://github.com/helium/HIP/blob/main/0074-mobile-poc-modeled-coverage-rewards.md#outdoor-radios
@@ -75,7 +75,20 @@ pub enum Error {
     InvalidSignalLevel(SignalLevel, RadioType),
 }
 
-/// Necessary checks for calculating coverage points is done during [RewardableRadio::new].
+/// Necessary checks for calculating coverage points is done during
+/// [RewardableRadio::new].
+///
+/// The data in this struct may be different from the input data, but
+/// it contains the values used for calculating coverage points.
+///
+/// - If more than the allowed speedtests were provided, only the speedtests
+///   considered are included here.
+///
+/// - When a radio covers boosted hexes, [CoveragePoints::location_trust_scores] will contain a
+///   trust score _after_ the boosted hex restriction has been applied.
+///
+/// - When a radio is not eligible for boosted hex rewards, [CoveragePoints::covered_hexes] will
+///   have no boosted_multiplier values.
 #[derive(Debug, Clone)]
 pub struct RewardableRadio {
     pub radio_type: RadioType,
@@ -87,18 +100,6 @@ pub struct RewardableRadio {
 }
 
 /// Output of calculating coverage points for a [RewardableRadio].
-///
-/// The only data included was used for calculating coverage points.
-///
-/// - If more than the allowed speedtests were provided, only the speedtests
-///   considered are included here.
-///
-/// - When a radio covers boosted hexes, [CoveragePoints::location_trust_scores] will contain a
-///   trust score _after_ the boosted hex restriction has been applied.
-///
-/// - When a radio is not eligible for boosted hex rewards, [CoveragePoints::covered_hexes] will
-///   have no boosted_multiplier values.
-///
 #[derive(Debug)]
 pub struct CoveragePoints {
     /// Value used when calculating poc_reward

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -57,7 +57,7 @@
 pub use crate::{
     hexes::CoveredHex,
     location::LocationTrust,
-    speedtest::{BytesPs, Speedtest},
+    speedtest::{BytesPs, Speedtest, SpeedtestTier},
 };
 use coverage_map::SignalLevel;
 use rust_decimal::Decimal;

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -175,7 +175,7 @@ impl RewardableRadio {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum BoostedHexStatus {
     Eligible,
     WifiLocationScoreBelowThreshold(Decimal),
@@ -261,7 +261,7 @@ impl RadioType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RadioThreshold {
     Verified,
     UnVerified,

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -74,15 +74,16 @@ pub enum Error {
     #[error("signal level {0:?} not allowed for {1:?}")]
     InvalidSignalLevel(SignalLevel, RadioType),
 }
+
 /// Necessary checks for calculating coverage points is done during [RewardableRadio::new].
 #[derive(Debug, Clone)]
 pub struct RewardableRadio {
-    radio_type: RadioType,
+    pub radio_type: RadioType,
+    pub radio_threshold: RadioThreshold,
+    pub boosted_hex_eligibility: BoostedHexStatus,
     speedtests: Speedtests,
     location_trust_scores: LocationTrustScores,
-    radio_threshold: RadioThreshold,
     covered_hexes: CoveredHexes,
-    boosted_hex_eligibility: BoostedHexStatus,
 }
 
 /// Output of calculating coverage points for a [RewardableRadio].

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -724,7 +724,7 @@ mod tests {
         #[case] expected: Decimal,
     ) {
         let outdoor_wifi = RewardableRadio::new(
-            RadioType::IndoorCbrs,
+            RadioType::OutdoorWifi,
             speedtest_maximum(),
             location_trust_maximum(),
             RadioThreshold::Verified,

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -70,7 +70,7 @@ pub mod speedtest;
 pub type Result<T = ()> = std::result::Result<T, Error>;
 pub type MaxOneMultplier = Decimal;
 
-/// Input Radio to calculation
+/// Necessary checks for calculating coverage points is done during [RewardableRadio::new].
 #[derive(Debug, Clone)]
 pub struct RewardableRadio {
     radio_type: RadioType,
@@ -81,6 +81,19 @@ pub struct RewardableRadio {
     boosted_hex_eligibility: BoostedHexStatus,
 }
 
+/// Output of calculating coverage points for a [RewardableRadio].
+///
+/// The only data included was used for calculating coverage points.
+///
+/// - If more than the allowed speedtests were provided, only the speedtests
+///   considered are included here.
+///
+/// - When a radio covers boosted hexes, [location_trust_scores] will contain a
+///   trust score _after_ the boosted hex restriction has been applied.
+///
+/// - When a radio is not eligible for boosted hex rewards, [covered_hexes] will
+///   have no boosted_multiplier values.
+///
 #[derive(Debug)]
 pub struct CoveragePoints {
     /// Value used when calculating poc_reward

--- a/coverage_point_calculator/src/location.rs
+++ b/coverage_point_calculator/src/location.rs
@@ -47,23 +47,25 @@ impl LocationTrustScores {
     ) -> Self {
         let trust_scores: Vec<_> = trust_scores
             .into_iter()
-            .map(|l| LocationTrust {
-                trust_score: l.boosted_trust_score(),
-                distance_to_asserted: l.distance_to_asserted,
-            })
+            .map(LocationTrust::into_boosted)
             .collect();
 
         Self::new(radio_type, trust_scores)
     }
 }
 impl LocationTrust {
-    fn boosted_trust_score(&self) -> Decimal {
+    fn into_boosted(self) -> Self {
         // Cap multipliers to 0.25x when a radio covers _any_ boosted hex
         // and it's distance to asserted is above the threshold.
-        if self.distance_to_asserted > RESTRICTIVE_MAX_DISTANCE {
+        let trust_score = if self.distance_to_asserted > RESTRICTIVE_MAX_DISTANCE {
             dec!(0.25).min(self.trust_score)
         } else {
             self.trust_score
+        };
+
+        LocationTrust {
+            trust_score,
+            distance_to_asserted: self.distance_to_asserted,
         }
     }
 }

--- a/coverage_point_calculator/src/speedtest.rs
+++ b/coverage_point_calculator/src/speedtest.rs
@@ -2,8 +2,6 @@ use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 
-use crate::MaxOneMultplier;
-
 const MIN_REQUIRED_SPEEDTEST_SAMPLES: usize = 2;
 const MAX_ALLOWED_SPEEDTEST_SAMPLES: usize = 6;
 
@@ -116,7 +114,7 @@ pub enum SpeedtestTier {
 }
 
 impl SpeedtestTier {
-    pub fn multiplier(&self) -> MaxOneMultplier {
+    pub fn multiplier(&self) -> Decimal {
         match self {
             SpeedtestTier::Good => dec!(1.00),
             SpeedtestTier::Acceptable => dec!(0.75),

--- a/coverage_point_calculator/src/speedtest.rs
+++ b/coverage_point_calculator/src/speedtest.rs
@@ -42,7 +42,7 @@ pub(crate) fn multiplier(speedtests: &[Speedtest]) -> Decimal {
     avg.multiplier()
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Speedtest {
     pub upload_speed: BytesPs,
     pub download_speed: BytesPs,

--- a/coverage_point_calculator/src/speedtest.rs
+++ b/coverage_point_calculator/src/speedtest.rs
@@ -12,16 +12,18 @@ type Millis = u32;
 pub struct BytesPs(u64);
 
 impl BytesPs {
+    const BYTES_PER_MEGABYTE: u64 = 125_000;
+
     pub fn new(bytes_per_second: u64) -> Self {
         Self(bytes_per_second)
     }
 
     pub fn mbps(megabytes_per_second: u64) -> Self {
-        Self(megabytes_per_second * 12500)
+        Self(megabytes_per_second * Self::BYTES_PER_MEGABYTE)
     }
 
     fn as_mbps(&self) -> u64 {
-        self.0 / 12500
+        self.0 / Self::BYTES_PER_MEGABYTE
     }
 }
 
@@ -229,6 +231,17 @@ mod tests {
 
         // Old speedtests should be unused
         assert_eq!(dec!(1), multiplier(&speedtests));
+    }
+
+    #[test]
+    fn test_real_bytes_per_second() {
+        // Random sampling from database for a download speed that should be
+        // "Acceptable". Other situational tests go through the ::mbps()
+        // constructor, so will always be consistent with each other.
+        assert_eq!(
+            SpeedtestTier::Acceptable,
+            SpeedtestTier::from_download(BytesPs::new(11_702_687))
+        );
     }
 
     fn date(year: i32, month: u32, day: u32) -> DateTime<Utc> {

--- a/coverage_point_calculator/src/speedtest.rs
+++ b/coverage_point_calculator/src/speedtest.rs
@@ -68,8 +68,8 @@ pub struct Speedtest {
 
 impl Speedtest {
     pub fn multiplier(&self) -> Decimal {
-        let upload = SpeedtestTier::from_upload(&self.upload_speed);
-        let download = SpeedtestTier::from_download(&self.download_speed);
+        let upload = SpeedtestTier::from_upload(self.upload_speed);
+        let download = SpeedtestTier::from_download(self.download_speed);
         let latency = SpeedtestTier::from_latency(self.latency_millis);
 
         let tier = upload.min(download).min(latency);
@@ -107,7 +107,7 @@ pub enum SpeedtestTier {
 }
 
 impl SpeedtestTier {
-    pub fn multiplier(&self) -> Decimal {
+    pub fn multiplier(self) -> Decimal {
         match self {
             SpeedtestTier::Good => dec!(1.00),
             SpeedtestTier::Acceptable => dec!(0.75),
@@ -117,7 +117,7 @@ impl SpeedtestTier {
         }
     }
 
-    fn from_download(bytes: &BytesPs) -> Self {
+    fn from_download(bytes: BytesPs) -> Self {
         match bytes.as_mbps() {
             100.. => Self::Good,
             75.. => Self::Acceptable,
@@ -127,7 +127,7 @@ impl SpeedtestTier {
         }
     }
 
-    fn from_upload(bytes: &BytesPs) -> Self {
+    fn from_upload(bytes: BytesPs) -> Self {
         match bytes.as_mbps() {
             10.. => Self::Good,
             8.. => Self::Acceptable,
@@ -156,18 +156,18 @@ mod tests {
     fn speedtest_teirs() {
         use SpeedtestTier::*;
         // download
-        assert_eq!(Good, SpeedtestTier::from_download(&BytesPs::mbps(100)));
-        assert_eq!(Acceptable, SpeedtestTier::from_download(&BytesPs::mbps(80)));
-        assert_eq!(Degraded, SpeedtestTier::from_download(&BytesPs::mbps(62)));
-        assert_eq!(Poor, SpeedtestTier::from_download(&BytesPs::mbps(42)));
-        assert_eq!(Fail, SpeedtestTier::from_download(&BytesPs::mbps(20)));
+        assert_eq!(Good, SpeedtestTier::from_download(BytesPs::mbps(100)));
+        assert_eq!(Acceptable, SpeedtestTier::from_download(BytesPs::mbps(80)));
+        assert_eq!(Degraded, SpeedtestTier::from_download(BytesPs::mbps(62)));
+        assert_eq!(Poor, SpeedtestTier::from_download(BytesPs::mbps(42)));
+        assert_eq!(Fail, SpeedtestTier::from_download(BytesPs::mbps(20)));
 
         // upload
-        assert_eq!(Good, SpeedtestTier::from_upload(&BytesPs::mbps(10)));
-        assert_eq!(Acceptable, SpeedtestTier::from_upload(&BytesPs::mbps(8)));
-        assert_eq!(Degraded, SpeedtestTier::from_upload(&BytesPs::mbps(6)));
-        assert_eq!(Poor, SpeedtestTier::from_upload(&BytesPs::mbps(4)));
-        assert_eq!(Fail, SpeedtestTier::from_upload(&BytesPs::mbps(1)));
+        assert_eq!(Good, SpeedtestTier::from_upload(BytesPs::mbps(10)));
+        assert_eq!(Acceptable, SpeedtestTier::from_upload(BytesPs::mbps(8)));
+        assert_eq!(Degraded, SpeedtestTier::from_upload(BytesPs::mbps(6)));
+        assert_eq!(Poor, SpeedtestTier::from_upload(BytesPs::mbps(4)));
+        assert_eq!(Fail, SpeedtestTier::from_upload(BytesPs::mbps(1)));
 
         // latency
         assert_eq!(Good, SpeedtestTier::from_latency(49));

--- a/coverage_point_calculator/src/speedtest.rs
+++ b/coverage_point_calculator/src/speedtest.rs
@@ -139,10 +139,10 @@ impl SpeedtestTier {
 
     fn from_latency(millis: Millis) -> Self {
         match millis {
-            ..=49 => Self::Good,
-            ..=59 => Self::Acceptable,
-            ..=74 => Self::Degraded,
-            ..=99 => Self::Poor,
+            00..=49 => Self::Good,
+            50..=59 => Self::Acceptable,
+            60..=74 => Self::Degraded,
+            75..=99 => Self::Poor,
             _ => Self::Fail,
         }
     }

--- a/coverage_point_calculator/src/speedtest.rs
+++ b/coverage_point_calculator/src/speedtest.rs
@@ -178,6 +178,26 @@ mod tests {
     }
 
     #[test]
+    fn minimum_required_speedtests_provided_for_multiplier_above_zero() {
+        let speedtest = Speedtest {
+            upload_speed: BytesPs::mbps(15),
+            download_speed: BytesPs::mbps(150),
+            latency_millis: 15,
+            timestamp: Utc::now(),
+        };
+        let speedtests = |num: usize| std::iter::repeat(speedtest).take(num).collect();
+
+        assert_eq!(
+            dec!(0),
+            Speedtests::new(speedtests(MIN_REQUIRED_SPEEDTEST_SAMPLES - 1)).multiplier
+        );
+        assert_eq!(
+            dec!(1),
+            Speedtests::new(speedtests(MIN_REQUIRED_SPEEDTEST_SAMPLES)).multiplier
+        );
+    }
+
+    #[test]
     fn restrict_to_maximum_speedtests_allowed() {
         let base = Speedtest {
             upload_speed: BytesPs::mbps(15),

--- a/coverage_point_calculator/src/speedtest.rs
+++ b/coverage_point_calculator/src/speedtest.rs
@@ -7,6 +7,7 @@ const MAX_ALLOWED_SPEEDTEST_SAMPLES: usize = 6;
 
 type Millis = u32;
 
+/// Bytes per second
 #[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd)]
 pub struct BytesPs(u64);
 

--- a/coverage_point_calculator/src/speedtest.rs
+++ b/coverage_point_calculator/src/speedtest.rs
@@ -209,22 +209,30 @@ mod tests {
             timestamp,
         };
 
+        // Intersperse new and old speedtests.
+        // new speedtests have 1.0 multipliers
+        // old speedtests have 0.0 multipliers
         let speedtests = Speedtests::new(vec![
             make_speedtest(date(2024, 4, 6), Millis::new(15)),
-            make_speedtest(date(2024, 4, 5), Millis::new(15)),
-            make_speedtest(date(2024, 4, 4), Millis::new(15)),
-            make_speedtest(date(2024, 4, 3), Millis::new(15)),
-            make_speedtest(date(2024, 4, 2), Millis::new(15)),
-            make_speedtest(date(2024, 4, 1), Millis::new(15)),
-            //
             make_speedtest(date(2022, 4, 6), Millis::new(999)),
+            // --
+            make_speedtest(date(2024, 4, 5), Millis::new(15)),
             make_speedtest(date(2022, 4, 5), Millis::new(999)),
+            // --
+            make_speedtest(date(2024, 4, 4), Millis::new(15)),
             make_speedtest(date(2022, 4, 4), Millis::new(999)),
+            // --
             make_speedtest(date(2022, 4, 3), Millis::new(999)),
+            make_speedtest(date(2024, 4, 3), Millis::new(15)),
+            // --
+            make_speedtest(date(2024, 4, 2), Millis::new(15)),
             make_speedtest(date(2022, 4, 2), Millis::new(999)),
+            // --
+            make_speedtest(date(2024, 4, 1), Millis::new(15)),
             make_speedtest(date(2022, 4, 1), Millis::new(999)),
         ]);
-        println!("{speedtests:?}");
+
+        // Old speedtests should be unused
         assert_eq!(dec!(1), speedtests.multiplier);
     }
 

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -5,7 +5,6 @@ use coverage_map::{RankedCoverage, SignalLevel};
 use coverage_point_calculator::{
     calculate_coverage_points,
     location::LocationTrust,
-    make_rewardable_radio,
     speedtest::{BytesPs, Speedtest},
     RadioThreshold, RadioType,
 };
@@ -53,7 +52,7 @@ fn base_radio_coverage_points() {
         (RadioType::OutdoorWifi, dec!(16)),
         (RadioType::OutdoorCbrs, dec!(4)),
     ] {
-        let radio = make_rewardable_radio(
+        let coverage_points = calculate_coverage_points(
             radio_type,
             RadioThreshold::Verified,
             speedtests.clone(),
@@ -62,7 +61,6 @@ fn base_radio_coverage_points() {
         )
         .unwrap();
 
-        let coverage_points = calculate_coverage_points(&radio);
         assert_eq!(
             expcted_base_coverage_point,
             coverage_points.total_coverage_points
@@ -115,7 +113,7 @@ fn radios_with_coverage() {
         (RadioType::OutdoorWifi, 25),
         (RadioType::OutdoorCbrs, 100),
     ] {
-        let radio = make_rewardable_radio(
+        let coverage_points = calculate_coverage_points(
             radio_type,
             RadioThreshold::Verified,
             default_speedtests.clone(),
@@ -124,7 +122,6 @@ fn radios_with_coverage() {
         )
         .unwrap();
 
-        let coverage_points = calculate_coverage_points(&radio);
         assert_eq!(dec!(400), coverage_points.total_coverage_points);
     }
 }

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroU32, str::FromStr};
+use std::num::NonZeroU32;
 
 use chrono::Utc;
 use coverage_map::{RankedCoverage, SignalLevel};
@@ -32,13 +32,8 @@ fn base_radio_coverage_points() {
         trust_score: dec!(1.0),
     }];
 
-    let pubkey = helium_crypto::PublicKeyBinary::from_str(
-        "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6",
-    )
-    .unwrap();
-
     let hexes = vec![RankedCoverage {
-        hotspot_key: pubkey,
+        hotspot_key: vec![1],
         cbsd_id: None,
         hex: hextree::Cell::from_raw(0x8c2681a3064edff).unwrap(),
         rank: 1,
@@ -79,13 +74,8 @@ fn radios_with_coverage() {
     // Enough hexes will be provided to each type of radio, that they are
     // awarded 400 coverage points.
 
-    let pubkey = helium_crypto::PublicKeyBinary::from_str(
-        "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6",
-    )
-    .unwrap();
-
     let base_hex = RankedCoverage {
-        hotspot_key: pubkey,
+        hotspot_key: vec![1],
         cbsd_id: None,
         hex: hextree::Cell::from_raw(0x8c2681a3064edff).unwrap(),
         rank: 1,

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -3,10 +3,7 @@ use std::num::NonZeroU32;
 use chrono::Utc;
 use coverage_map::{RankedCoverage, SignalLevel};
 use coverage_point_calculator::{
-    calculate_coverage_points,
-    location::LocationTrust,
-    speedtest::{BytesPs, Speedtest},
-    RadioThreshold, RadioType,
+    calculate_coverage_points, BytesPs, LocationTrust, RadioThreshold, RadioType, Speedtest,
 };
 use hex_assignments::{assignment::HexAssignments, Assignment};
 use rust_decimal_macros::dec;

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use coverage_map::{RankedCoverage, SignalLevel};
 use coverage_point_calculator::{
     calculate_coverage_points,
-    location::{LocationTrust, Meters},
+    location::LocationTrust,
     speedtest::{BytesPs, Speedtest},
     RadioThreshold, RadioType, RewardableRadio,
 };
@@ -28,7 +28,7 @@ fn base_radio_coverage_points() {
         },
     ];
     let location_trust_scores = vec![LocationTrust {
-        distance_to_asserted: Meters::new(1),
+        meters_to_asserted: 1,
         trust_score: dec!(1.0),
     }];
 
@@ -104,7 +104,7 @@ fn radios_with_coverage() {
         },
     ];
     let default_location_trust_scores = vec![LocationTrust {
-        distance_to_asserted: Meters::new(1),
+        meters_to_asserted: 1,
         trust_score: dec!(1.0),
     }];
 

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -77,7 +77,7 @@ fn base_radio_coverage_points() {
         .into_iter()
         .map(|r| {
             (
-                r.radio_type,
+                r.radio_type(),
                 calculate_coverage_points(r).total_coverage_points,
             )
         })
@@ -169,7 +169,7 @@ fn radio_unique_coverage() {
         .into_iter()
         .map(|r| {
             (
-                r.radio_type,
+                r.radio_type(),
                 calculate_coverage_points(r).total_coverage_points,
             )
         })

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -5,7 +5,7 @@ use coverage_map::{RankedCoverage, SignalLevel};
 use coverage_point_calculator::{
     calculate_coverage_points,
     location::{LocationTrust, Meters},
-    speedtest::{BytesPs, Millis, Speedtest},
+    speedtest::{BytesPs, Speedtest},
     RadioThreshold, RadioType, RewardableRadio,
 };
 use hex_assignments::{assignment::HexAssignments, Assignment};
@@ -17,13 +17,13 @@ fn base_radio_coverage_points() {
         Speedtest {
             upload_speed: BytesPs::mbps(15),
             download_speed: BytesPs::mbps(150),
-            latency: Millis::new(15),
+            latency_millis: 15,
             timestamp: Utc::now(),
         },
         Speedtest {
             upload_speed: BytesPs::mbps(15),
             download_speed: BytesPs::mbps(150),
-            latency: Millis::new(15),
+            latency_millis: 15,
             timestamp: Utc::now(),
         },
     ];
@@ -93,13 +93,13 @@ fn radios_with_coverage() {
         Speedtest {
             upload_speed: BytesPs::mbps(15),
             download_speed: BytesPs::mbps(150),
-            latency: Millis::new(15),
+            latency_millis: 15,
             timestamp: Utc::now(),
         },
         Speedtest {
             upload_speed: BytesPs::mbps(15),
             download_speed: BytesPs::mbps(150),
-            latency: Millis::new(15),
+            latency_millis: 15,
             timestamp: Utc::now(),
         },
     ];

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -1,9 +1,10 @@
 use std::num::NonZeroU32;
 
 use chrono::Utc;
-use coverage_map::{RankedCoverage, SignalLevel};
+use coverage_map::{BoostedHexMap, RankedCoverage, SignalLevel, UnrankedCoverage};
 use coverage_point_calculator::{
-    BytesPs, CoveragePoints, LocationTrust, RadioThreshold, RadioType, Speedtest,
+    BytesPs, CoveragePoints, LocationTrust, RadioThreshold, RadioType, Result, Speedtest,
+    SpeedtestTier,
 };
 use hex_assignments::{assignment::HexAssignments, Assignment};
 use rust_decimal_macros::dec;
@@ -120,5 +121,346 @@ fn radios_with_coverage() {
         .unwrap();
 
         assert_eq!(dec!(400), coverage_points.total_coverage_points);
+    }
+}
+
+#[test]
+fn cbrs_with_mixed_signal_level_coverage() -> Result {
+    // Scenario One
+    let coverage_points = indoor_cbrs_radio(
+        SpeedtestTier::Good,
+        &[
+            top_ranked_coverage(0x8c2681a3064d9ff, SignalLevel::High),
+            top_ranked_coverage(0x8c2681a3065d3ff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a306635ff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a3066e7ff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a3065adff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a339a4bff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a3065d7ff, SignalLevel::Low),
+        ],
+    )?;
+
+    assert_eq!(dec!(250), coverage_points.reward_shares);
+
+    Ok(())
+}
+
+#[test]
+fn cbrs_with_partially_overlapping_coverage_and_differing_speedtests() -> Result {
+    // Scenario two
+    // Two radios, with a single overlapping hex and differing speedtest scores.
+    let radio_1 = indoor_cbrs_radio(
+        SpeedtestTier::Degraded,
+        &[
+            top_ranked_coverage(0x8c2681a3064d9ff, SignalLevel::High),
+            second_ranked_coverage(0x8c2681a3065d3ff, SignalLevel::Low), // This hex is shared
+            top_ranked_coverage(0x8c2681a306635ff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a3066e7ff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a3065adff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a339a4bff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a3065d7ff, SignalLevel::Low),
+        ],
+    )?;
+
+    let radio_2 = indoor_cbrs_radio(
+        SpeedtestTier::Good,
+        &[
+            top_ranked_coverage(0x8c2681a30641dff, SignalLevel::High),
+            top_ranked_coverage(0x8c2681a3065d3ff, SignalLevel::Low), // This hex is shared
+            top_ranked_coverage(0x8c2681a3066a9ff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a306607ff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a3066e9ff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a306481ff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a302991ff, SignalLevel::Low),
+        ],
+    )?;
+
+    assert_eq!(dec!(112.5), radio_1.reward_shares);
+    assert_eq!(dec!(250), radio_2.reward_shares);
+
+    Ok(())
+}
+
+#[test]
+fn cbrs_with_wholly_overlapping_coverage_and_differing_speedtests() -> Result {
+    // Scenario Three
+    // All radios cover the same hexes.
+    // Seniority timestamps determine rank.
+    // Only the first ranked radio (radio_4) should receive rewards.
+
+    let mut coverage_map_builder = coverage_map::CoverageMapBuilder::default();
+    let mut insert_coverage = |cbsd_id: &str, timestamp: &str| {
+        coverage_map_builder.insert_coverage_object(coverage_map::CoverageObject {
+            indoor: true,
+            hotspot_key: vec![],
+            cbsd_id: Some(cbsd_id.to_string()),
+            seniority_timestamp: timestamp.parse().expect("valid timestamp"),
+            coverage: vec![
+                unranked_coverage(0x8c2681a3064d9ff, SignalLevel::High),
+                unranked_coverage(0x8c2681a3065d3ff, SignalLevel::Low),
+                unranked_coverage(0x8c2681a306635ff, SignalLevel::Low),
+                unranked_coverage(0x8c2681a3066e7ff, SignalLevel::Low),
+                unranked_coverage(0x8c2681a3065adff, SignalLevel::Low),
+                unranked_coverage(0x8c2681a339a4bff, SignalLevel::Low),
+                unranked_coverage(0x8c2681a3065d7ff, SignalLevel::Low),
+            ],
+        })
+    };
+
+    insert_coverage("serial-1", "2022-02-01 00:00:00.000000000 UTC");
+    insert_coverage("serial-2", "2022-02-01 00:00:00.000000000 UTC");
+    insert_coverage("serial-3", "2022-02-01 00:00:00.000000000 UTC");
+    insert_coverage("serial-4", "2022-01-31 00:00:00.000000000 UTC"); // earliest
+    insert_coverage("serial-5", "2022-02-01 00:00:00.000000000 UTC");
+    insert_coverage("serial-6", "2022-02-02 00:00:00.000000000 UTC"); // latest
+
+    let map = coverage_map_builder.build(&NoBoostedHexes, Utc::now());
+
+    let radio_1 = indoor_cbrs_radio(SpeedtestTier::Poor, map.get_cbrs_coverage("serial-1"))?;
+    let radio_2 = indoor_cbrs_radio(SpeedtestTier::Poor, map.get_cbrs_coverage("serial-2"))?;
+    let radio_3 = indoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-3"))?;
+    let radio_4 = indoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-4"))?;
+    let radio_5 = indoor_cbrs_radio(SpeedtestTier::Fail, map.get_cbrs_coverage("serial-5"))?;
+    let radio_6 = indoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-6"))?;
+
+    assert_eq!(dec!(0), radio_1.reward_shares);
+    assert_eq!(dec!(0), radio_2.reward_shares);
+    assert_eq!(dec!(0), radio_3.reward_shares);
+    assert_eq!(dec!(250), radio_4.reward_shares);
+    assert_eq!(dec!(0), radio_5.reward_shares);
+    assert_eq!(dec!(0), radio_6.reward_shares);
+
+    Ok(())
+}
+
+#[test]
+fn cbrs_outdoor_with_mixed_signal_level_coverage() -> Result {
+    // Scenario four
+    // Outdoor Cbrs with mixed signal level coverage
+
+    let radio = CoveragePoints::new(
+        RadioType::OutdoorCbrs,
+        RadioThreshold::Verified,
+        speedtests(SpeedtestTier::Good),
+        vec![], // Location Trust is ignored for Cbrs
+        vec![
+            top_ranked_coverage(0x8c2681a3064d9ff, SignalLevel::High),
+            top_ranked_coverage(0x8c2681a3065d3ff, SignalLevel::High),
+            top_ranked_coverage(0x8c2681a306635ff, SignalLevel::Medium),
+            top_ranked_coverage(0x8c2681a3066e7ff, SignalLevel::Medium),
+            top_ranked_coverage(0x8c2681a3065adff, SignalLevel::Medium),
+            top_ranked_coverage(0x8c2681a339a4bff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a3065d7ff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a306481ff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a30648bff, SignalLevel::Low),
+            top_ranked_coverage(0x8c2681a30646bff, SignalLevel::Low),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(dec!(19), radio.reward_shares);
+
+    Ok(())
+}
+
+#[test]
+fn cbrs_outdoor_with_single_overlapping_coverage() -> Result {
+    // Scenario Five
+    // 2 radios overlapping a single hex with a medium Signal Level.
+    // First radio has seniority.
+
+    let mut coverage_map_builder = coverage_map::CoverageMapBuilder::default();
+
+    coverage_map_builder.insert_coverage_object(coverage_map::CoverageObject {
+        indoor: false,
+        hotspot_key: vec![1],
+        cbsd_id: Some("serial-1".to_string()),
+        seniority_timestamp: "2022-02-01 00:00:00.000000000 UTC"
+            .parse()
+            .expect("valid timestamp"),
+        coverage: vec![
+            unranked_coverage(0x8c2681a302991ff, SignalLevel::High),
+            unranked_coverage(0x8c2681a306601ff, SignalLevel::High),
+            unranked_coverage(0x8c2681a306697ff, SignalLevel::High),
+            unranked_coverage(0x8c2681a3028a7ff, SignalLevel::Medium), // This hex is shared
+            unranked_coverage(0x8c2681a3064c1ff, SignalLevel::Medium),
+            unranked_coverage(0x8c2681a30671bff, SignalLevel::Low),
+            unranked_coverage(0x8c2681a306493ff, SignalLevel::Low),
+            unranked_coverage(0x8c2681a30659dff, SignalLevel::Low),
+        ],
+    });
+    coverage_map_builder.insert_coverage_object(coverage_map::CoverageObject {
+        indoor: false,
+        hotspot_key: vec![2],
+        cbsd_id: Some("serial-2".to_string()),
+        seniority_timestamp: "2022-02-01 00:00:01.000000000 UTC"
+            .parse()
+            .expect("valid timestamp"),
+        coverage: vec![
+            unranked_coverage(0x8c2681a3066abff, SignalLevel::High),
+            unranked_coverage(0x8c2681a3028a7ff, SignalLevel::Medium), // This hex is shared
+            unranked_coverage(0x8c2681a3066a9ff, SignalLevel::Low),
+            unranked_coverage(0x8c2681a3066a5ff, SignalLevel::Low),
+            unranked_coverage(0x8c2681a30640dff, SignalLevel::Low),
+        ],
+    });
+
+    let map = coverage_map_builder.build(&NoBoostedHexes, Utc::now());
+
+    let radio_1 = outdoor_cbrs_radio(SpeedtestTier::Degraded, map.get_cbrs_coverage("serial-1"))?;
+    let radio_2 = outdoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-2"))?;
+
+    assert_eq!(dec!(19) * dec!(0.5), radio_1.reward_shares);
+    assert_eq!(dec!(8), radio_2.reward_shares);
+
+    Ok(())
+}
+
+#[test]
+fn cbrs_indoor_with_wholly_overlapping_coverage_and_no_failing_speedtests() -> Result {
+    // Scenario Six
+    // Similar to Scenario Three, but there are no failing speedtests.
+    // Radios have the same coverage.
+
+    let mut coverage_map_builder = coverage_map::CoverageMapBuilder::default();
+    let mut insert_coverage = |cbsd_id: &str, timestamp: &str| {
+        coverage_map_builder.insert_coverage_object(coverage_map::CoverageObject {
+            indoor: true,
+            hotspot_key: vec![0],
+            cbsd_id: Some(cbsd_id.to_string()),
+            seniority_timestamp: timestamp.parse().expect("valid timestamp"),
+            coverage: vec![
+                unranked_coverage(0x8c2681a3064d9ff, SignalLevel::High),
+                unranked_coverage(0x8c2681a3065d3ff, SignalLevel::Low),
+                unranked_coverage(0x8c2681a306635ff, SignalLevel::Low),
+                unranked_coverage(0x8c2681a3066e7ff, SignalLevel::Low),
+                unranked_coverage(0x8c2681a3065adff, SignalLevel::Low),
+                unranked_coverage(0x8c2681a339a4bff, SignalLevel::Low),
+                unranked_coverage(0x8c2681a3065d7ff, SignalLevel::Low),
+            ],
+        })
+    };
+
+    insert_coverage("serial-1", "2022-02-01 00:00:00.000000000 UTC");
+    insert_coverage("serial-2", "2022-01-31 00:00:00.000000000 UTC"); // Oldest
+    insert_coverage("serial-3", "2022-02-01 00:00:00.000000000 UTC");
+    insert_coverage("serial-4", "2022-02-01 00:00:00.000000000 UTC");
+    insert_coverage("serial-5", "2022-02-01 00:00:00.000000000 UTC");
+    insert_coverage("serial-6", "2022-02-02 00:00:00.000000000 UTC"); // Newest
+    let map = coverage_map_builder.build(&NoBoostedHexes, Utc::now());
+
+    let radio_1 = indoor_cbrs_radio(SpeedtestTier::Poor, map.get_cbrs_coverage("serial-1"))?;
+    let radio_2 = indoor_cbrs_radio(SpeedtestTier::Poor, map.get_cbrs_coverage("serial-2"))?;
+    let radio_3 = indoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-3"))?;
+    let radio_4 = indoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-4"))?;
+    let radio_5 = indoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-5"))?;
+    let radio_6 = indoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-6"))?;
+
+    assert_eq!(dec!(0), radio_1.reward_shares);
+    assert_eq!(dec!(62.5), radio_2.reward_shares);
+    assert_eq!(dec!(0), radio_3.reward_shares);
+    assert_eq!(dec!(0), radio_4.reward_shares);
+    assert_eq!(dec!(0), radio_5.reward_shares);
+    assert_eq!(dec!(0), radio_6.reward_shares);
+
+    Ok(())
+}
+
+fn indoor_cbrs_radio(
+    speedtest_tier: SpeedtestTier,
+    coverage: &[RankedCoverage],
+) -> Result<CoveragePoints> {
+    CoveragePoints::new(
+        RadioType::IndoorCbrs,
+        RadioThreshold::Verified,
+        speedtests(speedtest_tier),
+        vec![],
+        coverage.to_owned(),
+    )
+}
+
+fn outdoor_cbrs_radio(
+    speedtest_tier: SpeedtestTier,
+    coverage: &[RankedCoverage],
+) -> Result<CoveragePoints> {
+    CoveragePoints::new(
+        RadioType::OutdoorCbrs,
+        RadioThreshold::Verified,
+        speedtests(speedtest_tier),
+        vec![],
+        coverage.to_owned(),
+    )
+}
+
+struct NoBoostedHexes;
+impl BoostedHexMap for NoBoostedHexes {
+    fn get_current_multiplier(
+        &self,
+        _cell: hextree::Cell,
+        _ts: chrono::DateTime<Utc>,
+    ) -> Option<NonZeroU32> {
+        None
+    }
+}
+
+fn speedtests(tier: SpeedtestTier) -> Vec<Speedtest> {
+    let upload_speed = BytesPs::mbps(match tier {
+        SpeedtestTier::Good => 10,
+        SpeedtestTier::Acceptable => 8,
+        SpeedtestTier::Degraded => 5,
+        SpeedtestTier::Poor => 2,
+        SpeedtestTier::Fail => 0,
+    });
+
+    vec![
+        Speedtest {
+            upload_speed: upload_speed.clone(),
+            download_speed: BytesPs::mbps(150),
+            latency_millis: 0,
+            timestamp: Utc::now(),
+        },
+        Speedtest {
+            upload_speed: upload_speed.clone(),
+            download_speed: BytesPs::mbps(150),
+            latency_millis: 0,
+            timestamp: Utc::now(),
+        },
+    ]
+}
+
+fn top_ranked_coverage(hex: u64, signal_level: SignalLevel) -> RankedCoverage {
+    ranked_coverage(hex, 1, signal_level)
+}
+
+fn second_ranked_coverage(hex: u64, signal_level: SignalLevel) -> RankedCoverage {
+    ranked_coverage(hex, 2, signal_level)
+}
+
+fn ranked_coverage(hex: u64, rank: usize, signal_level: SignalLevel) -> RankedCoverage {
+    RankedCoverage {
+        hex: hextree::Cell::from_raw(hex).expect("valid h3 hex"),
+        rank,
+        hotspot_key: vec![1],
+        cbsd_id: Some("serial".to_string()),
+        assignments: HexAssignments {
+            footfall: Assignment::A,
+            landtype: Assignment::A,
+            urbanized: Assignment::A,
+        },
+        boosted: None,
+        signal_level,
+    }
+}
+
+fn unranked_coverage(hex: u64, signal_level: SignalLevel) -> UnrankedCoverage {
+    UnrankedCoverage {
+        location: hextree::Cell::from_raw(hex).expect("valid h3 hex"),
+        signal_power: 42,
+        signal_level,
+        assignments: HexAssignments {
+            footfall: Assignment::A,
+            landtype: Assignment::A,
+            urbanized: Assignment::A,
+        },
     }
 }

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -61,7 +61,7 @@ fn base_radio_coverage_points() {
         )
         .unwrap();
 
-        let coverage_points = calculate_coverage_points(radio);
+        let coverage_points = calculate_coverage_points(&radio);
         assert_eq!(
             expcted_base_coverage_point,
             coverage_points.total_coverage_points
@@ -123,7 +123,7 @@ fn radios_with_coverage() {
         )
         .unwrap();
 
-        let coverage_points = calculate_coverage_points(radio);
+        let coverage_points = calculate_coverage_points(&radio);
         assert_eq!(dec!(400), coverage_points.total_coverage_points);
     }
 }

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -55,9 +55,9 @@ fn base_radio_coverage_points() {
     ] {
         let radio = make_rewardable_radio(
             radio_type,
+            RadioThreshold::Verified,
             speedtests.clone(),
             location_trust_scores.clone(),
-            RadioThreshold::Verified,
             hexes.clone(),
         )
         .unwrap();
@@ -117,9 +117,9 @@ fn radios_with_coverage() {
     ] {
         let radio = make_rewardable_radio(
             radio_type,
+            RadioThreshold::Verified,
             default_speedtests.clone(),
             default_location_trust_scores.clone(),
-            RadioThreshold::Verified,
             base_hex_iter.clone().take(num_hexes).collect(),
         )
         .unwrap();

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroU32;
 use chrono::Utc;
 use coverage_map::{RankedCoverage, SignalLevel};
 use coverage_point_calculator::{
-    calculate_coverage_points, BytesPs, LocationTrust, RadioThreshold, RadioType, Speedtest,
+    BytesPs, CoveragePoints, LocationTrust, RadioThreshold, RadioType, Speedtest,
 };
 use hex_assignments::{assignment::HexAssignments, Assignment};
 use rust_decimal_macros::dec;
@@ -49,7 +49,7 @@ fn base_radio_coverage_points() {
         (RadioType::OutdoorWifi, dec!(16)),
         (RadioType::OutdoorCbrs, dec!(4)),
     ] {
-        let coverage_points = calculate_coverage_points(
+        let coverage_points = CoveragePoints::new(
             radio_type,
             RadioThreshold::Verified,
             speedtests.clone(),
@@ -110,7 +110,7 @@ fn radios_with_coverage() {
         (RadioType::OutdoorWifi, 25),
         (RadioType::OutdoorCbrs, 100),
     ] {
-        let coverage_points = calculate_coverage_points(
+        let coverage_points = CoveragePoints::new(
             radio_type,
             RadioThreshold::Verified,
             default_speedtests.clone(),

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, num::NonZeroU32, str::FromStr};
 
+use chrono::Utc;
 use coverage_map::{RankedCoverage, SignalLevel};
 use coverage_point_calculator::{
     calculate_coverage_points,
@@ -17,11 +18,13 @@ fn base_radio_coverage_points() {
             upload_speed: BytesPs::mbps(15),
             download_speed: BytesPs::mbps(150),
             latency: Millis::new(15),
+            timestamp: Utc::now(),
         },
         Speedtest {
             upload_speed: BytesPs::mbps(15),
             download_speed: BytesPs::mbps(150),
             latency: Millis::new(15),
+            timestamp: Utc::now(),
         },
     ];
     let location_trust_scores = vec![LocationTrust {
@@ -66,13 +69,18 @@ fn base_radio_coverage_points() {
         radios.push(radio.clone());
         println!(
             "{radio_type:?} \t--> {}",
-            calculate_coverage_points(radio).coverage_points
+            calculate_coverage_points(radio).total_coverage_points
         );
     }
 
     let output = radios
         .into_iter()
-        .map(|r| (r.radio_type, calculate_coverage_points(r).coverage_points))
+        .map(|r| {
+            (
+                r.radio_type,
+                calculate_coverage_points(r).total_coverage_points,
+            )
+        })
         .collect::<Vec<_>>();
     println!("{output:#?}");
 }
@@ -124,11 +132,13 @@ fn radio_unique_coverage() {
             upload_speed: BytesPs::mbps(15),
             download_speed: BytesPs::mbps(150),
             latency: Millis::new(15),
+            timestamp: Utc::now(),
         },
         Speedtest {
             upload_speed: BytesPs::mbps(15),
             download_speed: BytesPs::mbps(150),
             latency: Millis::new(15),
+            timestamp: Utc::now(),
         },
     ];
     let default_location_trust_scores = vec![LocationTrust {
@@ -157,7 +167,12 @@ fn radio_unique_coverage() {
 
     let coverage_points = radios
         .into_iter()
-        .map(|r| (r.radio_type, calculate_coverage_points(r).coverage_points))
+        .map(|r| {
+            (
+                r.radio_type,
+                calculate_coverage_points(r).total_coverage_points,
+            )
+        })
         .collect::<Vec<_>>();
     println!("{coverage_points:#?}")
 }

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -5,8 +5,9 @@ use coverage_map::{RankedCoverage, SignalLevel};
 use coverage_point_calculator::{
     calculate_coverage_points,
     location::LocationTrust,
+    make_rewardable_radio,
     speedtest::{BytesPs, Speedtest},
-    RadioThreshold, RadioType, RewardableRadio,
+    RadioThreshold, RadioType,
 };
 use hex_assignments::{assignment::HexAssignments, Assignment};
 use rust_decimal_macros::dec;
@@ -52,7 +53,7 @@ fn base_radio_coverage_points() {
         (RadioType::OutdoorWifi, dec!(16)),
         (RadioType::OutdoorCbrs, dec!(4)),
     ] {
-        let radio = RewardableRadio::new(
+        let radio = make_rewardable_radio(
             radio_type,
             speedtests.clone(),
             location_trust_scores.clone(),
@@ -114,7 +115,7 @@ fn radios_with_coverage() {
         (RadioType::OutdoorWifi, 25),
         (RadioType::OutdoorCbrs, 100),
     ] {
-        let radio = RewardableRadio::new(
+        let radio = make_rewardable_radio(
             radio_type,
             default_speedtests.clone(),
             default_location_trust_scores.clone(),

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -404,6 +404,8 @@ impl BoostedHexMap for NoBoostedHexes {
 }
 
 fn speedtests(tier: SpeedtestTier) -> Vec<Speedtest> {
+    // SpeedtestTier is determined solely by upload_speed.
+    // Other values are far surpassing ::Good.
     let upload_speed = BytesPs::mbps(match tier {
         SpeedtestTier::Good => 10,
         SpeedtestTier::Acceptable => 8,
@@ -414,13 +416,13 @@ fn speedtests(tier: SpeedtestTier) -> Vec<Speedtest> {
 
     vec![
         Speedtest {
-            upload_speed: upload_speed.clone(),
+            upload_speed,
             download_speed: BytesPs::mbps(150),
             latency_millis: 0,
             timestamp: Utc::now(),
         },
         Speedtest {
-            upload_speed: upload_speed.clone(),
+            upload_speed,
             download_speed: BytesPs::mbps(150),
             latency_millis: 0,
             timestamp: Utc::now(),


### PR DESCRIPTION
Many changes to the rewards algorithm are contained in and across many HIPs. The blog post [MOBILE Proof of Coverage][mobile-poc-blog] contains a more thorough explanation of many of them. It is not exhaustive, but a great place to start.

Please comment if...
- You think something can be named more appropriately
- You have tests you'd like to see
- You think something is important and we should try to make it less hidden
- You can provide additional context to some part of how scores are calculated
- Saying hi
- You think more explanation could be provided to someone perusing the code
- You feel like

## Example Usage
```rs
type RadioId = (PublicKeyBinary, Some(String));

pub async fn coverage_points(
    &mut self,
    radio_id: &RadioId,
) -> anyhow::Result<coverage_point_calculator::CoveragePoints> {
    let pubkey = &radio_id.0;
    let average = self.speedtest_averages.get_average(pubkey).unwrap();
    let speedtests = self.speedtests.get(&radio_id).expect("speedtests").clone();
    let radio_type = self.radio_type(&radio_id);
    let trust_scores = self
        .trust_scores
        .get(&radio_id)
        .expect("trust scores")
        .clone();
    let verified = self.radio_threshold_verified(&radio_id);
    let ranked_coverage = self.coverage_map.hexes(&radio_id);

    let coverage_points = coverage_point_calculator::CoveragePoints::new(
        radio_type,
        RadioThreshold::Verified,
        speedtests,
        location_trust_scores,
        ranked_coverage,
    )?;

    Ok(coverage_points)
}
```

## Fields:
- `CoveredHex::base_coverage_points`
  - [HIP-74][modeled-coverage]
  - reduced cbrs radio coverage points [HIP-113][cbrs-experimental]
- `CoveredHex::assignment_multiplier`
  - [HIP-103][oracle-boosting]
- `CoveredHex::rank`
  - [HIP-105][hex-limits]
- `CoveredHex::boosted_multiplier`
  - must meet minimum subscriber thresholds [HIP-84][provider-boosting]
  - Wifi Location trust score >0.75 for boosted hex eligibility [HIP-93][wifi-aps]
- `CoveragePoints::location_trust_multiplier`
  - [HIP-98][qos-score]
  - states 30m requirement for boosted hexes [HIP-107][prevent-gaming]
  - increase Boosted hex restriction, 30m -> 50m [Pull Request][boosted-hex-restriction]
- `CoveragePoints::speedtest_multiplier`
  - [HIP-74][modeled-coverage]
  - added "Good" speedtest tier [HIP-98][qos-score]
    - latency is explicitly under limit in HIP <https://github.com/helium/oracles/pull/737>

## Notable Conditions:
- Location
  - If a Radio covers any boosted hexes, `LocationTrust` scores must meet distance requirements, or be degraded.
  - CBRS Radio's location is always trusted because of GPS.
- Speedtests
  - The latest 6 speedtests will be used.
  - There must be more than 2 speedtests.
- Covered Hexes
  - If a Radio is not `BoostedHexStatus::Eligible`, boost values are removed before calculations.

[modeled-coverage]:        https://github.com/helium/HIP/blob/main/0074-mobile-poc-modeled-coverage-rewards.md#outdoor-radios
[provider-boosting]:       https://github.com/helium/HIP/blob/main/0084-service-provider-hex-boosting.md
[wifi-aps]:                https://github.com/helium/HIP/blob/main/0093-addition-of-wifi-aps-to-mobile-subdao.md
[qos-score]:               https://github.com/helium/HIP/blob/main/0098-mobile-subdao-quality-of-service-requirements.md
[oracle-boosting]:         https://github.com/helium/HIP/blob/main/0103-oracle-hex-boosting.md
[hex-limits]:              https://github.com/helium/HIP/blob/main/0105-modification-of-mobile-subdao-hex-limits.md
[prevent-gaming]:          https://github.com/helium/HIP/blob/main/0107-preventing-gaming-within-the-mobile-network.md
[cbrs-experimental]:       https://github.com/helium/HIP/blob/main/0113-reward-cbrs-as-experimental.md
[mobile-poc-blog]:         https://docs.helium.com/mobile/proof-of-coverage
[boosted-hex-restriction]: https://github.com/helium/oracles/pull/808