### PR TITLE
Add migration for banning key type

### DIFF
--- a/mobile_config/migrations/20250411184550_add_banning_key_role.sql
+++ b/mobile_config/migrations/20250411184550_add_banning_key_role.sql
@@ -1,0 +1,1 @@
+ALTER TYPE key_role ADD VALUE IF NOT EXISTS 'banning';

--- a/mobile_config/src/lib.rs
+++ b/mobile_config/src/lib.rs
@@ -97,7 +97,7 @@ impl std::fmt::Display for KeyRole {
             Self::Oracle => "oracle",
             Self::Router => "router",
             Self::Pcs => "pcs",
-            Self::Banning => "ban",
+            Self::Banning => "banning",
         };
         f.write_str(s)
     }


### PR DESCRIPTION
This key supports submitting gateway bans to the ingester.

Fix the `"ban"` string representation to `"banning"` to match the sqlx type name on the enum.