### PR TITLE
cargo 1.83 updates

### DIFF
--- a/iot_config/src/lora_field.rs
+++ b/iot_config/src/lora_field.rs
@@ -297,7 +297,7 @@ impl<'de, const WIDTH: usize> Deserialize<'de> for LoraField<WIDTH> {
     {
         struct LoraFieldVisitor<const IN_WIDTH: usize>;
 
-        impl<'de, const IN_WIDTH: usize> serde::de::Visitor<'de> for LoraFieldVisitor<IN_WIDTH> {
+        impl<const IN_WIDTH: usize> serde::de::Visitor<'_> for LoraFieldVisitor<IN_WIDTH> {
             type Value = LoraField<IN_WIDTH>;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/iot_packet_verifier/src/pending.rs
+++ b/iot_packet_verifier/src/pending.rs
@@ -165,7 +165,7 @@ impl PendingTables for PgPool {
 }
 
 #[async_trait]
-impl<'a> AddPendingBurn for &'_ mut Transaction<'a, Postgres> {
+impl AddPendingBurn for &'_ mut Transaction<'_, Postgres> {
     async fn add_burned_amount(
         &mut self,
         payer: &PublicKeyBinary,

--- a/iot_packet_verifier/src/verifier.rs
+++ b/iot_packet_verifier/src/verifier.rs
@@ -138,8 +138,7 @@ pub const BYTES_PER_DC: u64 = 24;
 
 pub fn payload_size_to_dc(payload_size: u64) -> u64 {
     let payload_size = payload_size.max(BYTES_PER_DC);
-    // Integer div/ceil from: https://stackoverflow.com/a/2745086
-    (payload_size + BYTES_PER_DC - 1) / BYTES_PER_DC
+    payload_size.div_ceil(BYTES_PER_DC)
 }
 
 #[async_trait]
@@ -389,5 +388,17 @@ impl<T: Send> PacketWriter<T> for &'_ mut Vec<T> {
     async fn write(&mut self, packet: T) -> Result<(), ()> {
         (*self).push(packet);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_payload_size_to_dc() {
+        assert_eq!(1, payload_size_to_dc(1));
+        assert_eq!(1, payload_size_to_dc(24));
+        assert_eq!(2, payload_size_to_dc(25));
     }
 }

--- a/iot_verifier/src/main.rs
+++ b/iot_verifier/src/main.rs
@@ -29,7 +29,6 @@ use task_manager::TaskManager;
 #[derive(Debug, clap::Parser)]
 #[clap(version = env!("CARGO_PKG_VERSION"))]
 #[clap(about = "Helium POC IOT Verifier")]
-
 pub struct Cli {
     /// Optional configuration file to use. If present the toml file at the
     /// given path will be loaded. Environment variables can override the

--- a/mobile_packet_verifier/src/pending_burns.rs
+++ b/mobile_packet_verifier/src/pending_burns.rs
@@ -174,6 +174,17 @@ const BYTES_PER_DC: u64 = 20_000;
 
 fn bytes_to_dc(bytes: u64) -> u64 {
     let bytes = bytes.max(BYTES_PER_DC);
-    // Integer div/ceil from: https://stackoverflow.com/a/2745086
-    (bytes + BYTES_PER_DC - 1) / BYTES_PER_DC
+    bytes.div_ceil(BYTES_PER_DC)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bytes_to_dc() {
+        assert_eq!(1, bytes_to_dc(1));
+        assert_eq!(1, bytes_to_dc(20_000));
+        assert_eq!(2, bytes_to_dc(20_001));
+    }
 }


### PR DESCRIPTION
- remove unnecessary lifetimes
- type complexity hint in metrics
- remove manual `div_ceil`
- empty lines