### PR TITLE
RetryConfig and TimeoutConfig in file_store 

### DIFF
--- a/file_store/src/file_store.rs
+++ b/file_store/src/file_store.rs
@@ -3,7 +3,7 @@ use crate::{
     settings::{self, Settings},
     BytesMutStream, Error, FileInfo, FileInfoStream, Result,
 };
-use aws_config::meta::region::RegionProviderChain;
+use aws_config::{meta::region::RegionProviderChain, timeout::TimeoutConfig};
 use aws_sdk_s3::{types::ByteStream, Client, Endpoint, Region};
 use chrono::{DateTime, Utc};
 use futures::FutureExt;
@@ -63,6 +63,7 @@ impl FileStore {
         bucket: String,
         endpoint: Option<String>,
         region: Option<String>,
+        timeout_config: Option<TimeoutConfig>,
     ) -> Result<Self> {
         let endpoint: Option<Endpoint> = match &endpoint {
             Some(endpoint) => Uri::from_str(endpoint)
@@ -77,6 +78,10 @@ impl FileStore {
         let mut config = aws_config::from_env().region(region_provider);
         if let Some(endpoint) = endpoint {
             config = config.endpoint_resolver(endpoint);
+        }
+
+        if let Some(timeout) = timeout_config {
+            config = config.timeout_config(timeout);
         }
 
         let config = config.load().await;

--- a/file_store/src/file_store.rs
+++ b/file_store/src/file_store.rs
@@ -3,7 +3,7 @@ use crate::{
     settings::{self, Settings},
     BytesMutStream, Error, FileInfo, FileInfoStream, Result,
 };
-use aws_config::{meta::region::RegionProviderChain, timeout::TimeoutConfig};
+use aws_config::{meta::region::RegionProviderChain, retry::RetryConfig, timeout::TimeoutConfig};
 use aws_sdk_s3::{types::ByteStream, Client, Endpoint, Region};
 use chrono::{DateTime, Utc};
 use futures::FutureExt;
@@ -64,6 +64,7 @@ impl FileStore {
         endpoint: Option<String>,
         region: Option<String>,
         timeout_config: Option<TimeoutConfig>,
+        retry_config: Option<RetryConfig>,
     ) -> Result<Self> {
         let endpoint: Option<Endpoint> = match &endpoint {
             Some(endpoint) => Uri::from_str(endpoint)
@@ -82,6 +83,10 @@ impl FileStore {
 
         if let Some(timeout) = timeout_config {
             config = config.timeout_config(timeout);
+        }
+
+        if let Some(retry) = retry_config {
+            config = config.retry_config(retry);
         }
 
         let config = config.load().await;


### PR DESCRIPTION
When a connection problem occurs, downloading a file from AWS hangs.
Add the ability to configure timeout and retry policies in the `file_store`.