### PR TITLE
file store qol

### DIFF
--- a/boost_manager/src/main.rs
+++ b/boost_manager/src/main.rs
@@ -7,7 +7,6 @@ use clap::Parser;
 use file_store::{
     file_info_poller::LookbackBehavior,
     file_source, file_upload,
-    reward_manifest::RewardManifest,
     traits::{FileSinkCommitStrategy, FileSinkRollTime, FileSinkWriteExt},
     FileStore, FileType,
 };
@@ -91,16 +90,15 @@ impl Server {
 
         // setup the received for the rewards manifest files
         let file_store = FileStore::from_settings(&settings.verifier).await?;
-        let (manifest_receiver, manifest_server) =
-            file_source::continuous_source::<RewardManifest, _>()
-                .state(pool.clone())
-                .store(file_store)
-                .prefix(FileType::RewardManifest.to_string())
-                .lookback(LookbackBehavior::StartAfter(settings.start_after))
-                .poll_duration(reward_check_interval)
-                .offset(reward_check_interval * 2)
-                .create()
-                .await?;
+        let (manifest_receiver, manifest_server) = file_source::continuous_source()
+            .state(pool.clone())
+            .store(file_store)
+            .prefix(FileType::RewardManifest.to_string())
+            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .poll_duration(reward_check_interval)
+            .offset(reward_check_interval * 2)
+            .create()
+            .await?;
 
         // setup the writer for our updated hexes
         let (updated_hexes_sink, updated_hexes_sink_server) = BoostedHexUpdateV1::file_sink(

--- a/file_store/src/file_info_poller.rs
+++ b/file_store/src/file_info_poller.rs
@@ -5,6 +5,7 @@ use derive_builder::Builder;
 use futures::{future::LocalBoxFuture, stream::BoxStream, StreamExt};
 use futures_util::TryFutureExt;
 use retainer::Cache;
+use sqlx::PgPool;
 use std::{collections::VecDeque, marker::PhantomData, sync::Arc, time::Duration};
 use task_manager::ManagedTask;
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -122,7 +123,12 @@ pub struct FileInfoPollerConfig<Message, State, Store, Parser> {
 }
 
 #[derive(Clone)]
-pub struct FileInfoPollerServer<Message, State, Store, Parser> {
+pub struct FileInfoPollerServer<
+    Message,
+    State = PgPool,
+    Store = FileStore,
+    Parser = MsgDecodeFileInfoPollerParser,
+> {
     config: FileInfoPollerConfig<Message, State, Store, Parser>,
     sender: Sender<FileInfoStream<Message>>,
     file_queue: VecDeque<FileInfo>,

--- a/file_store/src/file_sink.rs
+++ b/file_store/src/file_sink.rs
@@ -170,13 +170,13 @@ impl<T> FileSinkClient<T> {
 
     pub async fn write(
         &self,
-        item: T,
+        item: impl Into<T>,
         labels: impl IntoIterator<Item = &(&'static str, &'static str)>,
     ) -> Result<oneshot::Receiver<Result>> {
         let (on_write_tx, on_write_rx) = oneshot::channel();
         let labels = labels.into_iter().map(Label::from);
         tokio::select! {
-            result = self.sender.send_timeout(Message::Data(on_write_tx, item), SEND_TIMEOUT) => match result {
+            result = self.sender.send_timeout(Message::Data(on_write_tx, item.into()), SEND_TIMEOUT) => match result {
                 Ok(_) => {
                     metrics::counter!(
                         self.metric.clone(),

--- a/iot_packet_verifier/src/daemon.rs
+++ b/iot_packet_verifier/src/daemon.rs
@@ -162,14 +162,13 @@ impl Cmd {
 
         let file_store = FileStore::from_settings(&settings.ingest).await?;
 
-        let (report_files, report_files_server) =
-            file_source::continuous_source::<PacketRouterPacketReport, _>()
-                .state(pool.clone())
-                .store(file_store)
-                .lookback(LookbackBehavior::StartAfter(settings.start_after))
-                .prefix(FileType::IotPacketReport.to_string())
-                .create()
-                .await?;
+        let (report_files, report_files_server) = file_source::continuous_source()
+            .state(pool.clone())
+            .store(file_store)
+            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .prefix(FileType::IotPacketReport.to_string())
+            .create()
+            .await?;
 
         let balance_store = balances.balances();
         let verifier_daemon = Daemon {

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -168,17 +168,16 @@ impl Cmd {
 
         let file_store = FileStore::from_settings(&settings.ingest).await?;
 
-        let (reports, reports_server) =
-            file_source::continuous_source::<DataTransferSessionIngestReport, _>()
-                .state(pool.clone())
-                .store(file_store)
-                .lookback(LookbackBehavior::StartAfter(
-                    Utc.timestamp_millis_opt(0).unwrap(),
-                ))
-                .prefix(FileType::DataTransferSessionIngestReport.to_string())
-                .lookback(LookbackBehavior::StartAfter(settings.start_after))
-                .create()
-                .await?;
+        let (reports, reports_server) = file_source::continuous_source()
+            .state(pool.clone())
+            .store(file_store)
+            .lookback(LookbackBehavior::StartAfter(
+                Utc.timestamp_millis_opt(0).unwrap(),
+            ))
+            .prefix(FileType::DataTransferSessionIngestReport.to_string())
+            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .create()
+            .await?;
 
         let resolver = MobileConfigClients::new(&settings.config_client)?;
 

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -95,14 +95,13 @@ impl CoverageDaemon {
         )
         .await?;
 
-        let (coverage_objs, coverage_objs_server) =
-            file_source::continuous_source::<CoverageObjectIngestReport, _>()
-                .state(pool.clone())
-                .store(file_store)
-                .lookback(LookbackBehavior::StartAfter(settings.start_after))
-                .prefix(FileType::CoverageObjectIngestReport.to_string())
-                .create()
-                .await?;
+        let (coverage_objs, coverage_objs_server) = file_source::continuous_source()
+            .state(pool.clone())
+            .store(file_store)
+            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .prefix(FileType::CoverageObjectIngestReport.to_string())
+            .create()
+            .await?;
 
         // let hex_boost_data = boosting_oracles::make_hex_boost_data(settings, geofence)?;
         let coverage_daemon = CoverageDaemon::new(

--- a/mobile_verifier/src/data_session.rs
+++ b/mobile_verifier/src/data_session.rs
@@ -37,14 +37,13 @@ impl DataSessionIngestor {
     ) -> anyhow::Result<impl ManagedTask> {
         let data_transfer_ingest = FileStore::from_settings(&settings.data_transfer_ingest).await?;
         // data transfers
-        let (data_session_ingest, data_session_ingest_server) =
-            file_source::continuous_source::<ValidDataTransferSession, _>()
-                .state(pool.clone())
-                .store(data_transfer_ingest)
-                .lookback(LookbackBehavior::StartAfter(settings.start_after))
-                .prefix(FileType::ValidDataTransferSession.to_string())
-                .create()
-                .await?;
+        let (data_session_ingest, data_session_ingest_server) = file_source::continuous_source()
+            .state(pool.clone())
+            .store(data_transfer_ingest)
+            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .prefix(FileType::ValidDataTransferSession.to_string())
+            .create()
+            .await?;
 
         let data_session_ingestor = DataSessionIngestor::new(pool.clone(), data_session_ingest);
 

--- a/mobile_verifier/src/heartbeats/cbrs.rs
+++ b/mobile_verifier/src/heartbeats/cbrs.rs
@@ -52,15 +52,14 @@ where
         geofence: GFV,
     ) -> anyhow::Result<impl ManagedTask> {
         // CBRS Heartbeats
-        let (cbrs_heartbeats, cbrs_heartbeats_server) =
-            file_source::continuous_source::<CbrsHeartbeatIngestReport, _>()
-                .state(pool.clone())
-                .store(file_store)
-                .lookback(LookbackBehavior::StartAfter(settings.start_after))
-                .prefix(FileType::CbrsHeartbeatIngestReport.to_string())
-                .queue_size(1)
-                .create()
-                .await?;
+        let (cbrs_heartbeats, cbrs_heartbeats_server) = file_source::continuous_source()
+            .state(pool.clone())
+            .store(file_store)
+            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .prefix(FileType::CbrsHeartbeatIngestReport.to_string())
+            .queue_size(1)
+            .create()
+            .await?;
 
         let cbrs_heartbeat_daemon = CbrsHeartbeatDaemon::new(
             pool,

--- a/mobile_verifier/src/heartbeats/wifi.rs
+++ b/mobile_verifier/src/heartbeats/wifi.rs
@@ -50,14 +50,13 @@ where
         geofence: GFV,
     ) -> anyhow::Result<impl ManagedTask> {
         // Wifi Heartbeats
-        let (wifi_heartbeats, wifi_heartbeats_server) =
-            file_source::continuous_source::<WifiHeartbeatIngestReport, _>()
-                .state(pool.clone())
-                .store(file_store)
-                .lookback(LookbackBehavior::StartAfter(settings.start_after))
-                .prefix(FileType::WifiHeartbeatIngestReport.to_string())
-                .create()
-                .await?;
+        let (wifi_heartbeats, wifi_heartbeats_server) = file_source::continuous_source()
+            .state(pool.clone())
+            .store(file_store)
+            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .prefix(FileType::WifiHeartbeatIngestReport.to_string())
+            .create()
+            .await?;
 
         let wifi_heartbeat_daemon = WifiHeartbeatDaemon::new(
             pool,

--- a/mobile_verifier/src/radio_threshold.rs
+++ b/mobile_verifier/src/radio_threshold.rs
@@ -90,7 +90,7 @@ where
             .await?;
 
         let (radio_threshold_ingest, radio_threshold_ingest_server) =
-            file_source::continuous_source::<RadioThresholdIngestReport, _>()
+            file_source::continuous_source()
                 .state(pool.clone())
                 .store(file_store.clone())
                 .lookback(LookbackBehavior::StartAfter(settings.start_after))
@@ -100,7 +100,7 @@ where
 
         // invalidated radio threshold reports
         let (invalidated_radio_threshold_ingest, invalidated_radio_threshold_ingest_server) =
-            file_source::continuous_source::<InvalidatedRadioThresholdIngestReport, _>()
+            file_source::continuous_source()
                 .state(pool.clone())
                 .store(file_store.clone())
                 .lookback(LookbackBehavior::StartAfter(settings.start_after))

--- a/mobile_verifier/src/sp_boosted_rewards_bans.rs
+++ b/mobile_verifier/src/sp_boosted_rewards_bans.rs
@@ -168,19 +168,14 @@ where
             )
             .await?;
 
-        let (receiver, ingest_server) = FileInfoPollerConfigBuilder::<
-            ServiceProviderBoostedRewardsBannedRadioIngestReportV1,
-            _,
-            _,
-            _,
-        >::default()
-        .parser(ProstFileInfoPollerParser)
-        .state(pool.clone())
-        .store(file_store)
-        .lookback(LookbackBehavior::StartAfter(settings.start_after))
-        .prefix(FileType::SPBoostedRewardsBannedRadioIngestReport.to_string())
-        .create()
-        .await?;
+        let (receiver, ingest_server) = FileInfoPollerConfigBuilder::default()
+            .parser(ProstFileInfoPollerParser)
+            .state(pool.clone())
+            .store(file_store)
+            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .prefix(FileType::SPBoostedRewardsBannedRadioIngestReport.to_string())
+            .create()
+            .await?;
 
         let ingestor = Self {
             pool,

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -83,14 +83,13 @@ where
         )
         .await?;
 
-        let (speedtests, speedtests_server) =
-            file_source::continuous_source::<CellSpeedtestIngestReport, _>()
-                .state(pool.clone())
-                .store(file_store)
-                .lookback(LookbackBehavior::StartAfter(settings.start_after))
-                .prefix(FileType::CellSpeedtestIngestReport.to_string())
-                .create()
-                .await?;
+        let (speedtests, speedtests_server) = file_source::continuous_source()
+            .state(pool.clone())
+            .store(file_store)
+            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .prefix(FileType::CellSpeedtestIngestReport.to_string())
+            .create()
+            .await?;
 
         let speedtest_daemon = SpeedtestDaemon::new(
             pool.clone(),

--- a/mobile_verifier/src/subscriber_location.rs
+++ b/mobile_verifier/src/subscriber_location.rs
@@ -64,7 +64,7 @@ where
             .await?;
 
         let (subscriber_location_ingest, subscriber_location_ingest_server) =
-            file_source::continuous_source::<SubscriberLocationIngestReport, _>()
+            file_source::continuous_source()
                 .state(pool.clone())
                 .store(file_store.clone())
                 .lookback(LookbackBehavior::StartAfter(settings.start_after))

--- a/mobile_verifier/src/subscriber_verified_mapping_event.rs
+++ b/mobile_verifier/src/subscriber_verified_mapping_event.rs
@@ -65,14 +65,13 @@ where
         file_store: FileStore,
         file_upload: FileUpload,
     ) -> anyhow::Result<impl ManagedTask> {
-        let (reports_receiver, reports_receiver_server) =
-            file_source::continuous_source::<SubscriberVerifiedMappingEventIngestReport, _>()
-                .state(pool.clone())
-                .store(file_store)
-                .lookback(LookbackBehavior::StartAfter(settings.start_after))
-                .prefix(FileType::SubscriberVerifiedMappingEventIngestReport.to_string())
-                .create()
-                .await?;
+        let (reports_receiver, reports_receiver_server) = file_source::continuous_source()
+            .state(pool.clone())
+            .store(file_store)
+            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .prefix(FileType::SubscriberVerifiedMappingEventIngestReport.to_string())
+            .create()
+            .await?;
 
         let (verified_report_sink, verified_report_sink_server) =
             VerifiedSubscriberVerifiedMappingEventIngestReportV1::file_sink(

--- a/mobile_verifier/src/unique_connections/ingestor.rs
+++ b/mobile_verifier/src/unique_connections/ingestor.rs
@@ -73,7 +73,7 @@ where
             .await?;
 
         let (unique_connections_ingest, unique_connections_server) =
-            file_source::Continuous::msg_source::<UniqueConnectionsIngestReport, _>()
+            file_source::continuous_source()
                 .state(pool.clone())
                 .store(file_store.clone())
                 .lookback(LookbackBehavior::StartAfter(settings.start_after))

--- a/mobile_verifier/src/unique_connections/ingestor.rs
+++ b/mobile_verifier/src/unique_connections/ingestor.rs
@@ -156,7 +156,7 @@ where
 
             self.verified_unique_connections_sink
                 .write(
-                    verified_report_proto.into(),
+                    verified_report_proto,
                     &[("report_status", verified_report_status.as_str_name())],
                 )
                 .await?;

--- a/reward_index/src/main.rs
+++ b/reward_index/src/main.rs
@@ -1,9 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
-use file_store::{
-    file_info_poller::LookbackBehavior, file_source, reward_manifest::RewardManifest, FileStore,
-    FileType,
-};
+use file_store::{file_info_poller::LookbackBehavior, file_source, FileStore, FileType};
 use reward_index::{settings::Settings, telemetry, Indexer};
 use std::path::PathBuf;
 use task_manager::TaskManager;
@@ -59,7 +56,7 @@ impl Server {
         telemetry::initialize(&pool).await?;
 
         let file_store = FileStore::from_settings(&settings.verifier).await?;
-        let (receiver, server) = file_source::continuous_source::<RewardManifest, _>()
+        let (receiver, server) = file_source::continuous_source()
             .state(pool.clone())
             .store(file_store.clone())
             .prefix(FileType::RewardManifest.to_string())


### PR DESCRIPTION
Providing defaults for `FileInfoPollerServer` to the most used types allows us to cleanup a lot of the generic code around `continuous_source()`.
```rs
pub struct FileInfoPollerServer<
    Message,
    State = PgPool,
    Store = FileStore,
    Parser = MsgDecodeFileInfoPollerParser,
>
```