### PR TITLE
UniqueConnections make radio eligible for boosted rewards

### DIFF
--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -509,7 +509,7 @@ impl CoverageShares {
             }
 
             let sp_boosted_reward_eligibility =
-                boosted_hex_eligibility.eligibility(pubkey, cbsd_id);
+                boosted_hex_eligibility.eligibility(radio_type, pubkey, cbsd_id);
 
             radio_infos.insert(
                 key,

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -422,6 +422,8 @@ async fn reward_poc(
 
     let boosted_hexes = BoostedHexes::get_all(hex_service_client).await?;
 
+    let unique_connections = unique_connections::db::get(pool, reward_period).await?;
+
     let boosted_hex_eligibility = BoostedHexEligibility::new(
         radio_threshold::verified_radio_thresholds(pool, reward_period).await?,
         sp_boosted_rewards_bans::db::get_banned_radios(
@@ -430,6 +432,7 @@ async fn reward_poc(
             reward_period.end,
         )
         .await?,
+        unique_connections.clone(),
     );
 
     let poc_banned_radios = sp_boosted_rewards_bans::db::get_banned_radios(
@@ -438,8 +441,6 @@ async fn reward_poc(
         reward_period.end,
     )
     .await?;
-
-    let unique_connections = unique_connections::db::get(pool, reward_period).await?;
 
     let coverage_shares = CoverageShares::new(
         pool,

--- a/mobile_verifier/src/rewarder/boosted_hex_eligibility.rs
+++ b/mobile_verifier/src/rewarder/boosted_hex_eligibility.rs
@@ -88,6 +88,36 @@ mod tests {
     }
 
     #[test]
+    fn wifi_eligible_with_unique_connections_even_if_no_radio_threshold() {
+        let keypair = generate_keypair();
+
+        let pub_key: PublicKeyBinary = keypair.public_key().to_vec().into();
+        let cbsd_id = "cbsd-id-1".to_string();
+
+        let mut unique_connections = UniqueConnectionCounts::default();
+        unique_connections.insert(pub_key.clone(), MINIMUM_UNIQUE_CONNECTIONS + 1);
+
+        let boosted_hex_eligibility = BoostedHexEligibility::new(
+            VerifiedRadioThresholds::default(),
+            BannedRadios::default(),
+            unique_connections,
+        );
+
+        let eligibility =
+            boosted_hex_eligibility.eligibility(RadioType::OutdoorWifi, pub_key.clone(), None);
+
+        assert_eq!(SPBoostedRewardEligibility::Eligible, eligibility);
+
+        let eligibility =
+            boosted_hex_eligibility.eligibility(RadioType::OutdoorCbrs, pub_key, Some(cbsd_id));
+
+        assert_eq!(
+            SPBoostedRewardEligibility::RadioThresholdNotMet,
+            eligibility
+        );
+    }
+
+    #[test]
     fn banned() {
         let keypair = generate_keypair();
 

--- a/mobile_verifier/src/unique_connections/mod.rs
+++ b/mobile_verifier/src/unique_connections/mod.rs
@@ -10,7 +10,7 @@ pub type UniqueConnectionCounts = HashMap<PublicKeyBinary, u64>;
 // hip-134:
 // https://github.com/helium/HIP/blob/main/0134-reward-mobile-carrier-offload-hotspots.md
 // A Hotspot serving >25 unique connections, as defined by the Carrier utlizing the hotspots for Carrier Offload, on a seven day rolling average.
-const MINIMUM_UNIQUE_CONNECTIONS: u64 = 25;
+pub const MINIMUM_UNIQUE_CONNECTIONS: u64 = 25;
 
 pub fn is_qualified(
     unique_connections: &UniqueConnectionCounts,


### PR DESCRIPTION
A radio hitting the unique connection threshold will now be eligible for boosted rewards without having to have the radio thresholds met(3 unique devices with 1mb transferred).  It will also override any service provider ban.