### PR TITLE
Add `coverage-map` and `coverage-point-calculator` to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,7 +136,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [file-store,ingest,mobile-packet-verifier,reward-scheduler,task-manager]
+        package: [coverage-map,coverage-point-calculator,file-store,ingest,mobile-packet-verifier,reward-scheduler,task-manager]
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}-tests-${{ matrix.package }}
       cancel-in-progress: true

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -392,7 +392,7 @@ mod tests {
     }
 
     #[test]
-    fn speedtests_effect_coverage_points() {
+    fn speedtests_effect_reward_shares() {
         let calculate_indoor_cbrs = |speedtests: Vec<Speedtest>| {
             CoveragePoints::new(
                 RadioType::IndoorCbrs,
@@ -419,7 +419,7 @@ mod tests {
         let indoor_cbrs = calculate_indoor_cbrs(speedtest_maximum());
         assert_eq!(
             base_coverage_points * SpeedtestTier::Good.multiplier(),
-            indoor_cbrs.total_coverage_points
+            indoor_cbrs.reward_shares
         );
 
         let indoor_cbrs = calculate_indoor_cbrs(vec![
@@ -428,7 +428,7 @@ mod tests {
         ]);
         assert_eq!(
             base_coverage_points * SpeedtestTier::Acceptable.multiplier(),
-            indoor_cbrs.total_coverage_points
+            indoor_cbrs.reward_shares
         );
 
         let indoor_cbrs = calculate_indoor_cbrs(vec![
@@ -437,7 +437,7 @@ mod tests {
         ]);
         assert_eq!(
             base_coverage_points * SpeedtestTier::Degraded.multiplier(),
-            indoor_cbrs.total_coverage_points
+            indoor_cbrs.reward_shares
         );
 
         let indoor_cbrs = calculate_indoor_cbrs(vec![
@@ -446,7 +446,7 @@ mod tests {
         ]);
         assert_eq!(
             base_coverage_points * SpeedtestTier::Poor.multiplier(),
-            indoor_cbrs.total_coverage_points
+            indoor_cbrs.reward_shares
         );
 
         let indoor_cbrs = calculate_indoor_cbrs(vec![
@@ -455,7 +455,7 @@ mod tests {
         ]);
         assert_eq!(
             base_coverage_points * SpeedtestTier::Fail.multiplier(),
-            indoor_cbrs.total_coverage_points
+            indoor_cbrs.reward_shares
         );
     }
 


### PR DESCRIPTION
We forgot to include new crates in the CI yaml.

`coverage-map` https://github.com/helium/oracles/pull/819
`coverage-point-calculator` https://github.com/helium/oracles/pull/824