### PR TITLE
Clear orphan coverage objects

### DIFF
--- a/mobile_verifier/migrations/38_coverage_objects_cascade_delete.sql
+++ b/mobile_verifier/migrations/38_coverage_objects_cascade_delete.sql
@@ -1,4 +1,7 @@
 ALTER TABLE
+    hexes DROP CONSTRAINT IF EXISTS hexes_uuid_fkey;
+
+ALTER TABLE
     hexes
 ADD
     CONSTRAINT hexes_uuid_fkey FOREIGN KEY (uuid) REFERENCES coverage_objects(uuid) ON DELETE CASCADE;

--- a/mobile_verifier/migrations/38_coverage_objects_cascade_delete.sql
+++ b/mobile_verifier/migrations/38_coverage_objects_cascade_delete.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    hexes
+ADD
+    CONSTRAINT hexes_uuid_fkey FOREIGN KEY (uuid) REFERENCES coverage_objects(uuid) ON DELETE CASCADE;

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -363,6 +363,33 @@ impl CoverageObject {
     }
 }
 
+pub async fn set_invalidated_at(
+    exec: &mut Transaction<'_, Postgres>,
+    invalidated_at: DateTime<Utc>,
+    inserted_at: Option<DateTime<Utc>>,
+    radio_key: KeyType<'_>,
+    uuid: Option<Uuid>,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"
+        UPDATE coverage_objects
+        SET invalidated_at = $1
+        WHERE inserted_at < $2
+            AND invalidated_at IS NULL
+            AND radio_key = $3
+            AND uuid != $4
+        "#,
+    )
+    .bind(invalidated_at)
+    .bind(inserted_at)
+    .bind(radio_key)
+    .bind(uuid)
+    .execute(&mut *exec)
+    .await?;
+
+    Ok(())
+}
+
 #[derive(Debug, Clone, FromRow)]
 pub struct HexCoverage {
     pub uuid: Uuid,
@@ -457,57 +484,41 @@ pub async fn clear_coverage_objects(
     tx: &mut Transaction<'_, Postgres>,
     timestamp: &DateTime<Utc>,
 ) -> Result<(), sqlx::Error> {
-    // Delete any hex coverage objects that were invalidated before the given timestamp
-    sqlx::query(
-        r#"
-        DELETE FROM hexes WHERE uuid IN (
-            SELECT uuid
-            FROM coverage_objects
-            WHERE invalidated_at < $1
-        )
-        "#,
-    )
-    .bind(timestamp)
-    .execute(&mut *tx)
-    .await?;
+    // We do not delete hexes here anymore because `38_coverage_objects_cascade_delete.sql` add CONSTRAINT ON DELETE CASCADE
 
+    // Remove all invalidated objects before timestamp
     sqlx::query("DELETE FROM coverage_objects WHERE invalidated_at < $1")
         .bind(timestamp)
         .execute(&mut *tx)
         .await?;
-    Ok(())
-}
 
-pub async fn clear_orphan_coverage_objects(
-    tx: &mut Transaction<'_, Postgres>,
-) -> Result<(), sqlx::Error> {
-    // Delete all hex coverage objects that are no invalidated and older than a month but save the latest one just in case
+    // Delete all but the latest valid coverage_objects entry per radio_key before a given timestamp
     sqlx::query(
-        r#"
-        WITH orphan_coverage_objects AS (
-            SELECT
-                uuid
-            FROM (
+            r#"
+            WITH orphan_coverage_objects AS (
                 SELECT
-                    uuid,
-                    radio_key,
-                    inserted_at,
-                    ROW_NUMBER() OVER (PARTITION BY radio_key ORDER BY inserted_at DESC) AS row_num
-                FROM
-                    coverage_objects
-                WHERE
-                    invalidated_at IS NULL
-                    AND inserted_at < date_trunc('month', CURRENT_DATE) - interval '1 month'
-            ) AS ranked_rows
-            WHERE row_num > 1
+                    uuid
+                FROM (
+                    SELECT
+                        uuid,
+                        radio_key,
+                        inserted_at,
+                        ROW_NUMBER() OVER (PARTITION BY radio_key ORDER BY inserted_at DESC) AS row_num
+                    FROM
+                        coverage_objects
+                    WHERE
+                        invalidated_at IS NULL AND inserted_at < $1
+                ) AS ranked_rows
+                WHERE row_num > 1
+            )
+            DELETE FROM coverage_objects
+            USING orphan_coverage_objects
+            WHERE coverage_objects.uuid = orphan_coverage_objects.uuid;
+            "#,
         )
-        DELETE FROM coverage_objects
-        USING orphan_coverage_objects
-        WHERE coverage_objects.uuid = orphan_coverage_objects.uuid;
-        "#,
-    )
-    .execute(&mut *tx)
-    .await?;
+        .bind(timestamp)
+        .execute(&mut *tx)
+        .await?;
 
     Ok(())
 }

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -492,7 +492,7 @@ pub async fn clear_coverage_objects(
         .execute(&mut *tx)
         .await?;
 
-    // Delete all but the latest valid coverage_objects entry per radio_key before a given timestamp
+    // Delete all but the last 10 valid coverage_objects entry per radio_key before a given timestamp
     sqlx::query(
             r#"
             WITH orphan_coverage_objects AS (
@@ -509,7 +509,7 @@ pub async fn clear_coverage_objects(
                     WHERE
                         invalidated_at IS NULL AND inserted_at < $1
                 ) AS ranked_rows
-                WHERE row_num > 1
+                WHERE row_num > 10
             )
             DELETE FROM coverage_objects
             USING orphan_coverage_objects


### PR DESCRIPTION
If we run, it will delete:
- Last month = 45k
- Last week = 75K

Total current records 120k

Doing last period and keeping the last 10 valid should delete about 62k coverage objects.
