### PR TITLE
Use link to sqlx repo instead of fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,7 +1788,6 @@ dependencies = [
  "file-store",
  "futures",
  "futures-util",
- "helium-crypto",
  "helium-proto",
  "http 0.2.11",
  "http-serde",
@@ -8593,7 +8592,7 @@ dependencies = [
 [[package]]
 name = "sqlx"
 version = "0.6.2"
-source = "git+https://github.com/helium/sqlx.git?rev=92a2268f02e0cac6fccb34d3e926347071dbb88d#92a2268f02e0cac6fccb34d3e926347071dbb88d"
+source = "git+https://github.com/launchbadge/sqlx.git?rev=42dd78fe931df651eac411316ed3eab87c2f79b2#42dd78fe931df651eac411316ed3eab87c2f79b2"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -8602,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "sqlx-core"
 version = "0.6.2"
-source = "git+https://github.com/helium/sqlx.git?rev=92a2268f02e0cac6fccb34d3e926347071dbb88d#92a2268f02e0cac6fccb34d3e926347071dbb88d"
+source = "git+https://github.com/launchbadge/sqlx.git?rev=42dd78fe931df651eac411316ed3eab87c2f79b2#42dd78fe931df651eac411316ed3eab87c2f79b2"
 dependencies = [
  "ahash 0.7.6",
  "atoi",
@@ -8658,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "sqlx-macros"
 version = "0.6.2"
-source = "git+https://github.com/helium/sqlx.git?rev=92a2268f02e0cac6fccb34d3e926347071dbb88d#92a2268f02e0cac6fccb34d3e926347071dbb88d"
+source = "git+https://github.com/launchbadge/sqlx.git?rev=42dd78fe931df651eac411316ed3eab87c2f79b2#42dd78fe931df651eac411316ed3eab87c2f79b2"
 dependencies = [
  "dotenvy",
  "either",
@@ -8676,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "sqlx-rt"
 version = "0.6.2"
-source = "git+https://github.com/helium/sqlx.git?rev=92a2268f02e0cac6fccb34d3e926347071dbb88d#92a2268f02e0cac6fccb34d3e926347071dbb88d"
+source = "git+https://github.com/launchbadge/sqlx.git?rev=42dd78fe931df651eac411316ed3eab87c2f79b2#42dd78fe931df651eac411316ed3eab87c2f79b2"
 dependencies = [
  "once_cell",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,8 @@ tower-http = { version = "0", features = ["trace"] }
 derive_builder = "0"
 
 [patch.crates-io]
+# v0.7.0-alpha.3
+# https://github.com/launchbadge/sqlx/commit/42dd78fe931df651eac411316ed3eab87c2f79b2
 sqlx = { git = "https://github.com/launchbadge/sqlx.git", rev = "42dd78fe931df651eac411316ed3eab87c2f79b2" }
 
 # When attempting to test proto changes without needing to push a branch you can

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ tower-http = { version = "0", features = ["trace"] }
 derive_builder = "0"
 
 [patch.crates-io]
-sqlx = { git = "https://github.com/helium/sqlx.git", rev = "92a2268f02e0cac6fccb34d3e926347071dbb88d" }
+sqlx = { git = "https://github.com/launchbadge/sqlx.git", rev = "42dd78fe931df651eac411316ed3eab87c2f79b2" }
 
 # When attempting to test proto changes without needing to push a branch you can
 # patch the github url to point to your local proto repo.

--- a/boost_manager/Cargo.toml
+++ b/boost_manager/Cargo.toml
@@ -37,11 +37,6 @@ chrono = { workspace = true, features = ["serde"] }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 helium-proto = { workspace = true }
-helium-crypto = { workspace = true, features = [
-    "sqlx-postgres",
-    "multisig",
-    "solana",
-] }
 rust_decimal = { workspace = true }
 rust_decimal_macros = { workspace = true }
 tonic = { workspace = true }


### PR DESCRIPTION
- Use the official SQLx repository link instead of the fork. It makes future updates a little bit easier and more transparent and we don't have to host fork in our repo. 
- Remove the unused `helium-crypto` dependency from `boost_manager`.

Updating `SQLx` further is currently impossible due to package conflicts, mainly because we are using an outdated Solana library.
Upgrading solana-client, solana-sdk, and solana-program to version ^2 could theoretically resolve these conflicts.