### PR TITLE
Fix Service Provider rewards math

### DIFF
--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -2275,7 +2275,7 @@ mod test {
             // force the service provider to have spend more DC than total rewardable
             ServiceProviderDCSessions::from([(sp1, total_rewards_value_in_dc * dec!(2.0))]),
             ServiceProviderPromotions::default(),
-            total_rewards_value_in_dc,
+            total_sp_rewards_in_bones,
             mobile_bone_price,
             epoch.clone(),
         );

--- a/mobile_verifier/src/service_provider/reward.rs
+++ b/mobile_verifier/src/service_provider/reward.rs
@@ -19,29 +19,11 @@ mod proto {
     };
 }
 
-pub fn rewards_per_share(
-    total_sp_dc: Decimal,
-    total_sp_rewards: Decimal,
-    mobile_bone_price: Decimal,
-) -> Decimal {
-    let total_sp_rewards_used = dc_to_mobile_bones(total_sp_dc, mobile_bone_price);
-    let capped_sp_rewards_used = total_sp_rewards_used.min(total_sp_rewards);
-
-    if capped_sp_rewards_used > Decimal::ZERO {
-        (capped_sp_rewards_used / total_sp_dc)
-            .round_dp_with_strategy(DEFAULT_PREC, RoundingStrategy::MidpointNearestEven)
-    } else {
-        Decimal::ZERO
-    }
-}
-
 /// Container for all Service Provider rewarding
 #[derive(Debug)]
 pub struct ServiceProviderRewardInfos {
     coll: Vec<RewardInfo>,
     total_sp_allocation: Decimal,
-    all_transfer: Decimal,
-    mobile_bone_price: Decimal,
     reward_epoch: Range<DateTime<Utc>>,
 }
 

--- a/mobile_verifier/src/service_provider/reward.rs
+++ b/mobile_verifier/src/service_provider/reward.rs
@@ -168,7 +168,7 @@ impl RewardInfo {
         total_allocation: Decimal,
         reward_period: &Range<DateTime<Utc>>,
     ) -> (u64, proto::MobileRewardShare) {
-        let amount = (total_allocation * self.realized_dc_perc).to_u64_rounded();
+        let amount = (total_allocation * self.realized_dc_perc).to_u64_floored(); // Rewarded BONES
 
         (
             amount,
@@ -210,8 +210,8 @@ impl RewardInfo {
         for r in self.promotions.iter() {
             let shares = Decimal::from(r.shares);
 
-            let service_provider_amount = (sp_amount_per_share * shares).to_u64_rounded();
-            let matched_amount = (matched_amount_per_share * shares).to_u64_rounded();
+            let service_provider_amount = (sp_amount_per_share * shares).to_u64_floored();
+            let matched_amount = (matched_amount_per_share * shares).to_u64_floored();
 
             let total_amount = service_provider_amount + matched_amount;
 
@@ -273,11 +273,11 @@ fn distribute_unalloc_under_limit(coll: &mut [RewardInfo]) {
 }
 
 trait DecimalRoundingExt {
-    fn to_u64_rounded(&self) -> u64;
+    fn to_u64_floored(&self) -> u64;
 }
 
 impl DecimalRoundingExt for Decimal {
-    fn to_u64_rounded(&self) -> u64 {
+    fn to_u64_floored(&self) -> u64 {
         use rust_decimal::{prelude::ToPrimitive, RoundingStrategy};
 
         self.round_dp_with_strategy(0, RoundingStrategy::ToZero)

--- a/mobile_verifier/src/service_provider/reward.rs
+++ b/mobile_verifier/src/service_provider/reward.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use chrono::{DateTime, Utc};
 
 use file_store::traits::TimestampEncode;
-use rust_decimal::Decimal;
+use rust_decimal::{Decimal, RoundingStrategy};
 use rust_decimal_macros::dec;
 
 use crate::reward_shares::dc_to_mobile_bones;
@@ -263,7 +263,10 @@ trait DecimalRoundingExt {
 impl DecimalRoundingExt for Decimal {
     fn to_u64_floored(&self) -> u64 {
         use rust_decimal::prelude::ToPrimitive;
-        self.floor().to_u64().unwrap_or(0)
+
+        self.round_dp_with_strategy(0, RoundingStrategy::ToZero)
+            .to_u64()
+            .unwrap_or(0)
     }
 }
 


### PR DESCRIPTION
**TLDR;**
Mixing unit is bad. mmmkay

Previously, for calculating which percentage of rewards a Service provider should receive, the calculation was suing this number as it's base.
`let used_allocation = total_sp_allocation.max(all_transfer);`

`total_sp_allocation` was the maximum number of Bones that could be rewarded in an epoch. `all_transfer` was all the DC transferred in the epoch. Because they were 2 different units, and Bones is at a scale far surpassing DC, the number would always be `total_sp_allocation`.

This is not a problem, until the amount of DC transferred when converted to Bones exceeds the amount allocated.

That leads to a situation where we would assume there is more rewards available than exist. Which in this case lead to matching rewards when there were non unallocated.

---

Now, we convert DC to bones as soon as possible. Since we're always working in the same units, the percentages should hold true.