### PR TITLE
Update Reward Indexer to use TaskManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6577,6 +6577,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "sqlx",
+ "task-manager",
  "thiserror",
  "tokio",
  "tonic",

--- a/reward_index/Cargo.toml
+++ b/reward_index/Cargo.toml
@@ -24,9 +24,6 @@ futures = { workspace = true }
 futures-util = { workspace = true }
 prost = { workspace = true }
 once_cell = { workspace = true }
-file-store = { path = "../file_store" }
-db-store = { path = "../db_store" }
-poc-metrics = { path = "../metrics" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -41,4 +38,9 @@ tonic = { workspace = true }
 rand = { workspace = true }
 async-trait = { workspace = true }
 humantime-serde = { workspace = true }
+
 custom-tracing = { path = "../custom_tracing" }
+db-store = { path = "../db_store" }
+file-store = { path = "../file_store" }
+poc-metrics = { path = "../metrics" }
+task-manager = { path = "../task_manager" }

--- a/reward_index/pkg/settings-template.toml
+++ b/reward_index/pkg/settings-template.toml
@@ -8,7 +8,16 @@
 # interval = "15 minutes"
 
 # Mode to operate the indexer in. "iot" or "mobile"
+#
 mode = "iot"
+
+# Operation Fund key is required when mode = "iot"
+#
+operation_fund_key = "iot-operation-fund-key"
+
+# Unallocated reward entity key is always required
+#
+unallocated_reward_entity_key = "unallocated-reward-entity-key"
 
 #
 [database]
@@ -36,23 +45,6 @@ max_connections = 10
 # Name of bucket to access verified data. Required
 #
 bucket = "mainnet-verified-bucket"
-
-# Region for bucket. Defaults to below
-#
-# region = "us-west-2"
-
-# Optional URL for AWS api endpoint. Inferred from aws config settings or aws
-# IAM context by default
-#
-# endpoint = "https://aws-s3-bucket.aws.com"
-
-
-[output]
-# Output bucket for indexed reward details
-
-# Name of bucket to write details to. Required
-#
-bucket = "mainnet-mobile-index-bucket"
 
 # Region for bucket. Defaults to below
 #


### PR DESCRIPTION
- use TaskManager for Server
- impl ManagedTask for Indexer
- Create and use single FileStore
- make `unallocated_reward_entity_key` required setting
- format `tokio::select!`
- restructure Settings and settings-template.toml to match
- Update Settings Environment override with more applicable prefix and separator

The Environment separator needs to be a `__` (double underscore) so settings with underscores parse correctly.

With a separator of `_` (single underscore)
`RI_operation_fund_key=fund_key` will parse to `operation.fund.key = "fund_key"`

With a separation of `__` (double underscore)
`RI__operation_fund_key` will parse to `operation_fund_key = "fund_key"`