### PR TITLE
Remove leap year when calculating rewards - Deploy on Aug. 1st, 2024

### DIFF
--- a/iot_verifier/src/reward_share.rs
+++ b/iot_verifier/src/reward_share.rs
@@ -18,7 +18,7 @@ const DEFAULT_PREC: u32 = 15;
 lazy_static! {
     // TODO: year 1 emissions allocate 30% of total to PoC with 6% to beacons and 24% to witnesses but subsequent years back
     // total PoC percentage off 1.5% each year; determine how beacons and witnesses will split the subsequent years' allocations
-    pub static ref REWARDS_PER_DAY: Decimal = (Decimal::from(32_500_000_000_u64) / Decimal::from(366)) * Decimal::from(1_000_000); //  88_797_814_207_650.273224043715847
+    pub static ref REWARDS_PER_DAY: Decimal = (Decimal::from(32_500_000_000_u64) / Decimal::from(365)) * Decimal::from(1_000_000); //  88_797_814_207_650.273224043715847
     static ref BEACON_REWARDS_PER_DAY_PERCENT: Decimal = dec!(0.06);
     static ref WITNESS_REWARDS_PER_DAY_PERCENT: Decimal = dec!(0.24);
     // Data transfer is allocated 50% of daily rewards
@@ -494,7 +494,7 @@ mod test {
 
         let operation_tokens_for_period = get_scheduled_ops_fund_tokens(epoch_duration);
         assert_eq!(
-            dec!(258_993_624_772.313296903460838),
+            dec!(259_703_196_347.031963470319635),
             operation_tokens_for_period
         );
     }
@@ -666,16 +666,16 @@ mod test {
         // assert the beacon and witness amount, these will now have an allocation
         // of any unused data transfer rewards
         assert_eq!(rewards.get(&gw4), None); // Validate zero-amount entry filtered out
-        assert_eq!(gw1_rewards.beacon_amount, 2_161_036_912);
-        assert_eq!(gw1_rewards.witness_amount, 51_301_137_137);
-        assert_eq!(gw2_rewards.beacon_amount, 43_220_738_247);
-        assert_eq!(gw2_rewards.witness_amount, 94_052_084_751);
-        assert_eq!(gw3_rewards.beacon_amount, 16_207_776_842);
-        assert_eq!(gw3_rewards.witness_amount, 68_401_516_182);
-        assert_eq!(gw5_rewards.beacon_amount, 4_322_073_824);
-        assert_eq!(gw5_rewards.witness_amount, 119_702_653_319);
-        assert_eq!(gw6_rewards.beacon_amount, 32_415_553_685);
-        assert_eq!(gw6_rewards.witness_amount, 59_851_326_659);
+        assert_eq!(gw1_rewards.beacon_amount, 2_166_977_857);
+        assert_eq!(gw1_rewards.witness_amount, 51_442_169_996);
+        assert_eq!(gw2_rewards.beacon_amount, 43_339_557_140);
+        assert_eq!(gw2_rewards.witness_amount, 94_310_644_993);
+        assert_eq!(gw3_rewards.beacon_amount, 16_252_333_927);
+        assert_eq!(gw3_rewards.witness_amount, 68_589_559_995);
+        assert_eq!(gw5_rewards.beacon_amount, 4_333_955_714);
+        assert_eq!(gw5_rewards.witness_amount, 120_031_729_992);
+        assert_eq!(gw6_rewards.beacon_amount, 32_504_667_855);
+        assert_eq!(gw6_rewards.witness_amount, 60_015_864_996);
 
         // assert the total POC rewards allocated equals TOTAL_POC_REWARDS_FOR_PERIOD
         // plus the remainder of the total dc transfer rewards for the period
@@ -701,7 +701,7 @@ mod test {
         // due to going from decimal to u64
         let unallocated_poc_reward_amount =
             total_poc_dc_reward_allocation - Decimal::from(allocated_gateway_rewards);
-        assert_eq!(unallocated_poc_reward_amount.to_u64().unwrap(), 6);
+        assert_eq!(unallocated_poc_reward_amount.to_u64().unwrap(), 3);
     }
 
     #[tokio::test]
@@ -849,29 +849,29 @@ mod test {
         // the sum of rewards distributed should not exceed the epoch amount
         // but due to rounding whilst going to u64 in compute_rewards,
         // is permitted to be a few bones less
-        assert_eq!(data_transfer_diff, 1);
+        assert_eq!(data_transfer_diff, 3);
 
         // assert the expected data transfer rewards amounts per gateway
-        assert_eq!(gw1_rewards.dc_transfer_amount, 25_693_811_981); // ~8.33% of total rewards
-        assert_eq!(gw2_rewards.dc_transfer_amount, 25_693_811_981); // ~8.33% of total rewards
-        assert_eq!(gw3_rewards.dc_transfer_amount, 25_693_811_981); // ~8.33% of total rewards
-        assert_eq!(gw5_rewards.dc_transfer_amount, 25_693_811_981); // ~8.33% of total rewards
-        assert_eq!(gw6_rewards.dc_transfer_amount, 205_550_495_851); // ~66.64% of total rewards, or 8x each of the other gateways
+        assert_eq!(gw1_rewards.dc_transfer_amount, 25_764_205_986); // ~8.33% of total rewards
+        assert_eq!(gw2_rewards.dc_transfer_amount, 25_764_205_986); // ~8.33% of total rewards
+        assert_eq!(gw3_rewards.dc_transfer_amount, 25_764_205_986); // ~8.33% of total rewards
+        assert_eq!(gw5_rewards.dc_transfer_amount, 25_764_205_986); // ~8.33% of total rewards
+        assert_eq!(gw6_rewards.dc_transfer_amount, 206_113_647_894); // ~66.64% of total rewards, or 8x each of the other gateways
 
         // assert the beacon and witness amount
         // these will be rewards solely from POC as there are zero unallocated
         // dc transfer rewards
         assert_eq!(rewards.get(&gw4), None); // Validate zero-amount entry filtered out
-        assert_eq!(gw1_rewards.beacon_amount, 813_166_796);
-        assert_eq!(gw1_rewards.witness_amount, 19_303_872_653);
-        assert_eq!(gw2_rewards.beacon_amount, 16_263_335_935);
-        assert_eq!(gw2_rewards.witness_amount, 35_390_433_198);
-        assert_eq!(gw3_rewards.beacon_amount, 6_098_750_975);
-        assert_eq!(gw3_rewards.witness_amount, 25_738_496_871);
-        assert_eq!(gw5_rewards.beacon_amount, 1_626_333_593);
-        assert_eq!(gw5_rewards.witness_amount, 45_042_369_525);
-        assert_eq!(gw6_rewards.beacon_amount, 12_197_501_951);
-        assert_eq!(gw6_rewards.witness_amount, 22_521_184_762);
+        assert_eq!(gw1_rewards.beacon_amount, 815_394_651);
+        assert_eq!(gw1_rewards.witness_amount, 19_356_759_976);
+        assert_eq!(gw2_rewards.beacon_amount, 16_307_893_020);
+        assert_eq!(gw2_rewards.witness_amount, 35_487_393_289);
+        assert_eq!(gw3_rewards.beacon_amount, 6_115_459_882);
+        assert_eq!(gw3_rewards.witness_amount, 25_809_013_301);
+        assert_eq!(gw5_rewards.beacon_amount, 1_630_789_302);
+        assert_eq!(gw5_rewards.witness_amount, 45_165_773_277);
+        assert_eq!(gw6_rewards.beacon_amount, 12_230_919_765);
+        assert_eq!(gw6_rewards.witness_amount, 22_582_886_638);
 
         // assert the total rewards allocated equals TOTAL_POC_REWARDS_FOR_PERIOD
         // plus 0% of the total dc transfer rewards for the period
@@ -896,7 +896,7 @@ mod test {
         // due to going from decimal to u64
         let unallocated_poc_reward_amount =
             total_poc_dc_reward_allocation - Decimal::from(allocated_gateway_rewards);
-        assert_eq!(unallocated_poc_reward_amount.to_u64().unwrap(), 8);
+        assert_eq!(unallocated_poc_reward_amount.to_u64().unwrap(), 7);
     }
 
     #[tokio::test]
@@ -1035,25 +1035,25 @@ mod test {
         assert_eq!(expected_data_transfer_percent.round(), dec!(55));
 
         // assert the expected dc amounts per gateway
-        assert_eq!(gw1_rewards.dc_transfer_amount, 30_832_573_816); // 10% of total
+        assert_eq!(gw1_rewards.dc_transfer_amount, 30_917_044_568); // 10% of total
         assert_eq!(gw2_rewards.dc_transfer_amount, 0); // 0% of total
-        assert_eq!(gw3_rewards.dc_transfer_amount, 61_665_147_632); // 20% of total
-        assert_eq!(gw5_rewards.dc_transfer_amount, 15_416_286_908); // 5% of total
-        assert_eq!(gw6_rewards.dc_transfer_amount, 61_665_147_632); // 20% of total
+        assert_eq!(gw3_rewards.dc_transfer_amount, 61_834_089_136); // 20% of total
+        assert_eq!(gw5_rewards.dc_transfer_amount, 15_458_522_284); // 5% of total
+        assert_eq!(gw6_rewards.dc_transfer_amount, 61_834_089_136); // 20% of total
 
         // assert the beacon and witness amount, these will now have an allocation
         // of any unused data transfer rewards
         assert_eq!(rewards.get(&gw4), None); // Validate zero-amount entry filtered out
-        assert_eq!(gw1_rewards.beacon_amount, 1_423_041_907);
-        assert_eq!(gw1_rewards.witness_amount, 33_781_777_466);
-        assert_eq!(gw2_rewards.beacon_amount, 28_460_838_158);
-        assert_eq!(gw2_rewards.witness_amount, 61_933_258_688);
-        assert_eq!(gw3_rewards.beacon_amount, 10_672_814_309);
-        assert_eq!(gw3_rewards.witness_amount, 45_042_369_955);
-        assert_eq!(gw5_rewards.beacon_amount, 2_846_083_815);
-        assert_eq!(gw5_rewards.witness_amount, 78_824_147_421);
-        assert_eq!(gw6_rewards.beacon_amount, 21_345_628_618);
-        assert_eq!(gw6_rewards.witness_amount, 39_412_073_710);
+        assert_eq!(gw1_rewards.beacon_amount, 1_426_940_702);
+        assert_eq!(gw1_rewards.witness_amount, 33_874_331_459);
+        assert_eq!(gw2_rewards.beacon_amount, 28_538_814_050);
+        assert_eq!(gw2_rewards.witness_amount, 62_102_941_009);
+        assert_eq!(gw3_rewards.beacon_amount, 10_702_055_268);
+        assert_eq!(gw3_rewards.witness_amount, 45_165_775_279);
+        assert_eq!(gw5_rewards.beacon_amount, 2_853_881_405);
+        assert_eq!(gw5_rewards.witness_amount, 79_040_106_739);
+        assert_eq!(gw6_rewards.beacon_amount, 21_404_110_537);
+        assert_eq!(gw6_rewards.witness_amount, 39_520_053_369);
 
         // assert the total POC rewards allocated equal TOTAL_POC_REWARDS_FOR_PERIOD
         // plus 45% of the total dc transfer rewards for the period
@@ -1081,7 +1081,7 @@ mod test {
         // due to going from decimal to u64
         let unallocated_poc_reward_amount =
             total_poc_dc_reward_allocation - Decimal::from(allocated_gateway_rewards);
-        assert_eq!(unallocated_poc_reward_amount.to_u64().unwrap(), 7);
+        assert_eq!(unallocated_poc_reward_amount.to_u64().unwrap(), 5);
     }
 
     #[test]

--- a/iot_verifier/tests/integrations/rewarder_operations.rs
+++ b/iot_verifier/tests/integrations/rewarder_operations.rs
@@ -19,7 +19,7 @@ async fn test_operations() -> anyhow::Result<()> {
         let expected_total = reward_share::get_scheduled_ops_fund_tokens(epoch.end - epoch.start)
             .to_u64()
             .unwrap();
-        assert_eq!(ops_reward.amount, 6_215_846_994_535);
+        assert_eq!(ops_reward.amount, 6_232_876_712_328);
         assert_eq!(ops_reward.amount, expected_total);
 
         // confirm the ops percentage amount matches expectations

--- a/iot_verifier/tests/integrations/rewarder_oracles.rs
+++ b/iot_verifier/tests/integrations/rewarder_oracles.rs
@@ -20,7 +20,7 @@ async fn test_oracles(_pool: PgPool) -> anyhow::Result<()> {
         let expected_total = reward_share::get_scheduled_oracle_tokens(epoch.end - epoch.start)
             .to_u64()
             .unwrap();
-        assert_eq!(unallocated_oracle_reward.amount, 6_215_846_994_535);
+        assert_eq!(unallocated_oracle_reward.amount, 6_232_876_712_328);
         assert_eq!(unallocated_oracle_reward.amount, expected_total);
 
         // confirm the ops percentage amount matches expectations

--- a/iot_verifier/tests/integrations/rewarder_poc_dc.rs
+++ b/iot_verifier/tests/integrations/rewarder_poc_dc.rs
@@ -41,21 +41,21 @@ async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
             gateway_rewards[0].hotspot_key,
             PublicKeyBinary::from_str(HOTSPOT_1).unwrap().as_ref()
         );
-        assert_eq!(gateway_rewards[0].beacon_amount, 1_775_956_284_153);
+        assert_eq!(gateway_rewards[0].beacon_amount, 1_780_821_917_808);
         assert_eq!(gateway_rewards[0].witness_amount, 0);
-        assert_eq!(gateway_rewards[0].dc_transfer_amount, 14_799_635_701_275);
+        assert_eq!(gateway_rewards[0].dc_transfer_amount, 14_840_182_648_401);
 
         assert_eq!(
             gateway_rewards[1].hotspot_key,
             PublicKeyBinary::from_str(HOTSPOT_2).unwrap().as_ref()
         );
         assert_eq!(gateway_rewards[1].beacon_amount, 0);
-        assert_eq!(gateway_rewards[1].witness_amount, 8_524_590_163_934);
-        assert_eq!(gateway_rewards[1].dc_transfer_amount, 29_599_271_402_550);
+        assert_eq!(gateway_rewards[1].witness_amount, 8_547_945_205_479);
+        assert_eq!(gateway_rewards[1].dc_transfer_amount, 29_680_365_296_803);
         // hotspot 2 should have double the dc rewards of hotspot 1
         assert_eq!(
             gateway_rewards[1].dc_transfer_amount,
-            gateway_rewards[0].dc_transfer_amount * 2
+            gateway_rewards[0].dc_transfer_amount * 2 + 1
         );
 
         assert_eq!(
@@ -63,7 +63,7 @@ async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
             PublicKeyBinary::from_str(HOTSPOT_3).unwrap().as_ref()
         );
         // hotspot 2 has double reward scale of hotspot 1 and thus double the beacon  amount
-        assert_eq!(gateway_rewards[2].beacon_amount, 3_551_912_568_306);
+        assert_eq!(gateway_rewards[2].beacon_amount, 3_561_643_835_616);
         assert_eq!(
             gateway_rewards[2].beacon_amount,
             gateway_rewards[0].beacon_amount * 2
@@ -76,7 +76,7 @@ async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
             PublicKeyBinary::from_str(HOTSPOT_4).unwrap().as_ref()
         );
         assert_eq!(gateway_rewards[3].beacon_amount, 0);
-        assert_eq!(gateway_rewards[3].witness_amount, 12_786_885_245_901);
+        assert_eq!(gateway_rewards[3].witness_amount, 12_821_917_808_219);
         assert_eq!(gateway_rewards[3].dc_transfer_amount, 0);
 
         // assert our unallocated reward
@@ -84,7 +84,7 @@ async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
             UnallocatedRewardType::Poc as i32,
             unallocated_poc_reward.reward_type
         );
-        assert_eq!(1, unallocated_poc_reward.amount);
+        assert_eq!(2, unallocated_poc_reward.amount);
 
         // confirm the total rewards allocated matches expectations
         let poc_sum: u64 = gateway_rewards

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -804,7 +804,7 @@ impl CalculatedPocRewardShares {
 }
 
 pub fn get_total_scheduled_tokens(duration: Duration) -> Decimal {
-    (TOTAL_EMISSIONS_POOL / dec!(366) / Decimal::from(Duration::hours(24).num_seconds()))
+    (TOTAL_EMISSIONS_POOL / dec!(365) / Decimal::from(Duration::hours(24).num_seconds()))
         * Decimal::from(duration.num_seconds())
 }
 
@@ -910,14 +910,14 @@ mod test {
             .round_dp_with_strategy(0, RoundingStrategy::ToZero)
             .to_u64()
             .unwrap_or(0);
-        assert_eq!(81_967_213_114_754, total_epoch_rewards);
+        assert_eq!(82_191_780_821_917, total_epoch_rewards);
 
         // verify total rewards allocated to mappers the epoch
         let total_mapper_rewards = get_scheduled_tokens_for_mappers(epoch.end - epoch.start)
             .round_dp_with_strategy(0, RoundingStrategy::ToZero)
             .to_u64()
             .unwrap_or(0);
-        assert_eq!(16_393_442_622_950, total_mapper_rewards);
+        assert_eq!(16_438_356_164_383, total_mapper_rewards);
 
         let expected_reward_per_subscriber = total_mapper_rewards / NUM_SUBSCRIBERS;
 
@@ -934,13 +934,13 @@ mod test {
         }
 
         // verify the total rewards awarded for discovery mapping
-        assert_eq!(16_393_442_620_000, allocated_mapper_rewards);
+        assert_eq!(16_438_356_160_000, allocated_mapper_rewards);
 
         // confirm the unallocated service provider reward amounts
         // this should not be more than the total number of subscribers ( 10 k)
         // as we can at max drop one bone per subscriber due to rounding
         let unallocated_mapper_reward_amount = total_mapper_rewards - allocated_mapper_rewards;
-        assert_eq!(unallocated_mapper_reward_amount, 2950);
+        assert_eq!(unallocated_mapper_reward_amount, 4383);
         assert!(unallocated_mapper_reward_amount < NUM_SUBSCRIBERS);
     }
 
@@ -980,7 +980,7 @@ mod test {
         // total_rewards will be in bones
         assert_eq!(
             (total_rewards / dec!(1_000_000) * dec!(24)).trunc(),
-            dec!(49_180_327)
+            dec!(49_315_068)
         );
 
         let reward_shares = DataTransferAndPocAllocatedRewardBuckets::new(&epoch);
@@ -1046,11 +1046,11 @@ mod test {
         // for POC and data transfer (which is 60% of the daily total emissions).
         let available_poc_rewards = get_scheduled_tokens_for_poc(epoch.end - epoch.start)
             - data_transfer_rewards.reward_sum;
-        assert_eq!(available_poc_rewards.trunc(), dec!(16_393_442_622_950));
+        assert_eq!(available_poc_rewards.trunc(), dec!(16_438_356_164_383));
         assert_eq!(
             // Rewards are automatically scaled
             data_transfer_rewards.reward(&owner).trunc(),
-            dec!(32_786_885_245_901)
+            dec!(32_876_712_328_767)
         );
         assert_eq!(data_transfer_rewards.reward_scale().round_dp(1), dec!(0.5));
     }
@@ -1570,31 +1570,31 @@ mod test {
             *owner_rewards
                 .get(&owner1)
                 .expect("Could not fetch owner1 rewards"),
-            260_213_374_966
+            260_926_288_322
         );
         assert_eq!(
             *owner_rewards
                 .get(&owner2)
                 .expect("Could not fetch owner2 rewards"),
-            975_800_156_122
+            978_473_581_207
         );
         assert_eq!(
             *owner_rewards
                 .get(&owner3)
                 .expect("Could not fetch owner3 rewards"),
-            32_526_671_870
+            32_615_786_040
         );
         assert_eq!(owner_rewards.get(&owner4), None);
 
         let owner5_reward = *owner_rewards
             .get(&owner5)
             .expect("Could not fetch owner5 rewards");
-        assert_eq!(owner5_reward, 520_426_749_934);
+        assert_eq!(owner5_reward, 521_852_576_647);
 
         let owner6_reward = *owner_rewards
             .get(&owner6)
             .expect("Could not fetch owner6 rewards");
-        assert_eq!(owner6_reward, 130_106_687_483);
+        assert_eq!(owner6_reward, 130_463_144_161);
 
         // confirm owner 6 reward is 0.25 of owner 5's reward
         // this is due to owner 6's hotspot not having a validation location timestamp
@@ -1604,7 +1604,7 @@ mod test {
         let owner7_reward = *owner_rewards
             .get(&owner6)
             .expect("Could not fetch owner7 rewards");
-        assert_eq!(owner7_reward, 130_106_687_483);
+        assert_eq!(owner7_reward, 130_463_144_161);
 
         // confirm owner 7 reward is 0.25 of owner 5's reward
         // owner 7's hotspot does have a validation location timestamp
@@ -1613,7 +1613,7 @@ mod test {
         assert_eq!((owner5_reward as f64 * 0.25) as u64, owner7_reward);
 
         // confirm total sum of allocated poc rewards
-        assert_eq!(allocated_poc_rewards, 2_049_180_327_858);
+        assert_eq!(allocated_poc_rewards, 2_054_794_520_538);
 
         // confirm the unallocated poc reward amounts
         let unallocated_sp_reward_amount = (reward_shares.total_poc()
@@ -1621,7 +1621,7 @@ mod test {
         .round_dp_with_strategy(0, RoundingStrategy::ToZero)
         .to_u64()
         .unwrap_or(0);
-        assert_eq!(unallocated_sp_reward_amount, 10);
+        assert_eq!(unallocated_sp_reward_amount, 9);
     }
 
     #[tokio::test]
@@ -1746,13 +1746,13 @@ mod test {
         let owner1_reward = *owner_rewards
             .get(&owner1)
             .expect("Could not fetch owner1 rewards");
-        assert_eq!(owner1_reward, 1_639_344_262_295);
+        assert_eq!(owner1_reward, 1_643_835_616_438);
 
         // sercomm
         let owner2_reward = *owner_rewards
             .get(&owner2)
             .expect("Could not fetch owner2 rewards");
-        assert_eq!(owner2_reward, 409_836_065_573);
+        assert_eq!(owner2_reward, 410_958_904_109);
     }
 
     #[tokio::test]
@@ -2013,13 +2013,13 @@ mod test {
         let owner1_reward = *owner_rewards
             .get(&owner1)
             .expect("Could not fetch owner1 rewards");
-        assert_eq!(owner1_reward, 1_639_344_262_295);
+        assert_eq!(owner1_reward, 1_643_835_616_438);
 
         // sercomm
         let owner2_reward = *owner_rewards
             .get(&owner2)
             .expect("Could not fetch owner2 rewards");
-        assert_eq!(owner2_reward, 409_836_065_573);
+        assert_eq!(owner2_reward, 410_958_904_109);
     }
 
     /// Test to ensure that rewards that are zeroed are not written out.
@@ -2203,7 +2203,7 @@ mod test {
             .round_dp_with_strategy(0, RoundingStrategy::ToZero)
             .to_u64()
             .unwrap_or(0);
-        assert_eq!(unallocated_sp_reward_amount, 341_530_053_644);
+        assert_eq!(unallocated_sp_reward_amount, 342_465_752_424);
     }
 
     #[tokio::test]

--- a/mobile_verifier/tests/integrations/hex_boosting.rs
+++ b/mobile_verifier/tests/integrations/hex_boosting.rs
@@ -335,9 +335,9 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
     );
     if let Ok((poc_rewards, unallocated_reward)) = rewards {
         // assert poc reward outputs
-        let exp_reward_1 = 16393442622950;
-        let exp_reward_2 = 16393442622950;
-        let exp_reward_3 = 16393442622950;
+        let exp_reward_1 = 16438356164383;
+        let exp_reward_2 = 16438356164383;
+        let exp_reward_3 = 16438356164383;
 
         assert_eq!(exp_reward_1, poc_rewards[0].total_poc_reward());
         assert_eq!(
@@ -672,9 +672,9 @@ async fn test_expired_boosted_hex(pool: PgPool) -> anyhow::Result<()> {
     );
     if let Ok((poc_rewards, unallocated_reward)) = rewards {
         // assert poc reward outputs
-        let exp_reward_1 = 16_393_442_622_950;
-        let exp_reward_2 = 16_393_442_622_950;
-        let exp_reward_3 = 16_393_442_622_950;
+        let exp_reward_1 = 16_438_356_164_383;
+        let exp_reward_2 = 16_438_356_164_383;
+        let exp_reward_3 = 16_438_356_164_383;
 
         assert_eq!(exp_reward_1, poc_rewards[0].total_poc_reward());
         assert_eq!(

--- a/mobile_verifier/tests/integrations/rewarder_mappers.rs
+++ b/mobile_verifier/tests/integrations/rewarder_mappers.rs
@@ -43,7 +43,7 @@ async fn test_mapper_rewards(pool: PgPool) -> anyhow::Result<()> {
             subscriber_rewards[0].subscriber_id
         );
         assert_eq!(
-            5_464_480_874_316,
+            5_479_452_054_794,
             subscriber_rewards[0].discovery_location_amount
         );
 
@@ -52,7 +52,7 @@ async fn test_mapper_rewards(pool: PgPool) -> anyhow::Result<()> {
             subscriber_rewards[1].subscriber_id
         );
         assert_eq!(
-            5_464_480_874_316,
+            5_479_452_054_794,
             subscriber_rewards[2].discovery_location_amount
         );
 
@@ -61,7 +61,7 @@ async fn test_mapper_rewards(pool: PgPool) -> anyhow::Result<()> {
             subscriber_rewards[2].subscriber_id
         );
         assert_eq!(
-            5_464_480_874_316,
+            5_479_452_054_794,
             subscriber_rewards[2].discovery_location_amount
         );
 
@@ -70,7 +70,7 @@ async fn test_mapper_rewards(pool: PgPool) -> anyhow::Result<()> {
             UnallocatedRewardType::Mapper as i32,
             unallocated_reward.reward_type
         );
-        assert_eq!(2, unallocated_reward.amount);
+        assert_eq!(1, unallocated_reward.amount);
 
         // confirm the total rewards allocated matches expectations
         let expected_sum = reward_shares::get_scheduled_tokens_for_mappers(epoch.end - epoch.start)

--- a/mobile_verifier/tests/integrations/rewarder_oracles.rs
+++ b/mobile_verifier/tests/integrations/rewarder_oracles.rs
@@ -23,7 +23,7 @@ async fn test_oracle_rewards(_pool: PgPool) -> anyhow::Result<()> {
             unallocated_reward.reward_type
         );
         // confirm our unallocated amount
-        assert_eq!(3_278_688_524_590, unallocated_reward.amount);
+        assert_eq!(3_287_671_232_876, unallocated_reward.amount);
 
         // confirm the total rewards allocated matches expectations
         let expected_sum = reward_shares::get_scheduled_tokens_for_oracles(epoch.end - epoch.start)

--- a/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
+++ b/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
@@ -88,7 +88,7 @@ async fn test_service_provider_rewards(pool: PgPool) -> anyhow::Result<()> {
             UnallocatedRewardType::ServiceProvider as i32,
             unallocated_reward.reward_type
         );
-        assert_eq!(8_196_721_305_475, unallocated_reward.amount);
+        assert_eq!(8_219_178_076_191, unallocated_reward.amount);
         // confirm the total rewards allocated matches expectations
         let expected_sum =
             reward_shares::get_scheduled_tokens_for_service_providers(epoch.end - epoch.start)


### PR DESCRIPTION
On Aug. 1 2024, rewards need to be calculated based on 365 days a year, not 366.