### PR TITLE
name rewards_info helpers and use static values

### DIFF
--- a/iot_verifier/src/reward_share.rs
+++ b/iot_verifier/src/reward_share.rs
@@ -465,14 +465,28 @@ mod test {
         (value / (*DC_USD_PRICE)).round_dp_with_strategy(0, RoundingStrategy::ToNegativeInfinity)
     }
 
-    fn default_rewards_info(total_emissions: u64, epoch_duration: Duration) -> EpochRewardInfo {
+    fn rewards_info_1_hour() -> EpochRewardInfo {
         let now = Utc::now();
+        let epoch_duration = Duration::hours(1);
         EpochRewardInfo {
             epoch_day: 1,
             epoch_address: EPOCH_ADDRESS.into(),
             sub_dao_address: SUB_DAO_ADDRESS.into(),
             epoch_period: (now - epoch_duration)..now,
-            epoch_emissions: Decimal::from(total_emissions),
+            epoch_emissions: dec!(100_000_000_000_000),
+            rewards_issued_at: now,
+        }
+    }
+
+    fn rewards_info_10_minutes() -> EpochRewardInfo {
+        let now = Utc::now();
+        let epoch_duration = Duration::minutes(10);
+        EpochRewardInfo {
+            epoch_day: 1,
+            epoch_address: EPOCH_ADDRESS.into(),
+            sub_dao_address: SUB_DAO_ADDRESS.into(),
+            epoch_period: (now - epoch_duration)..now,
+            epoch_emissions: Decimal::from(EMISSIONS_POOL_IN_BONES_10_MINUTES),
             rewards_issued_at: now,
         }
     }
@@ -486,7 +500,7 @@ mod test {
     #[test]
     fn test_poc_scheduled_tokens() {
         // set our rewards info
-        let rewards_info = default_rewards_info(100_000_000_000_000, Duration::hours(1));
+        let rewards_info = rewards_info_1_hour();
         let (beacon_v, witness_v) = get_scheduled_poc_tokens(rewards_info.epoch_emissions, dec!(0));
         assert_eq!(dec!(6_000_000_000_000), beacon_v);
         assert_eq!(dec!(24_000_000_000_000), witness_v);
@@ -495,7 +509,7 @@ mod test {
     #[test]
     fn test_poc_scheduled_tokens_with_dc_remainder() {
         // set our rewards info
-        let rewards_info = default_rewards_info(100_000_000_000_000, Duration::hours(1));
+        let rewards_info = rewards_info_1_hour();
         let (beacon_v, witness_v) =
             get_scheduled_poc_tokens(rewards_info.epoch_emissions, dec!(1_000_000_000_000));
         assert_eq!(dec!(6_200_000_000_000), beacon_v);
@@ -505,7 +519,7 @@ mod test {
     #[test]
     fn test_op_fund_scheduled_tokens() {
         // set our rewards info
-        let rewards_info = default_rewards_info(100_000_000_000_000, Duration::hours(1));
+        let rewards_info = rewards_info_1_hour();
         let v = get_scheduled_ops_fund_tokens(rewards_info.epoch_emissions);
         assert_eq!(dec!(7_000_000_000_000), v);
     }
@@ -513,7 +527,7 @@ mod test {
     #[test]
     fn test_oracles_scheduled_tokens() {
         // set our rewards info
-        let rewards_info = default_rewards_info(100_000_000_000_000, Duration::hours(1));
+        let rewards_info = rewards_info_1_hour();
         let v = get_scheduled_oracle_tokens(rewards_info.epoch_emissions);
         assert_eq!(dec!(7_000_000_000_000), v);
     }
@@ -559,8 +573,7 @@ mod test {
             .parse()
             .expect("failed gw6 parse");
 
-        let reward_info =
-            default_rewards_info(EMISSIONS_POOL_IN_BONES_10_MINUTES, Duration::minutes(10));
+        let reward_info = rewards_info_10_minutes();
         let total_data_transfer_tokens_for_period =
             get_scheduled_dc_tokens(reward_info.epoch_emissions);
         println!("total data transfer scheduled tokens: {total_data_transfer_tokens_for_period}");
@@ -774,8 +787,7 @@ mod test {
             .parse()
             .expect("failed gw6 parse");
 
-        let reward_info =
-            default_rewards_info(EMISSIONS_POOL_IN_BONES_10_MINUTES, Duration::minutes(10));
+        let reward_info = rewards_info_10_minutes();
         let total_data_transfer_tokens_for_period =
             get_scheduled_dc_tokens(reward_info.epoch_emissions);
         println!("total data transfer scheduled tokens: {total_data_transfer_tokens_for_period}");
@@ -974,8 +986,7 @@ mod test {
             .parse()
             .expect("failed gw6 parse");
 
-        let reward_info =
-            default_rewards_info(EMISSIONS_POOL_IN_BONES_10_MINUTES, Duration::minutes(10));
+        let reward_info = rewards_info_10_minutes();
         let total_data_transfer_tokens_for_period =
             get_scheduled_dc_tokens(reward_info.epoch_emissions);
         println!("total_data_transfer_tokens_for_period: {total_data_transfer_tokens_for_period}");

--- a/iot_verifier/tests/integrations/common/mod.rs
+++ b/iot_verifier/tests/integrations/common/mod.rs
@@ -40,14 +40,15 @@ pub const EPOCH_ADDRESS: &str = "112E7TxoNHV46M6tiPA8N1MkeMeQxc9ztb4JQLXBVAAUfq1
 pub const SUB_DAO_ADDRESS: &str = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6";
 pub const EMISSIONS_POOL_IN_BONES_24_HOURS: u64 = 89_041_095_890_411;
 
-pub fn default_rewards_info(total_emissions: u64, epoch_duration: Duration) -> EpochRewardInfo {
+pub fn rewards_info_24_hours() -> EpochRewardInfo {
     let now = Utc::now();
+    let epoch_duration = Duration::hours(24);
     EpochRewardInfo {
         epoch_day: 1,
         epoch_address: EPOCH_ADDRESS.into(),
         sub_dao_address: SUB_DAO_ADDRESS.into(),
         epoch_period: (now - epoch_duration)..now,
-        epoch_emissions: Decimal::from(total_emissions),
+        epoch_emissions: Decimal::from(EMISSIONS_POOL_IN_BONES_24_HOURS),
         rewards_issued_at: now,
     }
 }

--- a/iot_verifier/tests/integrations/rewarder_operations.rs
+++ b/iot_verifier/tests/integrations/rewarder_operations.rs
@@ -1,7 +1,4 @@
-use crate::common::{
-    self, default_rewards_info, MockFileSinkReceiver, EMISSIONS_POOL_IN_BONES_24_HOURS,
-};
-use chrono::Duration;
+use crate::common::{self, rewards_info_24_hours, MockFileSinkReceiver};
 use helium_proto::services::poc_lora::{IotRewardShare, OperationalReward};
 use iot_verifier::{reward_share, rewarder};
 use rust_decimal::{prelude::ToPrimitive, Decimal, RoundingStrategy};
@@ -11,7 +8,7 @@ use rust_decimal_macros::dec;
 async fn test_operations() -> anyhow::Result<()> {
     let (iot_rewards_client, mut iot_rewards) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = rewards_info_24_hours();
 
     let (_, rewards) = tokio::join!(
         rewarder::reward_operational(&iot_rewards_client, &reward_info),

--- a/iot_verifier/tests/integrations/rewarder_oracles.rs
+++ b/iot_verifier/tests/integrations/rewarder_oracles.rs
@@ -1,7 +1,4 @@
-use crate::common::{
-    self, default_rewards_info, MockFileSinkReceiver, EMISSIONS_POOL_IN_BONES_24_HOURS,
-};
-use chrono::Duration;
+use crate::common::{self, rewards_info_24_hours, MockFileSinkReceiver};
 use helium_proto::services::poc_lora::{IotRewardShare, UnallocatedReward};
 use iot_verifier::{reward_share, rewarder};
 use rust_decimal::{prelude::ToPrimitive, Decimal, RoundingStrategy};
@@ -12,7 +9,7 @@ use sqlx::PgPool;
 async fn test_oracles(_pool: PgPool) -> anyhow::Result<()> {
     let (iot_rewards_client, mut iot_rewards) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = rewards_info_24_hours();
 
     let (_, rewards) = tokio::join!(
         rewarder::reward_oracles(&iot_rewards_client, &reward_info),

--- a/iot_verifier/tests/integrations/rewarder_poc_dc.rs
+++ b/iot_verifier/tests/integrations/rewarder_poc_dc.rs
@@ -1,8 +1,5 @@
-use crate::common::{
-    self, default_price_info, default_rewards_info, MockFileSinkReceiver,
-    EMISSIONS_POOL_IN_BONES_24_HOURS,
-};
-use chrono::{DateTime, Duration as ChronoDuration, Duration, Utc};
+use crate::common::{self, default_price_info, rewards_info_24_hours, MockFileSinkReceiver};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_lora::{
     GatewayReward, IotRewardShare, UnallocatedReward, UnallocatedRewardType,
@@ -27,7 +24,7 @@ const HOTSPOT_4: &str = "11eX55faMbqZB7jzN4p67m6w7ScPMH6ubnvCjCPLh72J49PaJEL";
 async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
     let (iot_rewards_client, mut iot_rewards) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = rewards_info_24_hours();
 
     let price_info = default_price_info();
 

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -795,14 +795,28 @@ mod test {
         (hnt_value / DC_USD_PRICE).round_dp_with_strategy(0, RoundingStrategy::ToNegativeInfinity)
     }
 
-    fn default_rewards_info(total_emissions: u64, epoch_duration: Duration) -> EpochRewardInfo {
+    fn rewards_info_1_hour() -> EpochRewardInfo {
         let now = Utc::now();
+        let epoch_duration = Duration::hours(1);
         EpochRewardInfo {
             epoch_day: 1,
             epoch_address: EPOCH_ADDRESS.into(),
             sub_dao_address: SUB_DAO_ADDRESS.into(),
             epoch_period: (now - epoch_duration)..now,
-            epoch_emissions: Decimal::from(total_emissions),
+            epoch_emissions: Decimal::from(EMISSIONS_POOL_IN_BONES_1_HOUR),
+            rewards_issued_at: now,
+        }
+    }
+
+    fn rewards_info_24_hours() -> EpochRewardInfo {
+        let now = Utc::now();
+        let epoch_duration = Duration::hours(1);
+        EpochRewardInfo {
+            epoch_day: 1,
+            epoch_address: EPOCH_ADDRESS.into(),
+            sub_dao_address: SUB_DAO_ADDRESS.into(),
+            epoch_period: (now - epoch_duration)..now,
+            epoch_emissions: Decimal::from(EMISSIONS_POOL_IN_BONES_24_HOURS),
             rewards_issued_at: now,
         }
     }
@@ -813,30 +827,26 @@ mod test {
 
     #[test]
     fn test_poc_scheduled_tokens() {
-        let rewards_info = default_rewards_info(100_000_000_000_000, Duration::hours(1));
-        let v = get_scheduled_tokens_for_poc(rewards_info.epoch_emissions);
-        assert_eq!(dec!(60_000_000_000_000), v);
+        let v = get_scheduled_tokens_for_poc(dec!(100));
+        assert_eq!(dec!(60), v, "poc gets 60%");
     }
 
     #[test]
     fn test_mappers_scheduled_tokens() {
-        let rewards_info = default_rewards_info(100_000_000_000_000, Duration::hours(1));
-        let v = get_scheduled_tokens_for_mappers(rewards_info.epoch_emissions);
-        assert_eq!(dec!(20_000_000_000_000), v);
+        let v = get_scheduled_tokens_for_mappers(dec!(100));
+        assert_eq!(dec!(20), v, "mappers get 20%");
     }
 
     #[test]
     fn test_service_provider_scheduled_tokens() {
-        let rewards_info = default_rewards_info(100_000_000_000_000, Duration::hours(1));
-        let v = get_scheduled_tokens_for_service_providers(rewards_info.epoch_emissions);
-        assert_eq!(dec!(10_000_000_000_000), v);
+        let v = get_scheduled_tokens_for_service_providers(dec!(100));
+        assert_eq!(dec!(10), v, "service providers get 10%");
     }
 
     #[test]
     fn test_oracles_scheduled_tokens() {
-        let rewards_info = default_rewards_info(100_000_000_000_000, Duration::hours(1));
-        let v = get_scheduled_tokens_for_oracles(rewards_info.epoch_emissions);
-        assert_eq!(dec!(4_000_000_000_000), v);
+        let v = get_scheduled_tokens_for_oracles(dec!(100));
+        assert_eq!(dec!(4), v, "oracles get 4%");
     }
 
     #[test]
@@ -867,8 +877,7 @@ mod test {
         }
 
         // set our rewards info
-        let rewards_info =
-            default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+        let rewards_info = rewards_info_24_hours();
 
         // translate location shares into shares
         let shares = MapperShares::new(mapping_activity_shares);
@@ -947,7 +956,7 @@ mod test {
             },
         );
 
-        let rewards_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_1_HOUR, Duration::hours(1));
+        let rewards_info = rewards_info_1_hour();
 
         let total_rewards = get_scheduled_tokens_for_poc(rewards_info.epoch_emissions);
 
@@ -1012,8 +1021,7 @@ mod test {
                 .unwrap();
 
         // set our rewards info
-        let rewards_info =
-            default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+        let rewards_info = rewards_info_24_hours();
 
         let price_info = default_price_info();
         assert_eq!(price_info.price_per_token, dec!(100000000));
@@ -1213,8 +1221,7 @@ mod test {
 
         let speedtest_avgs = SpeedtestAverages { averages };
 
-        let rewards_info =
-            default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+        let rewards_info = rewards_info_24_hours();
 
         let reward_shares = new_poc_only(rewards_info.epoch_emissions);
 
@@ -1388,7 +1395,7 @@ mod test {
         // calculate the rewards for the sample group
         let mut owner_rewards = HashMap::<PublicKeyBinary, u64>::new();
 
-        let rewards_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_1_HOUR, Duration::hours(1));
+        let rewards_info = rewards_info_1_hour();
 
         let reward_shares = new_poc_only(rewards_info.epoch_emissions);
 
@@ -1533,7 +1540,7 @@ mod test {
         let mut owner_rewards = HashMap::<PublicKeyBinary, u64>::new();
         let duration = Duration::hours(1);
         let epoch = (now - duration)..now;
-        let rewards_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_1_HOUR, Duration::hours(1));
+        let rewards_info = rewards_info_1_hour();
 
         let reward_shares = new_poc_only(rewards_info.epoch_emissions);
         let unique_connection_counts = HashMap::from([(gw1.clone(), 42)]);
@@ -1591,7 +1598,7 @@ mod test {
         let now = Utc::now();
         // We should never see any radio shares from owner2, since all of them are
         // less than or equal to zero.
-        let rewards_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_1_HOUR, Duration::hours(1));
+        let rewards_info = rewards_info_1_hour();
 
         let uuid_1 = Uuid::new_v4();
         let uuid_2 = Uuid::new_v4();
@@ -1703,7 +1710,7 @@ mod test {
 
     #[tokio::test]
     async fn skip_empty_radio_rewards() {
-        let rewards_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_1_HOUR, Duration::hours(1));
+        let rewards_info = rewards_info_1_hour();
         let coverage_shares = CoverageShares {
             coverage_map: coverage_map::CoverageMapBuilder::default()
                 .build(&BoostedHexes::default(), rewards_info.epoch_period.start),
@@ -1722,7 +1729,7 @@ mod test {
 
         let sp1 = ServiceProvider::HeliumMobile;
 
-        let rewards_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_1_HOUR, Duration::hours(1));
+        let rewards_info = rewards_info_1_hour();
 
         let total_sp_rewards = service_provider::get_scheduled_tokens(rewards_info.epoch_emissions);
         let sp_reward_infos = ServiceProviderRewardInfos::new(
@@ -1762,7 +1769,7 @@ mod test {
         let hnt_bone_price = dec!(1.0);
         let sp1 = ServiceProvider::HeliumMobile;
 
-        let rewards_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_1_HOUR, Duration::hours(1));
+        let rewards_info = rewards_info_1_hour();
 
         let total_sp_rewards_in_bones = dec!(1_0000_0000);
         let total_rewards_value_in_dc = hnt_bones_to_dc(total_sp_rewards_in_bones, hnt_bone_price);
@@ -1809,7 +1816,7 @@ mod test {
         let hnt_bone_price = dec!(0.0001) / dec!(1_0000_0000);
         let sp1 = ServiceProvider::HeliumMobile;
 
-        let rewards_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_1_HOUR, Duration::hours(1));
+        let rewards_info = rewards_info_1_hour();
 
         let total_sp_rewards_in_bones = dec!(500_000_000) * dec!(1_0000_0000);
 
@@ -1853,8 +1860,7 @@ mod test {
         let hnt_bone_price = dec!(0.0001) / dec!(1_0000_0000);
         let sp1 = ServiceProvider::HeliumMobile;
 
-        let rewards_info =
-            default_rewards_info(EMISSIONS_POOL_IN_BONES_1_HOUR, Duration::hours(24));
+        let rewards_info = rewards_info_1_hour();
         let total_sp_rewards_in_bones = dec!(500_000_000) * dec!(1_0000_0000);
 
         let sp_reward_infos = ServiceProviderRewardInfos::new(

--- a/mobile_verifier/src/service_provider/reward.rs
+++ b/mobile_verifier/src/service_provider/reward.rs
@@ -278,21 +278,22 @@ mod tests {
     pub const EPOCH_ADDRESS: &str = "112E7TxoNHV46M6tiPA8N1MkeMeQxc9ztb4JQLXBVAAUfq1kJLoF";
     pub const SUB_DAO_ADDRESS: &str = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6";
 
-    pub fn default_rewards_info(total_emissions: u64, epoch_duration: Duration) -> EpochRewardInfo {
+    pub fn rewards_info_24_hours() -> EpochRewardInfo {
         let now = Utc::now();
+        let epoch_duration = Duration::hours(24);
         EpochRewardInfo {
             epoch_day: 1,
             epoch_address: EPOCH_ADDRESS.into(),
             sub_dao_address: SUB_DAO_ADDRESS.into(),
             epoch_period: (now - epoch_duration)..now,
-            epoch_emissions: Decimal::from(total_emissions),
+            epoch_emissions: dec!(82_191_780_821_917),
             rewards_issued_at: now,
         }
     }
 
     #[test]
     fn no_promotions() {
-        let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+        let reward_info = rewards_info_24_hours();
 
         let sp_infos = ServiceProviderRewardInfos::new(
             ServiceProviderDCSessions::from([(0, dec!(12)), (1, dec!(6))]),
@@ -315,7 +316,7 @@ mod tests {
 
     #[test]
     fn unallocated_reward_scaling_1() {
-        let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+        let reward_info = rewards_info_24_hours();
         let sp_infos = ServiceProviderRewardInfos::new(
             ServiceProviderDCSessions::from([(0, dec!(12)), (1, dec!(6))]),
             ServiceProviderPromotions::from(vec![
@@ -340,7 +341,7 @@ mod tests {
 
     #[test]
     fn unallocated_reward_scaling_2() {
-        let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+        let reward_info = rewards_info_24_hours();
         let sp_infos = ServiceProviderRewardInfos::new(
             ServiceProviderDCSessions::from([(0, dec!(12)), (1, dec!(6))]),
             ServiceProviderPromotions::from(vec![
@@ -381,7 +382,7 @@ mod tests {
 
     #[test]
     fn unallocated_reward_scaling_3() {
-        let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+        let reward_info = rewards_info_24_hours();
         let sp_infos = ServiceProviderRewardInfos::new(
             ServiceProviderDCSessions::from([(0, dec!(10)), (1, dec!(1000))]),
             ServiceProviderPromotions::from(vec![
@@ -406,7 +407,7 @@ mod tests {
 
     #[test]
     fn no_rewards_if_none_allocated() {
-        let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+        let reward_info = rewards_info_24_hours();
         let sp_infos = ServiceProviderRewardInfos::new(
             ServiceProviderDCSessions::from([(0, dec!(100))]),
             ServiceProviderPromotions::from(vec![make_test_promotion(0, "promo-0", 5000, 1)]),
@@ -420,7 +421,7 @@ mod tests {
 
     #[test]
     fn no_matched_rewards_if_no_unallocated() {
-        let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+        let reward_info = rewards_info_24_hours();
         let total_rewards = dec!(1000);
 
         let sp_infos = ServiceProviderRewardInfos::new(
@@ -441,7 +442,7 @@ mod tests {
 
     #[test]
     fn single_sp_unallocated_less_than_matched_distributed_by_shares() {
-        let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+        let reward_info = rewards_info_24_hours();
         // 100 unallocated
         let total_rewards = dec!(1100);
         let sp_session = dec!(1000);
@@ -481,7 +482,7 @@ mod tests {
 
     #[test]
     fn single_sp_unallocated_more_than_matched_promotion() {
-        let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+        let reward_info = rewards_info_24_hours();
         // 1,000 unallocated
         let total_rewards = dec!(11_000);
         let sp_session = dec!(1000);
@@ -521,7 +522,7 @@ mod tests {
 
     #[test]
     fn unallocated_matching_does_not_exceed_promotion() {
-        let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+        let reward_info = rewards_info_24_hours();
         // 100 unallocated
         let total_rewards = dec!(1100);
         let sp_session = dec!(1000);
@@ -561,7 +562,7 @@ mod tests {
 
     #[test]
     fn no_matched_promotions_full_bucket_allocation() {
-        let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+        let reward_info = rewards_info_24_hours();
         // The service providers DC session represents _more_ than the
         // available amount of sp_rewards for an epoch.
         // No matching on promotions should occur.
@@ -599,7 +600,7 @@ mod tests {
 
     #[test]
     fn no_matched_promotions_multiple_sp_full_bucket_allocation() {
-        let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+        let reward_info = rewards_info_24_hours();
         // The Service Providers DC sessions far surpass the
         // available amount of sp_rewards for an epoch.
         // No matching on promotions should occur.
@@ -712,7 +713,7 @@ mod tests {
             total_allocation in any::<u64>().prop_map(Decimal::from)
         ) {
 
-            let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+            let reward_info = rewards_info_24_hours();
             let sp_infos = ServiceProviderRewardInfos::new(
                 ServiceProviderDCSessions::from([(0, dc_session)]),
                 ServiceProviderPromotions::from(promotions),
@@ -738,7 +739,7 @@ mod tests {
             promotions in prop::collection::vec(arb_sp_promotion(), 0..10),
             mobile_bone_price in 1..5000
         ) {
-            let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+            let reward_info = rewards_info_24_hours();
             let total_allocation = service_provider::get_scheduled_tokens(reward_info.epoch_emissions);
 
             let sp_infos = ServiceProviderRewardInfos::new(

--- a/mobile_verifier/tests/integrations/common/mod.rs
+++ b/mobile_verifier/tests/integrations/common/mod.rs
@@ -353,14 +353,15 @@ impl GatewayResolver for GatewayClientAllOwnersValid {
     }
 }
 
-pub fn default_rewards_info(total_emissions: u64, epoch_duration: Duration) -> EpochRewardInfo {
+pub fn reward_info_24_hours() -> EpochRewardInfo {
     let now = Utc::now();
+    let epoch_duration = Duration::hours(24);
     EpochRewardInfo {
         epoch_day: 1,
         epoch_address: EPOCH_ADDRESS.into(),
         sub_dao_address: SUB_DAO_ADDRESS.into(),
         epoch_period: (now - epoch_duration)..now,
-        epoch_emissions: Decimal::from(total_emissions),
+        epoch_emissions: Decimal::from(EMISSIONS_POOL_IN_BONES_24_HOURS),
         rewards_issued_at: now,
     }
 }

--- a/mobile_verifier/tests/integrations/hex_boosting.rs
+++ b/mobile_verifier/tests/integrations/hex_boosting.rs
@@ -1,6 +1,6 @@
 use crate::common::{
-    self, default_price_info, default_rewards_info, MockFileSinkReceiver, MockHexBoostingClient,
-    RadioRewardV2Ext, EMISSIONS_POOL_IN_BONES_24_HOURS,
+    self, default_price_info, reward_info_24_hours, MockFileSinkReceiver, MockHexBoostingClient,
+    RadioRewardV2Ext,
 };
 use chrono::{DateTime, Duration as ChronoDuration, Duration, Utc};
 use file_store::{
@@ -58,7 +58,7 @@ async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
     let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
 
     let boost_period_length = Duration::days(30);
 
@@ -328,8 +328,7 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
 
     let hex_boosting_client = MockHexBoostingClient::new(boosted_hexes);
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
-
+    let reward_info = reward_info_24_hours();
     let price_info = default_price_info();
 
     let (_, rewards) = tokio::join!(
@@ -396,7 +395,7 @@ async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Res
     let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
     let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
 
     let boost_period_length = Duration::days(30);
 
@@ -614,7 +613,7 @@ async fn test_expired_boosted_hex(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
     let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
     let boost_period_length = Duration::days(30);
 
     // seed all the things
@@ -737,7 +736,7 @@ async fn test_reduced_location_score_with_boosted_hexes(pool: PgPool) -> anyhow:
     let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
     let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
     let boost_period_length = Duration::days(30);
 
     // seed all the things
@@ -915,7 +914,7 @@ async fn test_distance_from_asserted_removes_boosting_but_not_location_trust(
     let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
     let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
     let boost_period_length = Duration::days(30);
 
     // seed all the things
@@ -1094,7 +1093,7 @@ async fn test_poc_with_wifi_and_multi_coverage_boosted_hexes(pool: PgPool) -> an
     let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
     let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
 
     let boost_period_length = Duration::days(30);
 

--- a/mobile_verifier/tests/integrations/rewarder_mappers.rs
+++ b/mobile_verifier/tests/integrations/rewarder_mappers.rs
@@ -1,7 +1,5 @@
-use crate::common::{
-    self, default_rewards_info, MockFileSinkReceiver, EMISSIONS_POOL_IN_BONES_24_HOURS,
-};
-use chrono::{DateTime, Duration as ChronoDuration, Duration, Utc};
+use crate::common::{self, reward_info_24_hours, MockFileSinkReceiver};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use futures::{stream, StreamExt};
 use helium_crypto::PublicKeyBinary;
 use helium_proto::{
@@ -28,7 +26,7 @@ const HOTSPOT_1: &str = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6";
 async fn test_mapper_rewards(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
 
     // seed db
     let mut txn = pool.clone().begin().await?;

--- a/mobile_verifier/tests/integrations/rewarder_oracles.rs
+++ b/mobile_verifier/tests/integrations/rewarder_oracles.rs
@@ -1,5 +1,4 @@
-use crate::common::{self, default_rewards_info, MockFileSinkReceiver};
-use chrono::Duration;
+use crate::common::{self, reward_info_24_hours, MockFileSinkReceiver};
 use helium_proto::services::poc_mobile::{
     MobileRewardShare, UnallocatedReward, UnallocatedRewardType,
 };
@@ -12,7 +11,7 @@ use sqlx::PgPool;
 async fn test_oracle_rewards(_pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(82_191_780_821_917, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
 
     let (_, rewards) = tokio::join!(
         // run rewards for oracles

--- a/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
+++ b/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
@@ -1,10 +1,9 @@
 use std::ops::Range;
 
 use crate::common::{
-    self, default_price_info, default_rewards_info, MockHexBoostingClient, RadioRewardV2Ext,
-    EMISSIONS_POOL_IN_BONES_24_HOURS,
+    self, default_price_info, reward_info_24_hours, MockHexBoostingClient, RadioRewardV2Ext,
 };
-use chrono::{DateTime, Duration as ChronoDuration, Duration, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use file_store::{
     coverage::{CoverageObject as FSCoverageObject, KeyType, RadioHexSignalLevel},
     mobile_ban,
@@ -47,7 +46,7 @@ async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
     let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
 
     // seed all the things
     let mut txn = pool.clone().begin().await?;
@@ -121,7 +120,7 @@ async fn test_qualified_wifi_poc_rewards(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
     let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
 
     let pubkey: PublicKeyBinary = HOTSPOT_3.to_string().parse().unwrap(); // wifi hotspot
 
@@ -195,7 +194,7 @@ async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
     let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
 
     let pubkey: PublicKeyBinary = HOTSPOT_3.to_string().parse().unwrap(); // wifi hotspot
 
@@ -260,7 +259,7 @@ async fn test_all_banned_radio(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
     let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
 
     let pubkey: PublicKeyBinary = HOTSPOT_3.to_string().parse().unwrap(); // wifi hotspot
 
@@ -317,7 +316,7 @@ async fn test_data_banned_radio_still_receives_poc(pool: PgPool) -> anyhow::Resu
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
     let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
 
     let pubkey: PublicKeyBinary = HOTSPOT_3.to_string().parse().unwrap(); // wifi hotspot
 

--- a/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
+++ b/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
@@ -14,9 +14,7 @@ use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
 use sqlx::{PgPool, Postgres, Transaction};
 
-use crate::common::{
-    self, default_rewards_info, MockFileSinkReceiver, EMISSIONS_POOL_IN_BONES_24_HOURS,
-};
+use crate::common::{self, reward_info_24_hours, MockFileSinkReceiver};
 use mobile_config::client::{carrier_service_client::CarrierServiceVerifier, ClientError};
 use mobile_verifier::{data_session, reward_shares, rewarder, service_provider};
 
@@ -77,7 +75,7 @@ async fn test_service_provider_rewards(pool: PgPool) -> anyhow::Result<()> {
     let carrier_client = MockCarrierServiceClient::new(valid_sps);
     let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
 
     // seed db with test specific data
     let mut txn = pool.clone().begin().await?;
@@ -142,7 +140,7 @@ async fn test_service_provider_rewards_halt_on_invalid_sp(pool: PgPool) -> anyho
     valid_sps.insert(PAYER_1.to_string(), SP_1.to_string());
     let carrier_client = MockCarrierServiceClient::new(valid_sps);
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
 
     let mut txn = pool.clone().begin().await?;
     seed_hotspot_data_invalid_sp(reward_info.epoch_period.end, &mut txn).await?;
@@ -189,7 +187,7 @@ async fn test_service_provider_promotion_rewards(pool: PgPool) -> anyhow::Result
             ],
         }]);
 
-    let reward_info = default_rewards_info(EMISSIONS_POOL_IN_BONES_24_HOURS, Duration::hours(24));
+    let reward_info = reward_info_24_hours();
 
     let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
 


### PR DESCRIPTION
Tests where the values were different were testing percentages rather than anything specific to EpochRewardInfo.