### PR TITLE
Latest CI updates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,10 @@ jobs:
           key: ubuntu:20.04-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
-        run: cargo build
+        run: cargo build --all
+
+      - name: Build tests
+        run: cargo test --no-run
 
   fmt:
     runs-on: ubuntu-latest
@@ -186,7 +189,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -194,7 +197,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ubuntu:20.04-cargo-test-${{ matrix.package }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ubuntu:20.04-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build Test
         run: cargo test -p ${{ matrix.package }} --no-run

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,11 @@ on:
         description: "Release Version (e.g., 1.0.0)"
         required: false
         type: string
+      release_only:
+          description: "Release Only"
+          required: false
+          type: boolean
+          default: false
 env:
   CARGO_INCREMENTAL: 0 # this setting is automatically applied by rust-cache but documented here for explicitness
   CARGO_NET_RETRY: 10
@@ -28,6 +33,7 @@ jobs:
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}-fmt
       cancel-in-progress: true
+    if: github.event.inputs.release_only == false
     steps:
       - name: Install Dependencies
         run: |
@@ -56,6 +62,7 @@ jobs:
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}-clippy
       cancel-in-progress: true
+    if: github.event.inputs.release_only == false
     steps:
       - name: Install Dependencies
         run: |
@@ -86,6 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
+    if: github.event.inputs.release_only == false
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -108,7 +116,7 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     concurrency: 
-      group: ${{ github.workflow }}-${{ github.ref }}-tests-postgres-${{ matrix.package }}
+      group: ${{ github.workflow }}-${{ github.ref }}-tests-${{ matrix.package }}
       cancel-in-progress: true
     services:
       postgres:
@@ -122,6 +130,7 @@ jobs:
           --health-retries 5
         ports:
             - 5432:5432
+    if: github.event.inputs.release_only == false
     steps:
       - name: Install Dependencies
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -186,7 +186,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -194,7 +194,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ubuntu:20.04-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ubuntu:20.04-cargo-test-${{ matrix.package }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build Test
         run: cargo test -p ${{ matrix.package }} --no-run

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,14 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-fmt
       cancel-in-progress: true
     steps:
+      - name: Install Dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y tzdata curl build-essential pkg-config libssl-dev clang lld cmake unzip
+          ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+          dpkg-reconfigure -f noninteractive tzdata
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -48,6 +56,14 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-clippy
       cancel-in-progress: true
     steps:
+      - name: Install Dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y tzdata curl build-essential pkg-config libssl-dev clang lld cmake unzip
+          ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+          dpkg-reconfigure -f noninteractive tzdata
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: ["main"]
     tags: ["*"]
-  workflow_dispatch:  # Allows manual triggering
+  workflow_dispatch: # Allows manual triggering
     inputs:
       release_version:
         description: "Release Version (e.g., 1.0.0)"
@@ -20,6 +20,39 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
+    concurrency: 
+      group: ${{ github.workflow }}-${{ github.ref }}-build
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Rust install
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build
+        run: cargo build
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,10 +40,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@1.85.0
-        with:
-          components: rustfmt
+      - name: Setup rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Check formatting
         run: cargo fmt  -- --check
@@ -67,10 +65,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@1.85.0
-        with:
-          components: clippy
+      - name: Setup rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
       
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -133,7 +130,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Rust install
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -171,7 +168,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Rust install
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -220,7 +217,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Rust install
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,14 +29,6 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-fmt
       cancel-in-progress: true
     steps:
-      - name: Install Dependencies
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get update
-          apt-get install -y tzdata curl build-essential pkg-config libssl-dev clang lld cmake unzip
-          ln -fs /usr/share/zoneinfo/UTC /etc/localtime
-          dpkg-reconfigure -f noninteractive tzdata
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -56,14 +48,6 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-clippy
       cancel-in-progress: true
     steps:
-      - name: Install Dependencies
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get update
-          apt-get install -y tzdata curl build-essential pkg-config libssl-dev clang lld cmake unzip
-          ln -fs /usr/share/zoneinfo/UTC /etc/localtime
-          dpkg-reconfigure -f noninteractive tzdata
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -153,7 +137,7 @@ jobs:
     container:
       image: ubuntu:20.04
     concurrency: 
-      group: ${{ github.workflow }}-${{ github.ref }}-build
+      group: ${{ github.workflow }}-${{ github.ref }}-build-release
       cancel-in-progress: true
     if: > 
       (github.event_name == 'workflow_dispatch' && github.event.inputs.release_version != '') ||

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -216,9 +216,11 @@ jobs:
           ln -fs /usr/share/zoneinfo/UTC /etc/localtime
           dpkg-reconfigure -f noninteractive tzdata
 
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Rust install
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,51 +21,6 @@ env:
 
 jobs:
 
-  build:
-    runs-on: ubuntu-latest
-    container:
-      image: ubuntu:20.04
-    concurrency: 
-      group: ${{ github.workflow }}-${{ github.ref }}-build
-      cancel-in-progress: true
-    steps:
-      - name: Install Dependencies
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get update
-          apt-get install -y tzdata
-          ln -fs /usr/share/zoneinfo/UTC /etc/localtime
-          dpkg-reconfigure -f noninteractive tzdata
-          apt-get install -y curl build-essential pkg-config libssl-dev clang lld cmake unzip
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ubuntu:20.04-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Build
-        run: cargo build --all
-
-      - name: Build tests
-        run: cargo test --no-run
-
   fmt:
     runs-on: ubuntu-latest
     container:
@@ -188,17 +143,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ubuntu:20.04-cargo-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Build Test
         run: cargo test -p ${{ matrix.package }} --no-run
 
@@ -208,12 +152,57 @@ jobs:
         run: cargo test -p ${{ matrix.package }}  -- --include-ignored
 
   build-release:
-    needs: [build, fmt, clippy, tests]
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
+    concurrency: 
+      group: ${{ github.workflow }}-${{ github.ref }}-build
+      cancel-in-progress: true
+    if: > 
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.release_version != '') ||
+      (contains(github.ref, 'refs/tags/'))
+    steps:
+      - name: Install Dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y tzdata
+          ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+          dpkg-reconfigure -f noninteractive tzdata
+          apt-get install -y curl build-essential pkg-config libssl-dev clang lld cmake unzip
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Rust install
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ubuntu:20.04-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build Release
+        run: cargo build --all --release
+
+  upload-release:
+    needs: [build-release, fmt, clippy, tests]
     runs-on: ubuntu-latest
     container:
       image: ubuntu:20.04
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-build-release
+      group: ${{ github.workflow }}-${{ github.ref }}-upload-release
       cancel-in-progress: true
     if: > 
       (github.event_name == 'workflow_dispatch' && github.event.inputs.release_version != '') ||

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -191,7 +191,7 @@ jobs:
         run: cargo test -p ${{ matrix.package }}  -- --include-ignored
 
   build-release:
-    needs: [fmt, clippy, tests]
+    needs: [build, fmt, clippy, tests]
     runs-on: ubuntu-latest
     container:
       image: ubuntu:20.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -185,6 +185,17 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ubuntu:20.04-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Build Test
         run: cargo test -p ${{ matrix.package }} --no-run
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ on:
     inputs:
       release_version:
         description: "Release Version (e.g., 1.0.0)"
-        required: true
+        required: false
         type: string
 env:
   CARGO_INCREMENTAL: 0 # this setting is automatically applied by rust-cache but documented here for explicitness
@@ -20,54 +20,24 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    concurrency: 
-      group: ${{ github.workflow }}-${{ github.ref }}-build
-      cancel-in-progress: true
-    steps:
-      - name: Free Up Disk Space
-        run: |
-          echo "Freeing up disk space..."
-          echo "Disk space before cleanup:"
-          df -h
-          sudo apt-get clean
-          sudo rm -rf /usr/local/lib/android /usr/lib/jvm /usr/local/share/boost /opt/hostedtoolcache
-          docker system prune -a -f
-          echo "Disk space after cleanup:"
-          df -h
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Build
-        run: cargo build --all --tests 
 
   fmt:
     runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}-fmt
       cancel-in-progress: true
     steps:
+      - name: Install Dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y tzdata
+          ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+          dpkg-reconfigure -f noninteractive tzdata
+          apt-get install -y curl build-essential pkg-config libssl-dev clang lld cmake unzip
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -81,10 +51,21 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}-clippy
       cancel-in-progress: true
     steps:
+      - name: Install Dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y tzdata
+          ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+          dpkg-reconfigure -f noninteractive tzdata
+          apt-get install -y curl build-essential pkg-config libssl-dev clang lld cmake unzip
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -101,13 +82,31 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets -- -Dclippy::all -D warnings
 
-  tests-postgres:
-    needs: build
+  generate-matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Extract Cargo Workspace Members
+        id: get-matrix
+        run: |
+          MATRIX=$(cargo metadata --format-version=1 | jq -c '[.workspace_members[] | split("#")[0] | split("/") | last | gsub("_"; "-") | select(. != "metrics")]')
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo $MATRIX | jq
+        shell: bash
+
+  tests:
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
     strategy:
       fail-fast: false
       matrix:
-        package: [boost-manager,file-store,iot-config,iot-packet-verifier,iot-verifier,mobile-config,mobile-packet-verifier,mobile-verifier]
+        package: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}-tests-postgres-${{ matrix.package }}
       cancel-in-progress: true
@@ -124,6 +123,15 @@ jobs:
         ports:
             - 5432:5432
     steps:
+      - name: Install Dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y tzdata
+          ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+          dpkg-reconfigure -f noninteractive tzdata
+          apt-get install -y curl build-essential pkg-config libssl-dev clang lld cmake unzip
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -134,61 +142,14 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run unit and integration tests
         env:
-          DATABASE_URL: "postgres://postgres:postgres@localhost:5432/postgres"
-        run: cargo test -p ${{ matrix.package }}  -- --include-ignored
-  
-  tests:
-    needs: build
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        package: [coverage-map,coverage-point-calculator,ingest,reward-scheduler,task-manager]
-    concurrency: 
-      group: ${{ github.workflow }}-${{ github.ref }}-tests-${{ matrix.package }}
-      cancel-in-progress: true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Run unit and integration tests
+          DATABASE_URL: "postgres://postgres:postgres@postgres:5432/postgres"
         run: cargo test -p ${{ matrix.package }}  -- --include-ignored
 
   build-release:
-    needs: [fmt, clippy, tests, tests-postgres]
+    needs: [fmt, clippy, tests]
     runs-on: ubuntu-latest
     container:
       image: ubuntu:20.04
@@ -196,7 +157,8 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-build-release
       cancel-in-progress: true
     if: > 
-      (github.event_name == 'workflow_dispatch') || (contains(github.ref, 'refs/tags/'))
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.release_version != '') ||
+      (contains(github.ref, 'refs/tags/'))
     steps:
       - name: Show Inputs
         run: |
@@ -209,7 +171,7 @@ jobs:
           apt-get install -y tzdata
           ln -fs /usr/share/zoneinfo/UTC /etc/localtime
           dpkg-reconfigure -f noninteractive tzdata
-          apt-get install -y curl build-essential pkg-config libssl-dev unzip
+          apt-get install -y curl build-essential pkg-config libssl-dev clang lld cmake unzip
 
       - uses: actions/checkout@v4
 
@@ -219,18 +181,6 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      # TODO: update key when we retire 20.04
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ubuntu-20.04-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build Release
         run: cargo build --all --release

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,7 +68,6 @@ jobs:
       - name: Setup rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,15 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-build
       cancel-in-progress: true
     steps:
+      - name: Install Dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y tzdata
+          ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+          dpkg-reconfigure -f noninteractive tzdata
+          apt-get install -y curl build-essential pkg-config libssl-dev clang lld cmake unzip
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,10 +33,9 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -y tzdata
+          apt-get install -y tzdata curl build-essential pkg-config libssl-dev clang lld cmake unzip
           ln -fs /usr/share/zoneinfo/UTC /etc/localtime
           dpkg-reconfigure -f noninteractive tzdata
-          apt-get install -y curl build-essential pkg-config libssl-dev clang lld cmake unzip
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,10 +60,9 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -y tzdata
+          apt-get install -y tzdata curl build-essential pkg-config libssl-dev clang lld cmake unzip
           ln -fs /usr/share/zoneinfo/UTC /etc/localtime
           dpkg-reconfigure -f noninteractive tzdata
-          apt-get install -y curl build-essential pkg-config libssl-dev clang lld cmake unzip
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -127,10 +125,9 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -y tzdata
+          apt-get install -y tzdata curl build-essential pkg-config libssl-dev clang lld cmake unzip
           ln -fs /usr/share/zoneinfo/UTC /etc/localtime
           dpkg-reconfigure -f noninteractive tzdata
-          apt-get install -y curl build-essential pkg-config libssl-dev clang lld cmake unzip
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -166,10 +163,9 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -y tzdata
+          apt-get install -y tzdata curl build-essential pkg-config libssl-dev clang lld cmake unzip
           ln -fs /usr/share/zoneinfo/UTC /etc/localtime
           dpkg-reconfigure -f noninteractive tzdata
-          apt-get install -y curl build-essential pkg-config libssl-dev clang lld cmake unzip
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -216,10 +212,9 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -y tzdata
+          apt-get install -y tzdata curl build-essential pkg-config libssl-dev clang lld cmake unzip
           ln -fs /usr/share/zoneinfo/UTC /etc/localtime
           dpkg-reconfigure -f noninteractive tzdata
-          apt-get install -y curl build-essential pkg-config libssl-dev clang lld cmake unzip
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Rust install
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           components: rustfmt
 
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Rust install
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           components: clippy
       
@@ -133,7 +133,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Rust install
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -171,7 +171,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Rust install
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -220,7 +220,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Rust install
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,7 +58,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ubuntu:20.04-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
         run: cargo build
@@ -185,6 +185,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build Test
+        run: cargo test -p ${{ matrix.package }} --no-run
+
       - name: Run unit and integration tests
         env:
           DATABASE_URL: "postgres://postgres:postgres@postgres:5432/postgres"
@@ -223,6 +226,17 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ubuntu:20.04-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build Release
         run: cargo build --all --release

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,11 +12,6 @@ on:
         description: "Release Version (e.g., 1.0.0)"
         required: false
         type: string
-      release_only:
-          description: "Release Only"
-          required: false
-          type: boolean
-          default: false
 env:
   CARGO_INCREMENTAL: 0 # this setting is automatically applied by rust-cache but documented here for explicitness
   CARGO_NET_RETRY: 10
@@ -33,7 +28,6 @@ jobs:
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}-fmt
       cancel-in-progress: true
-    if: github.event.inputs.release_only == false
     steps:
       - name: Install Dependencies
         run: |
@@ -62,7 +56,6 @@ jobs:
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}-clippy
       cancel-in-progress: true
-    if: github.event.inputs.release_only == false
     steps:
       - name: Install Dependencies
         run: |
@@ -93,7 +86,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
-    if: github.event.inputs.release_only == false
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -130,7 +122,6 @@ jobs:
           --health-retries 5
         ports:
             - 5432:5432
-    if: github.event.inputs.release_only == false
     steps:
       - name: Install Dependencies
         run: |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
- Do not require `release_version` for manual trigger. The  release job will check for that or skip if left empty.
- Everything now runs in a container `ubuntu:20.04`, this makes runs more consistent.
- Tests are now run on a matrix generated prior based on `cargo metadata` so that new added tests or packages are not left out.
- Caching is now only for release as it seems to be faster to run test in a matrix individually without waisting 1min to pull cache. When releasing, a job to build the release will start right away and the upload job will wait for `[build-release, fmt, clippy, tests]`  to be completed.

Notes:
- I soon as we move away from `ubuntu:20.04` we should be able to remove the `Install Dependencies` step, saving us around 30s on every job.
- Cache is hardcoded to `ubuntu:20.04` for the moment.