### PR TITLE
update helium-lib to take router_key as a string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "helium-lib"
 version = "0.1.1"
-source = "git+https://github.com/helium/helium-wallet-rs.git?branch=mj%2Frouter-key-str#1cc2e49e747baac87067d38d046c43bbb206aa1c"
+source = "git+https://github.com/helium/helium-wallet-rs.git?branch=master#f7e0651d85679852d2b06033535c46053ce81ed4"
 dependencies = [
  "anchor-client",
  "anchor-spl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "helium-lib"
 version = "0.1.1"
-source = "git+https://github.com/helium/helium-wallet-rs.git?branch=mj%2Frouter-key-str#57d68e46ddd645e021b990fdeae9efdde67010ea"
+source = "git+https://github.com/helium/helium-wallet-rs.git?branch=mj%2Frouter-key-str#1cc2e49e747baac87067d38d046c43bbb206aa1c"
 dependencies = [
  "anchor-client",
  "anchor-spl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3612,8 +3612,8 @@ dependencies = [
 
 [[package]]
 name = "helium-lib"
-version = "0.0.0"
-source = "git+https://github.com/helium/helium-wallet-rs.git?branch=master#bf7ae8aec834b1dfb37c4f0f636dcfa6b121fa11"
+version = "0.1.1"
+source = "git+https://github.com/helium/helium-wallet-rs.git?branch=mj%2Frouter-key-str#67ca8ca925122965324f5c9d6abc438630435d31"
 dependencies = [
  "anchor-client",
  "anchor-spl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
  "rand_chacha 0.3.0",
  "rust_decimal",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "helium-lib"
 version = "0.1.1"
-source = "git+https://github.com/helium/helium-wallet-rs.git?branch=mj%2Frouter-key-str#67ca8ca925122965324f5c9d6abc438630435d31"
+source = "git+https://github.com/helium/helium-wallet-rs.git?branch=mj%2Frouter-key-str#57d68e46ddd645e021b990fdeae9efdde67010ea"
 dependencies = [
  "anchor-client",
  "anchor-spl",
@@ -9645,7 +9645,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
  "twox-hash",
  "xorf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ sqlx = { version = "0", features = [
 ] }
 helium-anchor-gen = { git = "https://github.com/helium/helium-anchor-gen.git" }
 helium-crypto = { version = "0.8.4", features = ["multisig", "solana"] }
-helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = "mj/router-key-str" }
+helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = "master" }
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
   "disktree",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ sqlx = { version = "0", features = [
 ] }
 helium-anchor-gen = { git = "https://github.com/helium/helium-anchor-gen.git" }
 helium-crypto = { version = "0.8.4", features = ["multisig"] }
-helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = "master" }
+helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = "mj/router-key-str" }
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
   "disktree",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ sqlx = { version = "0", features = [
   "runtime-tokio-rustls",
 ] }
 helium-anchor-gen = { git = "https://github.com/helium/helium-anchor-gen.git" }
-helium-crypto = { version = "0.8.4", features = ["multisig"] }
+helium-crypto = { version = "0.8.4", features = ["multisig", "solana"] }
 helium-lib = { git = "https://github.com/helium/helium-wallet-rs.git", branch = "mj/router-key-str" }
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
   "disktree",

--- a/solana/src/burn.rs
+++ b/solana/src/burn.rs
@@ -58,12 +58,7 @@ pub struct SolanaRpc {
 
 impl SolanaRpc {
     pub async fn new(settings: &Settings, sub_dao: SubDao) -> Result<Arc<Self>, SolanaRpcError> {
-        let Ok(keypair) = read_keypair_from_file(&settings.burn_keypair) else {
-            return Err(SolanaRpcError::FailedToReadKeypairError(
-                settings.burn_keypair.to_owned(),
-            ));
-        };
-
+        let keypair = read_keypair_from_file(&settings.burn_keypair)?;
         let provider = client::SolanaRpcClient::new_with_commitment(
             settings.rpc_url.clone(),
             CommitmentConfig::finalized(),

--- a/solana/src/burn.rs
+++ b/solana/src/burn.rs
@@ -1,6 +1,5 @@
 use crate::{
-    read_keypair_from_file, sender, GetSignature, Keypair, Pubkey, SolanaRpcError, SubDao,
-    Transaction,
+    read_keypair_from_file, sender, GetSignature, Keypair, SolanaRpcError, SubDao, Transaction,
 };
 use async_trait::async_trait;
 use helium_crypto::PublicKeyBinary;
@@ -91,8 +90,7 @@ impl SolanaNetwork for SolanaRpc {
     type Transaction = Transaction;
 
     async fn payer_balance(&self, payer: &PublicKeyBinary) -> Result<u64, SolanaRpcError> {
-        let payer_pubkey = Pubkey::try_from(payer.as_ref())?;
-        let delegated_dc_key = SubDao::Iot.delegated_dc_key(&payer_pubkey.to_string());
+        let delegated_dc_key = SubDao::Iot.delegated_dc_key(&payer.to_string());
         let escrow_account = SubDao::Iot.escrow_key(&delegated_dc_key);
 
         let amount = match token::balance_for_address(&self, &escrow_account).await? {
@@ -119,13 +117,12 @@ impl SolanaNetwork for SolanaRpc {
         payer: &PublicKeyBinary,
         amount: u64,
     ) -> Result<Self::Transaction, SolanaRpcError> {
-        let payer = Pubkey::try_from(payer.as_ref())?;
         let tx = dc::burn_delegated(
             self,
             self.sub_dao,
             &self.keypair,
             amount,
-            payer,
+            payer.to_string(),
             &self.transaction_opts,
         )
         .await?;

--- a/solana/src/burn.rs
+++ b/solana/src/burn.rs
@@ -85,7 +85,7 @@ impl SolanaNetwork for SolanaRpc {
     type Transaction = Transaction;
 
     async fn payer_balance(&self, payer: &PublicKeyBinary) -> Result<u64, SolanaRpcError> {
-        let delegated_dc_key = SubDao::Iot.delegated_dc_key(&payer.to_string());
+        let delegated_dc_key = SubDao::Iot.delegated_dc_key(payer);
         let escrow_account = SubDao::Iot.escrow_key(&delegated_dc_key);
 
         let amount = match token::balance_for_address(&self, &escrow_account).await? {
@@ -117,7 +117,7 @@ impl SolanaNetwork for SolanaRpc {
             self.sub_dao,
             &self.keypair,
             amount,
-            payer.to_string(),
+            payer,
             &self.transaction_opts,
         )
         .await?;

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -50,14 +50,11 @@ pub mod carrier;
 pub mod sender;
 pub mod start_boost;
 
-pub fn read_keypair_from_file<F: AsRef<Path>>(path: F) -> anyhow::Result<Keypair> {
+pub fn read_keypair_from_file<F: AsRef<Path>>(path: F) -> Result<Keypair, SolanaRpcError> {
     let path = path.as_ref();
-    let keypair = read_keypair_file(path).map_err(|_e| {
-        let path = path.display().to_string();
-        SolanaRpcError::FailedToReadKeypairError(path)
-    })?;
-    let bytes = keypair.to_bytes();
-    Ok(Keypair::try_from(&bytes)?)
+    let keypair = read_keypair_file(path)
+        .map_err(|_err| SolanaRpcError::FailedToReadKeypairError(path.display().to_string()))?;
+    Ok(keypair.into())
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -8,7 +8,7 @@ pub use helium_lib::{
     error,
     keypair::{Keypair, Pubkey, Signature},
 };
-pub use solana_sdk::transaction::Transaction as SolanaTransaction;
+pub use solana_sdk::transaction::VersionedTransaction as SolanaTransaction;
 
 #[derive(serde::Serialize)]
 pub struct Transaction {

--- a/solana/src/sender.rs
+++ b/solana/src/sender.rs
@@ -287,7 +287,7 @@ mod tests {
         let mut inner = solana_sdk::transaction::Transaction::default();
         inner.signatures.push(Signature::new_unique());
         Transaction {
-            inner,
+            inner: inner.into(),
             sent_block_height: 1,
         }
     }

--- a/solana/src/start_boost.rs
+++ b/solana/src/start_boost.rs
@@ -63,11 +63,7 @@ pub struct SolanaRpc {
 
 impl SolanaRpc {
     pub async fn new(settings: &Settings) -> Result<Arc<Self>, SolanaRpcError> {
-        let Ok(keypair) = read_keypair_from_file(&settings.start_authority_keypair) else {
-            return Err(SolanaRpcError::FailedToReadKeypairError(
-                settings.start_authority_keypair.to_owned(),
-            ));
-        };
+        let keypair = read_keypair_from_file(&settings.start_authority_keypair)?;
         let provider = client::SolanaRpcClient::new_with_commitment(
             settings.rpc_url.clone(),
             CommitmentConfig::finalized(),


### PR DESCRIPTION
`helium-lib` PR :: https://github.com/helium/helium-wallet-rs/pull/457

router keys are normally ecc-compact keys, those cannot be turned into solana Pubkeys. But they can still be used to derive the escrow accounts from.

Updating helium-lib, it has moved from using a regular `solana::Transaction` to `solana::VersionedTransaction`.