### PR TITLE
Change coverage map to treat hotspot_key as bytes rather than a PublicKeyBinary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,11 +2126,8 @@ name = "coverage-map"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "h3o",
- "helium-proto",
  "hex-assignments",
  "hextree",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,7 +2127,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "h3o",
- "helium-crypto",
  "helium-proto",
  "hex-assignments",
  "hextree",

--- a/coverage_map/Cargo.toml
+++ b/coverage_map/Cargo.toml
@@ -10,7 +10,6 @@ edition.workspace = true
 [dependencies]
 chrono = { workspace = true }
 h3o = { workspace = true }
-helium-crypto = { workspace = true }
 helium-proto = { workspace = true }
 hex-assignments = { path = "../hex_assignments" }
 hextree = { workspace = true }

--- a/coverage_map/Cargo.toml
+++ b/coverage_map/Cargo.toml
@@ -9,8 +9,5 @@ edition.workspace = true
 
 [dependencies]
 chrono = { workspace = true }
-h3o = { workspace = true }
-helium-proto = { workspace = true }
 hex-assignments = { path = "../hex_assignments" }
 hextree = { workspace = true }
-uuid = { workspace = true }

--- a/coverage_map/src/indoor.rs
+++ b/coverage_map/src/indoor.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use helium_crypto::PublicKeyBinary;
 use hex_assignments::assignment::HexAssignments;
 use hextree::Cell;
 
@@ -14,7 +13,7 @@ pub type IndoorCellTree = HashMap<Cell, BTreeMap<SignalLevel, BinaryHeap<IndoorC
 
 #[derive(Eq, Debug, Clone)]
 pub struct IndoorCoverageLevel {
-    hotspot_key: PublicKeyBinary,
+    hotspot_key: Vec<u8>,
     cbsd_id: Option<String>,
     seniority_timestamp: DateTime<Utc>,
     signal_level: SignalLevel,
@@ -53,7 +52,7 @@ pub fn insert_indoor_coverage_object(indoor: &mut IndoorCellTree, coverage_objec
 
 pub fn insert_indoor_coverage(
     indoor: &mut IndoorCellTree,
-    hotspot: &PublicKeyBinary,
+    hotspot: &[u8],
     cbsd_id: &Option<String>,
     seniority_timestamp: DateTime<Utc>,
     hex_coverage: UnrankedCoverage,
@@ -64,7 +63,7 @@ pub fn insert_indoor_coverage(
         .entry(hex_coverage.signal_level)
         .or_default()
         .push(IndoorCoverageLevel {
-            hotspot_key: hotspot.clone(),
+            hotspot_key: hotspot.to_vec(),
             cbsd_id: cbsd_id.clone(),
             seniority_timestamp,
             signal_level: hex_coverage.signal_level,
@@ -234,12 +233,9 @@ mod test {
     }
 
     fn indoor_cbrs_coverage(cbsd_id: &str, signal_level: SignalLevel) -> CoverageObject {
-        let owner: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
-            .parse()
-            .expect("failed owner parse");
         CoverageObject {
             indoor: true,
-            hotspot_key: owner,
+            hotspot_key: vec![1, 0],
             seniority_timestamp: Utc::now(),
             cbsd_id: Some(cbsd_id.to_string()),
             coverage: vec![UnrankedCoverage {
@@ -256,12 +252,9 @@ mod test {
         signal_level: SignalLevel,
         seniority_timestamp: DateTime<Utc>,
     ) -> CoverageObject {
-        let owner: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
-            .parse()
-            .expect("failed owner parse");
         CoverageObject {
             indoor: true,
-            hotspot_key: owner,
+            hotspot_key: vec![1, 0],
             seniority_timestamp,
             cbsd_id: Some(cbsd_id.to_string()),
             coverage: vec![UnrankedCoverage {
@@ -278,12 +271,9 @@ mod test {
         location: Cell,
         seniority_timestamp: DateTime<Utc>,
     ) -> CoverageObject {
-        let owner: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
-            .parse()
-            .expect("failed owner parse");
         CoverageObject {
             indoor: true,
-            hotspot_key: owner,
+            hotspot_key: vec![1, 0],
             seniority_timestamp,
             cbsd_id: Some(cbsd_id.to_string()),
             coverage: vec![UnrankedCoverage {

--- a/coverage_map/src/outdoor.rs
+++ b/coverage_map/src/outdoor.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use helium_crypto::PublicKeyBinary;
 use hex_assignments::assignment::HexAssignments;
 use hextree::Cell;
 
@@ -15,7 +14,7 @@ pub type OutdoorCellTree = HashMap<Cell, BinaryHeap<OutdoorCoverageLevel>>;
 
 #[derive(Eq, Debug, Clone)]
 pub struct OutdoorCoverageLevel {
-    hotspot_key: PublicKeyBinary,
+    hotspot_key: Vec<u8>,
     cbsd_id: Option<String>,
     seniority_timestamp: DateTime<Utc>,
     signal_power: i32,
@@ -62,7 +61,7 @@ pub fn insert_outdoor_coverage_object(
 
 pub fn insert_outdoor_coverage(
     outdoor: &mut OutdoorCellTree,
-    hotspot: &PublicKeyBinary,
+    hotspot: &[u8],
     cbsd_id: &Option<String>,
     seniority_timestamp: DateTime<Utc>,
     hex_coverage: UnrankedCoverage,
@@ -71,7 +70,7 @@ pub fn insert_outdoor_coverage(
         .entry(hex_coverage.location)
         .or_default()
         .push(OutdoorCoverageLevel {
-            hotspot_key: hotspot.clone(),
+            hotspot_key: hotspot.to_vec(),
             cbsd_id: cbsd_id.clone(),
             seniority_timestamp,
             signal_level: hex_coverage.signal_level,
@@ -171,12 +170,9 @@ mod test {
         signal_power: i32,
         seniority_timestamp: DateTime<Utc>,
     ) -> CoverageObject {
-        let owner: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
-            .parse()
-            .expect("failed owner parse");
         CoverageObject {
             indoor: false,
-            hotspot_key: owner,
+            hotspot_key: vec![0, 0],
             seniority_timestamp,
             cbsd_id: Some(cbsd_id.to_string()),
             coverage: vec![UnrankedCoverage {


### PR DESCRIPTION
In an effort to keep this crate simple and the deps small, refactored to treat the hotspot_key as just a bag of bytes rather than a PublicKeyBinary.