### PR TITLE
Nonblocking rewards sink for tests

### DIFF
--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -286,7 +286,7 @@ where
         let poc_dc_shares = reward_poc_and_dc(
             &self.pool,
             &self.hex_service_client,
-            &self.mobile_rewards,
+            self.mobile_rewards.clone(),
             &self.speedtest_averages,
             &reward_info,
             price_info.clone(),
@@ -394,7 +394,7 @@ where
 pub async fn reward_poc_and_dc(
     pool: &Pool<Postgres>,
     hex_service_client: &impl HexBoostingInfoResolver<Error = ClientError>,
-    mobile_rewards: &FileSinkClient<proto::MobileRewardShare>,
+    mobile_rewards: FileSinkClient<proto::MobileRewardShare>,
     speedtest_avg_sink: &FileSinkClient<proto::SpeedtestAvg>,
     reward_info: &EpochRewardInfo,
     price_info: PriceInfo,
@@ -420,7 +420,7 @@ pub async fn reward_poc_and_dc(
     // reward dc before poc so that we can calculate the unallocated dc reward
     // and carry this into the poc pool
     let dc_unallocated_amount = reward_dc(
-        mobile_rewards,
+        &mobile_rewards,
         reward_info,
         transfer_rewards,
         &reward_shares,
@@ -431,7 +431,7 @@ pub async fn reward_poc_and_dc(
     let (poc_unallocated_amount, calculated_poc_reward_shares) = reward_poc(
         pool,
         hex_service_client,
-        mobile_rewards,
+        &mobile_rewards,
         speedtest_avg_sink,
         reward_info,
         reward_shares,
@@ -444,7 +444,7 @@ pub async fn reward_poc_and_dc(
         .unwrap_or(0);
 
     write_unallocated_reward(
-        mobile_rewards,
+        &mobile_rewards,
         UnallocatedRewardType::Poc,
         poc_unallocated_amount,
         reward_info,

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -316,7 +316,7 @@ where
         .await?;
 
         // process rewards for oracles
-        reward_oracles(&self.mobile_rewards, &reward_info).await?;
+        reward_oracles(self.mobile_rewards.clone(), &reward_info).await?;
 
         self.speedtest_averages.commit().await?;
         let written_files = self.mobile_rewards.commit().await?.await??;
@@ -598,7 +598,7 @@ pub async fn reward_mappers(
 }
 
 pub async fn reward_oracles(
-    mobile_rewards: &FileSinkClient<proto::MobileRewardShare>,
+    mobile_rewards: FileSinkClient<proto::MobileRewardShare>,
     reward_info: &EpochRewardInfo,
 ) -> anyhow::Result<()> {
     // atm 100% of oracle rewards are assigned to 'unallocated'
@@ -611,7 +611,7 @@ pub async fn reward_oracles(
         .unwrap_or(0)
         - allocated_oracle_rewards;
     write_unallocated_reward(
-        mobile_rewards,
+        &mobile_rewards,
         UnallocatedRewardType::Oracle,
         unallocated_oracle_reward_amount,
         reward_info,

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -309,7 +309,7 @@ where
         reward_service_providers(
             dc_sessions,
             sp_promotions.clone(),
-            &self.mobile_rewards,
+            self.mobile_rewards.clone(),
             &reward_info,
             price_info.price_per_bone,
         )
@@ -623,7 +623,7 @@ pub async fn reward_oracles(
 pub async fn reward_service_providers(
     dc_sessions: ServiceProviderDCSessions,
     sp_promotions: ServiceProviderPromotions,
-    mobile_rewards: &FileSinkClient<proto::MobileRewardShare>,
+    mobile_rewards: FileSinkClient<proto::MobileRewardShare>,
     reward_info: &EpochRewardInfo,
     hnt_bone_price: Decimal,
 ) -> anyhow::Result<()> {
@@ -651,7 +651,7 @@ pub async fn reward_service_providers(
 
     // write out any unallocated service provider reward
     write_unallocated_reward(
-        mobile_rewards,
+        &mobile_rewards,
         UnallocatedRewardType::ServiceProvider,
         unallocated_sp_rewards,
         reward_info,

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -294,7 +294,7 @@ where
         .await?;
 
         // process rewards for mappers
-        reward_mappers(&self.pool, &self.mobile_rewards, &reward_info).await?;
+        reward_mappers(&self.pool, self.mobile_rewards.clone(), &reward_info).await?;
 
         // process rewards for service providers
         let dc_sessions = service_provider::get_dc_sessions(
@@ -552,7 +552,7 @@ pub async fn reward_dc(
 
 pub async fn reward_mappers(
     pool: &Pool<Postgres>,
-    mobile_rewards: &FileSinkClient<proto::MobileRewardShare>,
+    mobile_rewards: FileSinkClient<proto::MobileRewardShare>,
     reward_info: &EpochRewardInfo,
 ) -> anyhow::Result<()> {
     let rewardable_mapping_activity = subscriber_mapping_activity::db::rewardable_mapping_activity(
@@ -587,7 +587,7 @@ pub async fn reward_mappers(
         .unwrap_or(0)
         - allocated_mapping_rewards;
     write_unallocated_reward(
-        mobile_rewards,
+        &mobile_rewards,
         UnallocatedRewardType::Mapper,
         unallocated_mapping_reward_amount,
         reward_info,

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -205,7 +205,8 @@ where
         };
         self.verified_speedtest_file_sink
             .write(proto, &[("result", result.as_str_name())])
-            .await?;
+            .await?
+            .await??;
         Ok(())
     }
 }

--- a/mobile_verifier/src/speedtests_average.rs
+++ b/mobile_verifier/src/speedtests_average.rs
@@ -92,7 +92,7 @@ impl SpeedtestAverage {
     pub async fn write(
         &self,
         filesink: &FileSinkClient<proto::SpeedtestAvg>,
-    ) -> file_store::Result {
+    ) -> anyhow::Result<()> {
         filesink
             .write(
                 proto::SpeedtestAvg {
@@ -116,7 +116,10 @@ impl SpeedtestAverage {
                 },
                 &[("validity", self.validity.as_str_name())],
             )
-            .await?;
+            .await?
+            // wait to be written
+            .await??;
+
         Ok(())
     }
 

--- a/mobile_verifier/tests/integrations/common/mod.rs
+++ b/mobile_verifier/tests/integrations/common/mod.rs
@@ -283,25 +283,25 @@ pub struct FileSinkReceiver<T> {
 
 #[derive(Default, Debug)]
 pub struct MobileRewardShareMessages {
-    pub gateway_reward: Vec<GatewayReward>,
-    pub radio_reward: Vec<RadioReward>,
-    pub subscriber_reward: Vec<SubscriberReward>,
-    pub sp_reward: Vec<ServiceProviderReward>,
+    pub gateway_rewards: Vec<GatewayReward>,
+    pub radio_rewards: Vec<RadioReward>,
+    pub subscriber_rewards: Vec<SubscriberReward>,
+    pub sp_rewards: Vec<ServiceProviderReward>,
     pub unallocated: Vec<UnallocatedReward>,
-    pub radio_reward_v2: Vec<RadioRewardV2>,
-    pub promotion_reward: Vec<PromotionReward>,
+    pub radio_reward_v2s: Vec<RadioRewardV2>,
+    pub promotion_rewards: Vec<PromotionReward>,
 }
 
 impl MobileRewardShareMessages {
     fn insert(&mut self, item: MobileReward) {
         match item {
-            MobileReward::GatewayReward(inner) => self.gateway_reward.push(inner),
-            MobileReward::RadioReward(inner) => self.radio_reward.push(inner),
-            MobileReward::SubscriberReward(inner) => self.subscriber_reward.push(inner),
-            MobileReward::ServiceProviderReward(inner) => self.sp_reward.push(inner),
+            MobileReward::GatewayReward(inner) => self.gateway_rewards.push(inner),
+            MobileReward::RadioReward(inner) => self.radio_rewards.push(inner),
+            MobileReward::SubscriberReward(inner) => self.subscriber_rewards.push(inner),
+            MobileReward::ServiceProviderReward(inner) => self.sp_rewards.push(inner),
             MobileReward::UnallocatedReward(inner) => self.unallocated.push(inner),
-            MobileReward::RadioRewardV2(inner) => self.radio_reward_v2.push(inner),
-            MobileReward::PromotionReward(inner) => self.promotion_reward.push(inner),
+            MobileReward::RadioRewardV2(inner) => self.radio_reward_v2s.push(inner),
+            MobileReward::PromotionReward(inner) => self.promotion_rewards.push(inner),
         }
     }
 
@@ -313,14 +313,14 @@ impl MobileRewardShareMessages {
     }
 
     pub fn total_poc_rewards(&self) -> u64 {
-        self.radio_reward_v2
+        self.radio_reward_v2s
             .iter()
             .map(|reward| reward.total_poc_reward())
             .sum()
     }
 
     pub fn total_sub_discovery_amount(&self) -> u64 {
-        self.subscriber_reward
+        self.subscriber_rewards
             .iter()
             .map(|reward| reward.discovery_location_amount)
             .sum()

--- a/mobile_verifier/tests/integrations/common/mod.rs
+++ b/mobile_verifier/tests/integrations/common/mod.rs
@@ -79,32 +79,6 @@ impl SubDaoEpochRewardInfoResolver for MockSubDaoRewardsClient {
     }
 }
 
-pub struct MockFileSinkReceiver<T> {
-    pub receiver: tokio::sync::mpsc::Receiver<SinkMessage<T>>,
-}
-
-impl MockFileSinkReceiver<SpeedtestAvg> {
-    pub async fn get_all_speedtest_avgs(&mut self) -> Vec<SpeedtestAvg> {
-        let mut messages = vec![];
-        while let Ok(SinkMessage::Data(on_write_tx, msg)) = self.receiver.try_recv() {
-            let _ = on_write_tx.send(Ok(()));
-            messages.push(msg);
-        }
-        messages
-    }
-}
-
-pub fn create_file_sink<T>() -> (FileSinkClient<T>, MockFileSinkReceiver<T>) {
-    let (tx, rx) = tokio::sync::mpsc::channel(20);
-    (
-        FileSinkClient {
-            sender: tx,
-            metric: "metric".into(),
-        },
-        MockFileSinkReceiver { receiver: rx },
-    )
-}
-
 pub trait SubscriberRewardExt {
     fn subscriber_id_string(&self) -> String;
 }

--- a/mobile_verifier/tests/integrations/hex_boosting.rs
+++ b/mobile_verifier/tests/integrations/hex_boosting.rs
@@ -52,7 +52,7 @@ async fn update_assignments(pool: &PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -212,7 +212,7 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
     // thresholds for the radios have not been met
     // the end result is that no boosting takes place, the radios are awarded non boosted reward values
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
     let now = Utc::now();
     let epoch = (now - ChronoDuration::hours(24))..now;
     let boost_period_length = Duration::days(30);
@@ -334,7 +334,7 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
 #[sqlx::test]
 async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -514,7 +514,7 @@ async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Res
 #[sqlx::test]
 async fn test_expired_boosted_hex(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
 
     let reward_info = reward_info_24_hours();
     let boost_period_length = Duration::days(30);
@@ -614,7 +614,7 @@ async fn test_expired_boosted_hex(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn test_reduced_location_score_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
 
     let reward_info = reward_info_24_hours();
     let boost_period_length = Duration::days(30);
@@ -754,7 +754,7 @@ async fn test_distance_from_asserted_removes_boosting_but_not_location_trust(
     pool: PgPool,
 ) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
 
     let reward_info = reward_info_24_hours();
     let boost_period_length = Duration::days(30);
@@ -895,7 +895,7 @@ async fn test_distance_from_asserted_removes_boosting_but_not_location_trust(
 #[sqlx::test]
 async fn test_poc_with_wifi_and_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
 
     let reward_info = reward_info_24_hours();
 

--- a/mobile_verifier/tests/integrations/hex_boosting.rs
+++ b/mobile_verifier/tests/integrations/hex_boosting.rs
@@ -51,8 +51,8 @@ async fn update_assignments(pool: &PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -211,8 +211,8 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
     // this simulates the case where we have radios in boosted hexes but where the coverage
     // thresholds for the radios have not been met
     // the end result is that no boosting takes place, the radios are awarded non boosted reward values
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
     let now = Utc::now();
     let epoch = (now - ChronoDuration::hours(24))..now;
     let boost_period_length = Duration::days(30);
@@ -333,8 +333,8 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
 
 #[sqlx::test]
 async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -513,8 +513,8 @@ async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Res
 
 #[sqlx::test]
 async fn test_expired_boosted_hex(pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
     let boost_period_length = Duration::days(30);
@@ -613,8 +613,8 @@ async fn test_expired_boosted_hex(pool: PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn test_reduced_location_score_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
     let boost_period_length = Duration::days(30);
@@ -753,8 +753,8 @@ async fn test_reduced_location_score_with_boosted_hexes(pool: PgPool) -> anyhow:
 async fn test_distance_from_asserted_removes_boosting_but_not_location_trust(
     pool: PgPool,
 ) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
     let boost_period_length = Duration::days(30);
@@ -894,8 +894,8 @@ async fn test_distance_from_asserted_removes_boosting_but_not_location_trust(
 
 #[sqlx::test]
 async fn test_poc_with_wifi_and_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 

--- a/mobile_verifier/tests/integrations/hex_boosting.rs
+++ b/mobile_verifier/tests/integrations/hex_boosting.rs
@@ -148,7 +148,7 @@ async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
     let rewards = mobile_rewards.finish().await?;
 
     let poc_rewards = rewards
-        .radio_reward_v2
+        .radio_reward_v2s
         .as_keyed_map(|v| v.hotspot_key_string());
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1");
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2");
@@ -308,7 +308,7 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
     let rewards = mobile_rewards.finish().await?;
 
     let poc_rewards = rewards
-        .radio_reward_v2
+        .radio_reward_v2s
         .as_keyed_map(|v| v.hotspot_key_string());
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1");
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2");
@@ -441,7 +441,7 @@ async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Res
     let rewards = mobile_rewards.finish().await?;
 
     let poc_rewards = rewards
-        .radio_reward_v2
+        .radio_reward_v2s
         .as_keyed_map(|v| v.hotspot_key_string());
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1");
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2");
@@ -584,7 +584,7 @@ async fn test_expired_boosted_hex(pool: PgPool) -> anyhow::Result<()> {
     let rewards = mobile_rewards.finish().await?;
 
     let poc_rewards = rewards
-        .radio_reward_v2
+        .radio_reward_v2s
         .as_keyed_map(|v| v.hotspot_key_string());
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1");
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2");
@@ -690,7 +690,7 @@ async fn test_reduced_location_score_with_boosted_hexes(pool: PgPool) -> anyhow:
     let rewards = mobile_rewards.finish().await?;
 
     let poc_rewards = rewards
-        .radio_reward_v2
+        .radio_reward_v2s
         .as_keyed_map(|v| v.hotspot_key_string());
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1"); // full location trust 1 boost
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2"); // full location NO boosts
@@ -833,7 +833,7 @@ async fn test_distance_from_asserted_removes_boosting_but_not_location_trust(
     let rewards = mobile_rewards.finish().await?;
 
     let poc_rewards = rewards
-        .radio_reward_v2
+        .radio_reward_v2s
         .as_keyed_map(|v| v.hotspot_key_string());
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1"); // full location trust 1 boost
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2"); // full location trust NO boosts
@@ -999,7 +999,7 @@ async fn test_poc_with_wifi_and_multi_coverage_boosted_hexes(pool: PgPool) -> an
     let rewards = mobile_rewards.finish().await?;
 
     let poc_rewards = rewards
-        .radio_reward_v2
+        .radio_reward_v2s
         .as_keyed_map(|v| v.hotspot_key_string());
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1"); // 2 boosts at 10x
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2"); // 1 boost at 20x

--- a/mobile_verifier/tests/integrations/hex_boosting.rs
+++ b/mobile_verifier/tests/integrations/hex_boosting.rs
@@ -147,9 +147,7 @@ async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
 
     let rewards = mobile_rewards.finish().await?;
 
-    let poc_rewards = rewards
-        .radio_reward_v2s
-        .as_keyed_map(|v| v.hotspot_key_string());
+    let poc_rewards = rewards.radio_reward_v2s.as_keyed_map();
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1");
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2");
     let hotspot_3 = poc_rewards.get(HOTSPOT_3).expect("hotspot 3");
@@ -307,9 +305,7 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
 
     let rewards = mobile_rewards.finish().await?;
 
-    let poc_rewards = rewards
-        .radio_reward_v2s
-        .as_keyed_map(|v| v.hotspot_key_string());
+    let poc_rewards = rewards.radio_reward_v2s.as_keyed_map();
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1");
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2");
     let hotspot_3 = poc_rewards.get(HOTSPOT_3).expect("hotspot 3");
@@ -440,9 +436,7 @@ async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Res
 
     let rewards = mobile_rewards.finish().await?;
 
-    let poc_rewards = rewards
-        .radio_reward_v2s
-        .as_keyed_map(|v| v.hotspot_key_string());
+    let poc_rewards = rewards.radio_reward_v2s.as_keyed_map();
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1");
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2");
     let hotspot_3 = poc_rewards.get(HOTSPOT_3).expect("hotspot 3");
@@ -583,9 +577,7 @@ async fn test_expired_boosted_hex(pool: PgPool) -> anyhow::Result<()> {
 
     let rewards = mobile_rewards.finish().await?;
 
-    let poc_rewards = rewards
-        .radio_reward_v2s
-        .as_keyed_map(|v| v.hotspot_key_string());
+    let poc_rewards = rewards.radio_reward_v2s.as_keyed_map();
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1");
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2");
     let hotspot_3 = poc_rewards.get(HOTSPOT_3).expect("hotspot 3");
@@ -689,9 +681,7 @@ async fn test_reduced_location_score_with_boosted_hexes(pool: PgPool) -> anyhow:
 
     let rewards = mobile_rewards.finish().await?;
 
-    let poc_rewards = rewards
-        .radio_reward_v2s
-        .as_keyed_map(|v| v.hotspot_key_string());
+    let poc_rewards = rewards.radio_reward_v2s.as_keyed_map();
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1"); // full location trust 1 boost
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2"); // full location NO boosts
     let hotspot_3 = poc_rewards.get(HOTSPOT_3).expect("hotspot 3"); // reduced location trust 1 boost
@@ -832,9 +822,7 @@ async fn test_distance_from_asserted_removes_boosting_but_not_location_trust(
 
     let rewards = mobile_rewards.finish().await?;
 
-    let poc_rewards = rewards
-        .radio_reward_v2s
-        .as_keyed_map(|v| v.hotspot_key_string());
+    let poc_rewards = rewards.radio_reward_v2s.as_keyed_map();
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1"); // full location trust 1 boost
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2"); // full location trust NO boosts
     let hotspot_3 = poc_rewards.get(HOTSPOT_3).expect("hotspot 3"); // reduced location trust 1 boost
@@ -998,9 +986,7 @@ async fn test_poc_with_wifi_and_multi_coverage_boosted_hexes(pool: PgPool) -> an
 
     let rewards = mobile_rewards.finish().await?;
 
-    let poc_rewards = rewards
-        .radio_reward_v2s
-        .as_keyed_map(|v| v.hotspot_key_string());
+    let poc_rewards = rewards.radio_reward_v2s.as_keyed_map();
     let hotspot_1 = poc_rewards.get(HOTSPOT_1).expect("hotspot 1"); // 2 boosts at 10x
     let hotspot_2 = poc_rewards.get(HOTSPOT_2).expect("hotspot 2"); // 1 boost at 20x
     let hotspot_4 = poc_rewards.get(HOTSPOT_4).expect("hotspot 4"); // no boosts

--- a/mobile_verifier/tests/integrations/rewarder_mappers.rs
+++ b/mobile_verifier/tests/integrations/rewarder_mappers.rs
@@ -22,7 +22,7 @@ const HOTSPOT_1: &str = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6";
 
 #[sqlx::test]
 async fn test_mapper_rewards(pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
     let reward_info = reward_info_24_hours();
 
     // seed db

--- a/mobile_verifier/tests/integrations/rewarder_mappers.rs
+++ b/mobile_verifier/tests/integrations/rewarder_mappers.rs
@@ -1,13 +1,8 @@
-use crate::common::{self, reward_info_24_hours, MockFileSinkReceiver};
+use crate::common::{self, reward_info_24_hours, AsStringKeyedMap, SubscriberRewardExt};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use futures::{stream, StreamExt};
 use helium_crypto::PublicKeyBinary;
-use helium_proto::{
-    services::poc_mobile::{
-        MobileRewardShare, SubscriberReward, UnallocatedReward, UnallocatedRewardType,
-    },
-    Message,
-};
+use helium_proto::{services::poc_mobile::UnallocatedRewardType, Message};
 use mobile_verifier::{
     reward_shares, rewarder,
     subscriber_mapping_activity::{self, SubscriberMappingActivity},
@@ -15,7 +10,10 @@ use mobile_verifier::{
 use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
 use sqlx::{PgPool, Postgres, Transaction};
-use std::{str::FromStr, string::ToString};
+use std::{
+    str::{self, FromStr},
+    string::ToString,
+};
 
 const SUBSCRIBER_1: &str = "subscriber1";
 const SUBSCRIBER_2: &str = "subscriber2";
@@ -24,8 +22,7 @@ const HOTSPOT_1: &str = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6";
 
 #[sqlx::test]
 async fn test_mapper_rewards(pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
-
+    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
     let reward_info = reward_info_24_hours();
 
     // seed db
@@ -33,91 +30,49 @@ async fn test_mapper_rewards(pool: PgPool) -> anyhow::Result<()> {
     seed_mapping_data(reward_info.epoch_period.end, &mut txn).await?;
     txn.commit().await.expect("db txn failed");
 
-    let (_, rewards) = tokio::join!(
-        rewarder::reward_mappers(&pool, &mobile_rewards_client, &reward_info),
-        receive_expected_rewards(&mut mobile_rewards)
+    rewarder::reward_mappers(&pool, mobile_rewards_client, &reward_info).await?;
+
+    let rewards = mobile_rewards.finish().await?;
+    let subscriber_rewards = rewards
+        .subscriber_reward
+        .as_keyed_map(|reward| reward.subscriber_id_string());
+
+    // assert the mapper rewards
+    // all 3 subscribers will have an equal share,
+    // requirement is 1 qualifying mapping criteria report per epoch
+    // subscriber 1 has two qualifying mapping criteria reports,
+    // other two subscribers one qualifying mapping criteria reports
+    let sub_reward_1 = subscriber_rewards.get(SUBSCRIBER_1).expect("sub 1");
+    assert_eq!(5_479_452_054_794, sub_reward_1.discovery_location_amount);
+
+    let sub_reward_2 = subscriber_rewards.get(SUBSCRIBER_2).expect("sub 2");
+    assert_eq!(5_479_452_054_794, sub_reward_2.discovery_location_amount);
+
+    let sub_reward_3 = subscriber_rewards.get(SUBSCRIBER_3).expect("sub 3");
+    assert_eq!(5_479_452_054_794, sub_reward_3.discovery_location_amount);
+
+    // confirm our unallocated amount
+    let unallocated_reward = rewards.unallocated.first().expect("unallocated");
+    assert_eq!(
+        UnallocatedRewardType::Mapper as i32,
+        unallocated_reward.reward_type
     );
+    assert_eq!(1, unallocated_reward.amount);
 
-    if let Ok((subscriber_rewards, unallocated_reward)) = rewards {
-        // assert the mapper rewards
-        // all 3 subscribers will have an equal share,
-        // requirement is 1 qualifying mapping criteria report per epoch
-        // subscriber 1 has two qualifying mapping criteria reports,
-        // other two subscribers one qualifying mapping criteria reports
-        assert_eq!(
-            SUBSCRIBER_1.to_string().encode_to_vec(),
-            subscriber_rewards[0].subscriber_id
-        );
-        assert_eq!(
-            5_479_452_054_794,
-            subscriber_rewards[0].discovery_location_amount
-        );
+    // confirm the total rewards allocated matches expectations
+    let expected_sum = reward_shares::get_scheduled_tokens_for_mappers(reward_info.epoch_emissions)
+        .to_u64()
+        .unwrap();
+    let subscriber_sum =
+        rewards.total_sub_discovery_amount() + rewards.unallocated_amount_or_default();
+    assert_eq!(expected_sum, subscriber_sum);
 
-        assert_eq!(
-            SUBSCRIBER_2.to_string().encode_to_vec(),
-            subscriber_rewards[1].subscriber_id
-        );
-        assert_eq!(
-            5_479_452_054_794,
-            subscriber_rewards[2].discovery_location_amount
-        );
+    // confirm the rewarded percentage amount matches expectations
+    let percent = (Decimal::from(subscriber_sum) / reward_info.epoch_emissions)
+        .round_dp_with_strategy(2, RoundingStrategy::MidpointNearestEven);
+    assert_eq!(percent, dec!(0.2));
 
-        assert_eq!(
-            SUBSCRIBER_3.to_string().encode_to_vec(),
-            subscriber_rewards[2].subscriber_id
-        );
-        assert_eq!(
-            5_479_452_054_794,
-            subscriber_rewards[2].discovery_location_amount
-        );
-
-        // confirm our unallocated amount
-        assert_eq!(
-            UnallocatedRewardType::Mapper as i32,
-            unallocated_reward.reward_type
-        );
-        assert_eq!(1, unallocated_reward.amount);
-
-        // confirm the total rewards allocated matches expectations
-        let expected_sum =
-            reward_shares::get_scheduled_tokens_for_mappers(reward_info.epoch_emissions)
-                .to_u64()
-                .unwrap();
-        let subscriber_sum = subscriber_rewards[0].discovery_location_amount
-            + subscriber_rewards[1].discovery_location_amount
-            + subscriber_rewards[2].discovery_location_amount
-            + unallocated_reward.amount;
-        assert_eq!(expected_sum, subscriber_sum);
-
-        // confirm the rewarded percentage amount matches expectations
-        let percent = (Decimal::from(subscriber_sum) / reward_info.epoch_emissions)
-            .round_dp_with_strategy(2, RoundingStrategy::MidpointNearestEven);
-        assert_eq!(percent, dec!(0.2));
-    } else {
-        panic!("no rewards received");
-    };
     Ok(())
-}
-
-async fn receive_expected_rewards(
-    mobile_rewards: &mut MockFileSinkReceiver<MobileRewardShare>,
-) -> anyhow::Result<(Vec<SubscriberReward>, UnallocatedReward)> {
-    // get the filestore outputs from rewards run
-    // we will have 3 radio rewards, 1 wifi radio and 2 cbrs radios
-    let subscriber_reward1 = mobile_rewards.receive_subscriber_reward().await;
-    let subscriber_reward2 = mobile_rewards.receive_subscriber_reward().await;
-    let subscriber_reward3 = mobile_rewards.receive_subscriber_reward().await;
-    let mut subscriber_rewards = vec![subscriber_reward1, subscriber_reward2, subscriber_reward3];
-
-    subscriber_rewards.sort_by(|a, b| a.subscriber_id.cmp(&b.subscriber_id));
-
-    // expect one unallocated reward
-    let unallocated_reward = mobile_rewards.receive_unallocated_reward().await;
-
-    // should be no further msgs
-    mobile_rewards.assert_no_messages();
-
-    Ok((subscriber_rewards, unallocated_reward))
 }
 
 async fn seed_mapping_data(

--- a/mobile_verifier/tests/integrations/rewarder_mappers.rs
+++ b/mobile_verifier/tests/integrations/rewarder_mappers.rs
@@ -10,10 +10,7 @@ use mobile_verifier::{
 use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
 use sqlx::{PgPool, Postgres, Transaction};
-use std::{
-    str::{self, FromStr},
-    string::ToString,
-};
+use std::{str::FromStr, string::ToString};
 
 const SUBSCRIBER_1: &str = "subscriber1";
 const SUBSCRIBER_2: &str = "subscriber2";

--- a/mobile_verifier/tests/integrations/rewarder_mappers.rs
+++ b/mobile_verifier/tests/integrations/rewarder_mappers.rs
@@ -1,4 +1,4 @@
-use crate::common::{self, reward_info_24_hours, AsStringKeyedMap, SubscriberRewardExt};
+use crate::common::{self, reward_info_24_hours, AsStringKeyedMap};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use futures::{stream, StreamExt};
 use helium_crypto::PublicKeyBinary;
@@ -30,9 +30,7 @@ async fn test_mapper_rewards(pool: PgPool) -> anyhow::Result<()> {
     rewarder::reward_mappers(&pool, mobile_rewards_client, &reward_info).await?;
 
     let rewards = mobile_rewards.finish().await?;
-    let subscriber_rewards = rewards
-        .subscriber_rewards
-        .as_keyed_map(|reward| reward.subscriber_id_string());
+    let subscriber_rewards = rewards.subscriber_rewards.as_keyed_map();
 
     // assert the mapper rewards
     // all 3 subscribers will have an equal share,

--- a/mobile_verifier/tests/integrations/rewarder_mappers.rs
+++ b/mobile_verifier/tests/integrations/rewarder_mappers.rs
@@ -34,7 +34,7 @@ async fn test_mapper_rewards(pool: PgPool) -> anyhow::Result<()> {
 
     let rewards = mobile_rewards.finish().await?;
     let subscriber_rewards = rewards
-        .subscriber_reward
+        .subscriber_rewards
         .as_keyed_map(|reward| reward.subscriber_id_string());
 
     // assert the mapper rewards

--- a/mobile_verifier/tests/integrations/rewarder_oracles.rs
+++ b/mobile_verifier/tests/integrations/rewarder_oracles.rs
@@ -1,7 +1,5 @@
-use crate::common::{self, reward_info_24_hours, MockFileSinkReceiver};
-use helium_proto::services::poc_mobile::{
-    MobileRewardShare, UnallocatedReward, UnallocatedRewardType,
-};
+use crate::common::{self, reward_info_24_hours};
+use helium_proto::services::poc_mobile::UnallocatedRewardType;
 use mobile_verifier::{reward_shares, rewarder};
 use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
@@ -9,49 +7,33 @@ use sqlx::PgPool;
 
 #[sqlx::test]
 async fn test_oracle_rewards(_pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mut mobile_rewards) = common::create_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
 
     let reward_info = reward_info_24_hours();
 
-    let (_, rewards) = tokio::join!(
-        // run rewards for oracles
-        rewarder::reward_oracles(&mobile_rewards_client, &reward_info),
-        receive_expected_rewards(&mut mobile_rewards)
+    // run rewards for oracles
+    rewarder::reward_oracles(mobile_rewards_client, &reward_info).await?;
+
+    let rewards = mobile_rewards.finish().await?;
+    let unallocated_reward = rewards.unallocated.first().expect("Unallocated");
+
+    assert_eq!(
+        UnallocatedRewardType::Oracle as i32,
+        unallocated_reward.reward_type
     );
-    if let Ok(unallocated_reward) = rewards {
-        assert_eq!(
-            UnallocatedRewardType::Oracle as i32,
-            unallocated_reward.reward_type
-        );
-        // confirm our unallocated amount
-        assert_eq!(3_287_671_232_876, unallocated_reward.amount);
+    // confirm our unallocated amount
+    assert_eq!(3_287_671_232_876, unallocated_reward.amount);
 
-        // confirm the total rewards allocated matches expectations
-        let expected_sum =
-            reward_shares::get_scheduled_tokens_for_oracles(reward_info.epoch_emissions)
-                .to_u64()
-                .unwrap();
-        assert_eq!(expected_sum, unallocated_reward.amount);
+    // confirm the total rewards allocated matches expectations
+    let expected_sum = reward_shares::get_scheduled_tokens_for_oracles(reward_info.epoch_emissions)
+        .to_u64()
+        .unwrap();
+    assert_eq!(expected_sum, unallocated_reward.amount);
 
-        // confirm the rewarded percentage amount matches expectations
-        let percent = (Decimal::from(unallocated_reward.amount) / reward_info.epoch_emissions)
-            .round_dp_with_strategy(2, RoundingStrategy::MidpointNearestEven);
-        assert_eq!(percent, dec!(0.04));
-    } else {
-        panic!("no rewards received");
-    };
+    // confirm the rewarded percentage amount matches expectations
+    let percent = (Decimal::from(unallocated_reward.amount) / reward_info.epoch_emissions)
+        .round_dp_with_strategy(2, RoundingStrategy::MidpointNearestEven);
+    assert_eq!(percent, dec!(0.04));
+
     Ok(())
-}
-
-async fn receive_expected_rewards(
-    mobile_rewards: &mut MockFileSinkReceiver<MobileRewardShare>,
-) -> anyhow::Result<UnallocatedReward> {
-    // expect one unallocated reward
-    // as oracle rewards are currently 100% unallocated
-    let unallocated_reward = mobile_rewards.receive_unallocated_reward().await;
-
-    // should be no further msgs
-    mobile_rewards.assert_no_messages();
-
-    Ok(unallocated_reward)
 }

--- a/mobile_verifier/tests/integrations/rewarder_oracles.rs
+++ b/mobile_verifier/tests/integrations/rewarder_oracles.rs
@@ -7,7 +7,7 @@ use sqlx::PgPool;
 
 #[sqlx::test]
 async fn test_oracle_rewards(_pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 

--- a/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
+++ b/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
@@ -44,7 +44,7 @@ const PAYER_1: &str = "11eX55faMbqZB7jzN4p67m6w7ScPMH6ubnvCjCPLh72J49PaJEL";
 #[sqlx::test]
 async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -117,7 +117,7 @@ async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn test_qualified_wifi_poc_rewards(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -190,7 +190,7 @@ async fn test_qualified_wifi_poc_rewards(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -226,7 +226,7 @@ async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
 
     // ==============================================================
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
 
     // SP ban radio, zeroed rewards are filtered out
     let mut txn = pool.begin().await?;
@@ -253,7 +253,7 @@ async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn test_all_banned_radio(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -309,7 +309,7 @@ async fn test_all_banned_radio(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn test_data_banned_radio_still_receives_poc(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
 
     let reward_info = reward_info_24_hours();
 

--- a/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
+++ b/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
@@ -43,8 +43,8 @@ const PAYER_1: &str = "11eX55faMbqZB7jzN4p67m6w7ScPMH6ubnvCjCPLh72J49PaJEL";
 
 #[sqlx::test]
 async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -116,8 +116,8 @@ async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn test_qualified_wifi_poc_rewards(pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -189,8 +189,8 @@ async fn test_qualified_wifi_poc_rewards(pool: PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -225,8 +225,8 @@ async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
     assert_eq!(msgs.radio_reward_v2.len(), 3);
 
     // ==============================================================
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     // SP ban radio, zeroed rewards are filtered out
     let mut txn = pool.begin().await?;
@@ -252,8 +252,8 @@ async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn test_all_banned_radio(pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -308,8 +308,8 @@ async fn test_all_banned_radio(pool: PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn test_data_banned_radio_still_receives_poc(pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
+    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 

--- a/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
+++ b/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
@@ -71,8 +71,8 @@ async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
     .await?;
 
     let rewards = mobile_rewards.finish().await?;
-    let poc_rewards = rewards.radio_reward_v2;
-    let dc_rewards = rewards.gateway_reward;
+    let poc_rewards = rewards.radio_reward_v2s;
+    let dc_rewards = rewards.gateway_rewards;
     let unallocated_reward = rewards.unallocated.first();
 
     let poc_sum: u64 = poc_rewards.iter().map(|r| r.total_poc_reward()).sum();
@@ -159,8 +159,8 @@ async fn test_qualified_wifi_poc_rewards(pool: PgPool) -> anyhow::Result<()> {
     .await?;
 
     let msgs = mobile_rewards.finish().await?;
-    let poc_rewards = msgs.radio_reward_v2;
-    let dc_rewards = msgs.gateway_reward;
+    let poc_rewards = msgs.radio_reward_v2s;
+    let dc_rewards = msgs.gateway_rewards;
 
     // expecting single radio with poc rewards, no unallocated
     assert_eq!(poc_rewards.len(), 1);
@@ -221,8 +221,8 @@ async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
     .await?;
 
     let msgs = mobile_rewards.finish().await?;
-    assert_eq!(msgs.gateway_reward.len(), 3);
-    assert_eq!(msgs.radio_reward_v2.len(), 3);
+    assert_eq!(msgs.gateway_rewards.len(), 3);
+    assert_eq!(msgs.radio_reward_v2s.len(), 3);
 
     // ==============================================================
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
@@ -244,8 +244,8 @@ async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
     .await?;
 
     let msgs = mobile_rewards.finish().await?;
-    assert_eq!(msgs.gateway_reward.len(), 3);
-    assert_eq!(msgs.radio_reward_v2.len(), 2);
+    assert_eq!(msgs.gateway_rewards.len(), 3);
+    assert_eq!(msgs.radio_reward_v2s.len(), 2);
 
     Ok(())
 }
@@ -294,9 +294,9 @@ async fn test_all_banned_radio(pool: PgPool) -> anyhow::Result<()> {
     .await?;
 
     let rewards = mobile_rewards.finish().await?;
-    let poc_rewards = rewards.radio_reward_v2;
+    let poc_rewards = rewards.radio_reward_v2s;
 
-    let dc_rewards = rewards.gateway_reward;
+    let dc_rewards = rewards.gateway_rewards;
 
     // expecting single radio with poc rewards, no unallocated
     assert_eq!(poc_rewards.len(), 2);
@@ -349,8 +349,8 @@ async fn test_data_banned_radio_still_receives_poc(pool: PgPool) -> anyhow::Resu
     .await?;
 
     let rewards = mobile_rewards.finish().await?;
-    let poc_rewards = rewards.radio_reward_v2;
-    let dc_rewards = rewards.gateway_reward;
+    let poc_rewards = rewards.radio_reward_v2s;
+    let dc_rewards = rewards.gateway_rewards;
 
     assert_eq!(poc_rewards.len(), 3);
     assert_eq!(dc_rewards.len(), 0);

--- a/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
+++ b/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
@@ -63,13 +63,12 @@ async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
     rewarder::reward_poc_and_dc(
         &pool,
         &hex_boosting_client,
-        &mobile_rewards_client,
+        mobile_rewards_client,
         &speedtest_avg_client,
         &reward_info,
         price_info,
     )
     .await?;
-    drop(mobile_rewards_client);
 
     let rewards = mobile_rewards.finish().await?;
     let poc_rewards = rewards.radio_reward_v2;
@@ -152,13 +151,12 @@ async fn test_qualified_wifi_poc_rewards(pool: PgPool) -> anyhow::Result<()> {
     rewarder::reward_poc_and_dc(
         &pool,
         &hex_boosting_client,
-        &mobile_rewards_client,
+        mobile_rewards_client,
         &speedtest_avg_client,
         &reward_info,
         price_info,
     )
     .await?;
-    drop(mobile_rewards_client);
 
     let msgs = mobile_rewards.finish().await?;
     let poc_rewards = msgs.radio_reward_v2;
@@ -215,13 +213,12 @@ async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
     let _rewarder = rewarder::reward_poc_and_dc(
         &pool,
         &hex_boosting_client,
-        &mobile_rewards_client,
+        mobile_rewards_client,
         &speedtest_avg_client,
         &reward_info,
         price_info.clone(),
     )
     .await?;
-    drop(mobile_rewards_client);
 
     let msgs = mobile_rewards.finish().await?;
     assert_eq!(msgs.gateway_reward.len(), 3);
@@ -239,13 +236,12 @@ async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
     let _rewarder = rewarder::reward_poc_and_dc(
         &pool,
         &hex_boosting_client,
-        &mobile_rewards_client,
+        mobile_rewards_client,
         &speedtest_avg_client,
         &reward_info,
         price_info,
     )
     .await?;
-    drop(mobile_rewards_client);
 
     let msgs = mobile_rewards.finish().await?;
     assert_eq!(msgs.gateway_reward.len(), 3);
@@ -290,13 +286,12 @@ async fn test_all_banned_radio(pool: PgPool) -> anyhow::Result<()> {
     rewarder::reward_poc_and_dc(
         &pool,
         &hex_boosting_client,
-        &mobile_rewards_client,
+        mobile_rewards_client,
         &speedtest_avg_client,
         &reward_info,
         price_info,
     )
     .await?;
-    drop(mobile_rewards_client);
 
     let rewards = mobile_rewards.finish().await?;
     let poc_rewards = rewards.radio_reward_v2;
@@ -346,13 +341,12 @@ async fn test_data_banned_radio_still_receives_poc(pool: PgPool) -> anyhow::Resu
     rewarder::reward_poc_and_dc(
         &pool,
         &hex_boosting_client,
-        &mobile_rewards_client,
+        mobile_rewards_client,
         &speedtest_avg_client,
         &reward_info,
         price_info,
     )
     .await?;
-    drop(mobile_rewards_client);
 
     let rewards = mobile_rewards.finish().await?;
     let poc_rewards = rewards.radio_reward_v2;

--- a/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
+++ b/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
@@ -203,10 +203,7 @@ async fn test_service_provider_promotion_rewards(pool: PgPool) -> anyhow::Result
     .await?;
 
     let rewards = mobile_rewards.finish().await?;
-
-    let promo_rewards = rewards
-        .promotion_rewards
-        .as_keyed_map(|reward| reward.entity.to_owned());
+    let promo_rewards = rewards.promotion_rewards.as_keyed_map();
 
     // 1 share
     let promo_reward_1 = promo_rewards.get("one").expect("promo 1");

--- a/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
+++ b/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
@@ -97,7 +97,7 @@ async fn test_service_provider_rewards(pool: PgPool) -> anyhow::Result<()> {
 
     let rewards = mobile_rewards.finish().await?;
 
-    let sp_reward = rewards.sp_reward.first().expect("sp 1 reward");
+    let sp_reward = rewards.sp_rewards.first().expect("sp 1 reward");
     assert_eq!(5_999, sp_reward.amount);
 
     let unallocated_reward = rewards.unallocated.first().expect("unallocated");
@@ -205,7 +205,7 @@ async fn test_service_provider_promotion_rewards(pool: PgPool) -> anyhow::Result
     let rewards = mobile_rewards.finish().await?;
 
     let promo_rewards = rewards
-        .promotion_reward
+        .promotion_rewards
         .as_keyed_map(|reward| reward.entity.to_owned());
 
     // 1 share
@@ -224,7 +224,7 @@ async fn test_service_provider_promotion_rewards(pool: PgPool) -> anyhow::Result
     assert_eq!(promo_reward_3.matched_amount, 4_499);
 
     // dc_percentage * total_sp_allocation rounded down
-    let sp_reward = rewards.sp_reward.first().expect("sp 1 reward");
+    let sp_reward = rewards.sp_rewards.first().expect("sp 1 reward");
     assert_eq!(sp_reward.amount, 50_999);
 
     let unallocated_sp_rewards = get_unallocated_sp_rewards(reward_info.epoch_emissions);

--- a/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
+++ b/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
@@ -70,7 +70,7 @@ async fn test_service_provider_rewards(pool: PgPool) -> anyhow::Result<()> {
     let mut valid_sps = HashMap::<String, String>::new();
     valid_sps.insert(PAYER_1.to_string(), SP_1.to_string());
     let carrier_client = MockCarrierServiceClient::new(valid_sps);
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -179,7 +179,7 @@ async fn test_service_provider_promotion_rewards(pool: PgPool) -> anyhow::Result
 
     let reward_info = reward_info_24_hours();
 
-    let (mobile_rewards_client, mobile_rewards) = common::create_nonblocking_file_sink();
+    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
 
     let mut txn = pool.begin().await?;
     seed_hotspot_data(reward_info.epoch_period.end, &mut txn).await?; // DC transferred == 6,000 reward amount

--- a/mobile_verifier/tests/integrations/speedtests.rs
+++ b/mobile_verifier/tests/integrations/speedtests.rs
@@ -55,7 +55,7 @@ async fn speedtests_average_should_only_include_last_48_hours(
     let (_tx, rx) = tokio::sync::mpsc::channel(2);
     let gateway_info_resolver = MockGatewayInfoResolver {};
     let (speedtest_avg_client, speedtest_avg_receiver) = common::create_nonblocking_file_sink();
-    let (verified_client, _verified_receiver) = common::create_file_sink();
+    let (verified_client, _verified_receiver) = common::create_nonblocking_file_sink();
 
     let hotspot: PublicKeyBinary =
         "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6".parse()?;

--- a/mobile_verifier/tests/integrations/speedtests.rs
+++ b/mobile_verifier/tests/integrations/speedtests.rs
@@ -54,16 +54,8 @@ async fn speedtests_average_should_only_include_last_48_hours(
 ) -> anyhow::Result<()> {
     let (_tx, rx) = tokio::sync::mpsc::channel(2);
     let gateway_info_resolver = MockGatewayInfoResolver {};
-    let (speedtest_avg_client, mut speedtest_avg_receiver) = common::create_file_sink();
+    let (speedtest_avg_client, speedtest_avg_receiver) = common::create_nonblocking_file_sink();
     let (verified_client, _verified_receiver) = common::create_file_sink();
-
-    let daemon = SpeedtestDaemon::new(
-        pool,
-        gateway_info_resolver,
-        rx,
-        speedtest_avg_client,
-        verified_client,
-    );
 
     let hotspot: PublicKeyBinary =
         "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6".parse()?;
@@ -77,9 +69,20 @@ async fn speedtests_average_should_only_include_last_48_hours(
         speedtest(&hotspot, "2024-01-06 01:00:00", 10, 100, 10),
     ]);
 
-    assert!(daemon.process_file(stream).await.is_ok());
+    // Drop the daemon when it's done running
+    {
+        let daemon = SpeedtestDaemon::new(
+            pool,
+            gateway_info_resolver,
+            rx,
+            speedtest_avg_client,
+            verified_client,
+        );
 
-    let avgs = speedtest_avg_receiver.get_all_speedtest_avgs().await;
+        daemon.process_file(stream).await?;
+    }
+
+    let avgs = speedtest_avg_receiver.finish().await?;
 
     assert_eq!(6, avgs.len());
     assert_eq!(SpeedtestAvgValidity::TooFewSamples, avgs[0].validity());

--- a/mobile_verifier/tests/integrations/speedtests.rs
+++ b/mobile_verifier/tests/integrations/speedtests.rs
@@ -54,8 +54,8 @@ async fn speedtests_average_should_only_include_last_48_hours(
 ) -> anyhow::Result<()> {
     let (_tx, rx) = tokio::sync::mpsc::channel(2);
     let gateway_info_resolver = MockGatewayInfoResolver {};
-    let (speedtest_avg_client, speedtest_avg_receiver) = common::create_nonblocking_file_sink();
-    let (verified_client, _verified_receiver) = common::create_nonblocking_file_sink();
+    let (speedtest_avg_client, speedtest_avg_receiver) = common::create_file_sink();
+    let (verified_client, _verified_receiver) = common::create_file_sink();
 
     let hotspot: PublicKeyBinary =
         "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6".parse()?;

--- a/mobile_verifier/tests/integrations/speedtests.rs
+++ b/mobile_verifier/tests/integrations/speedtests.rs
@@ -69,7 +69,7 @@ async fn speedtests_average_should_only_include_last_48_hours(
         speedtest(&hotspot, "2024-01-06 01:00:00", 10, 100, 10),
     ]);
 
-    // Drop the daemon when it's done running
+    // Drop the daemon when it's done running to close the channel
     {
         let daemon = SpeedtestDaemon::new(
             pool,


### PR DESCRIPTION
Provide a testing FileSink that acks messages as they're written so we don't have to deal with race conditions in tests.

### Previously
```rs
    let (_, rewards) = tokio::join!(
        rewarder::reward_mappers(&pool, &mobile_rewards_client, &reward_info),
        receive_expected_rewards(&mut mobile_rewards)
    );
```

Tests required that you know how many messages you were expecting, otherwise the test would hang indefinitely either waiting for a written message to be acknowledged, or waiting for a message that would never be written.

### Now

The test `FileSinkReceiver` consumes all messages that are written as they come.
Functions in the rewarder now own a `FileSinkClient<T>`
```rs
pub async fn reward_poc_and_dc(
    pool: &Pool<Postgres>,
    hex_service_client: &impl HexBoostingInfoResolver<Error = ClientError>,
    mobile_rewards: FileSinkClient<proto::MobileRewardShare>,
    speedtest_avg_sink: &FileSinkClient<proto::SpeedtestAvg>,
    reward_info: &EpochRewardInfo,
    price_info: PriceInfo,
)
```

Cloning a `FileSinkClient<T>` is relatively cheap as it's just a channel and a metrics string.
When the rewarding function under test is done, it will drop the `Sender`, and we can know that all messages that will be written have been written.

We can then make assertions against all the messages written during the test. Whether they were expected or not.