### PR TITLE
Make Solana Errors concrete types

### DIFF
--- a/boost_manager/tests/integrations/updater_tests.rs
+++ b/boost_manager/tests/integrations/updater_tests.rs
@@ -20,7 +20,7 @@ pub struct MockTransaction {
 
 pub struct MockSolanaConnection {
     submitted: Mutex<Vec<MockTransaction>>,
-    error: Option<tonic::Status>,
+    error: Option<String>,
 }
 
 impl MockSolanaConnection {
@@ -34,7 +34,7 @@ impl MockSolanaConnection {
     fn with_error(error: String) -> Self {
         Self {
             submitted: Mutex::new(vec![]),
-            error: Some(tonic::Status::internal(error)),
+            error: Some(error),
         }
     }
 }
@@ -58,11 +58,7 @@ impl SolanaNetwork for MockSolanaConnection {
 
         self.error
             .as_ref()
-            .map(|err| {
-                Err(SolanaRpcError::HeliumLib(solana::error::Error::Grpc(
-                    err.to_owned(),
-                )))
-            })
+            .map(|err| Err(SolanaRpcError::Test(err.to_owned())))
             .unwrap_or(Ok(()))
     }
 

--- a/iot_config/src/client/org_client.rs
+++ b/iot_config/src/client/org_client.rs
@@ -11,12 +11,10 @@ use helium_proto::services::iot_config::{
 
 #[async_trait]
 pub trait Orgs: Send + Sync + 'static {
-    type Error: std::fmt::Debug + std::fmt::Display + Send + Sync + 'static;
-
-    async fn get(&mut self, oui: u64) -> Result<OrgResV1, Self::Error>;
-    async fn list(&mut self) -> Result<Vec<OrgV1>, Self::Error>;
-    async fn enable(&mut self, oui: u64) -> Result<(), Self::Error>;
-    async fn disable(&mut self, oui: u64) -> Result<(), Self::Error>;
+    async fn get(&mut self, oui: u64) -> Result<OrgResV1, ClientError>;
+    async fn list(&mut self) -> Result<Vec<OrgV1>, ClientError>;
+    async fn enable(&mut self, oui: u64) -> Result<(), ClientError>;
+    async fn disable(&mut self, oui: u64) -> Result<(), ClientError>;
 }
 
 #[derive(Clone)]
@@ -42,8 +40,6 @@ impl OrgClient {
 
 #[async_trait]
 impl Orgs for OrgClient {
-    type Error = ClientError;
-
     async fn get(&mut self, oui: u64) -> Result<OrgResV1, ClientError> {
         tracing::debug!(%oui, "retrieving org");
 

--- a/iot_packet_verifier/src/balances.rs
+++ b/iot_packet_verifier/src/balances.rs
@@ -62,8 +62,6 @@ impl<S> Debiter for BalanceCache<S>
 where
     S: SolanaNetwork,
 {
-    type Error = SolanaRpcError;
-
     /// Debits the balance from the cache, returning the remaining balance as an
     /// option if there was enough and none otherwise.
     async fn debit_if_sufficient(

--- a/iot_packet_verifier/src/balances.rs
+++ b/iot_packet_verifier/src/balances.rs
@@ -3,7 +3,7 @@ use crate::{
     verifier::Debiter,
 };
 use helium_crypto::PublicKeyBinary;
-use solana::burn::SolanaNetwork;
+use solana::{burn::SolanaNetwork, SolanaRpcError};
 use std::{
     collections::{hash_map::Entry, HashMap},
     sync::Arc,
@@ -62,7 +62,7 @@ impl<S> Debiter for BalanceCache<S>
 where
     S: SolanaNetwork,
 {
-    type Error = S::Error;
+    type Error = SolanaRpcError;
 
     /// Debits the balance from the cache, returning the remaining balance as an
     /// option if there was enough and none otherwise.
@@ -71,7 +71,7 @@ where
         payer: &PublicKeyBinary,
         amount: u64,
         trigger_balance_check_threshold: u64,
-    ) -> Result<Option<u64>, S::Error> {
+    ) -> Result<Option<u64>, SolanaRpcError> {
         let mut payer_accounts = self.payer_accounts.lock().await;
 
         // Fetch the balance if we haven't seen the payer before

--- a/iot_packet_verifier/src/burner.rs
+++ b/iot_packet_verifier/src/burner.rs
@@ -75,19 +75,18 @@ where
         burn_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {
-            #[rustfmt::skip]
             tokio::select! {
-                biased;
-                _ = shutdown.clone() => break,
-                _ = burn_timer.tick() => {
-		    match self.burn().await {
-			Ok(()) => continue,
-			Err(err) => {
-			    tracing::error!("Error while burning data credits: {err}");
-			    confirm_pending_txns(&self.pending_tables, &self.solana, &self.balances).await?;
-			}
-		    }
-		}
+                    biased;
+                    _ = shutdown.clone() => break,
+                    _ = burn_timer.tick() => {
+                    match self.burn().await {
+                        Ok(()) => continue,
+                        Err(err) => {
+                            tracing::error!("Error while burning data credits: {err}");
+                            confirm_pending_txns(&self.pending_tables, &self.solana, &self.balances).await?;
+                        }
+                    }
+                }
             }
         }
         tracing::info!("Stopping burner");

--- a/iot_packet_verifier/src/burner.rs
+++ b/iot_packet_verifier/src/burner.rs
@@ -5,7 +5,7 @@ use crate::{
     },
 };
 use futures::{future::LocalBoxFuture, TryFutureExt};
-use solana::{burn::SolanaNetwork, GetSignature};
+use solana::{burn::SolanaNetwork, GetSignature, SolanaRpcError};
 use std::time::Duration;
 use task_manager::ManagedTask;
 use tokio::time::{self, MissedTickBehavior};
@@ -69,7 +69,10 @@ where
     P: PendingTables + Send + Sync + 'static,
     S: SolanaNetwork,
 {
-    pub async fn run(mut self, shutdown: triggered::Listener) -> Result<(), BurnError<S::Error>> {
+    pub async fn run(
+        mut self,
+        shutdown: triggered::Listener,
+    ) -> Result<(), BurnError<SolanaRpcError>> {
         tracing::info!("Starting burner");
         let mut burn_timer = time::interval(self.burn_period);
         burn_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -94,7 +97,7 @@ where
         Ok(())
     }
 
-    pub async fn burn(&mut self) -> Result<(), BurnError<S::Error>> {
+    pub async fn burn(&mut self) -> Result<(), BurnError<SolanaRpcError>> {
         // Fetch the next payer and amount that should be burn. If no such burn
         // exists, perform no action.
         let Some(Burn { payer, amount }) = self.pending_tables.fetch_next_burn().await? else {

--- a/iot_packet_verifier/src/daemon.rs
+++ b/iot_packet_verifier/src/daemon.rs
@@ -84,8 +84,8 @@ where
                 self.minimum_allowed_balance,
                 &mut transaction,
                 reports,
-                &self.valid_packets,
-                &self.invalid_packets,
+                &mut self.valid_packets,
+                &mut self.invalid_packets,
             )
             .await?;
         transaction.commit().await?;

--- a/iot_packet_verifier/src/pending.rs
+++ b/iot_packet_verifier/src/pending.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use helium_crypto::PublicKeyBinary;
-use solana::burn::SolanaNetwork;
+use solana::{burn::SolanaNetwork, SolanaRpcError};
 use solana_sdk::signature::Signature;
 use sqlx::{postgres::PgRow, FromRow, PgPool, Postgres, Row, Transaction};
 use std::{collections::HashMap, sync::Arc};
@@ -58,7 +58,7 @@ pub async fn confirm_pending_txns<S>(
     pending_tables: &impl PendingTables,
     solana: &S,
     balances: &BalanceStore,
-) -> Result<(), ConfirmPendingError<S::Error>>
+) -> Result<(), ConfirmPendingError<SolanaRpcError>>
 where
     S: SolanaNetwork,
 {
@@ -387,6 +387,8 @@ impl<'a> PendingTablesTransaction<'a> for &'a MockPendingTables {
 
 #[cfg(test)]
 mod test {
+    use solana::SolanaRpcError;
+
     use crate::balances::PayerAccount;
 
     use super::*;
@@ -397,11 +399,10 @@ mod test {
 
     #[async_trait]
     impl SolanaNetwork for MockConfirmed {
-        type Error = std::convert::Infallible;
         type Transaction = Signature;
 
         #[allow(clippy::diverging_sub_expression)]
-        async fn payer_balance(&self, _payer: &PublicKeyBinary) -> Result<u64, Self::Error> {
+        async fn payer_balance(&self, _payer: &PublicKeyBinary) -> Result<u64, SolanaRpcError> {
             unreachable!()
         }
 
@@ -410,7 +411,7 @@ mod test {
             &self,
             _payer: &PublicKeyBinary,
             _amount: u64,
-        ) -> Result<Self::Transaction, Self::Error> {
+        ) -> Result<Self::Transaction, SolanaRpcError> {
             unreachable!()
         }
 
@@ -418,11 +419,11 @@ mod test {
         async fn submit_transaction(
             &self,
             _transaction: &Self::Transaction,
-        ) -> Result<(), Self::Error> {
+        ) -> Result<(), SolanaRpcError> {
             unreachable!()
         }
 
-        async fn confirm_transaction(&self, txn: &Signature) -> Result<bool, Self::Error> {
+        async fn confirm_transaction(&self, txn: &Signature) -> Result<bool, SolanaRpcError> {
             Ok(self.0.contains(txn))
         }
     }

--- a/iot_packet_verifier/src/pending.rs
+++ b/iot_packet_verifier/src/pending.rs
@@ -387,7 +387,6 @@ impl<'a> PendingTablesTransaction<'a> for &'a MockPendingTables {
 
 #[cfg(test)]
 mod test {
-    use solana::SolanaRpcError;
 
     use crate::balances::PayerAccount;
 

--- a/iot_packet_verifier/src/pending.rs
+++ b/iot_packet_verifier/src/pending.rs
@@ -45,20 +45,20 @@ pub trait PendingTables {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum ConfirmPendingError<S> {
+pub enum ConfirmPendingError {
     #[error("Sqlx error: {0}")]
     SqlxError(#[from] sqlx::Error),
     #[error("Chrono error: {0}")]
     ChronoError(#[from] chrono::OutOfRangeError),
     #[error("Solana error: {0}")]
-    SolanaError(S),
+    SolanaError(#[from] SolanaRpcError),
 }
 
 pub async fn confirm_pending_txns<S>(
     pending_tables: &impl PendingTables,
     solana: &S,
     balances: &BalanceStore,
-) -> Result<(), ConfirmPendingError<SolanaRpcError>>
+) -> Result<(), ConfirmPendingError>
 where
     S: SolanaNetwork,
 {

--- a/iot_packet_verifier/src/pending.rs
+++ b/iot_packet_verifier/src/pending.rs
@@ -165,7 +165,7 @@ impl PendingTables for PgPool {
 }
 
 #[async_trait]
-impl AddPendingBurn for &'_ mut Transaction<'_, Postgres> {
+impl AddPendingBurn for Transaction<'_, Postgres> {
     async fn add_burned_amount(
         &mut self,
         payer: &PublicKeyBinary,

--- a/iot_packet_verifier/src/verifier.rs
+++ b/iot_packet_verifier/src/verifier.rs
@@ -11,7 +11,7 @@ use helium_proto::services::{
     packet_verifier::{InvalidPacket, InvalidPacketReason, ValidPacket},
     router::packet_router_packet_report_v1::PacketType,
 };
-use iot_config::client::org_client::Orgs;
+use iot_config::client::{org_client::Orgs, ClientError};
 use solana::{burn::SolanaNetwork, SolanaRpcError};
 use std::{
     collections::{hash_map::Entry, HashMap},
@@ -271,9 +271,9 @@ pub enum MonitorError<S, E> {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum ConfigServerError<OrgsError> {
+pub enum ConfigServerError {
     #[error("orgs  error: {0}")]
-    OrgError(#[from] OrgsError),
+    OrgError(#[from] ClientError),
     #[error("not found: {0}")]
     NotFound(u64),
 }
@@ -297,7 +297,7 @@ impl<O> ConfigServer for Arc<Mutex<CachedOrgClient<O>>>
 where
     O: Orgs,
 {
-    type Error = ConfigServerError<O::Error>;
+    type Error = ConfigServerError;
 
     async fn fetch_org(
         &self,

--- a/iot_packet_verifier/src/verifier.rs
+++ b/iot_packet_verifier/src/verifier.rs
@@ -12,7 +12,7 @@ use helium_proto::services::{
     router::packet_router_packet_report_v1::PacketType,
 };
 use iot_config::client::org_client::Orgs;
-use solana::burn::SolanaNetwork;
+use solana::{burn::SolanaNetwork, SolanaRpcError};
 use std::{
     collections::{hash_map::Entry, HashMap},
     convert::Infallible,
@@ -203,7 +203,7 @@ pub trait ConfigServer: Sized + Send + Sync + 'static {
         minimum_allowed_balance: u64,
         monitor_period: Duration,
         shutdown: triggered::Listener,
-    ) -> Result<(), MonitorError<S::Error, Self::Error>>
+    ) -> Result<(), MonitorError<SolanaRpcError, Self::Error>>
     where
         S: SolanaNetwork,
         B: BalanceStore,

--- a/iot_packet_verifier/src/verifier.rs
+++ b/iot_packet_verifier/src/verifier.rs
@@ -75,8 +75,7 @@ where
             let payer = self
                 .config_server
                 .fetch_org(report.oui, &mut org_cache)
-                .await
-                .map_err(VerificationError::ConfigError)?;
+                .await?;
 
             if let Some(remaining_balance) = self
                 .debiter
@@ -85,8 +84,7 @@ where
             {
                 pending_burns
                     .add_burned_amount(&payer, debit_amount)
-                    .await
-                    .map_err(VerificationError::BurnError)?;
+                    .await?;
 
                 valid_packets
                     .write(ValidPacket {
@@ -100,10 +98,7 @@ where
                     .map_err(VerificationError::ValidPacketWriterError)?;
 
                 if remaining_balance < minimum_allowed_balance {
-                    self.config_server
-                        .disable_org(report.oui)
-                        .await
-                        .map_err(VerificationError::ConfigError)?;
+                    self.config_server.disable_org(report.oui).await?;
                 }
             } else {
                 invalid_packets
@@ -115,10 +110,8 @@ where
                     })
                     .await
                     .map_err(VerificationError::InvalidPacketWriterError)?;
-                self.config_server
-                    .disable_org(report.oui)
-                    .await
-                    .map_err(VerificationError::ConfigError)?;
+
+                self.config_server.disable_org(report.oui).await?;
             }
         }
 

--- a/iot_packet_verifier/tests/integration_tests.rs
+++ b/iot_packet_verifier/tests/integration_tests.rs
@@ -14,7 +14,7 @@ use iot_packet_verifier::{
     balances::{BalanceCache, PayerAccount},
     burner::Burner,
     pending::{confirm_pending_txns, AddPendingBurn, Burn, MockPendingTables, PendingTables},
-    verifier::{payload_size_to_dc, ConfigServer, Org, Verifier, BYTES_PER_DC},
+    verifier::{payload_size_to_dc, ConfigServer, ConfigServerError, Org, Verifier, BYTES_PER_DC},
 };
 use solana::{
     burn::{MockTransaction, SolanaNetwork},
@@ -53,27 +53,25 @@ impl MockConfigServer {
 
 #[async_trait]
 impl ConfigServer for MockConfigServer {
-    type Error = ();
-
     async fn fetch_org(
         &self,
         oui: u64,
         _cache: &mut HashMap<u64, PublicKeyBinary>,
-    ) -> Result<PublicKeyBinary, ()> {
+    ) -> Result<PublicKeyBinary, ConfigServerError> {
         Ok(self.payers.lock().await.get(&oui).unwrap().payer.clone())
     }
 
-    async fn disable_org(&self, oui: u64) -> Result<(), ()> {
+    async fn disable_org(&self, oui: u64) -> Result<(), ConfigServerError> {
         self.payers.lock().await.get_mut(&oui).unwrap().enabled = false;
         Ok(())
     }
 
-    async fn enable_org(&self, oui: u64) -> Result<(), ()> {
+    async fn enable_org(&self, oui: u64) -> Result<(), ConfigServerError> {
         self.payers.lock().await.get_mut(&oui).unwrap().enabled = true;
         Ok(())
     }
 
-    async fn list_orgs(&self) -> Result<Vec<Org>, ()> {
+    async fn list_orgs(&self) -> Result<Vec<Org>, ConfigServerError> {
         Ok(self
             .payers
             .lock()

--- a/iot_packet_verifier/tests/integration_tests.rs
+++ b/iot_packet_verifier/tests/integration_tests.rs
@@ -18,7 +18,7 @@ use iot_packet_verifier::{
 };
 use solana::{
     burn::{MockTransaction, SolanaNetwork},
-    GetSignature,
+    GetSignature, SolanaRpcError,
 };
 use solana_sdk::signature::Signature;
 use sqlx::PgPool;
@@ -593,10 +593,9 @@ impl MockSolanaNetwork {
 
 #[async_trait]
 impl SolanaNetwork for MockSolanaNetwork {
-    type Error = std::convert::Infallible;
     type Transaction = MockTransaction;
 
-    async fn payer_balance(&self, payer: &PublicKeyBinary) -> Result<u64, Self::Error> {
+    async fn payer_balance(&self, payer: &PublicKeyBinary) -> Result<u64, SolanaRpcError> {
         self.ledger.payer_balance(payer).await
     }
 
@@ -604,16 +603,16 @@ impl SolanaNetwork for MockSolanaNetwork {
         &self,
         payer: &PublicKeyBinary,
         amount: u64,
-    ) -> Result<MockTransaction, Self::Error> {
+    ) -> Result<MockTransaction, SolanaRpcError> {
         self.ledger.make_burn_transaction(payer, amount).await
     }
 
-    async fn submit_transaction(&self, txn: &MockTransaction) -> Result<(), Self::Error> {
+    async fn submit_transaction(&self, txn: &MockTransaction) -> Result<(), SolanaRpcError> {
         self.confirmed.lock().await.insert(txn.signature);
         self.ledger.submit_transaction(txn).await
     }
 
-    async fn confirm_transaction(&self, txn: &Signature) -> Result<bool, Self::Error> {
+    async fn confirm_transaction(&self, txn: &Signature) -> Result<bool, SolanaRpcError> {
         Ok(self.confirmed.lock().await.contains(txn))
     }
 }

--- a/iot_packet_verifier/tests/integration_tests.rs
+++ b/iot_packet_verifier/tests/integration_tests.rs
@@ -202,7 +202,7 @@ async fn test_config_unlocking() {
     verifier
         .verify(
             1,
-            balances.clone(),
+            &mut balances.clone(),
             stream::iter(vec![
                 packet_report(0, 0, 24, vec![1], false),
                 packet_report(0, 1, 48, vec![2], false),
@@ -260,7 +260,7 @@ async fn test_config_unlocking() {
     verifier
         .verify(
             1,
-            balances.clone(),
+            &mut balances.clone(),
             stream::iter(vec![
                 packet_report(0, 0, 24, vec![1], false),
                 packet_report(0, 1, 48, vec![2], false),
@@ -317,7 +317,7 @@ async fn test_verifier_free_packets() {
     verifier
         .verify(
             1,
-            balances.clone(),
+            &mut balances.clone(),
             stream::iter(packets),
             &mut valid_packets,
             &mut invalid_packets,
@@ -391,7 +391,7 @@ async fn test_verifier() {
     verifier
         .verify(
             1,
-            balances.clone(),
+            &mut balances.clone(),
             stream::iter(packets),
             &mut valid_packets,
             &mut invalid_packets,
@@ -472,7 +472,7 @@ async fn test_end_to_end() {
     verifier
         .verify(
             1,
-            pending_burns.clone(),
+            &mut pending_burns.clone(),
             stream::iter(vec![
                 packet_report(0, 0, BYTES_PER_DC as u32, vec![1], false),
                 packet_report(0, 1, BYTES_PER_DC as u32, vec![2], false),
@@ -552,7 +552,7 @@ async fn test_end_to_end() {
     verifier
         .verify(
             1,
-            pending_burns.clone(),
+            &mut pending_burns.clone(),
             stream::iter(vec![packet_report(
                 0,
                 4,
@@ -641,7 +641,7 @@ async fn test_pending_txns(pool: PgPool) -> anyhow::Result<()> {
     // Add both the burn amounts to the pending burns table
     {
         let mut transaction = pool.begin().await.unwrap();
-        (&mut transaction)
+        transaction
             .add_burned_amount(&payer, CONFIRMED_BURN_AMOUNT + UNCONFIRMED_BURN_AMOUNT)
             .await
             .unwrap();

--- a/mobile_packet_verifier/src/burner.rs
+++ b/mobile_packet_verifier/src/burner.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use file_store::file_sink::FileSinkClient;
 use helium_crypto::PublicKeyBinary;
 use helium_proto::services::packet_verifier::ValidDataTransferSession;
-use solana::{burn::SolanaNetwork, GetSignature};
+use solana::{burn::SolanaNetwork, GetSignature, SolanaRpcError};
 use sqlx::{Pool, Postgres};
 use tracing::Instrument;
 
@@ -90,7 +90,7 @@ where
     async fn transaction_confirmation_check(
         &self,
         pool: &Pool<Postgres>,
-        err: S::Error,
+        err: SolanaRpcError,
         txn: S::Transaction,
         payer: PublicKeyBinary,
         total_dcs: u64,

--- a/solana/src/burn.rs
+++ b/solana/src/burn.rs
@@ -93,7 +93,9 @@ impl SolanaRpc {
         let dc_mint = settings.dc_mint.parse()?;
         let dnt_mint = settings.dnt_mint.parse()?;
         let Ok(keypair) = read_keypair_file(&settings.burn_keypair) else {
-            return Err(SolanaRpcError::FailedToReadKeypairError);
+            return Err(SolanaRpcError::FailedToReadKeypairError(
+                settings.burn_keypair.to_owned(),
+            ));
         };
         let provider =
             RpcClient::new_with_commitment(settings.rpc_url.clone(), CommitmentConfig::finalized());

--- a/solana/src/burn.rs
+++ b/solana/src/burn.rs
@@ -209,8 +209,7 @@ impl SolanaNetwork for SolanaRpc {
                 &priority_fee_accounts,
                 self.min_priority_fee,
             )
-            .await
-            .map_err(|e| SolanaRpcError::RpcClientError(Box::new(e)))?;
+            .await?;
 
         tracing::info!(%priority_fee);
 
@@ -278,7 +277,7 @@ impl SolanaNetwork for SolanaRpc {
                     transaction = %signature,
                     "Data credit burn failed: {err:?}"
                 );
-                Err(SolanaRpcError::RpcClientError(Box::new(err)))
+                Err(err.into())
             }
         }
     }

--- a/solana/src/burn.rs
+++ b/solana/src/burn.rs
@@ -24,10 +24,7 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use std::{collections::HashMap, str::FromStr};
-use std::{
-    sync::Arc,
-    time::{Duration, SystemTime},
-};
+use std::{sync::Arc, time::SystemTime};
 use tokio::sync::Mutex;
 
 #[async_trait]

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -49,6 +49,9 @@ pub enum SolanaRpcError {
     FailedToReadKeypairError(String),
     #[error("crypto error: {0}")]
     Crypto(#[from] helium_crypto::Error),
+    // TODO: Remove when fully integrated with helium-lib
+    #[error("Test Error")]
+    Test(String),
 }
 
 impl From<helium_anchor_gen::anchor_lang::error::Error> for SolanaRpcError {

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -45,8 +45,8 @@ pub enum SolanaRpcError {
     InvalidKeypair,
     #[error("System time error: {0}")]
     SystemTimeError(#[from] SystemTimeError),
-    #[error("Failed to read keypair file")]
-    FailedToReadKeypairError,
+    #[error("Failed to read keypair file: {0}")]
+    FailedToReadKeypairError(String),
     #[error("crypto error: {0}")]
     Crypto(#[from] helium_crypto::Error),
 }

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -17,7 +17,7 @@ macro_rules! send_with_retry {
                 Err(err) => {
                     if attempt < 5 {
                         attempt += 1;
-                        tokio::time::sleep(Duration::from_secs(attempt)).await;
+                        tokio::time::sleep(std::time::Duration::from_secs(attempt)).await;
                         continue;
                     } else {
                         break Err(err);

--- a/solana/src/start_boost.rs
+++ b/solana/src/start_boost.rs
@@ -127,7 +127,7 @@ impl SolanaNetwork for SolanaRpc {
                     transaction = %signature,
                     "hex start boost failed: {err:?}"
                 );
-                Err(SolanaRpcError::RpcClientError(Box::new(err)))
+                Err(err.into())
             }
         }
     }

--- a/solana/src/start_boost.rs
+++ b/solana/src/start_boost.rs
@@ -50,7 +50,9 @@ pub struct SolanaRpc {
 impl SolanaRpc {
     pub async fn new(settings: &Settings) -> Result<Arc<Self>, SolanaRpcError> {
         let Ok(keypair) = read_keypair_file(&settings.start_authority_keypair) else {
-            return Err(SolanaRpcError::FailedToReadKeypairError);
+            return Err(SolanaRpcError::FailedToReadKeypairError(
+                settings.start_authority_keypair.to_owned(),
+            ));
         };
         let provider =
             RpcClient::new_with_commitment(settings.rpc_url.clone(), CommitmentConfig::finalized());


### PR DESCRIPTION
In attempting to bring the `helium-lib` PR https://github.com/helium/oracles/pull/850 back up to speed, and considering the ability to incorporate tracking transactions using `helium-lib`, I was really struggling with all the generics. 

All the times an associated `Error` type was something other than the concrete type used by the actual implementation, it was `()` of `Infallible`. So I thought it would be an okay idea to remove the associated types to make some of the errors paths easier to change up without having to chase down a bunch of generics.

- Removed associated `Error`
  - `Orgs` trait
  - `SolanaNetwork` trait
  - `Debiter` trait
  - `ConfigServer` trait
  - `PacketWriter` trait
- Removed generics from `Error`
  - `BurnError`
  - `ConfirmPendingError`
  - `VerificationError`
  - `MonitorError`
  - `ConfigServerError`
- Formatted `tokio::select!` in iot-packet-verifier burner
- Simplified generics in `Verifier::verify`