### PR TITLE
Makes oracles more friendly to use as library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ http = "<=0.2"
 triggered = "0"
 futures = "*"
 futures-util = "*"
-prost = "*"
+prost = "0.12"
 once_cell = "1"
 lazy_static = "1"
 config = { version = "0", default-features = false, features = ["toml"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ sqlx = { version = "0", features = [
   "runtime-tokio-rustls",
 ] }
 helium-anchor-gen = { git = "https://github.com/helium/helium-anchor-gen.git" }
-helium-crypto = { version = "0.8.4", features = ["sqlx-postgres", "multisig"] }
+helium-crypto = { version = "0.8.4", features = ["multisig"] }
 helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = "master" }
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
   "disktree",

--- a/iot_config/Cargo.toml
+++ b/iot_config/Cargo.toml
@@ -18,7 +18,7 @@ db-store = { path = "../db_store" }
 file-store = { path = "../file_store" }
 futures = { workspace = true }
 futures-util = { workspace = true }
-helium-crypto = { workspace = true }
+helium-crypto = { workspace = true, features = ["sqlx-postgres"] }
 helium-proto = { workspace = true }
 hextree = { workspace = true }
 http = { workspace = true }

--- a/iot_verifier/Cargo.toml
+++ b/iot_verifier/Cargo.toml
@@ -30,7 +30,7 @@ futures-util = { workspace = true }
 prost = { workspace = true }
 chrono = { workspace = true }
 helium-proto = { workspace = true }
-helium-crypto = { workspace = true }
+helium-crypto = { workspace = true, features = ["sqlx-postgres"] }
 async-trait = { workspace = true }
 h3o = { workspace = true, features = ["geo"] }
 xorf = { workspace = true }

--- a/mobile_config/Cargo.toml
+++ b/mobile_config/Cargo.toml
@@ -18,7 +18,7 @@ db-store = { path = "../db_store" }
 file-store = { path = "../file_store" }
 futures = { workspace = true }
 futures-util = { workspace = true }
-helium-crypto = { workspace = true }
+helium-crypto = { workspace = true, features = ["sqlx-postgres"] }
 helium-proto = { workspace = true }
 hextree = { workspace = true }
 http = { workspace = true }

--- a/mobile_verifier/Cargo.toml
+++ b/mobile_verifier/Cargo.toml
@@ -32,7 +32,7 @@ futures-util = { workspace = true }
 prost = { workspace = true }
 once_cell = { workspace = true }
 helium-proto = { workspace = true }
-helium-crypto = { workspace = true }
+helium-crypto = { workspace = true, features = ["sqlx-postgres"] }
 humantime = { workspace = true }
 rust_decimal = { workspace = true }
 rust_decimal_macros = { workspace = true }


### PR DESCRIPTION
## Use "prost = 0.12"

The `oracles` codebase is unable to compile with `prost = 0.13` version which breaks the compilation process for projects that use `oracles` crates.
Solution: using explicitly `prost = 0.12` 

## Use the helium-crypto feature in creates where it is required
Make it possible to use `oracles` with  `helium-crypto-rs` but without forced sqlx dependency  