### PR TITLE
Soft disable Service Provider promotions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,17 +1617,17 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=mj/verified-data-transfer#d8562d29307abbfc9f92a8c8a2b493336981de3f"
+source = "git+https://github.com/helium/proto?branch=master#47598512b7d282c34b619adf140403feeb138e71"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "prost",
  "rand 0.8.5",
  "rand_chacha 0.3.0",
  "rust_decimal",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -1791,7 +1791,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "http 0.2.11",
  "http-serde",
  "humantime-serde",
@@ -2642,7 +2642,7 @@ dependencies = [
  "axum 0.7.4",
  "bs58 0.4.0",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "http 0.2.11",
  "notify",
  "serde",
@@ -3242,7 +3242,7 @@ dependencies = [
  "futures-util",
  "h3o",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "hex-literal",
  "http 0.2.11",
  "lazy_static",
@@ -3806,7 +3806,7 @@ dependencies = [
  "bs58 0.5.0",
  "byteorder",
  "ed25519-compact",
- "getrandom 0.2.10",
+ "getrandom 0.1.16",
  "k256",
  "lazy_static",
  "multihash",
@@ -3855,7 +3855,7 @@ dependencies = [
  "h3o",
  "helium-anchor-gen 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git?branch=main)",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=master)",
+ "helium-proto",
  "hex",
  "hex-literal",
  "itertools",
@@ -3882,23 +3882,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#197ff9c6cde7dc0d8334d6b4e27c58779e6a7ce0"
-dependencies = [
- "bytes",
- "prost",
- "prost-build",
- "serde",
- "serde_json",
- "strum",
- "strum_macros",
- "tonic",
- "tonic-build",
-]
-
-[[package]]
-name = "helium-proto"
-version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=mj/verified-data-transfer#d8562d29307abbfc9f92a8c8a2b493336981de3f"
+source = "git+https://github.com/helium/proto?branch=master#47598512b7d282c34b619adf140403feeb138e71"
 dependencies = [
  "bytes",
  "prost",
@@ -3961,7 +3945,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "derive_builder",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "hextree",
  "rust_decimal",
  "rust_decimal_macros",
@@ -4386,7 +4370,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "http 0.2.11",
  "humantime-serde",
  "metrics",
@@ -4455,7 +4439,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "hextree",
  "http 0.2.11",
  "http-serde",
@@ -4497,7 +4481,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "http 0.2.11",
  "http-serde",
  "humantime-serde",
@@ -4539,7 +4523,7 @@ dependencies = [
  "futures-util",
  "h3o",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "http-serde",
  "humantime-serde",
  "iot-config",
@@ -5145,7 +5129,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "hextree",
  "http 0.2.11",
  "http-serde",
@@ -5185,7 +5169,7 @@ dependencies = [
  "futures",
  "h3o",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "mobile-config",
  "prost",
  "rand 0.8.5",
@@ -5230,7 +5214,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "http 0.2.11",
  "http-serde",
  "humantime-serde",
@@ -5274,7 +5258,7 @@ dependencies = [
  "futures-util",
  "h3o",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "hex-assignments",
  "hextree",
  "http-serde",
@@ -5642,7 +5626,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.58",
@@ -5958,7 +5942,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "http 0.2.11",
  "hyper 0.14.28",
  "jsonrpsee",
@@ -6041,7 +6025,7 @@ dependencies = [
  "futures-util",
  "helium-anchor-gen 0.1.0 (git+https://github.com/helium/helium-anchor-gen.git)",
  "helium-lib",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "humantime-serde",
  "metrics",
  "metrics-exporter-prometheus",
@@ -6166,7 +6150,7 @@ dependencies = [
  "custom-tracing",
  "file-store",
  "futures",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "humantime-serde",
  "metrics",
  "metrics-exporter-prometheus",
@@ -6217,7 +6201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.0",
  "itertools",
  "log",
  "multimap",
@@ -6718,7 +6702,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=mj/verified-data-transfer)",
+ "helium-proto",
  "humantime-serde",
  "lazy_static",
  "metrics",
@@ -9441,7 +9425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,10 +71,10 @@ helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = 
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
   "disktree",
 ] }
-helium-proto = { git = "https://github.com/helium/proto", branch = "mj/verified-data-transfer", features = [
+helium-proto = { git = "https://github.com/helium/proto", branch = "master", features = [
   "services",
 ] }
-beacon = { git = "https://github.com/helium/proto", branch = "mj/verified-data-transfer" }
+beacon = { git = "https://github.com/helium/proto", branch = "master" }
 solana-client = "1.18"
 solana-sdk = "1.18"
 solana-program = "1.18"

--- a/file_store/src/cli/dump_mobile_rewards.rs
+++ b/file_store/src/cli/dump_mobile_rewards.rs
@@ -3,7 +3,7 @@ use crate::{file_source, Result, Settings};
 use futures::stream::StreamExt;
 use helium_crypto::PublicKey;
 use helium_proto::services::poc_mobile::mobile_reward_share::Reward::*;
-use helium_proto::services::poc_mobile::promotion_reward::Entity;
+// use helium_proto::services::poc_mobile::promotion_reward::Entity;
 use helium_proto::services::poc_mobile::MobileRewardShare;
 use prost::Message;
 use serde_json::json;
@@ -24,7 +24,7 @@ impl Cmd {
         let mut subscriber_reward = vec![];
         let mut service_provider_reward = vec![];
         let mut unallocated_reward = vec![];
-        let mut promotion_reward = vec![];
+        // let mut promotion_reward = vec![];
 
         while let Some(result) = file_stream.next().await {
             let msg = result?;
@@ -62,21 +62,21 @@ impl Cmd {
                         "unallocated_reward_type": reward.reward_type,
                         "amount": reward.amount,
                     })),
-                    PromotionReward(reward) => {
-                        let entity = reward.entity.unwrap();
-                        match entity {
-                            Entity::SubscriberId(id) => promotion_reward.push(json!({
-                                "subscriber_id": uuid::Uuid::from_slice(&id).unwrap(),
-                                "service_provider_amount": reward.service_provider_amount,
-                                "matched_amount": reward.matched_amount,
-                            })),
-                            Entity::GatewayKey(key) => promotion_reward.push(json!({
-                                "gateway_key": PublicKey::try_from(key)?.to_string(),
-                                "service_provider_amount": reward.service_provider_amount,
-                                "matched_amount": reward.matched_amount,
-                            })),
-                        }
-                    }
+                    // PromotionReward(reward) => {
+                    //     let entity = reward.entity.unwrap();
+                    //     match entity {
+                    //         Entity::SubscriberId(id) => promotion_reward.push(json!({
+                    //             "subscriber_id": uuid::Uuid::from_slice(&id).unwrap(),
+                    //             "service_provider_amount": reward.service_provider_amount,
+                    //             "matched_amount": reward.matched_amount,
+                    //         })),
+                    //         Entity::GatewayKey(key) => promotion_reward.push(json!({
+                    //             "gateway_key": PublicKey::try_from(key)?.to_string(),
+                    //             "service_provider_amount": reward.service_provider_amount,
+                    //             "matched_amount": reward.matched_amount,
+                    //         })),
+                    //     }
+                    // }
                 },
                 None => todo!(),
             }
@@ -88,7 +88,7 @@ impl Cmd {
             "gateway_reward": gateway_reward,
             "subscriber_reward": subscriber_reward,
             "service_provider_reward": service_provider_reward,
-            "promotion_reward": promotion_reward,
+            // "promotion_reward": promotion_reward,
             "unallocated_reward": unallocated_reward,
         }))?;
 

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -313,7 +313,7 @@ where
             boosted_poc_bones_per_reward_share: Some(helium_proto::Decimal {
                 value: poc_dc_shares.boost.to_string(),
             }),
-            sp_allocations: service_provider::reward_data_sp_allocations(&self.pool).await?,
+            // sp_allocations: service_provider::reward_data_sp_allocations(&self.pool).await?,
         };
         self.reward_manifests
             .write(

--- a/mobile_verifier/src/service_provider/promotions/rewards.rs
+++ b/mobile_verifier/src/service_provider/promotions/rewards.rs
@@ -156,6 +156,54 @@ pub async fn clear_promotion_rewards(
     Ok(())
 }
 
+pub async fn fetch_promotion_rewards(
+    _pool: &PgPool,
+    _carrier: &impl CarrierServiceVerifier<Error = ClientError>,
+    _epoch: &Range<DateTime<Utc>>,
+) -> anyhow::Result<ServiceProviderPromotions> {
+    Ok(ServiceProviderPromotions::default())
+
+    // let rewards = sqlx::query_as(
+    //     r#"
+    //     SELECT
+    //         subscriber_id, NULL as gateway_key, SUM(shares)::bigint as shares, carrier_key
+    //     FROM
+    //         subscriber_promotion_rewards
+    //     WHERE
+    //         time_of_reward >= $1 AND time_of_reward < $2
+    //     GROUP BY
+    //         subscriber_id, carrier_key
+    //     UNION
+    //     SELECT
+    //         NULL as subscriber_id, gateway_key, SUM(shares)::bigint as shares, carrier_key
+    //     FROM
+    //         gateway_promotion_rewards
+    //     WHERE
+    //         time_of_reward >= $1 AND time_of_reward < $2
+    //     GROUP
+    //         BY gateway_key, carrier_key
+    //     "#,
+    // )
+    // .bind(epoch.start)
+    // .bind(epoch.end)
+    // .fetch(pool)
+    // .map_err(anyhow::Error::from)
+    // .and_then(|x: DbPromotionRewardShares| async move {
+    //     let service_provider_id = carrier
+    //         .payer_key_to_service_provider(&x.carrier_key.to_string())
+    //         .await?;
+    //     Ok(PromotionRewardShare {
+    //         service_provider_id: service_provider_id as ServiceProviderId,
+    //         rewardable_entity: x.rewardable_entity,
+    //         shares: x.shares,
+    //     })
+    // })
+    // .try_collect()
+    // .await?;
+
+    // Ok(ServiceProviderPromotions(rewards))
+}
+
 struct DbPromotionRewardShares {
     pub carrier_key: PublicKeyBinary,
     pub rewardable_entity: Entity,

--- a/mobile_verifier/src/service_provider/promotions/rewards.rs
+++ b/mobile_verifier/src/service_provider/promotions/rewards.rs
@@ -2,11 +2,10 @@ use std::ops::Range;
 
 use chrono::{DateTime, Utc};
 use file_store::promotion_reward::{Entity, PromotionReward};
-use futures::TryStreamExt;
-use helium_crypto::PublicKeyBinary;
+
 use mobile_config::client::{carrier_service_client::CarrierServiceVerifier, ClientError};
 use rust_decimal::Decimal;
-use sqlx::{postgres::PgRow, PgPool, Postgres, Row, Transaction};
+use sqlx::{PgPool, Postgres, Transaction};
 
 use crate::service_provider::ServiceProviderId;
 
@@ -95,52 +94,6 @@ pub async fn save_promotion_reward(
     Ok(())
 }
 
-pub async fn fetch_promotion_rewards(
-    pool: &PgPool,
-    carrier: &impl CarrierServiceVerifier<Error = ClientError>,
-    epoch: &Range<DateTime<Utc>>,
-) -> anyhow::Result<ServiceProviderPromotions> {
-    let rewards = sqlx::query_as(
-        r#"
-        SELECT
-            subscriber_id, NULL as gateway_key, SUM(shares)::bigint as shares, carrier_key
-        FROM
-            subscriber_promotion_rewards
-        WHERE
-            time_of_reward >= $1 AND time_of_reward < $2
-        GROUP BY
-            subscriber_id, carrier_key
-        UNION
-        SELECT
-            NULL as subscriber_id, gateway_key, SUM(shares)::bigint as shares, carrier_key
-        FROM
-            gateway_promotion_rewards
-        WHERE
-            time_of_reward >= $1 AND time_of_reward < $2
-        GROUP
-            BY gateway_key, carrier_key
-        "#,
-    )
-    .bind(epoch.start)
-    .bind(epoch.end)
-    .fetch(pool)
-    .map_err(anyhow::Error::from)
-    .and_then(|x: DbPromotionRewardShares| async move {
-        let service_provider_id = carrier
-            .payer_key_to_service_provider(&x.carrier_key.to_string())
-            .await?;
-        Ok(PromotionRewardShare {
-            service_provider_id: service_provider_id as ServiceProviderId,
-            rewardable_entity: x.rewardable_entity,
-            shares: x.shares,
-        })
-    })
-    .try_collect()
-    .await?;
-
-    Ok(ServiceProviderPromotions(rewards))
-}
-
 pub async fn clear_promotion_rewards(
     tx: &mut Transaction<'_, Postgres>,
     timestamp: &DateTime<Utc>,
@@ -204,24 +157,24 @@ pub async fn fetch_promotion_rewards(
     // Ok(ServiceProviderPromotions(rewards))
 }
 
-struct DbPromotionRewardShares {
-    pub carrier_key: PublicKeyBinary,
-    pub rewardable_entity: Entity,
-    pub shares: u64,
-}
+// struct DbPromotionRewardShares {
+//     pub carrier_key: PublicKeyBinary,
+//     pub rewardable_entity: Entity,
+//     pub shares: u64,
+// }
 
-impl sqlx::FromRow<'_, PgRow> for DbPromotionRewardShares {
-    fn from_row(row: &PgRow) -> sqlx::Result<Self> {
-        let subscriber_id: Option<Vec<u8>> = row.try_get("subscriber_id")?;
-        let shares: i64 = row.try_get("shares")?;
-        Ok(Self {
-            rewardable_entity: if let Some(subscriber_id) = subscriber_id {
-                Entity::SubscriberId(subscriber_id)
-            } else {
-                Entity::GatewayKey(row.try_get("gateway_key")?)
-            },
-            shares: shares as u64,
-            carrier_key: row.try_get("carrier_key")?,
-        })
-    }
-}
+// impl sqlx::FromRow<'_, PgRow> for DbPromotionRewardShares {
+//     fn from_row(row: &PgRow) -> sqlx::Result<Self> {
+//         let subscriber_id: Option<Vec<u8>> = row.try_get("subscriber_id")?;
+//         let shares: i64 = row.try_get("shares")?;
+//         Ok(Self {
+//             rewardable_entity: if let Some(subscriber_id) = subscriber_id {
+//                 Entity::SubscriberId(subscriber_id)
+//             } else {
+//                 Entity::GatewayKey(row.try_get("gateway_key")?)
+//             },
+//             shares: shares as u64,
+//             carrier_key: row.try_get("carrier_key")?,
+//         })
+//     }
+// }

--- a/mobile_verifier/src/service_provider/reward.rs
+++ b/mobile_verifier/src/service_provider/reward.rs
@@ -422,7 +422,6 @@ mod tests {
 
         let sp_2 = sp_infos.single_sp_rewards(1);
         assert_eq!(sp_2.amount, 0);
-        
 
         // let (promo_1, sp_1) = sp_infos.single_sp_rewards(0);
         // assert_eq!(promo_1.service_provider_amount, 6);
@@ -624,8 +623,6 @@ mod tests {
     //     assert_eq!(promo_rewards[1].service_provider_amount, 6);
     //     assert_eq!(promo_rewards[1].matched_amount, 6);
     // }
-
-    
 
     // trait PromoRewardFiltersExt {
     //     fn only_promotion_rewards(&self) -> Vec<PromotionReward>;

--- a/mobile_verifier/tests/integrations/common/mod.rs
+++ b/mobile_verifier/tests/integrations/common/mod.rs
@@ -9,9 +9,8 @@ use helium_proto::services::{
     mobile_config::NetworkKeyRole,
     poc_mobile::{
         mobile_reward_share::Reward as MobileReward, radio_reward_v2, GatewayReward,
-        MobileRewardShare, OracleBoostingHexAssignment, OracleBoostingReportV1, PromotionReward,
-        RadioReward, RadioRewardV2, ServiceProviderReward, SpeedtestAvg, SubscriberReward,
-        UnallocatedReward,
+        MobileRewardShare, OracleBoostingHexAssignment, OracleBoostingReportV1, RadioReward,
+        RadioRewardV2, ServiceProviderReward, SpeedtestAvg, SubscriberReward, UnallocatedReward,
     },
 };
 use hex_assignments::{Assignment, HexAssignment, HexBoostData};
@@ -163,15 +162,15 @@ impl MockFileSinkReceiver<MobileRewardShare> {
         }
     }
 
-    pub async fn receive_promotion_reward(&mut self) -> PromotionReward {
-        match self.receive("receive_promotion_reward").await {
-            Some(mobile_reward) => match mobile_reward.reward {
-                Some(MobileReward::PromotionReward(r)) => r,
-                _ => panic!("failed to get promotion reward"),
-            },
-            None => panic!("failed to receive promotion reward"),
-        }
-    }
+    // pub async fn receive_promotion_reward(&mut self) -> PromotionReward {
+    //     match self.receive("receive_promotion_reward").await {
+    //         Some(mobile_reward) => match mobile_reward.reward {
+    //             Some(MobileReward::PromotionReward(r)) => r,
+    //             _ => panic!("failed to get promotion reward"),
+    //         },
+    //         None => panic!("failed to receive promotion reward"),
+    //     }
+    // }
 
     pub async fn receive_unallocated_reward(&mut self) -> UnallocatedReward {
         match self.receive("receive_unallocated_reward").await {

--- a/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
+++ b/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
@@ -3,8 +3,6 @@ use std::string::ToString;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
-use file_store::promotion_reward::{self, PromotionReward};
-use helium_crypto::PublicKeyBinary;
 use helium_proto::{
     services::poc_mobile::{
         MobileRewardShare, ServiceProviderReward, UnallocatedReward, UnallocatedRewardType,
@@ -14,18 +12,10 @@ use helium_proto::{
 use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
 use sqlx::{PgPool, Postgres, Transaction};
-use uuid::Uuid;
 
 use crate::common::{self, MockFileSinkReceiver};
 use mobile_config::client::{carrier_service_client::CarrierServiceVerifier, ClientError};
-use mobile_verifier::{
-    data_session, reward_shares, rewarder,
-    service_provider::{
-        self,
-        promotions::{funds::save_promotion_fund, rewards::save_promotion_reward},
-        ServiceProviderId,
-    },
-};
+use mobile_verifier::{data_session, reward_shares, rewarder};
 
 const HOTSPOT_1: &str = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6";
 const HOTSPOT_2: &str = "11eX55faMbqZB7jzN4p67m6w7ScPMH6ubnvCjCPLh72J49PaJEL";
@@ -155,109 +145,109 @@ async fn test_service_provider_rewards_invalid_sp(pool: PgPool) -> anyhow::Resul
     Ok(())
 }
 
-#[sqlx::test]
-async fn test_service_provider_promotion_rewards(pool: PgPool) -> anyhow::Result<()> {
-    // Single SP has allocated shares for a few of their subscribers.
-    // Rewards are matched by the unallocated SP rewards for the subscribers
+// #[sqlx::test]
+// async fn test_service_provider_promotion_rewards(pool: PgPool) -> anyhow::Result<()> {
+//     // Single SP has allocated shares for a few of their subscribers.
+//     // Rewards are matched by the unallocated SP rewards for the subscribers
 
-    let valid_sps = HashMap::from_iter([(PAYER_1.to_string(), SP_1.to_string())]);
-    let carrier_client = MockCarrierServiceClient::new(valid_sps);
+//     let valid_sps = HashMap::from_iter([(PAYER_1.to_string(), SP_1.to_string())]);
+//     let carrier_client = MockCarrierServiceClient::new(valid_sps);
 
-    let now = Utc::now();
-    let epoch = (now - ChronoDuration::hours(24))..now;
-    let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
+//     let now = Utc::now();
+//     let epoch = (now - ChronoDuration::hours(24))..now;
+//     let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
 
-    let mut txn = pool.begin().await?;
-    seed_hotspot_data(epoch.end, &mut txn).await?; // DC transferred == 6,000 reward amount
-    seed_sp_promotion_rewards_with_random_subscribers(
-        PAYER_1.to_string().parse().unwrap(),
-        &[1, 2, 3],
-        &mut txn,
-    )
-    .await?;
-    // promotions allocated 10.00%
-    seed_sp_promotion_rewards_funds(&[(0, 1500)], &mut txn).await?;
-    txn.commit().await?;
+//     let mut txn = pool.begin().await?;
+//     seed_hotspot_data(epoch.end, &mut txn).await?; // DC transferred == 6,000 reward amount
+//     seed_sp_promotion_rewards_with_random_subscribers(
+//         PAYER_1.to_string().parse().unwrap(),
+//         &[1, 2, 3],
+//         &mut txn,
+//     )
+//     .await?;
+//     // promotions allocated 10.00%
+//     seed_sp_promotion_rewards_funds(&[(0, 1500)], &mut txn).await?;
+//     txn.commit().await?;
 
-    let (_, rewards) = tokio::join!(
-        rewarder::reward_service_providers(
-            &pool,
-            &carrier_client,
-            &mobile_rewards_client,
-            &epoch,
-            dec!(0.00001)
-        ),
-        async move {
-            let mut promos = vec![
-                mobile_rewards.receive_promotion_reward().await,
-                mobile_rewards.receive_promotion_reward().await,
-                mobile_rewards.receive_promotion_reward().await,
-            ];
-            // sort by awarded amount least -> most
-            promos.sort_by_key(|a| a.service_provider_amount);
+//     let (_, rewards) = tokio::join!(
+//         rewarder::reward_service_providers(
+//             &pool,
+//             &carrier_client,
+//             &mobile_rewards_client,
+//             &epoch,
+//             dec!(0.00001)
+//         ),
+//         async move {
+//             let mut promos = vec![
+//                 mobile_rewards.receive_promotion_reward().await,
+//                 mobile_rewards.receive_promotion_reward().await,
+//                 mobile_rewards.receive_promotion_reward().await,
+//             ];
+//             // sort by awarded amount least -> most
+//             promos.sort_by_key(|a| a.service_provider_amount);
 
-            let sp_reward = mobile_rewards.receive_service_provider_reward().await;
-            let unallocated = mobile_rewards.receive_unallocated_reward().await;
+//             let sp_reward = mobile_rewards.receive_service_provider_reward().await;
+//             let unallocated = mobile_rewards.receive_unallocated_reward().await;
 
-            mobile_rewards.assert_no_messages();
+//             mobile_rewards.assert_no_messages();
 
-            (promos, sp_reward, unallocated)
-        }
-    );
+//             (promos, sp_reward, unallocated)
+//         }
+//     );
 
-    let (promos, sp_reward, unallocated) = rewards;
-    let promo_reward_1 = promos[0].clone();
-    let promo_reward_2 = promos[1].clone();
-    let promo_reward_3 = promos[2].clone();
+//     let (promos, sp_reward, unallocated) = rewards;
+//     let promo_reward_1 = promos[0].clone();
+//     let promo_reward_2 = promos[1].clone();
+//     let promo_reward_3 = promos[2].clone();
 
-    // 1 share
-    assert_eq!(promo_reward_1.service_provider_amount, 1_500);
-    assert_eq!(promo_reward_1.matched_amount, 1_500);
+//     // 1 share
+//     assert_eq!(promo_reward_1.service_provider_amount, 1_500);
+//     assert_eq!(promo_reward_1.matched_amount, 1_500);
 
-    // 2 shares
-    assert_eq!(promo_reward_2.service_provider_amount, 3_000);
-    assert_eq!(promo_reward_2.matched_amount, 3_000);
+//     // 2 shares
+//     assert_eq!(promo_reward_2.service_provider_amount, 3_000);
+//     assert_eq!(promo_reward_2.matched_amount, 3_000);
 
-    // 3 shares
-    assert_eq!(promo_reward_3.service_provider_amount, 4_500);
-    assert_eq!(promo_reward_3.matched_amount, 4_500);
+//     // 3 shares
+//     assert_eq!(promo_reward_3.service_provider_amount, 4_500);
+//     assert_eq!(promo_reward_3.matched_amount, 4_500);
 
-    // dc_percentage * total_sp_allocation rounded down
-    assert_eq!(sp_reward.amount, 50_999);
+//     // dc_percentage * total_sp_allocation rounded down
+//     assert_eq!(sp_reward.amount, 50_999);
 
-    let unallocated_sp_rewards = get_unallocated_sp_rewards(&epoch);
-    let expected_unallocated = unallocated_sp_rewards
-        - 50_999 // 85% service provider rewards rounded down
-        - 9_000 // 15% service provider promotions
-        - 9_000; // matched promotion
+//     let unallocated_sp_rewards = get_unallocated_sp_rewards(&epoch);
+//     let expected_unallocated = unallocated_sp_rewards
+//         - 50_999 // 85% service provider rewards rounded down
+//         - 9_000 // 15% service provider promotions
+//         - 9_000; // matched promotion
 
-    assert_eq!(unallocated.amount, expected_unallocated);
+//     assert_eq!(unallocated.amount, expected_unallocated);
 
-    // Ensure the cleanup job can run
-    let mut txn = pool.begin().await?;
+//     // Ensure the cleanup job can run
+//     let mut txn = pool.begin().await?;
 
-    service_provider::db::clear_promotion_rewards(&mut txn, &Utc::now()).await?;
-    txn.commit().await?;
+//     service_provider::db::clear_promotion_rewards(&mut txn, &Utc::now()).await?;
+//     txn.commit().await?;
 
-    let promos = service_provider::db::fetch_promotion_rewards(
-        &pool,
-        &carrier_client,
-        &(epoch.start..Utc::now()),
-    )
-    .await?;
-    assert!(promos.is_empty());
+//     let promos = service_provider::db::fetch_promotion_rewards(
+//         &pool,
+//         &carrier_client,
+//         &(epoch.start..Utc::now()),
+//     )
+//     .await?;
+//     assert!(promos.is_empty());
 
-    let sp_allocations = service_provider::reward_data_sp_allocations(&pool).await?;
-    assert_eq!(
-        vec![helium_proto::ServiceProviderAllocation {
-            service_provider: 0,
-            incentive_escrow_fund_bps: 1500
-        }],
-        sp_allocations
-    );
+//     let sp_allocations = service_provider::reward_data_sp_allocations(&pool).await?;
+//     assert_eq!(
+//         vec![helium_proto::ServiceProviderAllocation {
+//             service_provider: 0,
+//             incentive_escrow_fund_bps: 1500
+//         }],
+//         sp_allocations
+//     );
 
-    Ok(())
-}
+//     Ok(())
+// }
 
 async fn receive_expected_rewards(
     mobile_rewards: &mut MockFileSinkReceiver<MobileRewardShare>,
@@ -331,47 +321,47 @@ async fn seed_hotspot_data_invalid_sp(
     Ok(())
 }
 
-// Service Provider promotion rewards are verified during ingest. When you write
-// directly to the database, the assumption is the entity and the payer are
-// valid.
-async fn seed_sp_promotion_rewards_with_random_subscribers(
-    payer: PublicKeyBinary,
-    sub_shares: &[u64],
-    txn: &mut Transaction<'_, Postgres>,
-) -> anyhow::Result<()> {
-    for &shares in sub_shares {
-        save_promotion_reward(
-            txn,
-            &PromotionReward {
-                entity: promotion_reward::Entity::SubscriberId(Uuid::new_v4().into()),
-                shares,
-                timestamp: Utc::now() - chrono::Duration::hours(2),
-                received_timestamp: Utc::now(),
-                carrier_pub_key: payer.clone(),
-                signature: vec![],
-            },
-        )
-        .await?;
-    }
+// // Service Provider promotion rewards are verified during ingest. When you write
+// // directly to the database, the assumption is the entity and the payer are
+// // valid.
+// async fn seed_sp_promotion_rewards_with_random_subscribers(
+//     payer: PublicKeyBinary,
+//     sub_shares: &[u64],
+//     txn: &mut Transaction<'_, Postgres>,
+// ) -> anyhow::Result<()> {
+//     for &shares in sub_shares {
+//         save_promotion_reward(
+//             txn,
+//             &PromotionReward {
+//                 entity: promotion_reward::Entity::SubscriberId(Uuid::new_v4().into()),
+//                 shares,
+//                 timestamp: Utc::now() - chrono::Duration::hours(2),
+//                 received_timestamp: Utc::now(),
+//                 carrier_pub_key: payer.clone(),
+//                 signature: vec![],
+//             },
+//         )
+//         .await?;
+//     }
 
-    Ok(())
-}
+//     Ok(())
+// }
 
-async fn seed_sp_promotion_rewards_funds(
-    sp_fund_allocations: &[(ServiceProviderId, u16)],
-    txn: &mut Transaction<'_, Postgres>,
-) -> anyhow::Result<()> {
-    for (sp_id, basis_points) in sp_fund_allocations {
-        save_promotion_fund(txn, *sp_id, *basis_points).await?;
-    }
+// async fn seed_sp_promotion_rewards_funds(
+//     sp_fund_allocations: &[(ServiceProviderId, u16)],
+//     txn: &mut Transaction<'_, Postgres>,
+// ) -> anyhow::Result<()> {
+//     for (sp_id, basis_points) in sp_fund_allocations {
+//         save_promotion_fund(txn, *sp_id, *basis_points).await?;
+//     }
 
-    Ok(())
-}
+//     Ok(())
+// }
 
-// Helper for turning Decimal -> u64 to compare against output rewards
-fn get_unallocated_sp_rewards(epoch: &std::ops::Range<DateTime<Utc>>) -> u64 {
-    reward_shares::get_scheduled_tokens_for_service_providers(epoch.end - epoch.start)
-        .round_dp_with_strategy(0, RoundingStrategy::ToZero)
-        .to_u64()
-        .unwrap_or(0)
-}
+// // Helper for turning Decimal -> u64 to compare against output rewards
+// fn get_unallocated_sp_rewards(epoch: &std::ops::Range<DateTime<Utc>>) -> u64 {
+//     reward_shares::get_scheduled_tokens_for_service_providers(epoch.end - epoch.start)
+//         .round_dp_with_strategy(0, RoundingStrategy::ToZero)
+//         .to_u64()
+//         .unwrap_or(0)
+// }

--- a/reward_index/src/indexer.rs
+++ b/reward_index/src/indexer.rs
@@ -9,10 +9,7 @@ use helium_crypto::PublicKeyBinary;
 use helium_proto::{
     services::{
         poc_lora::{iot_reward_share::Reward as IotReward, IotRewardShare},
-        poc_mobile::{
-            mobile_reward_share::Reward as MobileReward, promotion_reward::Entity,
-            MobileRewardShare, PromotionReward,
-        },
+        poc_mobile::{mobile_reward_share::Reward as MobileReward, MobileRewardShare},
     },
     Message, ServiceProvider,
 };
@@ -190,28 +187,28 @@ impl Indexer {
                         },
                         r.amount,
                     ))),
-                    Some(MobileReward::PromotionReward(PromotionReward {
-                        entity: Some(Entity::SubscriberId(subscriber_id)),
-                        service_provider_amount,
-                        matched_amount,
-                    })) => Ok(Some((
-                        RewardKey {
-                            key: bs58::encode(&subscriber_id).into_string(),
-                            reward_type: RewardType::MobileSubscriber,
-                        },
-                        service_provider_amount + matched_amount,
-                    ))),
-                    Some(MobileReward::PromotionReward(PromotionReward {
-                        entity: Some(Entity::GatewayKey(gateway_key)),
-                        service_provider_amount,
-                        matched_amount,
-                    })) => Ok(Some((
-                        RewardKey {
-                            key: PublicKeyBinary::from(gateway_key).to_string(),
-                            reward_type: RewardType::MobileGateway,
-                        },
-                        service_provider_amount + matched_amount,
-                    ))),
+                    // Some(MobileReward::PromotionReward(PromotionReward {
+                    //     entity: Some(Entity::SubscriberId(subscriber_id)),
+                    //     service_provider_amount,
+                    //     matched_amount,
+                    // })) => Ok(Some((
+                    //     RewardKey {
+                    //         key: bs58::encode(&subscriber_id).into_string(),
+                    //         reward_type: RewardType::MobileSubscriber,
+                    //     },
+                    //     service_provider_amount + matched_amount,
+                    // ))),
+                    // Some(MobileReward::PromotionReward(PromotionReward {
+                    //     entity: Some(Entity::GatewayKey(gateway_key)),
+                    //     service_provider_amount,
+                    //     matched_amount,
+                    // })) => Ok(Some((
+                    //     RewardKey {
+                    //         key: PublicKeyBinary::from(gateway_key).to_string(),
+                    //         reward_type: RewardType::MobileGateway,
+                    //     },
+                    //     service_provider_amount + matched_amount,
+                    // ))),
                     _ => bail!("got an invalid reward share"),
                 }
             }


### PR DESCRIPTION
[Proto PR](https://github.com/helium/proto/pull/422)

The groundwork for Service Provider promotions is fine. Some of the finer details are still in flux. 
This PR is disabling any part of service provider promotions that might be written to a public file that would lock us into those proto versions.