### PR TITLE
Avoid rate limit for protoc github action install

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache
         uses: actions/cache@v4
@@ -78,6 +80,8 @@ jobs:
       
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clippy
         run: cargo clippy --all-targets -- -Dclippy::all -D warnings
@@ -113,6 +117,8 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache
         uses: actions/cache@v4
@@ -149,6 +155,8 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache
         uses: actions/cache@v4
@@ -178,6 +186,8 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache
         uses: actions/cache@v4


### PR DESCRIPTION
Sometimes (more often than we want) we hit the rate limit to download the protoc action (see https://github.com/helium/oracles/actions/runs/9846105487/job/27183162620?pr=836). By logging in we get a higher rate limit.