### PR TITLE
Move sqlx importing under feature directive

### DIFF
--- a/file_store/src/file_info_poller.rs
+++ b/file_store/src/file_info_poller.rs
@@ -5,7 +5,6 @@ use derive_builder::Builder;
 use futures::{future::LocalBoxFuture, stream::BoxStream, StreamExt};
 use futures_util::TryFutureExt;
 use retainer::Cache;
-use sqlx::postgres::PgQueryResult;
 use std::{collections::VecDeque, marker::PhantomData, sync::Arc, time::Duration};
 use task_manager::ManagedTask;
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -413,6 +412,9 @@ impl FileInfoPollerStore for FileStore {
         self.get_raw(key).await
     }
 }
+
+#[cfg(feature = "sqlx-postgres")]
+use sqlx::postgres::PgQueryResult;
 
 #[cfg(feature = "sqlx-postgres")]
 #[async_trait::async_trait]


### PR DESCRIPTION
It fixes next compile error if file-store dependency used with `default-features = false` option

```
error[E0433]: failed to resolve: use of undeclared crate or module `sqlx`
 --> /home/kurotych/.cargo/git/checkouts/oracles-717ca87c3f481083/833b350/file_store/src/file_info_poller.rs:8:5
  |
8 | use sqlx::postgres::PgQueryResult;
  |     ^^^^ use of undeclared crate or module `sqlx`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `file-store` (lib) due to 1 previous error
```