### PR TITLE
[Mobile Config] Handle entity duplicates in Mobile radio tracker

### DIFF
--- a/mobile_config/tests/common/mod.rs
+++ b/mobile_config/tests/common/mod.rs
@@ -1,0 +1,133 @@
+use bs58;
+use chrono::{DateTime, Duration, Utc};
+use helium_crypto::PublicKeyBinary;
+use helium_crypto::{KeyTag, Keypair};
+use sqlx::PgPool;
+
+pub async fn add_mobile_tracker_record(
+    pool: &PgPool,
+    key: PublicKeyBinary,
+    last_changed_at: DateTime<Utc>,
+) {
+    let b58 = bs58::decode(key.to_string()).into_vec().unwrap();
+
+    sqlx::query(
+        r#"
+            INSERT INTO
+"mobile_radio_tracker" ("entity_key", "hash", "last_changed_at", "last_checked_at")
+            VALUES
+($1, $2, $3, $4);
+    "#,
+    )
+    .bind(b58)
+    .bind("hash")
+    .bind(last_changed_at)
+    .bind(last_changed_at + Duration::hours(1))
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn add_db_record(
+    pool: &PgPool,
+    asset: &str,
+    location: i64,
+    device_type: &str,
+    key: PublicKeyBinary,
+    created_at: DateTime<Utc>,
+    refreshed_at: Option<DateTime<Utc>>,
+    deployment_info: Option<&str>,
+) {
+    add_mobile_hotspot_infos(
+        pool,
+        asset,
+        location,
+        device_type,
+        created_at,
+        refreshed_at,
+        deployment_info,
+    )
+    .await;
+    add_asset_key(pool, asset, key).await;
+}
+
+pub async fn add_mobile_hotspot_infos(
+    pool: &PgPool,
+    asset: &str,
+    location: i64,
+    device_type: &str,
+    created_at: DateTime<Utc>,
+    refreshed_at: Option<DateTime<Utc>>,
+    deployment_info: Option<&str>,
+) {
+    sqlx::query(
+        r#"
+            INSERT INTO
+"mobile_hotspot_infos" ("asset", "location", "device_type", "created_at", "refreshed_at", "deployment_info")
+            VALUES
+($1, $2, $3::jsonb, $4, $5, $6::jsonb);
+    "#,
+    )
+    .bind(asset)
+    .bind(location)
+    .bind(device_type)
+    .bind(created_at)
+    .bind(refreshed_at)
+    .bind(deployment_info)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+pub async fn add_asset_key(pool: &PgPool, asset: &str, key: PublicKeyBinary) {
+    let b58 = bs58::decode(key.to_string()).into_vec().unwrap();
+    sqlx::query(
+        r#"
+    INSERT INTO
+    "key_to_assets" ("asset", "entity_key")
+    VALUES ($1, $2);
+    "#,
+    )
+    .bind(asset)
+    .bind(b58)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+pub async fn create_db_tables(pool: &PgPool) {
+    sqlx::query(
+        r#"
+        CREATE TABLE mobile_hotspot_infos (
+        asset character varying(255) NULL,
+        location numeric NULL,
+        device_type jsonb NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT NOW(),
+        refreshed_at timestamptz,
+        deployment_info jsonb,
+        is_full_hotspot bool NULL,
+        num_location_asserts integer NULL,
+        is_active bool NULL,
+        dc_onboarding_fee_paid numeric NULL
+    );"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        r#"
+        CREATE TABLE key_to_assets (
+            asset character varying(255) NULL,
+            entity_key bytea NULL
+        );"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+pub fn make_keypair() -> Keypair {
+    Keypair::generate(KeyTag::default(), &mut rand::rngs::OsRng)
+}

--- a/mobile_config/tests/gateway_service.rs
+++ b/mobile_config/tests/gateway_service.rs
@@ -1,9 +1,9 @@
 use std::vec;
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::{Duration, Utc};
 use futures::stream::StreamExt;
 
-use helium_crypto::{KeyTag, Keypair, PublicKey, PublicKeyBinary, Sign};
+use helium_crypto::{Keypair, PublicKey, Sign};
 use helium_proto::services::mobile_config::{
     self as proto, gateway_metadata_v2::DeploymentInfo, DeviceType, GatewayClient,
     GatewayInfoStreamReqV1, GatewayInfoStreamReqV2, GatewayInfoStreamResV2,
@@ -18,7 +18,7 @@ use sqlx::PgPool;
 use tokio::net::TcpListener;
 use tonic::{transport, Code};
 
-mod common;
+pub mod common;
 use common::*;
 
 #[sqlx::test]

--- a/mobile_config/tests/gateway_service.rs
+++ b/mobile_config/tests/gateway_service.rs
@@ -18,6 +18,9 @@ use sqlx::PgPool;
 use tokio::net::TcpListener;
 use tonic::{transport, Code};
 
+mod common;
+use common::*;
+
 #[sqlx::test]
 async fn gateway_info_authorization_errors(pool: PgPool) -> anyhow::Result<()> {
     // NOTE(mj): The information we're requesting does not exist in the DB for
@@ -536,130 +539,6 @@ async fn gateway_stream_info_v2_deployment_info(pool: PgPool) {
             }
         }
     }
-}
-
-async fn add_mobile_tracker_record(
-    pool: &PgPool,
-    key: PublicKeyBinary,
-    last_changed_at: DateTime<Utc>,
-) {
-    let b58 = bs58::decode(key.to_string()).into_vec().unwrap();
-
-    sqlx::query(
-        r#"
-            INSERT INTO
-"mobile_radio_tracker" ("entity_key", "hash", "last_changed_at", "last_checked_at")
-            VALUES
-($1, $2, $3, $4);
-    "#,
-    )
-    .bind(b58)
-    .bind("hash")
-    .bind(last_changed_at)
-    .bind(last_changed_at + Duration::hours(1))
-    .execute(pool)
-    .await
-    .unwrap();
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn add_db_record(
-    pool: &PgPool,
-    asset: &str,
-    location: i64,
-    device_type: &str,
-    key: PublicKeyBinary,
-    created_at: DateTime<Utc>,
-    refreshed_at: Option<DateTime<Utc>>,
-    deployment_info: Option<&str>,
-) {
-    add_mobile_hotspot_infos(
-        pool,
-        asset,
-        location,
-        device_type,
-        created_at,
-        refreshed_at,
-        deployment_info,
-    )
-    .await;
-    add_asset_key(pool, asset, key).await;
-}
-
-async fn add_mobile_hotspot_infos(
-    pool: &PgPool,
-    asset: &str,
-    location: i64,
-    device_type: &str,
-    created_at: DateTime<Utc>,
-    refreshed_at: Option<DateTime<Utc>>,
-    deployment_info: Option<&str>,
-) {
-    sqlx::query(
-        r#"
-            INSERT INTO
-"mobile_hotspot_infos" ("asset", "location", "device_type", "created_at", "refreshed_at", "deployment_info")
-            VALUES
-($1, $2, $3::jsonb, $4, $5, $6::jsonb);
-    "#,
-    )
-    .bind(asset)
-    .bind(location)
-    .bind(device_type)
-    .bind(created_at)
-    .bind(refreshed_at)
-    .bind(deployment_info)
-    .execute(pool)
-    .await
-    .unwrap();
-}
-
-async fn add_asset_key(pool: &PgPool, asset: &str, key: PublicKeyBinary) {
-    let b58 = bs58::decode(key.to_string()).into_vec().unwrap();
-    sqlx::query(
-        r#"
-    INSERT INTO
-    "key_to_assets" ("asset", "entity_key")
-    VALUES ($1, $2);
-    "#,
-    )
-    .bind(asset)
-    .bind(b58)
-    .execute(pool)
-    .await
-    .unwrap();
-}
-
-async fn create_db_tables(pool: &PgPool) {
-    sqlx::query(
-        r#"
-        CREATE TABLE mobile_hotspot_infos (
-        asset character varying(255) NULL,
-        location numeric NULL,
-        device_type jsonb NOT NULL,
-        created_at timestamptz NOT NULL DEFAULT NOW(),
-        refreshed_at timestamptz,
-        deployment_info jsonb
-    );"#,
-    )
-    .execute(pool)
-    .await
-    .unwrap();
-
-    sqlx::query(
-        r#"
-        CREATE TABLE key_to_assets (
-            asset character varying(255) NULL,
-            entity_key bytea NULL
-        );"#,
-    )
-    .execute(pool)
-    .await
-    .unwrap();
-}
-
-fn make_keypair() -> Keypair {
-    Keypair::generate(KeyTag::default(), &mut rand::rngs::OsRng)
 }
 
 fn make_gateway_stream_signed_req_v2(

--- a/mobile_config/tests/mobile_radio_tracker.rs
+++ b/mobile_config/tests/mobile_radio_tracker.rs
@@ -3,7 +3,7 @@ use helium_crypto::PublicKeyBinary;
 use mobile_config::mobile_radio_tracker::{get_tracked_radios, track_changes};
 use sqlx::PgPool;
 
-mod common;
+pub mod common;
 use common::*;
 
 #[sqlx::test]

--- a/mobile_config/tests/mobile_radio_tracker.rs
+++ b/mobile_config/tests/mobile_radio_tracker.rs
@@ -1,0 +1,64 @@
+use chrono::Utc;
+use helium_crypto::PublicKeyBinary;
+use mobile_config::mobile_radio_tracker::{get_tracked_radios, track_changes};
+use sqlx::PgPool;
+
+mod common;
+use common::*;
+
+#[sqlx::test]
+async fn mobile_tracker_handle_entity_duplicates(pool: PgPool) {
+    // In case of duplications mobile tracker must use newer (refreshed_at)
+    let asset1_pubkey = make_keypair().public_key().clone();
+    let asset1_hex_idx = 631711281837647359_i64;
+    create_db_tables(&pool).await;
+    let now = Utc::now();
+    let now_minus_hour = now - chrono::Duration::hours(1);
+    let pubkey_binary = PublicKeyBinary::from(asset1_pubkey.clone());
+
+    add_db_record(
+        &pool,
+        "asset1",
+        asset1_hex_idx,
+        "\"wifiIndoor\"",
+        asset1_pubkey.clone().into(),
+        now_minus_hour,
+        Some(now_minus_hour),
+        Some(r#"{"wifiInfoV0": {"antenna": 18, "azimuth": 160, "elevation": 5, "electricalDownTilt": 1, "mechanicalDownTilt": 2}}"#)
+    )
+    .await;
+
+    add_db_record(
+        &pool,
+        "asset1",
+        asset1_hex_idx,
+        "\"wifiIndoor\"",
+        asset1_pubkey.clone().into(),
+        now,
+        None,
+        Some(r#"{"wifiInfoV0": {"antenna": 18, "azimuth": 160, "elevation": 5, "electricalDownTilt": 1, "mechanicalDownTilt": 2}}"#)
+    )
+    .await;
+
+    add_db_record(
+        &pool,
+        "asset1",
+        asset1_hex_idx,
+        "\"wifiIndoor\"",
+        asset1_pubkey.clone().into(),
+        now,
+        Some(now),
+        Some(r#"{"wifiInfoV0": {"antenna": 18, "azimuth": 160, "elevation": 5, "electricalDownTilt": 1, "mechanicalDownTilt": 2}}"#)
+    )
+    .await;
+
+    let b58 = bs58::decode(pubkey_binary.to_string()).into_vec().unwrap();
+    track_changes(&pool, &pool).await.unwrap();
+    let tracked_radios = get_tracked_radios(&pool).await.unwrap();
+    assert_eq!(tracked_radios.len(), 1);
+    let tracked_radio = tracked_radios.get::<Vec<u8>>(&b58).unwrap();
+    assert_eq!(
+        tracked_radio.last_changed_at.timestamp_millis(),
+        now.timestamp_millis()
+    );
+}


### PR DESCRIPTION
During development testing, we encountered the following issue:

`ERROR mobile_config::mobile_radio_tracker: error in tracking changes to mobile radios err=error returned from database: ON CONFLICT DO UPDATE command cannot affect row a second time`

The root cause of this problem is the existence of duplicate entity keys in the key_to_assets table (on the dev server).

Solution: Handle `(entity_key, asset)` duplicates by fetching unique entries with the newer `refreshed_at`.

(Theoretically possible) Case where one entity_key maps to several different assets will still result in the error described above. Since I don't see a graceful recovery from such data corruption.