### PR TITLE
Make `modeled` field in `HexPoints` public

### DIFF
--- a/coverage_point_calculator/src/hexes.rs
+++ b/coverage_point_calculator/src/hexes.rs
@@ -29,7 +29,7 @@ pub struct HexPoints {
     ///
     /// This is a convenience field for debugging, hexes can reach similar
     /// values through different means, it helps to know the starting value.
-    modeled: Decimal,
+    pub modeled: Decimal,
     /// Points including Coverage affected multipliers
     ///
     /// modeled + (Rank * Assignment)

--- a/file_store/src/reward_manifest.rs
+++ b/file_store/src/reward_manifest.rs
@@ -14,8 +14,8 @@ pub struct RewardManifest {
 #[derive(Clone, Debug)]
 pub enum RewardData {
     MobileRewardData {
-        poc_bones_per_coverage_point: Decimal,
-        boosted_poc_bones_per_coverage_point: Decimal,
+        poc_bones_per_reward_share: Decimal,
+        boosted_poc_bones_per_reward_share: Decimal,
     },
     IotRewardData {
         poc_bones_per_beacon_reward_share: Decimal,
@@ -49,16 +49,16 @@ impl TryFrom<proto::RewardManifest> for RewardManifest {
             reward_data: match value.reward_data {
                 Some(proto::reward_manifest::RewardData::MobileRewardData(reward_data)) => {
                     Some(RewardData::MobileRewardData {
-                        poc_bones_per_coverage_point: reward_data
+                        poc_bones_per_reward_share: reward_data
                             .poc_bones_per_reward_share
-                            .ok_or(DecodeError::empty_field("poc_bones_per_coverage_point"))?
+                            .ok_or(DecodeError::empty_field("poc_bones_per_reward_share"))?
                             .value
                             .parse()
                             .map_err(DecodeError::from)?,
-                        boosted_poc_bones_per_coverage_point: reward_data
+                        boosted_poc_bones_per_reward_share: reward_data
                             .boosted_poc_bones_per_reward_share
                             .ok_or(DecodeError::empty_field(
-                                "boosted_poc_bones_per_coverage_point",
+                                "boosted_poc_bones_per_reward_share",
                             ))?
                             .value
                             .parse()


### PR DESCRIPTION
The `modeled` field in `HexPoints` is currently private. However, it is useful for upstream crates, so let's make it public.

This PR also fixes some naming in our file store struct for the mobile reward manifest