### PR TITLE
Fix rare case where the file info poller will re-process old files

### DIFF
--- a/file_store/src/file_info_poller.rs
+++ b/file_store/src/file_info_poller.rs
@@ -429,7 +429,7 @@ impl FileInfoPollerState for sqlx::Pool<sqlx::Postgres> {
         .bind(process_name)
         .bind(file_type)
         .bind(MAX_SIZE_OF_FILES_PROCESSED_TABLE - 1)
-        .fetch_one(self)
+        .fetch_optional(self)
         .await
         .map_err(Error::from)
     }


### PR DESCRIPTION
We found a case where on devnet, the reward indexer would re-process old files after cleaning out the files processed table. This is due to the offset being further back in time than the oldest file in the files processed table due to a burst of files. This PR fixes that by checking for a full files processed table, and if it is full limiting the offset to be at most the oldest timestamp in the table. 