### PR TITLE
Coverage Object/Heartbeat/Seniority bug

### DIFF
--- a/mobile_verifier/src/heartbeats/mod.rs
+++ b/mobile_verifier/src/heartbeats/mod.rs
@@ -39,7 +39,7 @@ pub enum HbType {
     Wifi,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum KeyType<'a> {
     Cbrs(&'a str),
     Wifi(&'a PublicKeyBinary),

--- a/mobile_verifier/src/seniority.rs
+++ b/mobile_verifier/src/seniority.rs
@@ -87,10 +87,12 @@ impl<'a> SeniorityUpdate<'a> {
     ) -> anyhow::Result<Self> {
         use proto::SeniorityUpdateReason::*;
 
+        const SENIORITY_UPDATE_SKIP_REASONS: [i32; 2] =
+            [HeartbeatNotSeen as i32, ServiceProviderBan as i32];
+
         if let Some(prev_seniority) = latest_seniority {
             if heartbeat.heartbeat.coverage_object != Some(prev_seniority.uuid) {
-                if [HeartbeatNotSeen as i32, ServiceProviderBan as i32]
-                    .contains(&prev_seniority.update_reason)
+                if SENIORITY_UPDATE_SKIP_REASONS.contains(&prev_seniority.update_reason)
                     && coverage_claim_time < prev_seniority.seniority_ts
                 {
                     Self::from_heartbeat(heartbeat, SeniorityUpdateAction::NoAction)

--- a/mobile_verifier/src/seniority.rs
+++ b/mobile_verifier/src/seniority.rs
@@ -88,7 +88,8 @@ impl<'a> SeniorityUpdate<'a> {
 
         if let Some(prev_seniority) = latest_seniority {
             if heartbeat.heartbeat.coverage_object != Some(prev_seniority.uuid) {
-                if prev_seniority.update_reason == HeartbeatNotSeen as i32
+                if [HeartbeatNotSeen as i32, ServiceProviderBan as i32]
+                    .contains(&prev_seniority.update_reason)
                     && coverage_claim_time < prev_seniority.seniority_ts
                 {
                     Self::from_heartbeat(heartbeat, SeniorityUpdateAction::NoAction)


### PR DESCRIPTION
Under normal circumstances the seniority timestamp for a radio is updated when the first valid hearbeat linked to a new coverage object is processed.  However during this check we skip updating seniority if the reason for the last update was HeartbeatNotSeen.  This check should also skip updating seniority if the last reason was ServiceProviderBan.


- [x] Add Test