### PR TITLE
Clippy updates for 1.84.0

### DIFF
--- a/boost_manager/src/updater.rs
+++ b/boost_manager/src/updater.rs
@@ -173,7 +173,7 @@ where
         Ok(())
     }
 
-    async fn confirm_txn<'a>(&self, txn_row: &TxnRow) -> Result<()> {
+    async fn confirm_txn(&self, txn_row: &TxnRow) -> Result<()> {
         if self.solana.confirm_transaction(&txn_row.txn_id).await? {
             tracing::info!("txn_id {} confirmed on chain, updated db", txn_row.txn_id);
             db::update_verified_txns_onchain(&self.pool, &txn_row.txn_id).await?

--- a/file_store/src/file_sink.rs
+++ b/file_store/src/file_sink.rs
@@ -676,7 +676,7 @@ mod tests {
             .file_name()
             .to_str()
             .and_then(|file_name| FileInfo::from_str(file_name).ok())
-            .map_or(false, |file_info| {
+            .is_some_and(|file_info| {
                 FileType::from_str(&file_info.prefix).expect("entropy report prefix")
                     == FileType::EntropyReport
             })

--- a/iot_config/src/route_service.rs
+++ b/iot_config/src/route_service.rs
@@ -63,11 +63,11 @@ impl RouteService {
         self.update_channel.clone()
     }
 
-    async fn verify_request_signature<'a, R>(
+    async fn verify_request_signature<R>(
         &self,
         signer: &PublicKey,
         request: &R,
-        id: OrgId<'a>,
+        id: OrgId<'_>,
     ) -> Result<(), Status>
     where
         R: MsgVerify,
@@ -117,11 +117,11 @@ impl RouteService {
         }
     }
 
-    async fn verify_request_signature_or_stream<'a, R>(
+    async fn verify_request_signature_or_stream<R>(
         &self,
         signer: &PublicKey,
         request: &R,
-        id: OrgId<'a>,
+        id: OrgId<'_>,
     ) -> Result<(), Status>
     where
         R: MsgVerify,
@@ -151,9 +151,9 @@ impl RouteService {
         DevAddrEuiValidator::new(route_id, admin_keys, &self.pool, check_constraints).await
     }
 
-    async fn validate_skf_devaddrs<'a>(
+    async fn validate_skf_devaddrs(
         &self,
-        route_id: &'a str,
+        route_id: &str,
         updates: &[route_skf_update_req_v1::RouteSkfUpdateV1],
     ) -> Result<(), Status> {
         let ranges: Vec<DevAddrRange> = route::list_devaddr_ranges_for_route(route_id, &self.pool)

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -514,7 +514,7 @@ where
             .witness_updater
             .get_last_witness(&beacon_report.report.pub_key)
             .await?;
-        Ok(last_witness.map_or(false, |lw| {
+        Ok(last_witness.is_some_and(|lw| {
             beacon_report.received_timestamp - lw.timestamp < *RECIPROCITY_WINDOW
         }))
     }
@@ -544,9 +544,8 @@ where
     ) -> anyhow::Result<bool> {
         let last_beacon_recip =
             LastBeaconReciprocity::get(&self.pool, &report.report.pub_key).await?;
-        Ok(last_beacon_recip.map_or(false, |lw| {
-            report.received_timestamp - lw.timestamp < *RECIPROCITY_WINDOW
-        }))
+        Ok(last_beacon_recip
+            .is_some_and(|lw| report.received_timestamp - lw.timestamp < *RECIPROCITY_WINDOW))
     }
 }
 

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -547,11 +547,11 @@ impl CoverageClaimTimeCache {
         Self { cache }
     }
 
-    pub async fn fetch_coverage_claim_time<'a, 'b>(
+    pub async fn fetch_coverage_claim_time<'a>(
         &self,
         radio_key: KeyType<'a>,
         coverage_object: &'a Option<Uuid>,
-        exec: &mut Transaction<'b, Postgres>,
+        exec: &mut Transaction<'_, Postgres>,
     ) -> Result<Option<DateTime<Utc>>, sqlx::Error> {
         let key = (radio_key.to_id(), *coverage_object);
         if let Some(coverage_claim_time) = self.cache.get(&key).await {

--- a/mobile_verifier/src/data_session.rs
+++ b/mobile_verifier/src/data_session.rs
@@ -215,7 +215,7 @@ pub async fn sum_data_sessions_to_dc_by_payer<'a>(
     .collect::<HashMap<String, u64>>())
 }
 
-pub async fn data_sessions_to_dc<'a>(
+pub async fn data_sessions_to_dc(
     stream: impl Stream<Item = Result<HotspotDataSession, sqlx::Error>>,
 ) -> Result<HotspotMap, sqlx::Error> {
     tokio::pin!(stream);

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -275,7 +275,7 @@ pub async fn get_latest_speedtests_for_pubkey(
     Ok(speedtests)
 }
 
-pub async fn aggregate_epoch_speedtests<'a>(
+pub async fn aggregate_epoch_speedtests(
     epoch_end: DateTime<Utc>,
     exec: &sqlx::Pool<sqlx::Postgres>,
 ) -> Result<EpochSpeedTests, sqlx::Error> {


### PR DESCRIPTION
- remove unnecessary lifetimes
- replace `.map_or` with `.is_some_and`