### PR TITLE
Fix default for custom tracing

### DIFF
--- a/custom_tracing/src/settings.rs
+++ b/custom_tracing/src/settings.rs
@@ -1,10 +1,18 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Settings {
     /// File name to be watched by custom tracing
     #[serde(default = "default_tracing_cfg_file")]
     pub tracing_cfg_file: String,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            tracing_cfg_file: default_tracing_cfg_file(),
+        }
+    }
 }
 
 pub fn default_tracing_cfg_file() -> String {


### PR DESCRIPTION
By default, file named `tracing.cfg` should be created where executable is started. This can be changed via config:
```
[custom_tracing]
tracing_cfg_file = "/tmp/tracing.cfg"
```

Notes: 
- File can be created after.
- Deletion of the file will remove custom filter (tested using `rm file` but for some reason when doing in editor it does something weird)
- Empty the file will remove the custom filter.