### PR TITLE
Update Solana workspace to use `helium-lib`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7319,6 +7319,7 @@ dependencies = [
  "futures",
  "helium-anchor-gen",
  "helium-crypto",
+ "helium-lib",
  "itertools",
  "metrics",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,8 +356,7 @@ dependencies = [
 [[package]]
 name = "anchor-gen"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3b9def91d1f0c23b99be210afea0990f931a1edae439ea30e0da50baeaea8f"
+source = "git+https://github.com/ChewingGlass/anchor-gen.git?branch=master#e6136a50918660c8bab0101568068419cbd23420"
 dependencies = [
  "anchor-generate-cpi-crate",
  "anchor-generate-cpi-interface",
@@ -366,8 +365,7 @@ dependencies = [
 [[package]]
 name = "anchor-generate-cpi-crate"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e8733d55b8492bde0d6f219c25769786758ff9e5e90a16e6a348f91284af50"
+source = "git+https://github.com/ChewingGlass/anchor-gen.git?branch=master#e6136a50918660c8bab0101568068419cbd23420"
 dependencies = [
  "anchor-idl",
  "syn 1.0.109",
@@ -376,8 +374,7 @@ dependencies = [
 [[package]]
 name = "anchor-generate-cpi-interface"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7092a50cf959ebf53460162cb07e88d4cc8ea7fa8c45292e80503a3186033daf"
+source = "git+https://github.com/ChewingGlass/anchor-gen.git?branch=master#e6136a50918660c8bab0101568068419cbd23420"
 dependencies = [
  "anchor-idl",
  "darling 0.14.2",
@@ -387,8 +384,7 @@ dependencies = [
 [[package]]
 name = "anchor-idl"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de2665dc06ee0bd3c7d08f47f136a3d5b1e34b7ac1bc632c86a812add04d68b"
+source = "git+https://github.com/ChewingGlass/anchor-gen.git?branch=master#e6136a50918660c8bab0101568068419cbd23420"
 dependencies = [
  "anchor-syn 0.24.2",
  "darling 0.14.2",
@@ -481,7 +477,7 @@ checksum = "6c4fd6e43b2ca6220d2ef1641539e678bfc31b6cc393cf892b373b5997b6a39a"
 dependencies = [
  "anchor-lang 0.29.0",
  "solana-program",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account",
  "spl-token 4.0.0",
  "spl-token-2022 0.9.0",
 ]
@@ -1625,7 +1621,7 @@ dependencies = [
  "rand_chacha 0.3.0",
  "rust_decimal",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -2129,19 +2125,10 @@ dependencies = [
 [[package]]
 name = "circuit-breaker"
 version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
-]
-
-[[package]]
-name = "circuit-breaker"
-version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
+ "anchor-lang 0.29.0",
 ]
 
 [[package]]
@@ -2780,19 +2767,10 @@ dependencies = [
 [[package]]
 name = "data-credits"
 version = "0.2.2"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
-]
-
-[[package]]
-name = "data-credits"
-version = "0.2.2"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
+ "anchor-lang 0.29.0",
 ]
 
 [[package]]
@@ -3167,19 +3145,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "fanout"
 version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
-]
-
-[[package]]
-name = "fanout"
-version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
+ "anchor-lang 0.29.0",
 ]
 
 [[package]]
@@ -3752,45 +3721,23 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helium-anchor-gen"
 version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
- "circuit-breaker 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
- "data-credits 0.2.2 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
- "fanout 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
- "helium-entity-manager 0.2.11 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
- "helium-sub-daos 0.1.8 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
- "hexboosting 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
- "lazy-distributor 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
- "lazy-transactions 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
- "mobile-entity-manager 0.1.3 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
- "price-oracle 0.2.1 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
- "rewards-oracle 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
- "treasury-management 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
- "voter-stake-registry 0.3.3 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
-]
-
-[[package]]
-name = "helium-anchor-gen"
-version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
- "circuit-breaker 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git)",
- "data-credits 0.2.2 (git+https://github.com/helium/helium-anchor-gen.git)",
- "fanout 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git)",
- "helium-entity-manager 0.2.11 (git+https://github.com/helium/helium-anchor-gen.git)",
- "helium-sub-daos 0.1.8 (git+https://github.com/helium/helium-anchor-gen.git)",
- "hexboosting 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git)",
- "lazy-distributor 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git)",
- "lazy-transactions 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git)",
- "mobile-entity-manager 0.1.3 (git+https://github.com/helium/helium-anchor-gen.git)",
- "price-oracle 0.2.1 (git+https://github.com/helium/helium-anchor-gen.git)",
- "rewards-oracle 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git)",
- "treasury-management 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git)",
- "voter-stake-registry 0.3.3 (git+https://github.com/helium/helium-anchor-gen.git)",
+ "anchor-lang 0.29.0",
+ "circuit-breaker",
+ "data-credits",
+ "fanout",
+ "helium-entity-manager",
+ "helium-sub-daos",
+ "hexboosting",
+ "lazy-distributor",
+ "lazy-transactions",
+ "mobile-entity-manager",
+ "price-oracle",
+ "rewards-oracle",
+ "treasury-management",
+ "voter-stake-registry",
 ]
 
 [[package]]
@@ -3821,25 +3768,16 @@ dependencies = [
 [[package]]
 name = "helium-entity-manager"
 version = "0.2.11"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
-]
-
-[[package]]
-name = "helium-entity-manager"
-version = "0.2.11"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
+ "anchor-lang 0.29.0",
 ]
 
 [[package]]
 name = "helium-lib"
 version = "0.0.0"
-source = "git+https://github.com/helium/helium-wallet-rs.git?branch=mj/oracles-updates#d928033da7918876d95d7936802170f3eee7b006"
+source = "git+https://github.com/helium/helium-wallet-rs.git?branch=master#4dd5d75d7e4c5dcce66575b68a060f03313446a9"
 dependencies = [
  "anchor-client",
  "anchor-spl",
@@ -3854,7 +3792,6 @@ dependencies = [
  "helium-crypto",
  "helium-proto",
  "hex",
- "hex-literal",
  "itertools",
  "jsonrpc_client",
  "lazy_static",
@@ -3869,7 +3806,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "spl-account-compression",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account",
  "thiserror",
  "tonic",
  "tracing",
@@ -3895,19 +3832,10 @@ dependencies = [
 [[package]]
 name = "helium-sub-daos"
 version = "0.1.8"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
-]
-
-[[package]]
-name = "helium-sub-daos"
-version = "0.1.8"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
+ "anchor-lang 0.29.0",
 ]
 
 [[package]]
@@ -3958,19 +3886,10 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 [[package]]
 name = "hexboosting"
 version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
-]
-
-[[package]]
-name = "hexboosting"
-version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
+ "anchor-lang 0.29.0",
 ]
 
 [[package]]
@@ -4778,37 +4697,19 @@ dependencies = [
 [[package]]
 name = "lazy-distributor"
 version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
-]
-
-[[package]]
-name = "lazy-distributor"
-version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
+ "anchor-lang 0.29.0",
 ]
 
 [[package]]
 name = "lazy-transactions"
 version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
-]
-
-[[package]]
-name = "lazy-transactions"
-version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
+ "anchor-lang 0.29.0",
 ]
 
 [[package]]
@@ -5181,19 +5082,10 @@ dependencies = [
 [[package]]
 name = "mobile-entity-manager"
 version = "0.1.3"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
-]
-
-[[package]]
-name = "mobile-entity-manager"
-version = "0.1.3"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
+ "anchor-lang 0.29.0",
 ]
 
 [[package]]
@@ -6046,19 +5938,10 @@ dependencies = [
 [[package]]
 name = "price-oracle"
 version = "0.2.1"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
-]
-
-[[package]]
-name = "price-oracle"
-version = "0.2.1"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
+ "anchor-lang 0.29.0",
 ]
 
 [[package]]
@@ -6704,19 +6587,10 @@ dependencies = [
 [[package]]
 name = "rewards-oracle"
 version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
-]
-
-[[package]]
-name = "rewards-oracle"
-version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
+ "anchor-lang 0.29.0",
 ]
 
 [[package]]
@@ -7473,8 +7347,8 @@ dependencies = [
  "solana-sdk",
  "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
- "spl-token-group-interface 0.1.0",
- "spl-token-metadata-interface 0.2.0",
+ "spl-token-group-interface",
+ "spl-token-metadata-interface",
  "thiserror",
  "zstd",
 ]
@@ -8078,7 +7952,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-sdk",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account",
  "spl-memo",
  "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
@@ -8240,22 +8114,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-associated-token-account"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e688554bac5838217ffd1fab7845c573ff106b6336bf7d290db7c98d5a8efd"
-dependencies = [
- "assert_matches",
- "borsh 1.5.1",
- "num-derive 0.4.2",
- "num-traits",
- "solana-program",
- "spl-token 4.0.0",
- "spl-token-2022 3.0.2",
- "thiserror",
-]
-
-[[package]]
 name = "spl-concurrent-merkle-tree"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8274,18 +8132,7 @@ checksum = "daa600f2fe56f32e923261719bae640d873edadbc5237681a39b8e37bfd4d263"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator-derive 0.1.2",
-]
-
-[[package]]
-name = "spl-discriminator"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d1814406e98b08c5cd02c1126f83fd407ad084adce0b05fda5730677822eac"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator-derive 0.2.0",
+ "spl-discriminator-derive",
 ]
 
 [[package]]
@@ -8295,18 +8142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07fd7858fc4ff8fb0e34090e41d7eb06a823e1057945c26d480bfc21d2338a93"
 dependencies = [
  "quote",
- "spl-discriminator-syn 0.1.2",
- "syn 2.0.58",
-]
-
-[[package]]
-name = "spl-discriminator-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
-dependencies = [
- "quote",
- "spl-discriminator-syn 0.2.0",
+ "spl-discriminator-syn",
  "syn 2.0.58",
 ]
 
@@ -8315,19 +8151,6 @@ name = "spl-discriminator-syn"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fea7be851bd98d10721782ea958097c03a0c2a07d8d4997041d0ece6319a63"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.8",
- "syn 2.0.58",
- "thiserror",
-]
-
-[[package]]
-name = "spl-discriminator-syn"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f05593b7ca9eac7caca309720f2eafb96355e037e6d373b909a80fe7b69b9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8364,20 +8187,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "solana-zk-token-sdk",
- "spl-program-error 0.3.1",
-]
-
-[[package]]
-name = "spl-pod"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ce669f48cf2eca1ec518916d8725596bfb655beb1c74374cf71dc6cb773c9"
-dependencies = [
- "borsh 1.5.1",
- "bytemuck",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-program-error 0.4.1",
+ "spl-program-error",
 ]
 
 [[package]]
@@ -8389,20 +8199,7 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
- "spl-program-error-derive 0.3.2",
- "thiserror",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49065093ea91f57b9b2bd81493ff705e2ad4e64507a07dbc02b085778e02770e"
-dependencies = [
- "num-derive 0.4.2",
- "num-traits",
- "solana-program",
- "spl-program-error-derive 0.4.1",
+ "spl-program-error-derive",
  "thiserror",
 ]
 
@@ -8419,18 +8216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-program-error-derive"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d375dd76c517836353e093c2dbb490938ff72821ab568b545fd30ab3256b3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.8",
- "syn 2.0.58",
-]
-
-[[package]]
 name = "spl-tlv-account-resolution"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8438,10 +8223,10 @@ checksum = "062e148d3eab7b165582757453632ffeef490c02c86a48bfdb4988f63eefb3b9"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
- "spl-program-error 0.3.1",
- "spl-type-length-value 0.3.1",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
 ]
 
 [[package]]
@@ -8452,24 +8237,10 @@ checksum = "56f335787add7fa711819f9e7c573f8145a5358a709446fe2d24bf2a88117c90"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
- "spl-program-error 0.3.1",
- "spl-type-length-value 0.3.1",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cace91ba08984a41556efe49cbf2edca4db2f577b649da7827d3621161784bf8"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.2.2",
- "spl-pod 0.2.2",
- "spl-program-error 0.4.1",
- "spl-type-length-value 0.4.3",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
 ]
 
 [[package]]
@@ -8516,11 +8287,11 @@ dependencies = [
  "solana-program",
  "solana-zk-token-sdk",
  "spl-memo",
- "spl-pod 0.1.1",
+ "spl-pod",
  "spl-token 4.0.0",
- "spl-token-metadata-interface 0.2.0",
+ "spl-token-metadata-interface",
  "spl-transfer-hook-interface 0.3.0",
- "spl-type-length-value 0.3.1",
+ "spl-type-length-value",
  "thiserror",
 ]
 
@@ -8539,36 +8310,12 @@ dependencies = [
  "solana-security-txt",
  "solana-zk-token-sdk",
  "spl-memo",
- "spl-pod 0.1.1",
+ "spl-pod",
  "spl-token 4.0.0",
- "spl-token-group-interface 0.1.0",
- "spl-token-metadata-interface 0.2.0",
+ "spl-token-group-interface",
+ "spl-token-metadata-interface",
  "spl-transfer-hook-interface 0.4.1",
- "spl-type-length-value 0.3.1",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5412f99ae7ee6e0afde00defaa354e6228e47e30c0e3adf553e2e01e6abb584"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.4.2",
- "num-traits",
- "num_enum 0.7.2",
- "solana-program",
- "solana-security-txt",
- "solana-zk-token-sdk",
- "spl-memo",
- "spl-pod 0.2.2",
- "spl-token 4.0.0",
- "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.3",
- "spl-transfer-hook-interface 0.6.3",
- "spl-type-length-value 0.4.3",
+ "spl-type-length-value",
  "thiserror",
 ]
 
@@ -8580,22 +8327,9 @@ checksum = "b889509d49fa74a4a033ca5dae6c2307e9e918122d97e58562f5c4ffa795c75d"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
- "spl-program-error 0.3.1",
-]
-
-[[package]]
-name = "spl-token-group-interface"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d419b5cfa3ee8e0f2386fd7e02a33b3ec8a7db4a9c7064a2ea24849dc4a273b6"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.2.2",
- "spl-pod 0.2.2",
- "spl-program-error 0.4.1",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
 ]
 
 [[package]]
@@ -8606,24 +8340,10 @@ checksum = "4c16ce3ba6979645fb7627aa1e435576172dd63088dc7848cb09aa331fa1fe4f"
 dependencies = [
  "borsh 0.10.3",
  "solana-program",
- "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
- "spl-program-error 0.3.1",
- "spl-type-length-value 0.3.1",
-]
-
-[[package]]
-name = "spl-token-metadata-interface"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30179c47e93625680dabb620c6e7931bd12d62af390f447bc7beb4a3a9b5feee"
-dependencies = [
- "borsh 1.5.1",
- "solana-program",
- "spl-discriminator 0.2.2",
- "spl-pod 0.2.2",
- "spl-program-error 0.4.1",
- "spl-type-length-value 0.4.3",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
 ]
 
 [[package]]
@@ -8635,11 +8355,11 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
- "spl-program-error 0.3.1",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
  "spl-tlv-account-resolution 0.4.0",
- "spl-type-length-value 0.3.1",
+ "spl-type-length-value",
 ]
 
 [[package]]
@@ -8651,27 +8371,11 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
- "spl-program-error 0.3.1",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
  "spl-tlv-account-resolution 0.5.2",
- "spl-type-length-value 0.3.1",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a98359769cd988f7b35c02558daa56d496a7e3bd8626e61f90a7c757eedb9b"
-dependencies = [
- "arrayref",
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.2.2",
- "spl-pod 0.2.2",
- "spl-program-error 0.4.1",
- "spl-tlv-account-resolution 0.6.3",
- "spl-type-length-value 0.4.3",
+ "spl-type-length-value",
 ]
 
 [[package]]
@@ -8682,22 +8386,9 @@ checksum = "8f9ebd75d29c5f48de5f6a9c114e08531030b75b8ac2c557600ac7da0b73b1e8"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
- "spl-program-error 0.3.1",
-]
-
-[[package]]
-name = "spl-type-length-value"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ce13429dbd41d2cee8a73931c05fda0b0c8ca156a8b0c19445642550bb61a"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.2.2",
- "spl-pod 0.2.2",
- "spl-program-error 0.4.1",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
 ]
 
 [[package]]
@@ -9391,19 +9082,10 @@ dependencies = [
 [[package]]
 name = "treasury-management"
 version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
-]
-
-[[package]]
-name = "treasury-management"
-version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
+ "anchor-lang 0.29.0",
 ]
 
 [[package]]
@@ -9648,19 +9330,10 @@ dependencies = [
 [[package]]
 name = "voter-stake-registry"
 version = "0.3.3"
-source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#3036b33793cfe54b20ab24761677493510d5bd50"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.30.1",
-]
-
-[[package]]
-name = "voter-stake-registry"
-version = "0.3.3"
-source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
-dependencies = [
- "anchor-gen",
- "anchor-lang 0.30.1",
+ "anchor-lang 0.29.0",
 ]
 
 [[package]]
@@ -10125,7 +9798,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
  "twox-hash",
  "xorf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,10 +2129,19 @@ dependencies = [
 [[package]]
 name = "circuit-breaker"
 version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
+ "anchor-lang 0.30.1",
+]
+
+[[package]]
+name = "circuit-breaker"
+version = "0.1.0"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
 ]
 
 [[package]]
@@ -2771,10 +2780,19 @@ dependencies = [
 [[package]]
 name = "data-credits"
 version = "0.2.2"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
+ "anchor-lang 0.30.1",
+]
+
+[[package]]
+name = "data-credits"
+version = "0.2.2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
 ]
 
 [[package]]
@@ -3149,10 +3167,19 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "fanout"
 version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
+ "anchor-lang 0.30.1",
+]
+
+[[package]]
+name = "fanout"
+version = "0.1.0"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
 ]
 
 [[package]]
@@ -3725,23 +3752,45 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helium-anchor-gen"
 version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
- "circuit-breaker",
- "data-credits",
- "fanout",
- "helium-entity-manager",
- "helium-sub-daos",
- "hexboosting",
- "lazy-distributor",
- "lazy-transactions",
- "mobile-entity-manager",
- "price-oracle",
- "rewards-oracle",
- "treasury-management",
- "voter-stake-registry",
+ "anchor-lang 0.30.1",
+ "circuit-breaker 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
+ "data-credits 0.2.2 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
+ "fanout 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
+ "helium-entity-manager 0.2.11 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
+ "helium-sub-daos 0.1.8 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
+ "hexboosting 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
+ "lazy-distributor 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
+ "lazy-transactions 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
+ "mobile-entity-manager 0.1.3 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
+ "price-oracle 0.2.1 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
+ "rewards-oracle 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
+ "treasury-management 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
+ "voter-stake-registry 0.3.3 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
+]
+
+[[package]]
+name = "helium-anchor-gen"
+version = "0.1.0"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
+ "circuit-breaker 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git)",
+ "data-credits 0.2.2 (git+https://github.com/helium/helium-anchor-gen.git)",
+ "fanout 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git)",
+ "helium-entity-manager 0.2.11 (git+https://github.com/helium/helium-anchor-gen.git)",
+ "helium-sub-daos 0.1.8 (git+https://github.com/helium/helium-anchor-gen.git)",
+ "hexboosting 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git)",
+ "lazy-distributor 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git)",
+ "lazy-transactions 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git)",
+ "mobile-entity-manager 0.1.3 (git+https://github.com/helium/helium-anchor-gen.git)",
+ "price-oracle 0.2.1 (git+https://github.com/helium/helium-anchor-gen.git)",
+ "rewards-oracle 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git)",
+ "treasury-management 0.2.0 (git+https://github.com/helium/helium-anchor-gen.git)",
+ "voter-stake-registry 0.3.3 (git+https://github.com/helium/helium-anchor-gen.git)",
 ]
 
 [[package]]
@@ -3754,7 +3803,7 @@ dependencies = [
  "bs58 0.5.0",
  "byteorder",
  "ed25519-compact",
- "getrandom 0.1.16",
+ "getrandom 0.2.10",
  "k256",
  "lazy_static",
  "multihash",
@@ -3772,16 +3821,25 @@ dependencies = [
 [[package]]
 name = "helium-entity-manager"
 version = "0.2.11"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
+ "anchor-lang 0.30.1",
+]
+
+[[package]]
+name = "helium-entity-manager"
+version = "0.2.11"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
 ]
 
 [[package]]
 name = "helium-lib"
 version = "0.0.0"
-source = "git+https://github.com/helium/helium-wallet-rs.git?branch=mj/oracles-updates#979dc86854294bfb476c49138ae003b9dfb343e0"
+source = "git+https://github.com/helium/helium-wallet-rs.git?branch=mj/oracles-updates#a13efec54ec98ad73588b19b9c696719a31553bc"
 dependencies = [
  "anchor-client",
  "anchor-spl",
@@ -3811,7 +3869,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "spl-account-compression",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account 3.0.2",
  "thiserror",
  "tonic",
  "tracing",
@@ -3837,10 +3895,19 @@ dependencies = [
 [[package]]
 name = "helium-sub-daos"
 version = "0.1.8"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
+ "anchor-lang 0.30.1",
+]
+
+[[package]]
+name = "helium-sub-daos"
+version = "0.1.8"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
 ]
 
 [[package]]
@@ -3891,10 +3958,19 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 [[package]]
 name = "hexboosting"
 version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
+ "anchor-lang 0.30.1",
+]
+
+[[package]]
+name = "hexboosting"
+version = "0.1.0"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
 ]
 
 [[package]]
@@ -4702,19 +4778,37 @@ dependencies = [
 [[package]]
 name = "lazy-distributor"
 version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
+ "anchor-lang 0.30.1",
+]
+
+[[package]]
+name = "lazy-distributor"
+version = "0.2.0"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
 ]
 
 [[package]]
 name = "lazy-transactions"
 version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
+ "anchor-lang 0.30.1",
+]
+
+[[package]]
+name = "lazy-transactions"
+version = "0.2.0"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
 ]
 
 [[package]]
@@ -5087,10 +5181,19 @@ dependencies = [
 [[package]]
 name = "mobile-entity-manager"
 version = "0.1.3"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
+ "anchor-lang 0.30.1",
+]
+
+[[package]]
+name = "mobile-entity-manager"
+version = "0.1.3"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
 ]
 
 [[package]]
@@ -5520,7 +5623,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.58",
@@ -5943,10 +6046,19 @@ dependencies = [
 [[package]]
 name = "price-oracle"
 version = "0.2.1"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
+ "anchor-lang 0.30.1",
+]
+
+[[package]]
+name = "price-oracle"
+version = "0.2.1"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
 ]
 
 [[package]]
@@ -6060,7 +6172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
- "heck 0.4.0",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -6592,10 +6704,19 @@ dependencies = [
 [[package]]
 name = "rewards-oracle"
 version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
+ "anchor-lang 0.30.1",
+]
+
+[[package]]
+name = "rewards-oracle"
+version = "0.2.0"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
 ]
 
 [[package]]
@@ -9270,10 +9391,19 @@ dependencies = [
 [[package]]
 name = "treasury-management"
 version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
+ "anchor-lang 0.30.1",
+]
+
+[[package]]
+name = "treasury-management"
+version = "0.2.0"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
 ]
 
 [[package]]
@@ -9316,7 +9446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -9518,10 +9648,19 @@ dependencies = [
 [[package]]
 name = "voter-stake-registry"
 version = "0.3.3"
-source = "git+https://github.com/helium/helium-anchor-gen.git#a7e694d49245ca9830bcfef68cce34f230c91011"
+source = "git+https://github.com/helium/helium-anchor-gen.git?branch=main#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
 dependencies = [
  "anchor-gen",
- "anchor-lang 0.29.0",
+ "anchor-lang 0.30.1",
+]
+
+[[package]]
+name = "voter-stake-registry"
+version = "0.3.3"
+source = "git+https://github.com/helium/helium-anchor-gen.git#ef686c1b0ba0ab2bd0e0377e0bf2a44630938da2"
+dependencies = [
+ "anchor-gen",
+ "anchor-lang 0.30.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "helium-lib"
 version = "0.0.0"
-source = "git+https://github.com/helium/helium-wallet-rs.git?branch=mj/oracles-updates#a13efec54ec98ad73588b19b9c696719a31553bc"
+source = "git+https://github.com/helium/helium-wallet-rs.git?branch=mj/oracles-updates#d928033da7918876d95d7936802170f3eee7b006"
 dependencies = [
  "anchor-client",
  "anchor-spl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3781,7 +3781,7 @@ dependencies = [
 [[package]]
 name = "helium-lib"
 version = "0.0.0"
-source = "git+https://github.com/helium/helium-wallet-rs.git?branch=master#6b8a6bbf343027087a401cd907c9f6c848991aac"
+source = "git+https://github.com/helium/helium-wallet-rs.git?branch=mj/oracles-updates#979dc86854294bfb476c49138ae003b9dfb343e0"
 dependencies = [
  "anchor-client",
  "anchor-spl",
@@ -3811,7 +3811,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "spl-account-compression",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account 2.3.0",
  "thiserror",
  "tonic",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ sqlx = { version = "0", features = [
   "macros",
   "runtime-tokio-rustls",
 ] }
-helium-anchor-gen = { git = "https://github.com/helium/helium-anchor-gen.git" }
+helium-anchor-gen = { git = "https://github.com/helium/helium-anchor-gen.git", branch = "mj/unbump-anchor-lang" }
 helium-crypto = { version = "0.8.4", features = ["multisig"] }
 helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = "mj/oracles-updates" }
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ sqlx = { version = "0", features = [
 ] }
 helium-anchor-gen = { git = "https://github.com/helium/helium-anchor-gen.git" }
 helium-crypto = { version = "0.8.4", features = ["multisig"] }
-helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = "master" }
+helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = "mj/oracles-updates" }
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
   "disktree",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ sqlx = { version = "0", features = [
   "macros",
   "runtime-tokio-rustls",
 ] }
-helium-anchor-gen = { git = "https://github.com/helium/helium-anchor-gen.git", branch = "mj/unbump-anchor-lang" }
+helium-anchor-gen = { git = "https://github.com/helium/helium-anchor-gen.git" }
 helium-crypto = { version = "0.8.4", features = ["multisig"] }
 helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = "mj/oracles-updates" }
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ sqlx = { version = "0", features = [
 ] }
 helium-anchor-gen = { git = "https://github.com/helium/helium-anchor-gen.git" }
 helium-crypto = { version = "0.8.4", features = ["multisig"] }
-helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = "mj/oracles-updates" }
+helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = "master" }
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
   "disktree",
 ] }

--- a/iot_packet_verifier/src/daemon.rs
+++ b/iot_packet_verifier/src/daemon.rs
@@ -112,7 +112,7 @@ impl Cmd {
                 bail!("Missing solana section in settings");
             };
             // Set up the solana RpcClient:
-            Some(SolanaRpc::new(solana_settings).await?)
+            Some(SolanaRpc::new(solana_settings, solana::SubDao::Iot).await?)
         } else {
             None
         };

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -128,7 +128,7 @@ impl Cmd {
                 bail!("Missing solana section in settings");
             };
             // Set up the solana RpcClient:
-            Some(SolanaRpc::new(solana_settings).await?)
+            Some(SolanaRpc::new(solana_settings, solana::SubDao::Mobile).await?)
         } else {
             None
         };

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -8,22 +8,22 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = {workspace = true}
+async-trait = { workspace = true }
 anchor-client = { workspace = true }
-clap = {workspace = true}
-chrono = {workspace = true}
-file-store = {path = "../file_store"}
-futures = {workspace = true}
-helium-anchor-gen = {workspace = true}
-helium-crypto = {workspace = true}
-itertools = {workspace = true}
-metrics = {workspace = true}
-serde = {workspace = true}
-sha2 = {workspace = true}
-solana-client = {workspace = true}
-solana-program = {workspace = true}
-solana-sdk = {workspace = true}
-spl-token = {workspace = true}
-thiserror = {workspace = true}
-tokio = {workspace = true}
-tracing = {workspace = true}
+clap = { workspace = true }
+chrono = { workspace = true }
+file-store = { path = "../file_store" }
+futures = { workspace = true }
+helium-anchor-gen = { workspace = true }
+helium-crypto = { workspace = true }
+itertools = { workspace = true }
+metrics = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
+solana-client = { workspace = true }
+solana-program = { workspace = true }
+solana-sdk = { workspace = true }
+spl-token = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -16,6 +16,7 @@ file-store = { path = "../file_store" }
 futures = { workspace = true }
 helium-anchor-gen = { workspace = true }
 helium-crypto = { workspace = true }
+helium-lib = { workspace = true }
 itertools = { workspace = true }
 metrics = { workspace = true }
 serde = { workspace = true }

--- a/solana/src/burn.rs
+++ b/solana/src/burn.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use helium_crypto::PublicKeyBinary;
-use helium_lib::{client, dc, token};
+use helium_lib::{client, dc, token, TransactionOpts};
 use serde::Deserialize;
 use solana_sdk::{
     commitment_config::CommitmentConfig, signature::Signature, transaction::Transaction,
@@ -54,6 +54,7 @@ pub struct SolanaRpc {
     provider: client::SolanaRpcClient,
     keypair: Keypair,
     payers_to_monitor: Vec<PublicKeyBinary>,
+    transaction_opts: TransactionOpts,
 }
 
 impl SolanaRpc {
@@ -80,6 +81,7 @@ impl SolanaRpc {
             provider,
             keypair,
             payers_to_monitor: settings.payers_to_monitor()?,
+            transaction_opts: TransactionOpts::default(),
         }))
     }
 }
@@ -125,7 +127,15 @@ impl SolanaNetwork for SolanaRpc {
         amount: u64,
     ) -> Result<Self::Transaction, Self::Error> {
         let payer = Pubkey::try_from(payer.as_ref())?;
-        let tx = dc::burn_delegated(self, self.sub_dao, &self.keypair, amount, payer).await?;
+        let tx = dc::burn_delegated(
+            self,
+            self.sub_dao,
+            &self.keypair,
+            amount,
+            payer,
+            &self.transaction_opts,
+        )
+        .await?;
 
         Ok(tx)
     }

--- a/solana/src/burn.rs
+++ b/solana/src/burn.rs
@@ -4,9 +4,7 @@ use helium_crypto::PublicKeyBinary;
 use helium_lib::{client, dc, token};
 use serde::Deserialize;
 use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{read_keypair_file, Signature},
-    transaction::Transaction,
+    commitment_config::CommitmentConfig, signature::Signature, transaction::Transaction,
 };
 use std::convert::Infallible;
 use std::{collections::HashMap, str::FromStr};
@@ -58,9 +56,10 @@ pub struct SolanaRpc {
 
 impl SolanaRpc {
     pub async fn new(settings: &Settings, sub_dao: SubDao) -> Result<Arc<Self>, SolanaRpcError> {
-        let Ok(keypair) = read_keypair_file(&settings.burn_keypair) else {
+        let Ok(keypair) = Keypair::read_from_file(&settings.burn_keypair) else {
             return Err(SolanaRpcError::FailedToReadKeypairError);
         };
+
         let provider = client::SolanaRpcClient::new_with_commitment(
             settings.rpc_url.clone(),
             CommitmentConfig::finalized(),
@@ -77,7 +76,7 @@ impl SolanaRpc {
         Ok(Arc::new(Self {
             sub_dao,
             provider,
-            keypair: keypair.into(),
+            keypair,
             payers_to_monitor: settings.payers_to_monitor()?,
         }))
     }

--- a/solana/src/burn.rs
+++ b/solana/src/burn.rs
@@ -1,32 +1,16 @@
-use crate::{send_with_retry, GetSignature, SolanaRpcError};
-use anchor_client::RequestBuilder;
+use crate::{send_with_retry, GetSignature, Keypair, Pubkey, SolanaRpcError, SubDao};
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
-use helium_anchor_gen::{
-    anchor_lang::{AccountDeserialize, ToAccountMetas},
-    data_credits::{self, accounts, instruction},
-    helium_sub_daos::{self, DaoV0, SubDaoV0},
-};
 use helium_crypto::PublicKeyBinary;
-use helium_lib::client::SolanaRpcClient;
-use itertools::Itertools;
+use helium_lib::{client, dc, token};
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
-use solana_client::{client_error::ClientError, nonblocking::rpc_client::RpcClient};
 use solana_sdk::{
     commitment_config::CommitmentConfig,
-    compute_budget::ComputeBudgetInstruction,
-    pubkey::Pubkey,
-    signature::{read_keypair_file, Keypair, Signature},
-    signer::Signer,
+    signature::{read_keypair_file, Signature},
     transaction::Transaction,
 };
 use std::convert::Infallible;
 use std::{collections::HashMap, str::FromStr};
-use std::{
-    sync::Arc,
-    time::{Duration, SystemTime},
-};
+use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 
 #[async_trait]
@@ -50,18 +34,9 @@ pub trait SolanaNetwork: Send + Sync + 'static {
 #[derive(Debug, Deserialize)]
 pub struct Settings {
     rpc_url: String,
-    cluster: String,
     burn_keypair: String,
-    dc_mint: String,
-    dnt_mint: String,
     #[serde(default)]
     payers_to_monitor: Vec<String>,
-    #[serde(default = "min_priority_fee")]
-    min_priority_fee: u64,
-}
-
-fn min_priority_fee() -> u64 {
-    1
 }
 
 impl Settings {
@@ -75,45 +50,41 @@ impl Settings {
 }
 
 pub struct SolanaRpc {
-    provider: SolanaRpcClient,
-    program_cache: BurnProgramCache,
-    cluster: String,
-    keypair: [u8; 64],
+    sub_dao: SubDao,
+    provider: client::SolanaRpcClient,
+    keypair: Keypair,
     payers_to_monitor: Vec<PublicKeyBinary>,
-    priority_fee: PriorityFee,
-    min_priority_fee: u64,
 }
 
 impl SolanaRpc {
-    pub async fn new(settings: &Settings) -> Result<Arc<Self>, SolanaRpcError> {
-        let dc_mint = settings.dc_mint.parse()?;
-        let dnt_mint = settings.dnt_mint.parse()?;
+    pub async fn new(settings: &Settings, sub_dao: SubDao) -> Result<Arc<Self>, SolanaRpcError> {
         let Ok(keypair) = read_keypair_file(&settings.burn_keypair) else {
             return Err(SolanaRpcError::FailedToReadKeypairError);
         };
-        let provider = SolanaRpcClient::new_with_commitment(
+        let provider = client::SolanaRpcClient::new_with_commitment(
             settings.rpc_url.clone(),
             CommitmentConfig::finalized(),
         );
-        let program_cache = BurnProgramCache::new(&provider, dc_mint, dnt_mint).await?;
-        if program_cache.dc_burn_authority != keypair.pubkey() {
-            return Err(SolanaRpcError::InvalidKeypair);
-        }
+
+        // FIXME: The dc_burn_authority is fetched in helium-lib.
+        // I'm not sure I understand what should happen to this check.
+        //
+        // let program_cache = BurnProgramCache::new(&provider, dc_mint, dnt_mint).await?;
+        // if program_cache.dc_burn_authority != keypair.pubkey() {
+        //     return Err(SolanaRpcError::InvalidKeypair);
+        // }
 
         Ok(Arc::new(Self {
-            cluster: settings.cluster.clone(),
+            sub_dao,
             provider,
-            program_cache,
-            keypair: keypair.to_bytes(),
+            keypair: keypair.into(),
             payers_to_monitor: settings.payers_to_monitor()?,
-            priority_fee: PriorityFee::default(),
-            min_priority_fee: settings.min_priority_fee,
         }))
     }
 }
 
-impl AsRef<SolanaRpcClient> for SolanaRpc {
-    fn as_ref(&self) -> &helium_lib::client::SolanaRpcClient {
+impl AsRef<client::SolanaRpcClient> for SolanaRpc {
+    fn as_ref(&self) -> &client::SolanaRpcClient {
         &self.provider
     }
 }
@@ -124,8 +95,11 @@ impl SolanaNetwork for SolanaRpc {
     type Transaction = Transaction;
 
     async fn payer_balance(&self, payer: &PublicKeyBinary) -> Result<u64, Self::Error> {
-        let escrow_account = escrow_dc_account_for_payer(&self.program_cache.sub_dao, payer);
-        let amount = match helium_lib::token::balance_for_address(&self, &escrow_account).await? {
+        let payer_pubkey = Pubkey::try_from(payer.as_ref())?;
+        let delegated_dc_key = SubDao::Iot.delegated_dc_key(&payer_pubkey.to_string());
+        let escrow_account = SubDao::Iot.escrow_key(&delegated_dc_key);
+
+        let amount = match token::balance_for_address(&self, &escrow_account).await? {
             Some(token_balance) => token_balance.amount.amount,
             None => {
                 tracing::info!(%payer, "Account not found, no balance");
@@ -149,102 +123,10 @@ impl SolanaNetwork for SolanaRpc {
         payer: &PublicKeyBinary,
         amount: u64,
     ) -> Result<Self::Transaction, Self::Error> {
-        // Fetch the sub dao epoch info:
-        const EPOCH_LENGTH: u64 = 60 * 60 * 24;
-        let epoch = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)?
-            .as_secs()
-            / EPOCH_LENGTH;
-        let (sub_dao_epoch_info, _) = Pubkey::find_program_address(
-            &[
-                "sub_dao_epoch_info".as_bytes(),
-                self.program_cache.sub_dao.as_ref(),
-                &epoch.to_le_bytes(),
-            ],
-            &helium_sub_daos::ID,
-        );
+        let payer = Pubkey::try_from(payer.as_ref())?;
+        let tx = dc::burn_delegated(self, self.sub_dao, &self.keypair, amount, payer).await?;
 
-        // Fetch escrow account
-        let ddc_key = delegated_data_credits(&self.program_cache.sub_dao, payer);
-        let (escrow_account, _) = Pubkey::find_program_address(
-            &["escrow_dc_account".as_bytes(), &ddc_key.to_bytes()],
-            &data_credits::ID,
-        );
-
-        let accounts = accounts::BurnDelegatedDataCreditsV0 {
-            sub_dao_epoch_info,
-            dao: self.program_cache.dao,
-            sub_dao: self.program_cache.sub_dao,
-            account_payer: self.program_cache.account_payer,
-            data_credits: self.program_cache.data_credits,
-            delegated_data_credits: delegated_data_credits(&self.program_cache.sub_dao, payer),
-            token_program: spl_token::id(),
-            helium_sub_daos_program: helium_sub_daos::id(),
-            system_program: solana_program::system_program::id(),
-            dc_burn_authority: self.program_cache.dc_burn_authority,
-            dc_mint: self.program_cache.dc_mint,
-            escrow_account,
-            registrar: self.program_cache.registrar,
-        };
-
-        let priority_fee_accounts: Vec<_> = accounts
-            .to_account_metas(None)
-            .into_iter()
-            .map(|x| x.pubkey)
-            .unique()
-            .take(MAX_RECENT_PRIORITY_FEE_ACCOUNTS)
-            .collect();
-
-        // Get a new priority fee. Can't be done in Sync land
-        let priority_fee = self
-            .priority_fee
-            .get_estimate(
-                &self.provider,
-                &priority_fee_accounts,
-                self.min_priority_fee,
-            )
-            .await
-            .map_err(|e| SolanaRpcError::RpcClientError(Box::new(e)))?;
-
-        tracing::info!(%priority_fee);
-
-        // This is Sync land: anything async in here will error.
-        let instructions = {
-            let request = RequestBuilder::from(
-                data_credits::id(),
-                &self.cluster,
-                std::rc::Rc::new(Keypair::from_bytes(&self.keypair).unwrap()),
-                Some(CommitmentConfig::finalized()),
-            );
-
-            let args = instruction::BurnDelegatedDataCreditsV0 {
-                _args: data_credits::BurnDelegatedDataCreditsArgsV0 { amount },
-            };
-
-            // As far as I can tell, the instructions function does not actually have any
-            // error paths.
-            request
-                // Set priority fees:
-                .instruction(ComputeBudgetInstruction::set_compute_unit_limit(300_000))
-                .instruction(ComputeBudgetInstruction::set_compute_unit_price(
-                    priority_fee,
-                ))
-                // Create burn transaction
-                .accounts(accounts)
-                .args(args)
-                .instructions()
-                .unwrap()
-        };
-
-        let blockhash = self.provider.get_latest_blockhash().await?;
-        let signer = Keypair::from_bytes(&self.keypair).unwrap();
-
-        Ok(Transaction::new_signed_with_payer(
-            &instructions,
-            Some(&signer.pubkey()),
-            &[&signer],
-            blockhash,
-        ))
+        Ok(tx)
     }
 
     async fn submit_transaction(&self, tx: &Self::Transaction) -> Result<(), Self::Error> {
@@ -288,121 +170,6 @@ impl SolanaNetwork for SolanaRpc {
                 .await?,
             Some(Ok(()))
         ))
-    }
-}
-
-#[derive(Default)]
-pub struct PriorityFee {
-    last_estimate: Arc<Mutex<LastEstimate>>,
-}
-
-pub const MAX_RECENT_PRIORITY_FEE_ACCOUNTS: usize = 128;
-
-impl PriorityFee {
-    pub async fn get_estimate(
-        &self,
-        provider: &SolanaRpcClient,
-        accounts: &[Pubkey],
-        min_priority_fee: u64,
-    ) -> Result<u64, ClientError> {
-        let mut last_estimate = self.last_estimate.lock().await;
-        match last_estimate.time_taken {
-            Some(time_taken) if (Utc::now() - time_taken) < chrono::Duration::minutes(15) => {
-                return Ok(last_estimate.fee_estimate)
-            }
-            _ => (),
-        }
-        // Find a new estimate
-        let time_taken = Utc::now();
-        let recent_fees = provider.get_recent_prioritization_fees(accounts).await?;
-        let mut max_per_slot = Vec::new();
-        for (slot, fees) in &recent_fees.into_iter().group_by(|x| x.slot) {
-            let Some(maximum) = fees.map(|x| x.prioritization_fee).max() else {
-                continue;
-            };
-            max_per_slot.push((slot, maximum));
-        }
-        // Only take the most recent 20 maximum fees:
-        max_per_slot.sort_by(|a, b| a.0.cmp(&b.0).reverse());
-        let mut max_per_slot: Vec<_> = max_per_slot.into_iter().take(20).map(|x| x.1).collect();
-        max_per_slot.sort();
-        // Get the median:
-        let num_recent_fees = max_per_slot.len();
-        let mid = num_recent_fees / 2;
-        let estimate = if num_recent_fees == 0 {
-            min_priority_fee
-        } else if num_recent_fees % 2 == 0 {
-            // If the number of samples is even, taken the mean of the two median fees
-            (max_per_slot[mid - 1] + max_per_slot[mid]) / 2
-        } else {
-            max_per_slot[mid]
-        }
-        .max(min_priority_fee);
-        *last_estimate = LastEstimate::new(time_taken, estimate);
-        Ok(estimate)
-    }
-}
-
-#[derive(Copy, Clone, Default)]
-pub struct LastEstimate {
-    time_taken: Option<DateTime<Utc>>,
-    fee_estimate: u64,
-}
-
-impl LastEstimate {
-    fn new(time_taken: DateTime<Utc>, fee_estimate: u64) -> Self {
-        Self {
-            time_taken: Some(time_taken),
-            fee_estimate,
-        }
-    }
-}
-
-/// Cached pubkeys for the burn program
-pub struct BurnProgramCache {
-    pub account_payer: Pubkey,
-    pub data_credits: Pubkey,
-    pub sub_dao: Pubkey,
-    pub dao: Pubkey,
-    pub dc_mint: Pubkey,
-    pub dc_burn_authority: Pubkey,
-    pub registrar: Pubkey,
-}
-
-impl BurnProgramCache {
-    pub async fn new(
-        provider: &SolanaRpcClient,
-        dc_mint: Pubkey,
-        dnt_mint: Pubkey,
-    ) -> Result<Self, SolanaRpcError> {
-        let (account_payer, _) =
-            Pubkey::find_program_address(&["account_payer".as_bytes()], &data_credits::ID);
-        let (data_credits, _) =
-            Pubkey::find_program_address(&["dc".as_bytes(), dc_mint.as_ref()], &data_credits::ID);
-        let (sub_dao, _) = Pubkey::find_program_address(
-            &["sub_dao".as_bytes(), dnt_mint.as_ref()],
-            &helium_sub_daos::ID,
-        );
-        let (dao, dc_burn_authority) = {
-            let account_data = provider.get_account_data(&sub_dao).await?;
-            let mut account_data = account_data.as_ref();
-            let sub_dao = SubDaoV0::try_deserialize(&mut account_data)?;
-            (sub_dao.dao, sub_dao.dc_burn_authority)
-        };
-        let registrar = {
-            let account_data = provider.get_account_data(&dao).await?;
-            let mut account_data = account_data.as_ref();
-            DaoV0::try_deserialize(&mut account_data)?.registrar
-        };
-        Ok(Self {
-            account_payer,
-            data_credits,
-            sub_dao,
-            dao,
-            dc_mint,
-            dc_burn_authority,
-            registrar,
-        })
     }
 }
 
@@ -510,29 +277,4 @@ impl SolanaNetwork for Arc<Mutex<HashMap<PublicKeyBinary, u64>>> {
     async fn confirm_transaction(&self, _txn: &Signature) -> Result<bool, Self::Error> {
         Ok(true)
     }
-}
-
-fn escrow_dc_account_for_payer(sub_dao: &Pubkey, payer: &PublicKeyBinary) -> Pubkey {
-    let ddc_key = delegated_data_credits(sub_dao, payer);
-    let (escrow_account, _) = Pubkey::find_program_address(
-        &["escrow_dc_account".as_bytes(), &ddc_key.to_bytes()],
-        &data_credits::ID,
-    );
-    escrow_account
-}
-
-/// Returns the PDA for the Delegated Data Credits of the given `payer`.
-fn delegated_data_credits(sub_dao: &Pubkey, payer: &PublicKeyBinary) -> Pubkey {
-    let mut hasher = Sha256::new();
-    hasher.update(payer.to_string());
-    let sha_digest = hasher.finalize();
-    let (ddc_key, _) = Pubkey::find_program_address(
-        &[
-            "delegated_data_credits".as_bytes(),
-            sub_dao.as_ref(),
-            &sha_digest,
-        ],
-        &data_credits::ID,
-    );
-    ddc_key
 }

--- a/solana/src/burn.rs
+++ b/solana/src/burn.rs
@@ -1,4 +1,6 @@
-use crate::{send_with_retry, GetSignature, Keypair, Pubkey, SolanaRpcError, SubDao};
+use crate::{
+    read_keypair_from_file, send_with_retry, GetSignature, Keypair, Pubkey, SolanaRpcError, SubDao,
+};
 use async_trait::async_trait;
 use helium_crypto::PublicKeyBinary;
 use helium_lib::{client, dc, token};
@@ -7,8 +9,8 @@ use solana_sdk::{
     commitment_config::CommitmentConfig, signature::Signature, transaction::Transaction,
 };
 use std::convert::Infallible;
+use std::sync::Arc;
 use std::{collections::HashMap, str::FromStr};
-use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 
 #[async_trait]
@@ -56,7 +58,7 @@ pub struct SolanaRpc {
 
 impl SolanaRpc {
     pub async fn new(settings: &Settings, sub_dao: SubDao) -> Result<Arc<Self>, SolanaRpcError> {
-        let Ok(keypair) = Keypair::read_from_file(&settings.burn_keypair) else {
+        let Ok(keypair) = read_keypair_from_file(&settings.burn_keypair) else {
             return Err(SolanaRpcError::FailedToReadKeypairError);
         };
 

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -22,7 +22,7 @@ macro_rules! send_with_retry {
                 Err(err) => {
                     if attempt < 5 {
                         attempt += 1;
-                        tokio::time::sleep(Duration::from_secs(attempt)).await;
+                        tokio::time::sleep(std::time::Duration::from_secs(attempt)).await;
                         continue;
                     } else {
                         break Err(err);

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -2,7 +2,7 @@ use solana_client::client_error::ClientError;
 use solana_sdk::pubkey::ParsePubkeyError;
 use solana_sdk::signature::Signature;
 use solana_sdk::transaction::Transaction;
-use std::time::SystemTimeError;
+use std::{fs::File, io::Read, path::Path, time::SystemTimeError};
 
 pub use helium_lib::{
     dao::SubDao,
@@ -33,6 +33,13 @@ macro_rules! send_with_retry {
     }};
 }
 pub(crate) use send_with_retry;
+
+pub fn read_keypair_from_file<F: AsRef<Path>>(path: F) -> anyhow::Result<Keypair> {
+    let mut file = File::open(path.as_ref())?;
+    let mut sk_buf = [0u8; 64];
+    file.read_exact(&mut sk_buf)?;
+    Ok(Keypair::try_from(&sk_buf)?)
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum SolanaRpcError {

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -4,6 +4,11 @@ use solana_sdk::signature::Signature;
 use solana_sdk::transaction::Transaction;
 use std::time::SystemTimeError;
 
+pub use helium_lib::{
+    dao::SubDao,
+    keypair::{Keypair, Pubkey},
+};
+
 pub mod burn;
 pub mod carrier;
 pub mod start_boost;

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -49,6 +49,10 @@ pub enum SolanaRpcError {
     FailedToReadKeypairError,
     #[error("crypto error: {0}")]
     Crypto(#[from] helium_crypto::Error),
+    #[error("helium-lib error: {0}")]
+    HeliumLib(#[from] helium_lib::error::Error),
+    #[error("Parse Solana Pubkey from slice error: {0}")]
+    ParsePubkeyFromSliceError(#[from] std::array::TryFromSliceError),
 }
 
 impl From<helium_anchor_gen::anchor_lang::error::Error> for SolanaRpcError {

--- a/solana/src/start_boost.rs
+++ b/solana/src/start_boost.rs
@@ -1,4 +1,6 @@
-use crate::{send_with_retry, GetSignature, Keypair, Pubkey, SolanaRpcError};
+use crate::{
+    read_keypair_from_file, send_with_retry, GetSignature, Keypair, Pubkey, SolanaRpcError,
+};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use file_store::hex_boost::BoostedHexActivation;
@@ -9,7 +11,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig, signature::Signature, signer::Signer,
     transaction::Transaction,
 };
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 #[async_trait]
 pub trait SolanaNetwork: Send + Sync + 'static {
@@ -39,7 +41,7 @@ pub struct SolanaRpc {
 
 impl SolanaRpc {
     pub async fn new(settings: &Settings) -> Result<Arc<Self>, SolanaRpcError> {
-        let Ok(keypair) = Keypair::read_from_file(&settings.start_authority_keypair) else {
+        let Ok(keypair) = read_keypair_from_file(&settings.start_authority_keypair) else {
             return Err(SolanaRpcError::FailedToReadKeypairError);
         };
         let provider = client::SolanaRpcClient::new_with_commitment(

--- a/solana/src/start_boost.rs
+++ b/solana/src/start_boost.rs
@@ -6,9 +6,7 @@ use helium_lib::{boosting, client};
 use serde::Deserialize;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{read_keypair_file, Signature},
-    signer::Signer,
+    commitment_config::CommitmentConfig, signature::Signature, signer::Signer,
     transaction::Transaction,
 };
 use std::{sync::Arc, time::Duration};
@@ -41,7 +39,7 @@ pub struct SolanaRpc {
 
 impl SolanaRpc {
     pub async fn new(settings: &Settings) -> Result<Arc<Self>, SolanaRpcError> {
-        let Ok(keypair) = read_keypair_file(&settings.start_authority_keypair) else {
+        let Ok(keypair) = Keypair::read_from_file(&settings.start_authority_keypair) else {
             return Err(SolanaRpcError::FailedToReadKeypairError);
         };
         let provider = client::SolanaRpcClient::new_with_commitment(
@@ -52,7 +50,7 @@ impl SolanaRpc {
         Ok(Arc::new(Self {
             provider,
             start_authority: keypair.pubkey(),
-            keypair: keypair.into(),
+            keypair,
         }))
     }
 }


### PR DESCRIPTION
Companion helium-lib PR https://github.com/helium/helium-wallet-rs/pull/401

Still in progress of moving the `solana` workspace to use `helium-lib` when it can.

- Settings cleanup has not been done yet.
- Thinking about moving boosting transaction size to `helium-lib`.
- No work done yet in `price` workspace.
- Not sure how I feel about how boosted hexes are provided to `helium-lib` 