### PR TITLE
Add CLI for fetching sp promotions

### DIFF
--- a/mobile_config/src/client/carrier_service_client.rs
+++ b/mobile_config/src/client/carrier_service_client.rs
@@ -1,6 +1,6 @@
 use super::{call_with_retry, ClientError, Settings, CACHE_EVICTION_FREQUENCY};
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use file_store::traits::{MsgVerify, TimestampEncode};
 use helium_crypto::{Keypair, PublicKey, Sign};
 use helium_proto::{
@@ -19,6 +19,7 @@ pub trait CarrierServiceVerifier {
 
     async fn list_incentive_promotions(
         &self,
+        epoch_start: &DateTime<Utc>,
     ) -> Result<Vec<ServiceProviderPromotions>, Self::Error>;
 }
 #[derive(Clone)]
@@ -69,9 +70,10 @@ impl CarrierServiceVerifier for CarrierServiceClient {
 
     async fn list_incentive_promotions(
         &self,
+        epoch_start: &DateTime<Utc>,
     ) -> Result<Vec<ServiceProviderPromotions>, Self::Error> {
         let mut request = mobile_config::CarrierIncentivePromotionListReqV1 {
-            timestamp: Utc::now().encode_timestamp(),
+            timestamp: epoch_start.encode_timestamp(),
             signer: self.signing_key.public_key().into(),
             signature: vec![],
         };

--- a/mobile_verifier/src/cli/mod.rs
+++ b/mobile_verifier/src/cli/mod.rs
@@ -1,3 +1,4 @@
 pub mod reward_from_db;
 pub mod server;
+pub mod service_provider_promotions;
 pub mod verify_disktree;

--- a/mobile_verifier/src/cli/service_provider_promotions.rs
+++ b/mobile_verifier/src/cli/service_provider_promotions.rs
@@ -1,29 +1,35 @@
 use crate::{service_provider, Settings};
 use anyhow::Result;
-use chrono::DateTime;
+use chrono::{DateTime, Utc};
 use mobile_config::client::CarrierServiceClient;
 
 #[derive(Debug, clap::Args)]
-pub struct Cmd {}
+pub struct Cmd {
+    #[clap(long)]
+    start: Option<DateTime<Utc>>,
+}
 
 impl Cmd {
     pub async fn run(self, settings: &Settings) -> Result<()> {
-        let carrier_client = CarrierServiceClient::from_settings(&settings.config_client)?;
-        let promos = service_provider::get_promotions(&carrier_client).await?;
+        let epoch_start = match self.start {
+            Some(dt) => dt,
+            None => Utc::now(),
+        };
 
+        let carrier_client = CarrierServiceClient::from_settings(&settings.config_client)?;
+        let promos = service_provider::get_promotions(&carrier_client, &epoch_start).await?;
+
+        println!("Promotions as of {epoch_start}");
         for sp in promos.into_proto() {
             println!("Service Provider: {:?}", sp.service_provider());
             println!("  incentive_escrow_bps: {:?}", sp.incentive_escrow_fund_bps);
             println!("  Promotions: ({})", sp.promotions.len());
             for promo in sp.promotions {
-                println!("    name: {}", promo.entity);
                 let start = DateTime::from_timestamp(promo.start_ts as i64, 0).unwrap();
                 let end = DateTime::from_timestamp(promo.end_ts as i64, 0).unwrap();
-                let duration = (end - start).to_std()?;
-                println!(
-                    "    duration: {} ({start:?} -> {end:?})",
-                    humantime::format_duration(duration)
-                );
+                let duration = humantime::format_duration((end - start).to_std()?);
+                println!("    name: {}", promo.entity);
+                println!("    duration: {duration} ({start:?} -> {end:?})",);
                 println!("    shares: {}", promo.shares);
             }
         }

--- a/mobile_verifier/src/cli/service_provider_promotions.rs
+++ b/mobile_verifier/src/cli/service_provider_promotions.rs
@@ -1,0 +1,33 @@
+use crate::{service_provider, Settings};
+use anyhow::Result;
+use chrono::DateTime;
+use mobile_config::client::CarrierServiceClient;
+
+#[derive(Debug, clap::Args)]
+pub struct Cmd {}
+
+impl Cmd {
+    pub async fn run(self, settings: &Settings) -> Result<()> {
+        let carrier_client = CarrierServiceClient::from_settings(&settings.config_client)?;
+        let promos = service_provider::get_promotions(&carrier_client).await?;
+
+        for sp in promos.into_proto() {
+            println!("Service Provider: {:?}", sp.service_provider());
+            println!("  incentive_escrow_bps: {:?}", sp.incentive_escrow_fund_bps);
+            println!("  Promotions: ({})", sp.promotions.len());
+            for promo in sp.promotions {
+                println!("    name: {}", promo.entity);
+                let start = DateTime::from_timestamp(promo.start_ts as i64, 0).unwrap();
+                let end = DateTime::from_timestamp(promo.end_ts as i64, 0).unwrap();
+                let duration = (end - start).to_std()?;
+                println!(
+                    "    duration: {} ({start:?} -> {end:?})",
+                    humantime::format_duration(duration)
+                );
+                println!("    shares: {}", promo.shares);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/mobile_verifier/src/main.rs
+++ b/mobile_verifier/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use mobile_verifier::{
-    cli::{reward_from_db, server, verify_disktree},
+    cli::{reward_from_db, server, service_provider_promotions, verify_disktree},
     Settings,
 };
 use std::path;
@@ -37,6 +37,8 @@ pub enum Cmd {
     /// Go through every cell and ensure it's value can be turned into an Assignment.
     /// NOTE: This can take a very long time. Run with a --release binary.
     VerifyDisktree(verify_disktree::Cmd),
+    /// Print active Service Provider Promotions
+    ServiceProviderPromotions(service_provider_promotions::Cmd),
 }
 
 impl Cmd {
@@ -45,6 +47,7 @@ impl Cmd {
             Self::Server(cmd) => cmd.run(&settings).await,
             Self::RewardFromDb(cmd) => cmd.run(&settings).await,
             Self::VerifyDisktree(cmd) => cmd.run(&settings).await,
+            Self::ServiceProviderPromotions(cmd) => cmd.run(&settings).await,
         }
     }
 }

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -277,7 +277,8 @@ where
         let dc_sessions =
             service_provider::get_dc_sessions(&self.pool, &self.carrier_client, reward_period)
                 .await?;
-        let sp_promotions = service_provider::get_promotions(&self.carrier_client).await?;
+        let sp_promotions =
+            service_provider::get_promotions(&self.carrier_client, &reward_period.start).await?;
         reward_service_providers(
             dc_sessions,
             sp_promotions.clone(),

--- a/mobile_verifier/src/service_provider/dc_sessions.rs
+++ b/mobile_verifier/src/service_provider/dc_sessions.rs
@@ -136,6 +136,7 @@ pub mod tests {
 
             async fn list_incentive_promotions(
                 &self,
+                _epoch_start: &DateTime<Utc>,
             ) -> Result<Vec<ServiceProviderPromotions>, Self::Error> {
                 Ok(vec![])
             }

--- a/mobile_verifier/src/service_provider/promotions.rs
+++ b/mobile_verifier/src/service_provider/promotions.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use mobile_config::client::{carrier_service_client::CarrierServiceVerifier, ClientError};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -10,8 +11,9 @@ mod proto {
 
 pub async fn get_promotions(
     client: &impl CarrierServiceVerifier<Error = ClientError>,
+    epoch_start: &DateTime<Utc>,
 ) -> anyhow::Result<ServiceProviderPromotions> {
-    let promos = client.list_incentive_promotions().await?;
+    let promos = client.list_incentive_promotions(epoch_start).await?;
     Ok(ServiceProviderPromotions(promos))
 }
 

--- a/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
+++ b/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
@@ -62,6 +62,7 @@ impl CarrierServiceVerifier for MockCarrierServiceClient {
 
     async fn list_incentive_promotions(
         &self,
+        _epoch_start: &DateTime<Utc>,
     ) -> Result<Vec<ServiceProviderPromotions>, Self::Error> {
         Ok(self.promotions.clone())
     }
@@ -83,7 +84,9 @@ async fn test_service_provider_rewards(pool: PgPool) -> anyhow::Result<()> {
     txn.commit().await?;
 
     let dc_sessions = service_provider::get_dc_sessions(&pool, &carrier_client, &epoch).await?;
-    let sp_promotions = carrier_client.list_incentive_promotions().await?;
+    let sp_promotions = carrier_client
+        .list_incentive_promotions(&epoch.start)
+        .await?;
 
     let (_, rewards) = tokio::join!(
         rewarder::reward_service_providers(
@@ -194,7 +197,9 @@ async fn test_service_provider_promotion_rewards(pool: PgPool) -> anyhow::Result
     txn.commit().await?;
 
     let dc_sessions = service_provider::get_dc_sessions(&pool, &carrier_client, &epoch).await?;
-    let sp_promotions = carrier_client.list_incentive_promotions().await?;
+    let sp_promotions = carrier_client
+        .list_incentive_promotions(&epoch.start)
+        .await?;
 
     let (_, rewards) = tokio::join!(
         rewarder::reward_service_providers(


### PR DESCRIPTION
Fetch from mobile-config the same way they as the rewarder does. Print them in a nice little list.

Running with no options defaults to `Utc::now()`.

```sh
>>> ./mobile-verifier -c ../../mobile-verifier.toml service-provider-promotions 

Service Provider: HeliumMobile
  incentive_escrow_bps: 396
  Promotions: (1)
    name: Referral Elite
    duration: 1year 2months 1day 20h 52m 48s (2024-10-29T00:00:00Z -> 2025-12-31T00:00:00Z)
    shares: 100
```

Passing the `--start` option.

```sh
>>> ./mobile-verifier -c ../../mobile-verifier.toml service-provider-promotions --start "2024-10-30T00:00:00Z"
Promotions as of 2024-10-30 00:00:00 UTC
Service Provider: HeliumMobile
  incentive_escrow_bps: 396
  Promotions: (1)
    name: Referral Elite
    duration: 1year 2months 1day 20h 52m 48s (2024-10-29T00:00:00Z -> 2025-12-31T00:00:00Z)
    shares: 100

>>> ./mobile-verifier -c ../../mobile-verifier.toml service-provider-promotions --start "2024-10-29T01:00:00Z"
Promotions as of 2024-10-29 01:00:00 UTC
Service Provider: HeliumMobile
  incentive_escrow_bps: 396
  Promotions: (1)
    name: Referral Elite
    duration: 1year 2months 1day 20h 52m 48s (2024-10-29T00:00:00Z -> 2025-12-31T00:00:00Z)
    shares: 100
```