### PR TITLE
Use reward_v2 for Indexing rewards

### DIFF
--- a/reward_index/src/indexer.rs
+++ b/reward_index/src/indexer.rs
@@ -139,19 +139,17 @@ impl Indexer {
             settings::Mode::Mobile => {
                 let share = MobileRewardShare::decode(msg)?;
                 match share.reward {
-                    Some(MobileReward::RadioReward(r)) => Ok(Some((
+                    Some(MobileReward::RadioReward(_r)) => {
+                        // RadioReward has been replaced by RadioRewardV2
+                        Ok(None)
+                    }
+                    Some(MobileReward::RadioRewardV2(r)) => Ok(Some((
                         RewardKey {
                             key: PublicKeyBinary::from(r.hotspot_key).to_string(),
                             reward_type: RewardType::MobileGateway,
                         },
-                        r.poc_reward,
+                        r.base_poc_reward + r.boosted_poc_reward,
                     ))),
-                    Some(MobileReward::RadioRewardV2(_)) => {
-                        // NOTE: Eventually radio_reward_v2 will replace
-                        // radio_reward as the source of rewards, then
-                        // radio_reward will cease to be written.
-                        Ok(None)
-                    }
 
                     Some(MobileReward::GatewayReward(r)) => Ok(Some((
                         RewardKey {


### PR DESCRIPTION
RewardV2 has been written out for some time now, switch indexer over to use it so we can stop writing rewardv1. Stopping the writing of reward_v1 will happen in a separate release.