### PR TITLE
unique connections timestamp

### DIFF
--- a/mobile_verifier/src/cli/reward_from_db.rs
+++ b/mobile_verifier/src/cli/reward_from_db.rs
@@ -6,8 +6,7 @@ use crate::{
     rewarder::boosted_hex_eligibility::BoostedHexEligibility,
     sp_boosted_rewards_bans::BannedRadios,
     speedtests_average::SpeedtestAverages,
-    unique_connections::UniqueConnectionCounts,
-    Settings,
+    unique_connections, Settings,
 };
 use anyhow::Result;
 use chrono::NaiveDateTime;
@@ -44,6 +43,8 @@ impl Cmd {
         let speedtest_averages =
             SpeedtestAverages::aggregate_epoch_averages(epoch.end, &pool).await?;
 
+        let unique_connections = unique_connections::db::get(&pool, &epoch).await?;
+
         let reward_shares = CoverageShares::new(
             &pool,
             heartbeats,
@@ -51,7 +52,7 @@ impl Cmd {
             &BoostedHexes::default(),
             &BoostedHexEligibility::default(),
             &BannedRadios::default(),
-            &UniqueConnectionCounts::default(),
+            &unique_connections,
             &epoch,
         )
         .await?;

--- a/mobile_verifier/src/unique_connections/ingestor.rs
+++ b/mobile_verifier/src/unique_connections/ingestor.rs
@@ -128,6 +128,9 @@ where
         &self,
         file_info_stream: FileInfoStream<UniqueConnectionsIngestReport>,
     ) -> anyhow::Result<()> {
+        let file_info = file_info_stream.file_info.clone();
+        tracing::info!(?file_info, "processing file");
+
         let mut txn = self.pool.begin().await?;
         let mut stream = file_info_stream.into_stream(&mut txn).await?;
 
@@ -162,6 +165,7 @@ where
         db::save(&mut txn, &verified).await?;
         txn.commit().await?;
         self.verified_unique_connections_sink.commit().await?;
+        tracing::info!(?file_info, "txn and sink committed");
 
         Ok(())
     }


### PR DESCRIPTION
When reading a UniqueConnections report from proto, the timestamp was incorrectly converted into seconds.

- Added a test that round trips through proto to make sure timestamps are encoded/decoded properly
- Added logging for processing unique connection reports
- use available unique connections in `reward_from_db` command