### PR TITLE
HIP-122 restrict boosting from poc bucket

### DIFF
--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -8,16 +8,19 @@ use crate::{BoostedHexStatus, RadioType, Result};
 /// Breakdown of points for a hex.
 ///
 /// Example:
-///   Outdoor Wifi with 1-hex boosted 5x,
-///   Rank 2, Assignment AAA:
-///     SplitPoints {
-///       modeled: 16,
-///       base: 8,
-///       boosted: 32
-///     }
-///
-///   Rank 2 splits modeled points in half.
-///   Boost at 5x adds 32 points ( (8 * 5) - 8 )
+/// - Outdoor Wifi
+/// - 1 hex boosted at `5x`
+/// - Rank 2
+/// - Assignment: `AAA`
+/// <pre>
+/// SplitPoints {
+///   modeled: 16,
+///   base: 8,
+///   boosted: 32
+/// }
+/// </pre>
+/// Rank 2 splits modeled points in half.
+/// Boost at `5x` adds 32 points `( (8 * 5) - 8 )`
 #[derive(Debug, Default, Clone)]
 pub struct HexPoints {
     /// Default points received for hex

--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -26,7 +26,10 @@ pub struct HexPoints {
     /// Default points received for hex
     ///
     /// (RadioType, SignalLevel) points
-    pub modeled: Decimal,
+    ///
+    /// This is a convenience field for debugging, hexes can reach similar
+    /// values through different means, it helps to know the starting value.
+    modeled: Decimal,
     /// Points including Coverage affected multipliers
     ///
     /// modeled + (Rank * Assignment)

--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -5,13 +5,46 @@ use rust_decimal_macros::dec;
 
 use crate::{BoostedHexStatus, RadioType, Result};
 
+/// Breakdown of points for a hex.
+///
+/// Example:
+///   Outdoor Wifi with 1-hex boosted 5x,
+///   Rank 2, Assignment AAA:
+///     SplitPoints {
+///       modeled: 16,
+///       base: 8,
+///       boosted: 32
+///     }
+///
+///   Rank 2 splits modeled points in half.
+///   Boost at 5x adds 32 points ( (8 * 5) - 8 )
+#[derive(Debug, Default, Clone)]
+pub struct HexPoints {
+    /// Default points received for hex
+    ///
+    /// (RadioType, SignalLevel) points
+    modeled: Decimal,
+    /// Points including Coverage affected multipliers
+    ///
+    /// modeled + (Rank * Assignment)
+    base: Decimal,
+    /// Points _over_ normal received from hex boosting.
+    ///
+    /// (base * Boost multiplier) - base
+    boosted: Decimal,
+}
+
+impl HexPoints {
+    pub(crate) fn total_coverage_points(&self) -> Decimal {
+        self.base + self.boosted
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct CoveredHex {
     pub hex: hextree::Cell,
-    /// Default points received from (RadioType, SignalLevel) pair.
-    pub base_coverage_points: Decimal,
-    /// Coverage points including assignment, rank, and boosted hex multipliers.
-    pub calculated_coverage_points: Decimal,
+    /// Breakdown of points for a hex
+    pub points: HexPoints,
     /// Oracle boosted Assignments
     pub assignments: HexAssignments,
     pub assignment_multiplier: Decimal,
@@ -32,7 +65,7 @@ pub(crate) fn clean_covered_hexes(
     let covered_hexes = ranked_coverage
         .into_iter()
         .map(|ranked| {
-            let base_coverage_points = radio_type.base_coverage_points(&ranked.signal_level)?;
+            let modeled_coverage_points = radio_type.base_coverage_points(&ranked.signal_level)?;
             let rank_multiplier = radio_type.rank_multiplier(ranked.rank);
 
             let boosted_multiplier = if boosted_hex_status.is_eligible() {
@@ -49,15 +82,23 @@ pub(crate) fn clean_covered_hexes(
                 ranked.assignments.boosting_multiplier()
             };
 
-            let calculated_coverage_points = base_coverage_points
+            let base_coverage_points =
+                modeled_coverage_points * assignment_multiplier * rank_multiplier;
+
+            let calculated_coverage_points = modeled_coverage_points
                 * assignment_multiplier
                 * rank_multiplier
                 * boosted_multiplier.unwrap_or(dec!(1));
 
+            let boosted_coverage_points = calculated_coverage_points - base_coverage_points;
+
             Ok(CoveredHex {
                 hex: ranked.hex,
-                base_coverage_points,
-                calculated_coverage_points,
+                points: HexPoints {
+                    modeled: modeled_coverage_points,
+                    base: base_coverage_points,
+                    boosted: boosted_coverage_points,
+                },
                 assignments: ranked.assignments,
                 assignment_multiplier,
                 rank: ranked.rank,
@@ -70,11 +111,14 @@ pub(crate) fn clean_covered_hexes(
     Ok(covered_hexes)
 }
 
-pub(crate) fn calculated_coverage_points(covered_hexes: &[CoveredHex]) -> Decimal {
+pub(crate) fn calculated_coverage_points(covered_hexes: &[CoveredHex]) -> HexPoints {
     covered_hexes
         .iter()
-        .map(|hex| hex.calculated_coverage_points)
-        .sum()
+        .fold(HexPoints::default(), |acc, hex| HexPoints {
+            modeled: acc.modeled + hex.points.modeled,
+            base: acc.base + hex.points.base,
+            boosted: acc.boosted + hex.points.boosted,
+        })
 }
 
 #[cfg(test)]

--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -26,15 +26,15 @@ pub struct HexPoints {
     /// Default points received for hex
     ///
     /// (RadioType, SignalLevel) points
-    pub(crate) modeled: Decimal,
+    pub modeled: Decimal,
     /// Points including Coverage affected multipliers
     ///
     /// modeled + (Rank * Assignment)
-    pub(crate) base: Decimal,
+    pub base: Decimal,
     /// Points _over_ normal received from hex boosting.
     ///
     /// (base * Boost multiplier) - base
-    pub(crate) boosted: Decimal,
+    pub boosted: Decimal,
 }
 
 #[derive(Debug, Clone)]

--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -23,21 +23,15 @@ pub struct HexPoints {
     /// Default points received for hex
     ///
     /// (RadioType, SignalLevel) points
-    modeled: Decimal,
+    pub(crate) modeled: Decimal,
     /// Points including Coverage affected multipliers
     ///
     /// modeled + (Rank * Assignment)
-    base: Decimal,
+    pub(crate) base: Decimal,
     /// Points _over_ normal received from hex boosting.
     ///
     /// (base * Boost multiplier) - base
-    boosted: Decimal,
-}
-
-impl HexPoints {
-    pub(crate) fn total_coverage_points(&self) -> Decimal {
-        self.base + self.boosted
-    }
+    pub(crate) boosted: Decimal,
 }
 
 #[derive(Debug, Clone)]

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -106,8 +106,8 @@ pub fn calculate_reward_shares<'a>(
         |(total, boosted, poc), radio| {
             (
                 total + radio.total_points(),
-                boosted + radio.boosted_points(),
-                poc + radio.coverage_points(),
+                boosted + radio.total_boosted_points(),
+                poc + radio.total_base_points(),
             )
         },
     );
@@ -117,9 +117,9 @@ pub fn calculate_reward_shares<'a>(
     }
 
     let shares_per_point = allocated_rewards.total() / total_points;
+    let boost_within_limit = allocated_rewards.boost_rewards >= shares_per_point * boost_points;
 
-    if allocated_rewards.boost_rewards >= shares_per_point * boost_points {
-        // Within boosted reward limit, use the already calculated shares ratio
+    if boost_within_limit {
         Ok(CalculatedRewardShares {
             normal: shares_per_point,
             boost: shares_per_point,
@@ -217,7 +217,7 @@ impl CoveragePoints {
     /// Accumulated points related to entire radio.
     /// coverage points * speedtest
     pub fn total_points(&self) -> Decimal {
-        self.coverage_points() * self.speedtest_multiplier
+        self.total_base_points() + self.total_boosted_points()
     }
 
     pub fn total_base_points(&self) -> Decimal {

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -74,63 +74,6 @@ pub type Result<T = ()> = std::result::Result<T, Error>;
 pub enum Error {
     #[error("signal level {0:?} not allowed for {1:?}")]
     InvalidSignalLevel(SignalLevel, RadioType),
-    #[error("No points to calculate reward shares")]
-    NoPoints,
-}
-
-#[derive(Debug)]
-pub struct AllocatedRewardShares {
-    pub poc_rewards: Decimal,
-    pub boost_rewards: Decimal,
-    pub extra_rewards: Decimal,
-}
-
-impl AllocatedRewardShares {
-    fn total(&self) -> Decimal {
-        self.poc_rewards + self.boost_rewards + self.extra_rewards
-    }
-}
-
-#[derive(Debug)]
-pub struct CalculatedRewardShares {
-    pub normal: Decimal,
-    pub boost: Decimal,
-}
-
-pub fn calculate_reward_shares<'a>(
-    allocated_rewards: AllocatedRewardShares,
-    radios: impl Iterator<Item = &'a CoveragePoints>,
-) -> Result<CalculatedRewardShares> {
-    let (total_points, boost_points, poc_points) = radios.fold(
-        (dec!(0), dec!(0), dec!(0)),
-        |(total, boosted, poc), radio| {
-            (
-                total + radio.total_points(),
-                boosted + radio.total_boosted_points(),
-                poc + radio.total_base_points(),
-            )
-        },
-    );
-
-    if total_points.is_zero() {
-        return Err(Error::NoPoints);
-    }
-
-    let shares_per_point = allocated_rewards.total() / total_points;
-    let boost_within_limit = allocated_rewards.boost_rewards >= shares_per_point * boost_points;
-
-    if boost_within_limit {
-        Ok(CalculatedRewardShares {
-            normal: shares_per_point,
-            boost: shares_per_point,
-        })
-    } else {
-        // Over boosted reward limit, need to calculate 2 share ratios
-        let normal = (allocated_rewards.poc_rewards + allocated_rewards.extra_rewards) / poc_points;
-        let boost = allocated_rewards.boost_rewards / boost_points;
-
-        Ok(CalculatedRewardShares { normal, boost })
-    }
 }
 
 /// Output of calculating coverage points for a Radio.
@@ -209,32 +152,30 @@ impl CoveragePoints {
 
     /// Accumulated points related only to coverage.
     /// (Hex * Rank * Assignment) * Location Trust
+    /// Used for reporting.
     pub fn coverage_points(&self) -> Decimal {
-        let total_coverage_points = self.base_points() + self.boosted_points();
+        let total_coverage_points = self.coverage_points.base + self.boosted_points();
         total_coverage_points * self.location_trust_multiplier
     }
 
     /// Accumulated points related to entire radio.
     /// coverage points * speedtest
+    /// Used in calculating rewards
     pub fn total_points(&self) -> Decimal {
         self.total_base_points() + self.total_boosted_points()
     }
 
+    /// Useful for grabbing only base points when calculating reward shares
     pub fn total_base_points(&self) -> Decimal {
-        self.base_points() * self.speedtest_multiplier * self.location_trust_multiplier
+        self.coverage_points.base * self.speedtest_multiplier * self.location_trust_multiplier
     }
 
+    /// Useful for grabbing only boost points when calculating reward shares
     pub fn total_boosted_points(&self) -> Decimal {
         self.boosted_points() * self.speedtest_multiplier * self.location_trust_multiplier
     }
 
-    /// Accumulated points without boosting
-    pub fn base_points(&self) -> Decimal {
-        self.coverage_points.base
-    }
-
-    /// Accumulated applicable boost points
-    pub fn boosted_points(&self) -> Decimal {
+    fn boosted_points(&self) -> Decimal {
         match self.boosted_hex_eligibility {
             BoostedHexStatus::Eligible => self.coverage_points.boosted,
             BoostedHexStatus::WifiLocationScoreBelowThreshold(_) => dec!(0),

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -138,7 +138,6 @@ impl CoveragePoints {
 
         Ok(CoveragePoints {
             coverage_points: hex_coverage_points,
-
             location_trust_multiplier,
             speedtest_multiplier,
             radio_type,

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -91,7 +91,7 @@ pub enum Error {
 ///   have no boosted_multiplier values.
 #[derive(Debug, Clone)]
 pub struct CoveragePoints {
-    ///
+    /// Breakdown of coverage points by source
     pub coverage_points: HexPoints,
     /// Location Trust Multiplier, maximum of 1
     ///

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -88,6 +88,25 @@ pub enum Error {
 ///
 /// - When a radio is not eligible for boosted hex rewards, [CoveragePoints::covered_hexes] will
 ///   have no boosted_multiplier values.
+///
+/// #### Terminology
+///
+/// *Points*
+///
+/// The value provided from covering hexes. These include hex related modifiers.
+/// - Rank
+/// - Oracle boosting.
+///
+/// *Multipliers*
+///
+/// Values relating to a radio that modify it's points.
+/// - Location Trust
+/// - Speedtest
+///
+/// *Shares*
+///
+/// The result of multiplying Points and Multipliers together.
+///
 #[derive(Debug, Clone)]
 pub struct CoveragePoints {
     /// Breakdown of coverage points by source
@@ -159,17 +178,17 @@ impl CoveragePoints {
     /// Accumulated points related to entire radio.
     /// coverage points * speedtest
     /// Used in calculating rewards
-    pub fn total_points(&self) -> Decimal {
-        self.total_base_points() + self.total_boosted_points()
+    pub fn total_shares(&self) -> Decimal {
+        self.total_base_shares() + self.total_boosted_shares()
     }
 
     /// Useful for grabbing only base points when calculating reward shares
-    pub fn total_base_points(&self) -> Decimal {
+    pub fn total_base_shares(&self) -> Decimal {
         self.coverage_points.base * self.speedtest_multiplier * self.location_trust_multiplier
     }
 
     /// Useful for grabbing only boost points when calculating reward shares
-    pub fn total_boosted_points(&self) -> Decimal {
+    pub fn total_boosted_shares(&self) -> Decimal {
         self.boosted_points() * self.speedtest_multiplier * self.location_trust_multiplier
     }
 
@@ -435,7 +454,7 @@ mod tests {
         let indoor_cbrs = calculate_indoor_cbrs(speedtest_maximum());
         assert_eq!(
             base_coverage_points * SpeedtestTier::Good.multiplier(),
-            indoor_cbrs.total_points()
+            indoor_cbrs.total_shares()
         );
 
         let indoor_cbrs = calculate_indoor_cbrs(vec![
@@ -444,7 +463,7 @@ mod tests {
         ]);
         assert_eq!(
             base_coverage_points * SpeedtestTier::Acceptable.multiplier(),
-            indoor_cbrs.total_points()
+            indoor_cbrs.total_shares()
         );
 
         let indoor_cbrs = calculate_indoor_cbrs(vec![
@@ -453,7 +472,7 @@ mod tests {
         ]);
         assert_eq!(
             base_coverage_points * SpeedtestTier::Degraded.multiplier(),
-            indoor_cbrs.total_points()
+            indoor_cbrs.total_shares()
         );
 
         let indoor_cbrs = calculate_indoor_cbrs(vec![
@@ -462,7 +481,7 @@ mod tests {
         ]);
         assert_eq!(
             base_coverage_points * SpeedtestTier::Poor.multiplier(),
-            indoor_cbrs.total_points()
+            indoor_cbrs.total_shares()
         );
 
         let indoor_cbrs = calculate_indoor_cbrs(vec![
@@ -471,7 +490,7 @@ mod tests {
         ]);
         assert_eq!(
             base_coverage_points * SpeedtestTier::Fail.multiplier(),
-            indoor_cbrs.total_points()
+            indoor_cbrs.total_shares()
         );
     }
 

--- a/coverage_point_calculator/src/lib.rs
+++ b/coverage_point_calculator/src/lib.rs
@@ -5,7 +5,7 @@
 //! place to start.
 //!
 //! ## Important Fields
-//! - [CoveredHex::base_coverage_points]
+//! - [CoveredHex::points]
 //!   - [HIP-74][modeled-coverage]
 //!   - reduced cbrs radio coverage points [HIP-113][cbrs-experimental]
 //!
@@ -55,12 +55,11 @@
 //! [boosted-hex-restriction]: https://github.com/helium/oracles/pull/808
 //!
 pub use crate::{
-    hexes::CoveredHex,
+    hexes::{CoveredHex, HexPoints},
     location::LocationTrust,
     speedtest::{BytesPs, Speedtest, SpeedtestTier},
 };
 use coverage_map::SignalLevel;
-use hexes::HexPoints;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -61,7 +61,7 @@ fn base_radio_coverage_points() {
 
         assert_eq!(
             expcted_base_coverage_point,
-            coverage_points.total_coverage_points
+            coverage_points.coverage_points()
         );
     }
 }
@@ -120,7 +120,7 @@ fn radios_with_coverage() {
         )
         .unwrap();
 
-        assert_eq!(dec!(400), coverage_points.total_coverage_points);
+        assert_eq!(dec!(400), coverage_points.coverage_points());
     }
 }
 
@@ -140,7 +140,7 @@ fn cbrs_with_mixed_signal_level_coverage() -> Result {
         ],
     )?;
 
-    assert_eq!(dec!(250), coverage_points.reward_shares);
+    assert_eq!(dec!(250), coverage_points.total_points());
 
     Ok(())
 }
@@ -175,8 +175,8 @@ fn cbrs_with_partially_overlapping_coverage_and_differing_speedtests() -> Result
         ],
     )?;
 
-    assert_eq!(dec!(112.5), radio_1.reward_shares);
-    assert_eq!(dec!(250), radio_2.reward_shares);
+    assert_eq!(dec!(112.5), radio_1.total_points());
+    assert_eq!(dec!(250), radio_2.total_points());
 
     Ok(())
 }
@@ -223,12 +223,12 @@ fn cbrs_with_wholly_overlapping_coverage_and_differing_speedtests() -> Result {
     let radio_5 = indoor_cbrs_radio(SpeedtestTier::Fail, map.get_cbrs_coverage("serial-5"))?;
     let radio_6 = indoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-6"))?;
 
-    assert_eq!(dec!(0), radio_1.reward_shares);
-    assert_eq!(dec!(0), radio_2.reward_shares);
-    assert_eq!(dec!(0), radio_3.reward_shares);
-    assert_eq!(dec!(250), radio_4.reward_shares);
-    assert_eq!(dec!(0), radio_5.reward_shares);
-    assert_eq!(dec!(0), radio_6.reward_shares);
+    assert_eq!(dec!(0), radio_1.total_points());
+    assert_eq!(dec!(0), radio_2.total_points());
+    assert_eq!(dec!(0), radio_3.total_points());
+    assert_eq!(dec!(250), radio_4.total_points());
+    assert_eq!(dec!(0), radio_5.total_points());
+    assert_eq!(dec!(0), radio_6.total_points());
 
     Ok(())
 }
@@ -258,7 +258,7 @@ fn cbrs_outdoor_with_mixed_signal_level_coverage() -> Result {
     )
     .unwrap();
 
-    assert_eq!(dec!(19), radio.reward_shares);
+    assert_eq!(dec!(19), radio.total_points());
 
     Ok(())
 }
@@ -310,8 +310,8 @@ fn cbrs_outdoor_with_single_overlapping_coverage() -> Result {
     let radio_1 = outdoor_cbrs_radio(SpeedtestTier::Degraded, map.get_cbrs_coverage("serial-1"))?;
     let radio_2 = outdoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-2"))?;
 
-    assert_eq!(dec!(19) * dec!(0.5), radio_1.reward_shares);
-    assert_eq!(dec!(8), radio_2.reward_shares);
+    assert_eq!(dec!(19) * dec!(0.5), radio_1.total_points());
+    assert_eq!(dec!(8), radio_2.total_points());
 
     Ok(())
 }
@@ -356,12 +356,12 @@ fn cbrs_indoor_with_wholly_overlapping_coverage_and_no_failing_speedtests() -> R
     let radio_5 = indoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-5"))?;
     let radio_6 = indoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-6"))?;
 
-    assert_eq!(dec!(0), radio_1.reward_shares);
-    assert_eq!(dec!(62.5), radio_2.reward_shares);
-    assert_eq!(dec!(0), radio_3.reward_shares);
-    assert_eq!(dec!(0), radio_4.reward_shares);
-    assert_eq!(dec!(0), radio_5.reward_shares);
-    assert_eq!(dec!(0), radio_6.reward_shares);
+    assert_eq!(dec!(0), radio_1.total_points());
+    assert_eq!(dec!(62.5), radio_2.total_points());
+    assert_eq!(dec!(0), radio_3.total_points());
+    assert_eq!(dec!(0), radio_4.total_points());
+    assert_eq!(dec!(0), radio_5.total_points());
+    assert_eq!(dec!(0), radio_6.total_points());
 
     Ok(())
 }

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -61,7 +61,7 @@ fn base_radio_coverage_points() {
 
         assert_eq!(
             expcted_base_coverage_point,
-            coverage_points.coverage_points()
+            coverage_points.coverage_points_v1()
         );
     }
 }
@@ -120,7 +120,7 @@ fn radios_with_coverage() {
         )
         .unwrap();
 
-        assert_eq!(dec!(400), coverage_points.coverage_points());
+        assert_eq!(dec!(400), coverage_points.coverage_points_v1());
     }
 }
 

--- a/coverage_point_calculator/tests/coverage_point_calculator.rs
+++ b/coverage_point_calculator/tests/coverage_point_calculator.rs
@@ -140,7 +140,7 @@ fn cbrs_with_mixed_signal_level_coverage() -> Result {
         ],
     )?;
 
-    assert_eq!(dec!(250), coverage_points.total_points());
+    assert_eq!(dec!(250), coverage_points.total_shares());
 
     Ok(())
 }
@@ -175,8 +175,8 @@ fn cbrs_with_partially_overlapping_coverage_and_differing_speedtests() -> Result
         ],
     )?;
 
-    assert_eq!(dec!(112.5), radio_1.total_points());
-    assert_eq!(dec!(250), radio_2.total_points());
+    assert_eq!(dec!(112.5), radio_1.total_shares());
+    assert_eq!(dec!(250), radio_2.total_shares());
 
     Ok(())
 }
@@ -223,12 +223,12 @@ fn cbrs_with_wholly_overlapping_coverage_and_differing_speedtests() -> Result {
     let radio_5 = indoor_cbrs_radio(SpeedtestTier::Fail, map.get_cbrs_coverage("serial-5"))?;
     let radio_6 = indoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-6"))?;
 
-    assert_eq!(dec!(0), radio_1.total_points());
-    assert_eq!(dec!(0), radio_2.total_points());
-    assert_eq!(dec!(0), radio_3.total_points());
-    assert_eq!(dec!(250), radio_4.total_points());
-    assert_eq!(dec!(0), radio_5.total_points());
-    assert_eq!(dec!(0), radio_6.total_points());
+    assert_eq!(dec!(0), radio_1.total_shares());
+    assert_eq!(dec!(0), radio_2.total_shares());
+    assert_eq!(dec!(0), radio_3.total_shares());
+    assert_eq!(dec!(250), radio_4.total_shares());
+    assert_eq!(dec!(0), radio_5.total_shares());
+    assert_eq!(dec!(0), radio_6.total_shares());
 
     Ok(())
 }
@@ -258,7 +258,7 @@ fn cbrs_outdoor_with_mixed_signal_level_coverage() -> Result {
     )
     .unwrap();
 
-    assert_eq!(dec!(19), radio.total_points());
+    assert_eq!(dec!(19), radio.total_shares());
 
     Ok(())
 }
@@ -310,8 +310,8 @@ fn cbrs_outdoor_with_single_overlapping_coverage() -> Result {
     let radio_1 = outdoor_cbrs_radio(SpeedtestTier::Degraded, map.get_cbrs_coverage("serial-1"))?;
     let radio_2 = outdoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-2"))?;
 
-    assert_eq!(dec!(19) * dec!(0.5), radio_1.total_points());
-    assert_eq!(dec!(8), radio_2.total_points());
+    assert_eq!(dec!(19) * dec!(0.5), radio_1.total_shares());
+    assert_eq!(dec!(8), radio_2.total_shares());
 
     Ok(())
 }
@@ -356,12 +356,12 @@ fn cbrs_indoor_with_wholly_overlapping_coverage_and_no_failing_speedtests() -> R
     let radio_5 = indoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-5"))?;
     let radio_6 = indoor_cbrs_radio(SpeedtestTier::Good, map.get_cbrs_coverage("serial-6"))?;
 
-    assert_eq!(dec!(0), radio_1.total_points());
-    assert_eq!(dec!(62.5), radio_2.total_points());
-    assert_eq!(dec!(0), radio_3.total_points());
-    assert_eq!(dec!(0), radio_4.total_points());
-    assert_eq!(dec!(0), radio_5.total_points());
-    assert_eq!(dec!(0), radio_6.total_points());
+    assert_eq!(dec!(0), radio_1.total_shares());
+    assert_eq!(dec!(62.5), radio_2.total_shares());
+    assert_eq!(dec!(0), radio_3.total_shares());
+    assert_eq!(dec!(0), radio_4.total_shares());
+    assert_eq!(dec!(0), radio_5.total_shares());
+    assert_eq!(dec!(0), radio_6.total_shares());
 
     Ok(())
 }

--- a/mobile_verifier/src/cli/reward_from_db.rs
+++ b/mobile_verifier/src/cli/reward_from_db.rs
@@ -1,7 +1,9 @@
 use crate::{
     heartbeats::HeartbeatReward,
     radio_threshold::VerifiedRadioThresholds,
-    reward_shares::{get_scheduled_tokens_for_poc, CoverageShares},
+    reward_shares::{
+        get_scheduled_tokens_for_poc, CoverageShares, DataTransferAndPocAllocatedRewardShares,
+    },
     speedtests_average::SpeedtestAverages,
     Settings,
 };
@@ -10,7 +12,6 @@ use chrono::NaiveDateTime;
 use helium_crypto::PublicKey;
 use helium_proto::services::poc_mobile as proto;
 use mobile_config::boosted_hex_info::BoostedHexes;
-use rust_decimal::Decimal;
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -54,7 +55,7 @@ impl Cmd {
         let mut total_rewards = 0_u64;
         let mut owner_rewards = HashMap::<_, u64>::new();
         let radio_rewards = reward_shares
-            .into_rewards(Decimal::ZERO, &epoch)
+            .into_rewards(&DataTransferAndPocAllocatedRewardShares::default(), &epoch)
             .ok_or(anyhow::anyhow!("no rewardable events"))?;
         for (_reward_amount, reward) in radio_rewards {
             if let Some(proto::mobile_reward_share::Reward::RadioReward(proto::RadioReward {

--- a/mobile_verifier/src/cli/reward_from_db.rs
+++ b/mobile_verifier/src/cli/reward_from_db.rs
@@ -2,7 +2,7 @@ use crate::{
     heartbeats::HeartbeatReward,
     radio_threshold::VerifiedRadioThresholds,
     reward_shares::{
-        get_scheduled_tokens_for_poc, CoverageShares, DataTransferAndPocAllocatedRewardShares,
+        get_scheduled_tokens_for_poc, CoverageShares, DataTransferAndPocAllocatedRewardBuckets,
     },
     speedtests_average::SpeedtestAverages,
     Settings,
@@ -55,7 +55,10 @@ impl Cmd {
         let mut total_rewards = 0_u64;
         let mut owner_rewards = HashMap::<_, u64>::new();
         let radio_rewards = reward_shares
-            .into_rewards(&DataTransferAndPocAllocatedRewardShares::default(), &epoch)
+            .into_rewards(
+                DataTransferAndPocAllocatedRewardBuckets::new(&epoch),
+                &epoch,
+            )
             .ok_or(anyhow::anyhow!("no rewardable events"))?;
         for (_reward_amount, reward) in radio_rewards {
             if let Some(proto::mobile_reward_share::Reward::RadioReward(proto::RadioReward {

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -747,10 +747,11 @@ impl CalculatedPocRewardShares {
     }
 
     fn poc_reward(&self, points: &coverage_point_calculator::CoveragePoints) -> u64 {
-        let base_reward = self.normal * points.total_base_shares();
-        let boosted_reward = self.boost * points.total_boosted_shares();
+        let base_reward = self.normal * points.total_base_shares().to_u64().unwrap_or_default();
+        let boosted_reward =
+            self.boost * points.total_boosted_shares().to_u64().unwrap_or_default();
 
-        (base_reward + boosted_reward).to_u64().unwrap_or_default()
+        base_reward + boosted_reward
     }
 }
 

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -391,7 +391,7 @@ pub fn coverage_point_to_mobile_reward_share(
     let speedtest_multiplier = to_proto_value(coverage_points.speedtest_multiplier);
 
     let coverage_points = coverage_points
-        .coverage_points()
+        .coverage_points_v1()
         .to_u64()
         .unwrap_or_default();
 

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -662,6 +662,7 @@ impl CoverageShares {
             allocated_rewards,
             coverage_points_iter,
         );
+
         let rewards_per_share = match calculate_reward_shares {
             Ok(rewards_per_share) => rewards_per_share,
             Err(err) => {

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -400,7 +400,7 @@ pub fn coverage_point_to_mobile_reward_share(
     let speedtest_multiplier = to_proto_value(coverage_points.speedtest_multiplier);
 
     let coverage_points = coverage_points
-        .total_coverage_points
+        .coverage_points()
         .to_u64()
         .unwrap_or_default();
 
@@ -608,7 +608,7 @@ impl CoverageShares {
             let seniority = radio_info.seniority.clone();
             let coverage_object_uuid = radio_info.coverage_obj_uuid;
 
-            total_shares += points.reward_shares;
+            total_shares += points.total_points();
             processed_radios.push((radio_id.clone(), points, seniority, coverage_object_uuid));
         }
 
@@ -621,7 +621,7 @@ impl CoverageShares {
             processed_radios
                 .into_iter()
                 .map(move |(id, points, seniority, coverage_object_uuid)| {
-                    let poc_reward = rewards_per_share * points.reward_shares;
+                    let poc_reward = rewards_per_share * points.total_points();
                     let poc_reward = poc_reward.to_u64().unwrap_or_default();
 
                     let mobile_reward_share = coverage_point_to_mobile_reward_share(
@@ -642,7 +642,7 @@ impl CoverageShares {
     pub fn test_hotspot_reward_shares(&self, hotspot: &RadioId) -> Decimal {
         self.coverage_points(hotspot)
             .expect("reward shares for hotspot")
-            .reward_shares
+            .total_points()
     }
 }
 

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -647,7 +647,7 @@ impl CoverageShares {
     pub fn test_hotspot_reward_shares(&self, hotspot: &RadioId) -> Decimal {
         self.coverage_points(hotspot)
             .expect("reward shares for hotspot")
-            .total_points()
+            .total_shares()
     }
 }
 
@@ -718,9 +718,9 @@ impl CalculatedPocRewardShares {
             (dec!(0), dec!(0), dec!(0)),
             |(total, boosted, poc), radio| {
                 (
-                    total + radio.total_points(),
-                    boosted + radio.total_boosted_points(),
-                    poc + radio.total_base_points(),
+                    total + radio.total_shares(),
+                    boosted + radio.total_boosted_shares(),
+                    poc + radio.total_base_shares(),
                 )
             },
         );
@@ -747,8 +747,8 @@ impl CalculatedPocRewardShares {
     }
 
     fn poc_reward(&self, points: &coverage_point_calculator::CoveragePoints) -> u64 {
-        let base_reward = self.normal * points.total_base_points();
-        let boosted_reward = self.boost * points.total_boosted_points();
+        let base_reward = self.normal * points.total_base_shares();
+        let boosted_reward = self.boost * points.total_boosted_shares();
 
         (base_reward + boosted_reward).to_u64().unwrap_or_default()
     }

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -747,9 +747,12 @@ impl CalculatedPocRewardShares {
     }
 
     fn poc_reward(&self, points: &coverage_point_calculator::CoveragePoints) -> u64 {
-        let base_reward = self.normal * points.total_base_shares().to_u64().unwrap_or_default();
-        let boosted_reward =
-            self.boost * points.total_boosted_shares().to_u64().unwrap_or_default();
+        let base_reward = (self.normal * points.total_base_shares())
+            .to_u64()
+            .unwrap_or_default();
+        let boosted_reward = (self.boost * points.total_boosted_shares())
+            .to_u64()
+            .unwrap_or_default();
 
         base_reward + boosted_reward
     }

--- a/mobile_verifier/tests/integrations/common/mod.rs
+++ b/mobile_verifier/tests/integrations/common/mod.rs
@@ -58,16 +58,16 @@ pub struct MockFileSinkReceiver {
 }
 
 impl MockFileSinkReceiver {
-    pub async fn receive(&mut self) -> Option<Vec<u8>> {
+    pub async fn receive(&mut self, caller: &str) -> Option<Vec<u8>> {
         match timeout(seconds(2), self.receiver.recv()).await {
             Ok(Some(SinkMessage::Data(on_write_tx, msg))) => {
                 let _ = on_write_tx.send(Ok(()));
                 Some(msg)
             }
             Ok(None) => None,
-            Err(e) => panic!("timeout while waiting for message1 {:?}", e),
+            Err(e) => panic!("{caller}: timeout while waiting for message1 {:?}", e),
             Ok(Some(unexpected_msg)) => {
-                println!("ignoring unexpected msg {:?}", unexpected_msg);
+                println!("{caller}: ignoring unexpected msg {:?}", unexpected_msg);
                 None
             }
         }
@@ -99,7 +99,7 @@ impl MockFileSinkReceiver {
     }
 
     pub async fn receive_radio_reward(&mut self) -> RadioReward {
-        match self.receive().await {
+        match self.receive("receive_radio_reward").await {
             Some(bytes) => {
                 let mobile_reward = MobileRewardShare::decode(bytes.as_slice())
                     .expect("failed to decode expected radio reward");
@@ -114,7 +114,7 @@ impl MockFileSinkReceiver {
     }
 
     pub async fn receive_gateway_reward(&mut self) -> GatewayReward {
-        match self.receive().await {
+        match self.receive("receive_gateway_reward").await {
             Some(bytes) => {
                 let mobile_reward = MobileRewardShare::decode(bytes.as_slice())
                     .expect("failed to decode expected gateway reward");
@@ -129,7 +129,7 @@ impl MockFileSinkReceiver {
     }
 
     pub async fn receive_service_provider_reward(&mut self) -> ServiceProviderReward {
-        match self.receive().await {
+        match self.receive("receive_service_provider_reward").await {
             Some(bytes) => {
                 let mobile_reward = MobileRewardShare::decode(bytes.as_slice())
                     .expect("failed to decode expected service provider reward");
@@ -144,7 +144,7 @@ impl MockFileSinkReceiver {
     }
 
     pub async fn receive_subscriber_reward(&mut self) -> SubscriberReward {
-        match self.receive().await {
+        match self.receive("receive_subscriber_reward").await {
             Some(bytes) => {
                 let mobile_reward = MobileRewardShare::decode(bytes.as_slice())
                     .expect("failed to decode expected subscriber reward");
@@ -159,7 +159,7 @@ impl MockFileSinkReceiver {
     }
 
     pub async fn receive_unallocated_reward(&mut self) -> UnallocatedReward {
-        match self.receive().await {
+        match self.receive("receive_unallocated_reward").await {
             Some(bytes) => {
                 let mobile_reward = MobileRewardShare::decode(bytes.as_slice())
                     .expect("failed to decode expected unallocated reward");

--- a/mobile_verifier/tests/integrations/hex_boosting.rs
+++ b/mobile_verifier/tests/integrations/hex_boosting.rs
@@ -179,29 +179,26 @@ async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
         PublicKeyBinary::from(hotspot_3.hotspot_key.clone()).to_string()
     );
 
-    // Let's figure out how to calculate rewards for 3 similar radios whose
-    // only difference is boosting.
-    {
-        let (regular_poc, boosted_poc) = get_poc_allocation_buckets(epoch_duration);
+    // Calculating expected rewards
+    let (regular_poc, boosted_poc) = get_poc_allocation_buckets(epoch_duration);
 
-        // With regular poc now 50% of total emissions, that will be split
-        // between the 3 radios equally. 900 comes from IndoorWifi 400 *
-        // 0.75 speedtest multiplier * 3 radios
-        let regular_share = regular_poc / dec!(900);
+    // With regular poc now 50% of total emissions, that will be split
+    // between the 3 radios equally. 900 comes from IndoorWifi 400 *
+    // 0.75 speedtest multiplier * 3 radios
+    let regular_share = regular_poc / dec!(900);
 
-        // Boosted hexes are 10x and 20x.
-        // (300 * 19) + (300 * 9) = 8400;
-        // To get points _only_ from boosting.
-        let boosted_share = boosted_poc / dec!(8400);
+    // Boosted hexes are 10x and 20x.
+    // (300 * 19) + (300 * 9) = 8400;
+    // To get points _only_ from boosting.
+    let boosted_share = boosted_poc / dec!(8400);
 
-        let exp_reward_1 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(19));
-        let exp_reward_2 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(9));
-        let exp_reward_3 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(0));
+    let exp_reward_1 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(19));
+    let exp_reward_2 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(9));
+    let exp_reward_3 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(0));
 
-        assert_eq!(exp_reward_1.to_u64().unwrap(), hotspot_2.poc_reward); // 20x boost
-        assert_eq!(exp_reward_2.to_u64().unwrap(), hotspot_1.poc_reward); // 10x boost
-        assert_eq!(exp_reward_3.to_u64().unwrap(), hotspot_3.poc_reward); // no boost
-    }
+    assert_eq!(exp_reward_1.to_u64().unwrap(), hotspot_2.poc_reward); // 20x boost
+    assert_eq!(exp_reward_2.to_u64().unwrap(), hotspot_1.poc_reward); // 10x boost
+    assert_eq!(exp_reward_3.to_u64().unwrap(), hotspot_3.poc_reward); // no boost
 
     // assert the boosted hexes in the radio rewards
     // assert the number of boosted hexes for each radio
@@ -524,38 +521,36 @@ async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Res
         PublicKeyBinary::from(hotspot_3.hotspot_key.clone()).to_string()
     );
 
-    // Let's figure out how to calculate rewards for 3 IndoorWifi radios where:
+    // Calculating expected rewards
     // - 2 covered hexes boosted at 10x
     // - 1 covered hex boosted at 20x
     // - 1 covered hex no boost
-    {
-        let (regular_poc, boosted_poc) = get_poc_allocation_buckets(epoch_duration);
+    let (regular_poc, boosted_poc) = get_poc_allocation_buckets(epoch_duration);
 
-        // With regular poc now 50% of total emissions, that will be split
-        // between the 3 radios equally.
-        // 1200 comes from IndoorWifi 400 * 0.75 speedtest multiplier * 4 hexes
-        let regular_share = regular_poc / dec!(1200);
+    // With regular poc now 50% of total emissions, that will be split
+    // between the 3 radios equally.
+    // 1200 comes from IndoorWifi 400 * 0.75 speedtest multiplier * 4 hexes
+    let regular_share = regular_poc / dec!(1200);
 
-        // Boosted hexes are 2 at 10x and 1 at 20x.
-        // (300 * (9 * 2)) + (300 * 19) = 11,100;
-        // To get points _only_ from boosting.
-        let boosted_share = boosted_poc / dec!(11_100);
+    // Boosted hexes are 2 at 10x and 1 at 20x.
+    // (300 * (9 * 2)) + (300 * 19) = 11,100;
+    // To get points _only_ from boosting.
+    let boosted_share = boosted_poc / dec!(11_100);
 
-        let hex_coverage = |hexes: u8| regular_share * dec!(300) * Decimal::from(hexes);
-        let boost_coverage = |mult: u8| boosted_share * dec!(300) * Decimal::from(mult);
+    let hex_coverage = |hexes: u8| regular_share * dec!(300) * Decimal::from(hexes);
+    let boost_coverage = |mult: u8| boosted_share * dec!(300) * Decimal::from(mult);
 
-        let exp_reward_1 = hex_coverage(2) + boost_coverage(18);
-        let exp_reward_2 = hex_coverage(1) + boost_coverage(19);
-        let exp_reward_3 = hex_coverage(1) + boost_coverage(0);
+    let exp_reward_1 = hex_coverage(2) + boost_coverage(18);
+    let exp_reward_2 = hex_coverage(1) + boost_coverage(19);
+    let exp_reward_3 = hex_coverage(1) + boost_coverage(0);
 
-        assert_eq!(exp_reward_1.to_u64().unwrap(), hotspot_1.poc_reward); // 2 at 10x boost
-        assert_eq!(exp_reward_2.to_u64().unwrap(), hotspot_2.poc_reward); // 1 at 20x boost
-        assert_eq!(exp_reward_3.to_u64().unwrap(), hotspot_3.poc_reward); // 1 at no boost
+    assert_eq!(exp_reward_1.to_u64().unwrap(), hotspot_1.poc_reward); // 2 at 10x boost
+    assert_eq!(exp_reward_2.to_u64().unwrap(), hotspot_2.poc_reward); // 1 at 20x boost
+    assert_eq!(exp_reward_3.to_u64().unwrap(), hotspot_3.poc_reward); // 1 at no boost
 
-        // hotspot 1 and 2 should have the same coverage points, but different poc rewards.
-        assert_eq!(hotspot_1.coverage_points, hotspot_2.coverage_points);
-        assert_ne!(hotspot_1.poc_reward, hotspot_2.poc_reward);
-    }
+    // hotspot 1 and 2 should have the same coverage points, but different poc rewards.
+    assert_eq!(hotspot_1.coverage_points, hotspot_2.coverage_points);
+    assert_ne!(hotspot_1.poc_reward, hotspot_2.poc_reward);
 
     // assert the number of boosted hexes for each radio
     assert_eq!(1, hotspot_2.boosted_hexes.len());
@@ -812,34 +807,31 @@ async fn test_reduced_location_score_with_boosted_hexes(pool: PgPool) -> anyhow:
         PublicKeyBinary::from(hotspot_3.hotspot_key.clone()).to_string()
     );
 
-    // Let's figure out how to calculate rewards for 3 similar radios with
-    // different location trust and boosting.
-    {
-        let (regular_poc, boosted_poc) = get_poc_allocation_buckets(epoch_duration);
+    // Calculating expected rewards
+    let (regular_poc, boosted_poc) = get_poc_allocation_buckets(epoch_duration);
 
-        // Here's how we get the regular shares per coverage points
-        // | base coverage point | speedtest | location | total |
-        // |---------------------|-----------|----------|-------|
-        // | 400                 | 0.75      | 1.00     | 300   |
-        // | 400                 | 0.75      | 1.00     | 300   |
-        // | 400                 | 0.75      | 0.25     | 75    |
-        // |---------------------|-----------|----------|-------|
-        //                                              | 675   |
-        let regular_share = regular_poc / dec!(675);
+    // Here's how we get the regular shares per coverage points
+    // | base coverage point | speedtest | location | total |
+    // |---------------------|-----------|----------|-------|
+    // | 400                 | 0.75      | 1.00     | 300   |
+    // | 400                 | 0.75      | 1.00     | 300   |
+    // | 400                 | 0.75      | 0.25     | 75    |
+    // |---------------------|-----------|----------|-------|
+    //                                              | 675   |
+    let regular_share = regular_poc / dec!(675);
 
-        // Boosted hexes are 2x, only one radio qualifies based on the location trust
-        // 300 * 1 == 300
-        // To get points _only_ from boosting.
-        let boosted_share = boosted_poc / dec!(300);
+    // Boosted hexes are 2x, only one radio qualifies based on the location trust
+    // 300 * 1 == 300
+    // To get points _only_ from boosting.
+    let boosted_share = boosted_poc / dec!(300);
 
-        let exp_reward_1 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(1));
-        let exp_reward_2 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(0));
-        let exp_reward_3 = (regular_share * dec!(75)) + (boosted_share * dec!(75) * dec!(0));
+    let exp_reward_1 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(1));
+    let exp_reward_2 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(0));
+    let exp_reward_3 = (regular_share * dec!(75)) + (boosted_share * dec!(75) * dec!(0));
 
-        assert_eq!(exp_reward_1.to_u64().unwrap(), hotspot_1.poc_reward);
-        assert_eq!(exp_reward_2.to_u64().unwrap(), hotspot_2.poc_reward);
-        assert_eq!(exp_reward_3.to_u64().unwrap(), hotspot_3.poc_reward);
-    }
+    assert_eq!(exp_reward_1.to_u64().unwrap(), hotspot_1.poc_reward);
+    assert_eq!(exp_reward_2.to_u64().unwrap(), hotspot_2.poc_reward);
+    assert_eq!(exp_reward_3.to_u64().unwrap(), hotspot_3.poc_reward);
 
     // assert the number of boosted hexes for each radio
     //hotspot 1 has one boosted hex
@@ -1015,38 +1007,34 @@ async fn test_poc_with_cbrs_and_multi_coverage_boosted_hexes(pool: PgPool) -> an
         PublicKeyBinary::from(hotspot_3.hotspot_key.clone()).to_string()
     );
 
-    // Let's figure out how to calculate rewards for 2 Wifi and 1 Cbrs radios with
-    // different location trust and boosting.
-    {
-        let (regular_poc, boosted_poc) = get_poc_allocation_buckets(epoch_duration);
+    // Calculating expected rewards
+    let (regular_poc, boosted_poc) = get_poc_allocation_buckets(epoch_duration);
 
-        // Here's how we get the regular shares per coverage points
-        // | base coverage point | speedtest | location | total |
-        // |---------------------|-----------|----------|-------|
-        // | 400 x 2             | 0.75      | 1.00     | 600   |
-        // | 400                 | 0.75      | 1.00     | 300   |
-        // | 100                 | 0.75      | 1.00     | 75    |
-        // |---------------------|-----------|----------|-------|
-        //                                              | 975   |
-        let regular_share = regular_poc / dec!(975);
+    // Here's how we get the regular shares per coverage points
+    // | base coverage point | speedtest | location | total |
+    // |---------------------|-----------|----------|-------|
+    // | 400 x 2             | 0.75      | 1.00     | 600   |
+    // | 400                 | 0.75      | 1.00     | 300   |
+    // | 100                 | 0.75      | 1.00     | 75    |
+    // |---------------------|-----------|----------|-------|
+    //                                              | 975   |
+    let regular_share = regular_poc / dec!(975);
 
-        // Boosted hexes are 2 at 10x and 1 at 20x.
-        // Only wifi is targeted with Boosts.
-        // (300 * (9 * 2)) + (300 * 19) == 11,100
-        // To get points _only_ from boosting.
-        let boosted_share = boosted_poc / dec!(11_100);
+    // Boosted hexes are 2 at 10x and 1 at 20x.
+    // Only wifi is targeted with Boosts.
+    // (300 * (9 * 2)) + (300 * 19) == 11,100
+    // To get points _only_ from boosting.
+    let boosted_share = boosted_poc / dec!(11_100);
 
-        let exp_reward_1 =
-            (regular_share * dec!(300) * dec!(2)) + (boosted_share * dec!(300) * dec!(18));
-        let exp_reward_2 =
-            (regular_share * dec!(300) * dec!(1)) + (boosted_share * dec!(300) * dec!(19));
-        let exp_reward_3 =
-            (regular_share * dec!(75) * dec!(1)) + (boosted_share * dec!(75) * dec!(0));
+    let exp_reward_1 =
+        (regular_share * dec!(300) * dec!(2)) + (boosted_share * dec!(300) * dec!(18));
+    let exp_reward_2 =
+        (regular_share * dec!(300) * dec!(1)) + (boosted_share * dec!(300) * dec!(19));
+    let exp_reward_3 = (regular_share * dec!(75) * dec!(1)) + (boosted_share * dec!(75) * dec!(0));
 
-        assert_eq!(exp_reward_1.to_u64().unwrap(), hotspot_1.poc_reward);
-        assert_eq!(exp_reward_2.to_u64().unwrap(), hotspot_2.poc_reward);
-        assert_eq!(exp_reward_3.to_u64().unwrap(), hotspot_3.poc_reward);
-    }
+    assert_eq!(exp_reward_1.to_u64().unwrap(), hotspot_1.poc_reward);
+    assert_eq!(exp_reward_2.to_u64().unwrap(), hotspot_2.poc_reward);
+    assert_eq!(exp_reward_3.to_u64().unwrap(), hotspot_3.poc_reward);
 
     // assert the number of boosted hexes for each radio
     assert_eq!(1, hotspot_2.boosted_hexes.len());

--- a/mobile_verifier/tests/integrations/hex_boosting.rs
+++ b/mobile_verifier/tests/integrations/hex_boosting.rs
@@ -192,13 +192,16 @@ async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
     // To get points _only_ from boosting.
     let boosted_share = boosted_poc / dec!(8400);
 
-    let exp_reward_1 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(19));
-    let exp_reward_2 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(9));
-    let exp_reward_3 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(0));
+    let exp_reward_1 =
+        rounded(regular_share * dec!(300)) + rounded(boosted_share * dec!(300) * dec!(19));
+    let exp_reward_2 =
+        rounded(regular_share * dec!(300)) + rounded(boosted_share * dec!(300) * dec!(9));
+    let exp_reward_3 =
+        rounded(regular_share * dec!(300)) + rounded(boosted_share * dec!(300) * dec!(0));
 
-    assert_eq!(exp_reward_1.to_u64().unwrap(), hotspot_2.poc_reward); // 20x boost
-    assert_eq!(exp_reward_2.to_u64().unwrap(), hotspot_1.poc_reward); // 10x boost
-    assert_eq!(exp_reward_3.to_u64().unwrap(), hotspot_3.poc_reward); // no boost
+    assert_eq!(exp_reward_1, hotspot_2.poc_reward); // 20x boost
+    assert_eq!(exp_reward_2, hotspot_1.poc_reward); // 10x boost
+    assert_eq!(exp_reward_3, hotspot_3.poc_reward); // no boost
 
     // assert the boosted hexes in the radio rewards
     // assert the number of boosted hexes for each radio
@@ -540,13 +543,13 @@ async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Res
     let hex_coverage = |hexes: u8| regular_share * dec!(300) * Decimal::from(hexes);
     let boost_coverage = |mult: u8| boosted_share * dec!(300) * Decimal::from(mult);
 
-    let exp_reward_1 = hex_coverage(2) + boost_coverage(18);
-    let exp_reward_2 = hex_coverage(1) + boost_coverage(19);
-    let exp_reward_3 = hex_coverage(1) + boost_coverage(0);
+    let exp_reward_1 = rounded(hex_coverage(2)) + rounded(boost_coverage(18));
+    let exp_reward_2 = rounded(hex_coverage(1)) + rounded(boost_coverage(19));
+    let exp_reward_3 = rounded(hex_coverage(1)) + rounded(boost_coverage(0));
 
-    assert_eq!(exp_reward_1.to_u64().unwrap(), hotspot_1.poc_reward); // 2 at 10x boost
-    assert_eq!(exp_reward_2.to_u64().unwrap(), hotspot_2.poc_reward); // 1 at 20x boost
-    assert_eq!(exp_reward_3.to_u64().unwrap(), hotspot_3.poc_reward); // 1 at no boost
+    assert_eq!(exp_reward_1, hotspot_1.poc_reward); // 2 at 10x boost
+    assert_eq!(exp_reward_2, hotspot_2.poc_reward); // 1 at 20x boost
+    assert_eq!(exp_reward_3, hotspot_3.poc_reward); // 1 at no boost
 
     // hotspot 1 and 2 should have the same coverage points, but different poc rewards.
     assert_eq!(hotspot_1.coverage_points, hotspot_2.coverage_points);
@@ -825,13 +828,16 @@ async fn test_reduced_location_score_with_boosted_hexes(pool: PgPool) -> anyhow:
     // To get points _only_ from boosting.
     let boosted_share = boosted_poc / dec!(300);
 
-    let exp_reward_1 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(1));
-    let exp_reward_2 = (regular_share * dec!(300)) + (boosted_share * dec!(300) * dec!(0));
-    let exp_reward_3 = (regular_share * dec!(75)) + (boosted_share * dec!(75) * dec!(0));
+    let exp_reward_1 =
+        rounded(regular_share * dec!(300)) + rounded(boosted_share * dec!(300) * dec!(1));
+    let exp_reward_2 =
+        rounded(regular_share * dec!(300)) + rounded(boosted_share * dec!(300) * dec!(0));
+    let exp_reward_3 =
+        rounded(regular_share * dec!(75)) + rounded(boosted_share * dec!(75) * dec!(0));
 
-    assert_eq!(exp_reward_1.to_u64().unwrap(), hotspot_1.poc_reward);
-    assert_eq!(exp_reward_2.to_u64().unwrap(), hotspot_2.poc_reward);
-    assert_eq!(exp_reward_3.to_u64().unwrap(), hotspot_3.poc_reward);
+    assert_eq!(exp_reward_1, hotspot_1.poc_reward);
+    assert_eq!(exp_reward_2, hotspot_2.poc_reward);
+    assert_eq!(exp_reward_3, hotspot_3.poc_reward);
 
     // assert the number of boosted hexes for each radio
     //hotspot 1 has one boosted hex
@@ -1026,15 +1032,16 @@ async fn test_poc_with_cbrs_and_multi_coverage_boosted_hexes(pool: PgPool) -> an
     // To get points _only_ from boosting.
     let boosted_share = boosted_poc / dec!(11_100);
 
-    let exp_reward_1 =
-        (regular_share * dec!(300) * dec!(2)) + (boosted_share * dec!(300) * dec!(18));
-    let exp_reward_2 =
-        (regular_share * dec!(300) * dec!(1)) + (boosted_share * dec!(300) * dec!(19));
-    let exp_reward_3 = (regular_share * dec!(75) * dec!(1)) + (boosted_share * dec!(75) * dec!(0));
+    let exp_reward_1 = rounded(regular_share * dec!(300) * dec!(2))
+        + rounded(boosted_share * dec!(300) * dec!(18));
+    let exp_reward_2 = rounded(regular_share * dec!(300) * dec!(1))
+        + rounded(boosted_share * dec!(300) * dec!(19));
+    let exp_reward_3 =
+        rounded(regular_share * dec!(75) * dec!(1)) + rounded(boosted_share * dec!(75) * dec!(0));
 
-    assert_eq!(exp_reward_1.to_u64().unwrap(), hotspot_1.poc_reward);
-    assert_eq!(exp_reward_2.to_u64().unwrap(), hotspot_2.poc_reward);
-    assert_eq!(exp_reward_3.to_u64().unwrap(), hotspot_3.poc_reward);
+    assert_eq!(exp_reward_1, hotspot_1.poc_reward);
+    assert_eq!(exp_reward_2, hotspot_2.poc_reward);
+    assert_eq!(exp_reward_3, hotspot_3.poc_reward);
 
     // assert the number of boosted hexes for each radio
     assert_eq!(1, hotspot_2.boosted_hexes.len());
@@ -1074,6 +1081,10 @@ async fn test_poc_with_cbrs_and_multi_coverage_boosted_hexes(pool: PgPool) -> an
     assert_eq!(percent, dec!(0.6));
 
     Ok(())
+}
+
+fn rounded(num: Decimal) -> u64 {
+    num.to_u64().unwrap_or_default()
 }
 
 async fn receive_expected_rewards(

--- a/mobile_verifier/tests/integrations/hex_boosting.rs
+++ b/mobile_verifier/tests/integrations/hex_boosting.rs
@@ -6,9 +6,12 @@ use file_store::{
     speedtest::CellSpeedtest,
 };
 use helium_crypto::PublicKeyBinary;
-use helium_proto::services::poc_mobile::{
-    CoverageObjectValidity, HeartbeatValidity, RadioReward, SeniorityUpdateReason, SignalLevel,
-    UnallocatedReward,
+use helium_proto::services::{
+    poc_lora::UnallocatedRewardType,
+    poc_mobile::{
+        CoverageObjectValidity, HeartbeatValidity, RadioReward, SeniorityUpdateReason, SignalLevel,
+        UnallocatedReward,
+    },
 };
 use hextree::Cell;
 use mobile_config::boosted_hex_info::BoostedHexInfo;
@@ -52,6 +55,7 @@ async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
     let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
     let now = Utc::now();
     let epoch = (now - ChronoDuration::hours(24))..now;
+    let epoch_duration = epoch.end - epoch.start;
     let boost_period_length = Duration::days(30);
 
     // seed all the things
@@ -129,6 +133,10 @@ async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
 
     let hex_boosting_client = MockHexBoostingClient::new(boosted_hexes);
 
+    let total_poc_emissions = reward_shares::get_scheduled_tokens_for_poc(epoch_duration)
+        .to_u64()
+        .unwrap();
+
     let (_, rewards) = tokio::join!(
         // run rewards for poc and dc
         rewarder::reward_poc_and_dc(
@@ -139,75 +147,106 @@ async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
             &epoch,
             dec!(0.0001)
         ),
-        receive_expected_rewards(&mut mobile_rewards)
+        receive_expected_rewards_maybe_unallocated(
+            &mut mobile_rewards,
+            ExpectUnallocated::NoWhenValue(total_poc_emissions)
+        )
     );
-    if let Ok((poc_rewards, unallocated_reward)) = rewards {
-        // assert poc reward outputs
-        let exp_reward_1 = 31_729_243_786_356;
-        let exp_reward_2 = 15_864_621_893_178;
-        let exp_reward_3 = 1_586_462_189_317;
 
-        assert_eq!(exp_reward_1, poc_rewards[0].poc_reward);
-        assert_eq!(
-            HOTSPOT_2.to_string(),
-            PublicKeyBinary::from(poc_rewards[0].hotspot_key.clone()).to_string()
-        );
-        assert_eq!(exp_reward_2, poc_rewards[1].poc_reward);
-        assert_eq!(
-            HOTSPOT_1.to_string(),
-            PublicKeyBinary::from(poc_rewards[1].hotspot_key.clone()).to_string()
-        );
-        assert_eq!(exp_reward_3, poc_rewards[2].poc_reward);
-        assert_eq!(
-            HOTSPOT_3.to_string(),
-            PublicKeyBinary::from(poc_rewards[2].hotspot_key.clone()).to_string()
-        );
-
-        // assert the boosted hexes in the radio rewards
-        // assert the number of boosted hexes for each radio
-        assert_eq!(1, poc_rewards[0].boosted_hexes.len());
-        assert_eq!(1, poc_rewards[1].boosted_hexes.len());
-        // hotspot 3 has no boosted hexes as all its hex boosts are 1x multiplier
-        // and those get filtered out as they dont affect points
-        assert_eq!(0, poc_rewards[2].boosted_hexes.len());
-
-        // assert the hex boost multiplier values
-        assert_eq!(20, poc_rewards[0].boosted_hexes[0].multiplier);
-        assert_eq!(10, poc_rewards[1].boosted_hexes[0].multiplier);
-
-        // assert the hex boost location values
-        assert_eq!(
-            0x8a1fb49642dffff_u64,
-            poc_rewards[0].boosted_hexes[0].location
-        );
-        assert_eq!(
-            0x8a1fb466d2dffff_u64,
-            poc_rewards[1].boosted_hexes[0].location
-        );
-
-        // hotspot1 should have 20x the reward of hotspot 3
-        assert_eq!(poc_rewards[0].poc_reward / poc_rewards[2].poc_reward, 20);
-        // hotspot1 should have 10x the reward of hotspot 3
-        assert_eq!(poc_rewards[1].poc_reward / poc_rewards[2].poc_reward, 10);
-
-        // confirm the total rewards allocated matches expectations
-        let poc_sum: u64 = poc_rewards.iter().map(|r| r.poc_reward).sum();
-        let unallocated_sum: u64 = unallocated_reward.amount;
-        let total = poc_sum + unallocated_sum;
-
-        let expected_sum = reward_shares::get_scheduled_tokens_for_poc(epoch.end - epoch.start)
-            .to_u64()
-            .unwrap();
-        assert_eq!(expected_sum, total);
-
-        // confirm the rewarded percentage amount matches expectations
-        let daily_total = reward_shares::get_total_scheduled_tokens(epoch.end - epoch.start);
-        let percent = (Decimal::from(total) / daily_total)
-            .round_dp_with_strategy(2, RoundingStrategy::MidpointNearestEven);
-        assert_eq!(percent, dec!(0.6));
-    } else {
+    let Ok((poc_rewards, unallocated_reward)) = rewards else {
         panic!("no rewards received");
     };
+
+    let mut poc_rewards = poc_rewards.iter();
+    let hotspot_2 = poc_rewards.next().unwrap();
+    let hotspot_1 = poc_rewards.next().unwrap();
+    let hotspot_3 = poc_rewards.next().unwrap();
+    assert_eq!(
+        None,
+        poc_rewards.next(),
+        "Received more hotspots than expected in rewards"
+    );
+    assert_eq!(
+        HOTSPOT_2.to_string(),
+        PublicKeyBinary::from(hotspot_2.hotspot_key.clone()).to_string()
+    );
+    assert_eq!(
+        HOTSPOT_1.to_string(),
+        PublicKeyBinary::from(hotspot_1.hotspot_key.clone()).to_string()
+    );
+    assert_eq!(
+        HOTSPOT_3.to_string(),
+        PublicKeyBinary::from(hotspot_3.hotspot_key.clone()).to_string()
+    );
+
+    // Let's figure out how to calculate rewards for 3 similar radios whose
+    // only difference is boosting.
+    {
+        // To not deal with percentages of percentages, let's start with the
+        // total emissions and work from there.
+        let total_emissions = reward_shares::get_total_scheduled_tokens(epoch_duration);
+        let data_transfer = total_emissions * dec!(0.4);
+        let regular_poc = total_emissions * dec!(0.1);
+        let boosted_poc = total_emissions * dec!(0.1);
+
+        // There is no data transfer in this test to be rewarded, so we know
+        // the entirety of the unallocated amount will be put in the poc
+        // pool.
+        let regular_poc = regular_poc + data_transfer;
+
+        // With regular poc now 50% of total emissions, that will be split
+        // between the 3 radios equally. 900 comes from IndoorWifi 400 *
+        // 0.75 speedtest multiplier * 3 radios
+        let regular_per_share = regular_poc / dec!(900);
+
+        // Boosted hexes are 10x and 20x.
+        // (300 * 9) + (300 * 19) = 8400;
+        // To get points _only_ from boosting.
+        let boosted_per_share = boosted_poc / dec!(8400);
+
+        let base_reward = regular_per_share * dec!(300);
+        let expected_reward_1 = base_reward + (boosted_per_share * dec!(300) * dec!(19));
+        let expected_reward_2 = base_reward + (boosted_per_share * dec!(300) * dec!(9));
+        let expected_reward_3 = base_reward + (boosted_per_share * dec!(300) * dec!(0));
+
+        let (exp_reward_1, exp_reward_2, exp_reward_3) = (
+            expected_reward_1.to_u64().unwrap(),
+            expected_reward_2.to_u64().unwrap(),
+            expected_reward_3.to_u64().unwrap(),
+        );
+
+        assert_eq!(exp_reward_1, hotspot_2.poc_reward); // 20x boost
+        assert_eq!(exp_reward_2, hotspot_1.poc_reward); // 10x boost
+        assert_eq!(exp_reward_3, hotspot_3.poc_reward); // no boost
+    }
+
+    // assert the boosted hexes in the radio rewards
+    // assert the number of boosted hexes for each radio
+    assert_eq!(1, hotspot_2.boosted_hexes.len());
+    assert_eq!(1, hotspot_1.boosted_hexes.len());
+    // hotspot 3 has no boosted hexes as all its hex boosts are 1x multiplier
+    // and those get filtered out as they dont affect points
+    assert_eq!(0, hotspot_3.boosted_hexes.len());
+
+    // assert the hex boost multiplier values
+    assert_eq!(20, hotspot_2.boosted_hexes[0].multiplier);
+    assert_eq!(10, hotspot_1.boosted_hexes[0].multiplier);
+
+    // assert the hex boost location values
+    assert_eq!(0x8a1fb49642dffff_u64, hotspot_2.boosted_hexes[0].location);
+    assert_eq!(0x8a1fb466d2dffff_u64, hotspot_1.boosted_hexes[0].location);
+
+    // confirm the total rewards allocated matches expectations
+    let poc_sum = hotspot_1.poc_reward + hotspot_2.poc_reward + hotspot_3.poc_reward;
+    let total = poc_sum + unallocated_reward.amount;
+    assert_eq!(total_poc_emissions, total);
+
+    // confirm the rewarded percentage amount matches expectations
+    let daily_total = reward_shares::get_total_scheduled_tokens(epoch.end - epoch.start);
+    let percent = (Decimal::from(total) / daily_total)
+        .round_dp_with_strategy(2, RoundingStrategy::MidpointNearestEven);
+    assert_eq!(percent, dec!(0.6));
+
     Ok(())
 }
 
@@ -991,6 +1030,18 @@ async fn test_poc_with_cbrs_and_multi_coverage_boosted_hexes(pool: PgPool) -> an
 async fn receive_expected_rewards(
     mobile_rewards: &mut MockFileSinkReceiver,
 ) -> anyhow::Result<(Vec<RadioReward>, UnallocatedReward)> {
+    receive_expected_rewards_maybe_unallocated(mobile_rewards, ExpectUnallocated::Yes).await
+}
+
+enum ExpectUnallocated {
+    Yes,
+    NoWhenValue(u64),
+}
+
+async fn receive_expected_rewards_maybe_unallocated(
+    mobile_rewards: &mut MockFileSinkReceiver,
+    expect_unallocated: ExpectUnallocated,
+) -> anyhow::Result<(Vec<RadioReward>, UnallocatedReward)> {
     // get the filestore outputs from rewards run
     // we will have 3 radio rewards, 1 wifi radio and 2 cbrs radios
     let radio_reward1 = mobile_rewards.receive_radio_reward().await;
@@ -1001,8 +1052,27 @@ async fn receive_expected_rewards(
     // after sorting reward 1 = cbrs radio1, 2 = cbrs radio2, 3 = wifi radio
     poc_rewards.sort_by(|a, b| b.hotspot_key.cmp(&a.hotspot_key));
 
-    // expect one unallocated reward for poc
-    let unallocated_poc_reward = mobile_rewards.receive_unallocated_reward().await;
+    let unallocated_poc_reward = match expect_unallocated {
+        ExpectUnallocated::Yes => mobile_rewards.receive_unallocated_reward().await,
+        ExpectUnallocated::NoWhenValue(max_emission) => {
+            let total: u64 = poc_rewards.iter().map(|p| p.poc_reward).sum();
+            let emitted_is_total = total == max_emission;
+            tracing::info!(
+                emitted_is_total,
+                total,
+                max_emission,
+                "receiving expected rewards unallocated amount"
+            );
+            if emitted_is_total {
+                UnallocatedReward {
+                    reward_type: UnallocatedRewardType::Poc.into(),
+                    amount: 0,
+                }
+            } else {
+                mobile_rewards.receive_unallocated_reward().await
+            }
+        }
+    };
 
     // should be no further msgs
     mobile_rewards.assert_no_messages();


### PR DESCRIPTION
Reference: [HIP-122](https://github.com/helium/HIP/blob/main/0122-amend-service-provider-hex-boosting.md)

## `DataTransferAndPocAllocatedRewardBuckets` and `CalculatedPocRewardShares`

Data Transfer rewards used to be calculated to fit within the `MAX_DATA_TRANSFER_REWARDS_PERCENT` from the total scheduled tokens for an epoch. This has been moved to the construction of `DataTransferAndPocAllocatedRewardBuckets` so boosted poc rewards can be carved out of the poc allocation as soon as possible. 

After Data Transfer has been rewarded, the unallocated amount is rolled into the normal POC bucket with `reward_shares.handle_unallocated_data_transfer(dc_unallocated_amount);`.

Unallocated Data Transfer rewards are allowed to increase the POC rewards, **but not service provider boosted rewards**.
(In the case where boosted rewards do not exceed 10%, nothing extra needs to be done.)

## `CoveragePoints` and `HexPoints`

To ensure we can do reward calculations with regard to the boosted poc pool, we store the points received from service provider boosting per hex separate from the points received by covering a hex.

Any time boosted points are used in code or comment they **do not** include base points from covering a hex.
#### Example:
An IndoorWifi radio with good SignalLevel receives `400` coverage points from a hex.
If that hex is boosted `10x`, the radio receives `4,000` coverage points.
But they are stored `{ base: 400, boosted: 3,600 }`, because the radio receives `3,600` additional points thanks to Service Provider Boosting.

## `hex_boosting.rs` test file

Tests where boosting did not exceed 10% of rewards were untouched.

For the rest, I attempted to recreate the math that derives the expected rewards for radios.
For a sense of how expected rewards changed with few radios and few hexes, some examples.
(These tests include the 40% data transfer bucket as well)

#### `test_poc_with_boosted_hexes`
- 3 IndoorWifi radios
- 2 boosted hexes at `20x` and `10x`

| | Old Expected Reward | New Expected Reward |
|---|---|---|
| 20x boosted | 31,729,243,786,356 | 19,223,263,075,722 |
| 10x boosted | 15,864,621,893,178 | 16,295,862,607,338 |
| No boost | 1,586,462,189,317 | 13,661,202,185,792 |

The boosts contributed significantly less than before.

#### `test_poc_with_multi_coverage_boosted_hexes`
- 3 Indoor Wifi Radios
- 2 boosted hexes at `10x`, 1 at `20x`

| | Old Expected Reward | New Expected Reward |
|---|---|---|
| 1 at 20x boosted | 23,990,403,838,464 | 14,455,028,799,291 |
| 2 at 10x boosted | 23,990,403,838,464 | 24,479,397,430,217 | 
| No boost | 1,199,520,191,923 | 10,245,901,639,344 |

Covering more hexes is much more valuable than a strong boosted hex.