### PR TITLE
[Mobile Config] Add updated_at to GatewayInfoV2 (response)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,11 +1615,11 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2#8b16ffeb119343f1d81c27d1084c30685fb35c05"
+source = "git+https://github.com/helium/proto?branch=master#4085e00c6f4d82c3da798ae1bc97324bc9cada2e"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "prost",
  "rand 0.8.5",
  "rand_chacha 0.3.0",
@@ -1788,7 +1788,7 @@ dependencies = [
  "file-store",
  "futures",
  "futures-util",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "http 0.2.11",
  "http-serde",
  "humantime-serde",
@@ -2630,7 +2630,7 @@ dependencies = [
  "axum 0.7.4",
  "bs58 0.4.0",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "http 0.2.11",
  "notify",
  "serde",
@@ -3212,7 +3212,7 @@ dependencies = [
  "futures-util",
  "h3o",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "hex-literal",
  "http 0.2.11",
  "lazy_static",
@@ -3794,7 +3794,7 @@ dependencies = [
  "h3o",
  "helium-anchor-gen",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=master)",
+ "helium-proto",
  "hex",
  "hex-literal",
  "itertools",
@@ -3821,23 +3821,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#b4c8c8f47dfff38a2ff1b7fe14e1b2a1beea651c"
-dependencies = [
- "bytes",
- "prost",
- "prost-build",
- "serde",
- "serde_json",
- "strum",
- "strum_macros",
- "tonic",
- "tonic-build",
-]
-
-[[package]]
-name = "helium-proto"
-version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2#8b16ffeb119343f1d81c27d1084c30685fb35c05"
+source = "git+https://github.com/helium/proto?branch=master#4085e00c6f4d82c3da798ae1bc97324bc9cada2e"
 dependencies = [
  "bytes",
  "prost",
@@ -3891,7 +3875,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "derive_builder",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "hextree",
  "rust_decimal",
  "rust_decimal_macros",
@@ -4307,7 +4291,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "http 0.2.11",
  "humantime-serde",
  "metrics",
@@ -4377,7 +4361,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "hextree",
  "http 0.2.11",
  "http-serde",
@@ -4419,7 +4403,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "http 0.2.11",
  "http-serde",
  "humantime-serde",
@@ -4461,7 +4445,7 @@ dependencies = [
  "futures-util",
  "h3o",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "http-serde",
  "humantime-serde",
  "iot-config",
@@ -5050,7 +5034,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "hextree",
  "http 0.2.11",
  "http-serde",
@@ -5091,7 +5075,7 @@ dependencies = [
  "futures",
  "h3o",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "mobile-config",
  "prost",
  "rand 0.8.5",
@@ -5127,7 +5111,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "http 0.2.11",
  "http-serde",
  "humantime-serde",
@@ -5171,7 +5155,7 @@ dependencies = [
  "futures-util",
  "h3o",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "hex-assignments",
  "hextree",
  "http-serde",
@@ -5855,7 +5839,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "http 0.2.11",
  "hyper 0.14.28",
  "jsonrpsee",
@@ -5938,7 +5922,7 @@ dependencies = [
  "futures-util",
  "helium-anchor-gen",
  "helium-lib",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "humantime-serde",
  "metrics",
  "metrics-exporter-prometheus",
@@ -6577,7 +6561,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
+ "helium-proto",
  "humantime-serde",
  "lazy_static",
  "metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,17 +1615,17 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#b4c8c8f47dfff38a2ff1b7fe14e1b2a1beea651c"
+source = "git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2#8b16ffeb119343f1d81c27d1084c30685fb35c05"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "prost",
  "rand 0.8.5",
  "rand_chacha 0.3.0",
  "rust_decimal",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -1788,7 +1788,7 @@ dependencies = [
  "file-store",
  "futures",
  "futures-util",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "http 0.2.11",
  "http-serde",
  "humantime-serde",
@@ -2630,7 +2630,7 @@ dependencies = [
  "axum 0.7.4",
  "bs58 0.4.0",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "http 0.2.11",
  "notify",
  "serde",
@@ -3212,7 +3212,7 @@ dependencies = [
  "futures-util",
  "h3o",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "hex-literal",
  "http 0.2.11",
  "lazy_static",
@@ -3794,7 +3794,7 @@ dependencies = [
  "h3o",
  "helium-anchor-gen",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=master)",
  "hex",
  "hex-literal",
  "itertools",
@@ -3822,6 +3822,22 @@ dependencies = [
 name = "helium-proto"
 version = "0.1.0"
 source = "git+https://github.com/helium/proto?branch=master#b4c8c8f47dfff38a2ff1b7fe14e1b2a1beea651c"
+dependencies = [
+ "bytes",
+ "prost",
+ "prost-build",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
+name = "helium-proto"
+version = "0.1.0"
+source = "git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2#8b16ffeb119343f1d81c27d1084c30685fb35c05"
 dependencies = [
  "bytes",
  "prost",
@@ -3875,7 +3891,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "derive_builder",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "hextree",
  "rust_decimal",
  "rust_decimal_macros",
@@ -4291,7 +4307,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "http 0.2.11",
  "humantime-serde",
  "metrics",
@@ -4361,7 +4377,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "hextree",
  "http 0.2.11",
  "http-serde",
@@ -4403,7 +4419,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "http 0.2.11",
  "http-serde",
  "humantime-serde",
@@ -4445,7 +4461,7 @@ dependencies = [
  "futures-util",
  "h3o",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "http-serde",
  "humantime-serde",
  "iot-config",
@@ -5034,7 +5050,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "hextree",
  "http 0.2.11",
  "http-serde",
@@ -5075,7 +5091,7 @@ dependencies = [
  "futures",
  "h3o",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "mobile-config",
  "prost",
  "rand 0.8.5",
@@ -5111,7 +5127,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "http 0.2.11",
  "http-serde",
  "humantime-serde",
@@ -5155,7 +5171,7 @@ dependencies = [
  "futures-util",
  "h3o",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "hex-assignments",
  "hextree",
  "http-serde",
@@ -5839,7 +5855,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "http 0.2.11",
  "hyper 0.14.28",
  "jsonrpsee",
@@ -5922,7 +5938,7 @@ dependencies = [
  "futures-util",
  "helium-anchor-gen",
  "helium-lib",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "humantime-serde",
  "metrics",
  "metrics-exporter-prometheus",
@@ -6063,7 +6079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
- "heck 0.4.0",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -6561,7 +6577,7 @@ dependencies = [
  "futures",
  "futures-util",
  "helium-crypto",
- "helium-proto",
+ "helium-proto 0.1.0 (git+https://github.com/helium/proto?branch=updated_at_gateway_info_v2)",
  "humantime-serde",
  "lazy_static",
  "metrics",
@@ -9988,7 +10004,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
  "twox-hash",
  "xorf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,10 +70,10 @@ helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = 
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
   "disktree",
 ] }
-helium-proto = { git = "https://github.com/helium/proto", branch = "master", features = [
+helium-proto = { git = "https://github.com/helium/proto", branch = "updated_at_gateway_info_v2", features = [
   "services",
 ] }
-beacon = { git = "https://github.com/helium/proto", branch = "master" }
+beacon = { git = "https://github.com/helium/proto", branch = "updated_at_gateway_info_v2" }
 solana-client = "1.18"
 solana-sdk = "1.18"
 solana-program = "1.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,10 +70,10 @@ helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = 
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
   "disktree",
 ] }
-helium-proto = { git = "https://github.com/helium/proto", branch = "updated_at_gateway_info_v2", features = [
+helium-proto = { git = "https://github.com/helium/proto", branch = "master", features = [
   "services",
 ] }
-beacon = { git = "https://github.com/helium/proto", branch = "updated_at_gateway_info_v2" }
+beacon = { git = "https://github.com/helium/proto", branch = "master" }
 solana-client = "1.18"
 solana-sdk = "1.18"
 solana-program = "1.18"

--- a/mobile_config/src/gateway_info.rs
+++ b/mobile_config/src/gateway_info.rs
@@ -514,9 +514,8 @@ pub(crate) mod db {
                 device_type,
                 created_at: Some(created_at),
                 refreshed_at,
-                // TODO rework comment
-                // updated_at is last_changed_at field from mobile_radio_tracker table of
-                // the mobile_config database
+                // The updated_at field should be determined by considering the last_changed_at
+                // value from the mobile_radio_tracker table.
                 updated_at: None,
             })
         }

--- a/mobile_config/src/gateway_info.rs
+++ b/mobile_config/src/gateway_info.rs
@@ -103,9 +103,11 @@ pub struct GatewayInfo {
     pub address: PublicKeyBinary,
     pub metadata: Option<GatewayMetadata>,
     pub device_type: DeviceType,
-    // None for GatewayInfoProto (V1)
-    pub updated_at: Option<DateTime<Utc>>,
+    // Optional fields are None for GatewayInfoProto (V1)
     pub created_at: Option<DateTime<Utc>>,
+    // updated_at refers to the last time the data was actually changed.
+    pub updated_at: Option<DateTime<Utc>>,
+    // refreshed_at indicates the last time the chain was consulted, regardless of data changes.
     pub refreshed_at: Option<DateTime<Utc>>,
 }
 

--- a/mobile_config/src/gateway_service.rs
+++ b/mobile_config/src/gateway_service.rs
@@ -358,6 +358,7 @@ fn handle_updated_at(
             gateway_info.updated_at = Some(*updated_at);
             return Some(gateway_info);
         }
+        return None;
     }
     // Fallback solution #1. Try to use refreshed_at as updated_at field and check
     // min_updated_at
@@ -366,6 +367,7 @@ fn handle_updated_at(
             gateway_info.updated_at = Some(refreshed_at);
             return Some(gateway_info);
         }
+        return None;
     }
     // Fallback solution #2. Try to use created_at as updated_at field and check
     // min_updated_at
@@ -374,6 +376,7 @@ fn handle_updated_at(
             gateway_info.updated_at = Some(created_at);
             return Some(gateway_info);
         }
+        return None;
     }
     None
 }

--- a/mobile_config/src/gateway_service.rs
+++ b/mobile_config/src/gateway_service.rs
@@ -3,7 +3,7 @@ use crate::{
     key_cache::KeyCache,
     telemetry, verify_public_key, GrpcResult, GrpcStreamResult,
 };
-use chrono::{TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use file_store::traits::{MsgVerify, TimestampEncode};
 use futures::{
     future,
@@ -15,12 +15,12 @@ use helium_proto::{
     services::mobile_config::{
         self, GatewayInfoBatchReqV1, GatewayInfoReqV1, GatewayInfoResV1, GatewayInfoResV2,
         GatewayInfoStreamReqV1, GatewayInfoStreamReqV2, GatewayInfoStreamResV1,
-        GatewayInfoStreamResV2,
+        GatewayInfoStreamResV2, GatewayInfoV2,
     },
     Message,
 };
 use sqlx::{Pool, Postgres};
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use tonic::{Request, Response, Status};
 
 pub struct GatewayService {
@@ -129,6 +129,12 @@ impl mobile_config::Gateway for GatewayService {
         let pubkey: PublicKeyBinary = request.address.into();
         tracing::debug!(pubkey = pubkey.to_string(), "fetching gateway info (v2)");
 
+        let updated_at = gateway_info::db::get_updated_at(&self.mobile_config_db_pool, &pubkey)
+            .await
+            .map_err(|_| {
+                Status::internal("error fetching updated_at field for gateway info (v2)")
+            })?;
+
         gateway_info::db::get_info(&self.metadata_pool, &pubkey)
             .await
             .map_err(|_| Status::internal("error fetching gateway info (v2)"))?
@@ -137,15 +143,26 @@ impl mobile_config::Gateway for GatewayService {
                     telemetry::count_gateway_chain_lookup("not-found");
                     Err(Status::not_found(pubkey.to_string()))
                 },
-                |info| {
+                |mut info| {
                     if info.metadata.is_some() {
                         telemetry::count_gateway_chain_lookup("asserted");
                     } else {
                         telemetry::count_gateway_chain_lookup("not-asserted");
                     };
-                    let info = info
+
+                    // determine updated_at
+                    if let Some(v) = updated_at {
+                        info.updated_at = Some(v)
+                    } else if info.refreshed_at.is_some() {
+                        info.updated_at = info.refreshed_at;
+                    } else {
+                        info.updated_at = info.created_at;
+                    }
+
+                    let info: GatewayInfoV2 = info
                         .try_into()
                         .map_err(|_| Status::internal("error serializing gateway info (v2)"))?;
+
                     let mut res = GatewayInfoResV2 {
                         info: Some(info),
                         timestamp: Utc::now().encode_timestamp(),
@@ -212,7 +229,8 @@ impl mobile_config::Gateway for GatewayService {
             "fetching gateways' info batch"
         );
 
-        let pool = self.metadata_pool.clone();
+        let metadata_db_pool = self.metadata_pool.clone();
+        let mobile_config_db_pool = self.mobile_config_db_pool.clone();
         let signing_key = self.signing_key.clone();
         let batch_size = request.batch_size;
         let addresses = request
@@ -224,7 +242,19 @@ impl mobile_config::Gateway for GatewayService {
         let (tx, rx) = tokio::sync::mpsc::channel(100);
 
         tokio::spawn(async move {
-            let stream = gateway_info::db::batch_info_stream(&pool, &addresses)?;
+            let min_updated_at = DateTime::UNIX_EPOCH;
+            let updated_radios = get_updated_radios(&mobile_config_db_pool, min_updated_at).await?;
+
+            let stream = gateway_info::db::batch_info_stream(&metadata_db_pool, &addresses)?;
+            let stream = stream
+                .filter_map(|gateway_info| {
+                    future::ready(handle_updated_at(
+                        gateway_info,
+                        &updated_radios,
+                        min_updated_at,
+                    ))
+                })
+                .boxed();
             stream_multi_gateways_info(stream, tx.clone(), signing_key.clone(), batch_size).await
         });
 
@@ -291,30 +321,61 @@ impl mobile_config::Gateway for GatewayService {
         );
 
         tokio::spawn(async move {
-            let stream = gateway_info::db::all_info_stream(&metadata_db_pool, &device_types);
-            if request.min_updated_at > 0 {
-                let min_updated_at = Utc
-                    .timestamp_opt(request.min_updated_at as i64, 0)
-                    .single()
-                    .ok_or(Status::invalid_argument(
-                        "Invalid min_refreshed_at argument",
-                    ))?;
+            let min_updated_at = Utc
+                .timestamp_opt(request.min_updated_at as i64, 0)
+                .single()
+                .ok_or(Status::invalid_argument(
+                    "Invalid min_refreshed_at argument",
+                ))?;
 
-                let updated_radios =
-                    get_updated_radios(&mobile_config_db_pool, min_updated_at).await?;
-                let stream = stream
-                    .filter(|v| future::ready(updated_radios.contains(&v.address)))
-                    .boxed();
-                stream_multi_gateways_info(stream, tx.clone(), signing_key.clone(), batch_size)
-                    .await
-            } else {
-                stream_multi_gateways_info(stream, tx.clone(), signing_key.clone(), batch_size)
-                    .await
-            }
+            let updated_radios = get_updated_radios(&mobile_config_db_pool, min_updated_at).await?;
+            let stream = gateway_info::db::all_info_stream(&metadata_db_pool, &device_types);
+            let stream = stream
+                .filter_map(|gateway_info| {
+                    future::ready(handle_updated_at(
+                        gateway_info,
+                        &updated_radios,
+                        min_updated_at,
+                    ))
+                })
+                .boxed();
+            stream_multi_gateways_info(stream, tx.clone(), signing_key.clone(), batch_size).await
         });
 
         Ok(Response::new(GrpcStreamResult::new(rx)))
     }
+}
+
+fn handle_updated_at(
+    mut gateway_info: GatewayInfo,
+    updated_radios: &HashMap<PublicKeyBinary, chrono::DateTime<Utc>>,
+    min_updated_at: chrono::DateTime<Utc>,
+) -> Option<GatewayInfo> {
+    // Check mobile_radio_tracker HashMap
+    if let Some(updated_at) = updated_radios.get(&gateway_info.address) {
+        // It could be already filtered by min_updated_at but recheck won't hurt
+        if updated_at >= &min_updated_at {
+            gateway_info.updated_at = Some(*updated_at);
+            return Some(gateway_info);
+        }
+    }
+    // Fallback solution #1. Try to use refreshed_at as updated_at field and check
+    // min_updated_at
+    if let Some(refreshed_at) = gateway_info.refreshed_at {
+        if refreshed_at >= min_updated_at {
+            gateway_info.updated_at = Some(refreshed_at);
+            return Some(gateway_info);
+        }
+    }
+    // Fallback solution #2. Try to use created_at as updated_at field and check
+    // min_updated_at
+    if let Some(created_at) = gateway_info.created_at {
+        if created_at >= min_updated_at {
+            gateway_info.updated_at = Some(created_at);
+            return Some(gateway_info);
+        }
+    }
+    None
 }
 
 trait GatewayInfoStreamRes {

--- a/mobile_config/tests/gateway_service.rs
+++ b/mobile_config/tests/gateway_service.rs
@@ -588,6 +588,97 @@ async fn gateway_info_v2(pool: PgPool) {
 }
 
 #[sqlx::test]
+async fn gateway_info_stream_v2_updated_at_check(pool: PgPool) {
+    let admin_key = make_keypair();
+    let asset1_pubkey = make_keypair().public_key().clone();
+    let asset1_hex_idx = 631711281837647359_i64;
+    let asset2_pubkey = make_keypair().public_key().clone();
+    let asset2_hex_idx = 631711286145955327_i64;
+    let asset3_hex_idx = 631711286145006591_i64;
+    let asset3_pubkey = make_keypair().public_key().clone();
+
+    let created_at = Utc::now() - Duration::hours(5);
+    let refreshed_at = Utc::now() - Duration::hours(3);
+    let updated_at = Utc::now() - Duration::hours(4);
+
+    create_db_tables(&pool).await;
+    add_db_record(
+        &pool,
+        "asset1",
+        asset1_hex_idx,
+        "\"wifiIndoor\"",
+        asset1_pubkey.clone().into(),
+        created_at,
+        Some(refreshed_at),
+        Some(r#"{"wifiInfoV0": {"antenna": 18, "azimuth": 161, "elevation": 2, "electricalDownTilt": 3, "mechanicalDownTilt": 4}}"#)
+    )
+    .await;
+
+    add_db_record(
+        &pool,
+        "asset2",
+        asset2_hex_idx,
+        "\"wifiIndoor\"",
+        asset2_pubkey.clone().into(),
+        created_at,
+        None,
+        Some(r#"{"wifiInfoV0": {"antenna": 18, "azimuth": 161, "elevation": 2, "electricalDownTilt": 3, "mechanicalDownTilt": 4}}"#)
+    )
+    .await;
+
+    add_db_record(
+        &pool,
+        "asset3",
+        asset3_hex_idx,
+        "\"wifiDataOnly\"",
+        asset3_pubkey.clone().into(),
+        created_at,
+        Some(refreshed_at),
+        None,
+    )
+    .await;
+    add_mobile_tracker_record(&pool, asset3_pubkey.clone().into(), updated_at).await;
+
+    let (addr, _handle) = spawn_gateway_service(pool.clone(), admin_key.public_key().clone()).await;
+    let mut client = GatewayClient::connect(addr).await.unwrap();
+
+    let req = make_gateway_stream_signed_req_v2(&admin_key, &[], 0);
+    let stream = client.info_stream_v2(req).await.unwrap().into_inner();
+
+    let resp = stream
+        .filter_map(|result| async { result.ok() })
+        .collect::<Vec<GatewayInfoStreamResV2>>()
+        .await;
+    let gateways = resp.first().unwrap().gateways.clone();
+    assert_eq!(gateways.len(), 3);
+    assert_eq!(
+        gateways
+            .iter()
+            .find(|v| v.address == asset1_pubkey.to_vec())
+            .unwrap()
+            .updated_at,
+        refreshed_at.timestamp() as u64
+    );
+    assert_eq!(
+        gateways
+            .iter()
+            .find(|v| v.address == asset2_pubkey.to_vec())
+            .unwrap()
+            .updated_at,
+        created_at.timestamp() as u64
+    );
+
+    assert_eq!(
+        gateways
+            .iter()
+            .find(|v| v.address == asset3_pubkey.to_vec())
+            .unwrap()
+            .updated_at,
+        updated_at.timestamp() as u64
+    );
+}
+
+#[sqlx::test]
 async fn gateway_stream_info_v2_deployment_info(pool: PgPool) {
     let admin_key = make_keypair();
     let asset1_pubkey = make_keypair().public_key().clone();

--- a/mobile_verifier/tests/integrations/speedtests.rs
+++ b/mobile_verifier/tests/integrations/speedtests.rs
@@ -35,6 +35,8 @@ impl GatewayInfoResolver for MockGatewayInfoResolver {
             metadata: None,
             device_type: DeviceType::Cbrs,
             created_at: None,
+            refreshed_at: None,
+            updated_at: None,
         }))
     }
 


### PR DESCRIPTION
The updated_at field in the response is required to complete the workflow for fetching only the most recently changed hotspots.

This solution is unoptimized since updated_radios is fetched every time. The performance (for v2 endpoints) might be  impacted.

The `updated_radios` hashmap should be cached in future versions.

https://github.com/helium/proto/pull/436