### PR TITLE
Return error in `average_distance` and `multiplier` functions instead of panic

### DIFF
--- a/coverage_point_calculator/src/location.rs
+++ b/coverage_point_calculator/src/location.rs
@@ -59,6 +59,16 @@ mod tests {
     use super::*;
 
     #[test]
+    fn average_distance_should_not_panic() {
+        average_distance(&[]);
+    }
+
+    #[test]
+    fn multiplier_should_not_panic() {
+        multiplier(&[]);
+    }
+
+    #[test]
     fn distance_does_not_effect_multiplier() {
         let trust_scores = vec![
             LocationTrust {

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -757,11 +757,17 @@ fn eligible_for_coverage_map(
         return false;
     }
 
-    let multiplier = coverage_point_calculator::location::multiplier(trust_scores);
-    if multiplier <= dec!(0.0) {
-        return false;
+    match coverage_point_calculator::location::multiplier(trust_scores) {
+        Ok(multiplier) => {
+            if multiplier <= dec!(0.0) {
+                return false;
+            }
+        }
+        Err(e) => {
+            tracing::error!(?e, "multiplier calculation failed");
+            return false;
+        }
     }
-
     true
 }
 


### PR DESCRIPTION
Return error in `average_distance` and `multiplier` functions instead of panic