### PR TITLE
Add new metric for latest file_info_poller file timestamp

### DIFF
--- a/file_store/src/file_info_poller.rs
+++ b/file_store/src/file_info_poller.rs
@@ -92,7 +92,7 @@ where
         ).set(latency.num_seconds() as f64);
 
         metrics::gauge!(
-            "file-info-poller-timestamp",
+            "file-processing-timestamp",
             "file-type" => self.file_info.prefix.clone(), "process-name" => self.process_name.clone(),
         ).set(self.file_info.timestamp.timestamp_millis() as f64);
 

--- a/file_store/src/file_info_poller.rs
+++ b/file_store/src/file_info_poller.rs
@@ -88,13 +88,17 @@ where
         let latency = Utc::now() - self.file_info.timestamp;
         metrics::gauge!(
             "file-processing-latency",
-            "file-type" => self.file_info.prefix.clone(), "process-name" => self.process_name.clone(),
-        ).set(latency.num_seconds() as f64);
+            "file-type" => self.file_info.prefix.clone(),
+            "process-name" => self.process_name.clone(),
+        )
+        .set(latency.num_seconds() as f64);
 
         metrics::gauge!(
             "file-processing-timestamp",
-            "file-type" => self.file_info.prefix.clone(), "process-name" => self.process_name.clone(),
-        ).set(self.file_info.timestamp.timestamp_millis() as f64);
+            "file-type" => self.file_info.prefix.clone(),
+            "process-name" => self.process_name.clone(),
+        )
+        .set(self.file_info.timestamp.timestamp_millis() as f64);
 
         recorder.record(&self.process_name, &self.file_info).await?;
         Ok(futures::stream::iter(self.data.into_iter()).boxed())

--- a/file_store/src/file_info_poller.rs
+++ b/file_store/src/file_info_poller.rs
@@ -91,6 +91,11 @@ where
             "file-type" => self.file_info.prefix.clone(), "process-name" => self.process_name.clone(),
         ).set(latency.num_seconds() as f64);
 
+        metrics::gauge!(
+            "file-info-poller-timestamp",
+            "file-type" => self.file_info.prefix.clone(), "process-name" => self.process_name.clone(),
+        ).set(self.file_info.timestamp.timestamp_millis() as f64);
+
         recorder.record(&self.process_name, &self.file_info).await?;
         Ok(futures::stream::iter(self.data.into_iter()).boxed())
     }


### PR DESCRIPTION
Add a new metric to file_info_poller to record the timestamp of the file currently being processed.  Idea is to write alerts in the form of `time() - file_info_poller_timestamp` which will alert if the service has no new files to pick up

the current metric outputs `Utc::now() - file_timestamp` which will not alert until a new value is picked up.  Should we remove current metric?