### PR TITLE
Remove Generic Associated Error Types

### DIFF
--- a/boost_manager/src/activator.rs
+++ b/boost_manager/src/activator.rs
@@ -11,7 +11,7 @@ use helium_proto::{
 };
 use mobile_config::{
     boosted_hex_info::{BoostedHex, BoostedHexes},
-    client::{hex_boosting_client::HexBoostingInfoResolver, ClientError},
+    client::hex_boosting_client::HexBoostingInfoResolver,
 };
 use poc_metrics::record_duration;
 use sqlx::{Pool, Postgres, Transaction};
@@ -28,7 +28,7 @@ pub struct Activator<A> {
 
 impl<A> ManagedTask for Activator<A>
 where
-    A: HexBoostingInfoResolver<Error = ClientError>,
+    A: HexBoostingInfoResolver,
 {
     fn start_task(
         self: Box<Self>,
@@ -45,7 +45,7 @@ where
 
 impl<A> Activator<A>
 where
-    A: HexBoostingInfoResolver<Error = ClientError>,
+    A: HexBoostingInfoResolver,
 {
     pub async fn new(
         pool: Pool<Postgres>,

--- a/boost_manager/src/watcher.rs
+++ b/boost_manager/src/watcher.rs
@@ -6,8 +6,7 @@ use file_store::traits::TimestampEncode;
 use futures::{future::LocalBoxFuture, TryFutureExt};
 use helium_proto::BoostedHexUpdateV1 as BoostedHexUpdateProto;
 use mobile_config::{
-    boosted_hex_info::BoostedHexes,
-    client::{hex_boosting_client::HexBoostingInfoResolver, ClientError},
+    boosted_hex_info::BoostedHexes, client::hex_boosting_client::HexBoostingInfoResolver,
 };
 use sqlx::{PgExecutor, Pool, Postgres};
 use task_manager::ManagedTask;
@@ -24,7 +23,7 @@ pub struct Watcher<A> {
 
 impl<A> ManagedTask for Watcher<A>
 where
-    A: HexBoostingInfoResolver<Error = ClientError>,
+    A: HexBoostingInfoResolver,
 {
     fn start_task(
         self: Box<Self>,
@@ -41,7 +40,7 @@ where
 
 impl<A> Watcher<A>
 where
-    A: HexBoostingInfoResolver<Error = ClientError>,
+    A: HexBoostingInfoResolver,
 {
     pub async fn new(
         pool: Pool<Postgres>,

--- a/boost_manager/tests/integrations/common/mod.rs
+++ b/boost_manager/tests/integrations/common/mod.rs
@@ -25,8 +25,6 @@ impl MockHexBoostingClient {
 
 #[async_trait]
 impl HexBoostingInfoResolver for MockHexBoostingClient {
-    type Error = ClientError;
-
     async fn stream_boosted_hexes_info(&mut self) -> Result<BoostedHexInfoStream, ClientError> {
         Ok(stream::iter(self.boosted_hexes.clone()).boxed())
     }

--- a/iot_config/src/client/mod.rs
+++ b/iot_config/src/client/mod.rs
@@ -31,19 +31,17 @@ pub enum ClientError {
 
 #[async_trait::async_trait]
 pub trait Gateways: Clone + Send + Sync + 'static {
-    type Error: std::fmt::Debug + Send + Sync + 'static;
-
     async fn resolve_gateway_info(
         &mut self,
         address: &PublicKeyBinary,
-    ) -> Result<Option<GatewayInfo>, Self::Error>;
+    ) -> Result<Option<GatewayInfo>, ClientError>;
 
-    async fn stream_gateways_info(&mut self) -> Result<GatewayInfoStream, Self::Error>;
+    async fn stream_gateways_info(&mut self) -> Result<GatewayInfoStream, ClientError>;
 
     async fn resolve_region_params(
         &mut self,
         region: Region,
-    ) -> Result<RegionParamsInfo, Self::Error>;
+    ) -> Result<RegionParamsInfo, ClientError>;
 }
 
 #[derive(Clone, Debug)]
@@ -101,8 +99,6 @@ impl Client {
 
 #[async_trait::async_trait]
 impl Gateways for Client {
-    type Error = ClientError;
-
     async fn resolve_region_params(
         &mut self,
         region: Region,
@@ -128,7 +124,7 @@ impl Gateways for Client {
     async fn resolve_gateway_info(
         &mut self,
         address: &PublicKeyBinary,
-    ) -> Result<Option<gateway_info::GatewayInfo>, Self::Error> {
+    ) -> Result<Option<gateway_info::GatewayInfo>, ClientError> {
         let mut request = iot_config::GatewayInfoReqV1 {
             address: address.clone().into(),
             signer: self.signing_key.public_key().into(),
@@ -150,7 +146,7 @@ impl Gateways for Client {
 
     async fn stream_gateways_info(
         &mut self,
-    ) -> Result<gateway_info::GatewayInfoStream, Self::Error> {
+    ) -> Result<gateway_info::GatewayInfoStream, ClientError> {
         let mut request = iot_config::GatewayInfoStreamReqV1 {
             batch_size: self.batch_size,
             signer: self.signing_key.public_key().into(),

--- a/iot_verifier/tests/integrations/runner_tests.rs
+++ b/iot_verifier/tests/integrations/runner_tests.rs
@@ -9,6 +9,7 @@ use helium_proto::services::poc_lora::{
     LoraInvalidWitnessReportV1, LoraPocV1, LoraWitnessReportReqV1, VerificationStatus,
 };
 use helium_proto::Region as ProtoRegion;
+use iot_config::client::ClientError;
 use iot_config::{
     client::{Gateways, RegionParamsInfo},
     gateway_info::{GatewayInfo, GatewayInfoStream},
@@ -36,16 +37,14 @@ pub struct MockIotConfigClient {
 
 #[async_trait]
 impl Gateways for MockIotConfigClient {
-    type Error = anyhow::Error;
-
     async fn resolve_gateway_info(
         &mut self,
         _address: &PublicKeyBinary,
-    ) -> Result<Option<GatewayInfo>, Self::Error> {
+    ) -> Result<Option<GatewayInfo>, ClientError> {
         Ok(Some(self.resolve_gateway.clone()))
     }
 
-    async fn stream_gateways_info(&mut self) -> Result<GatewayInfoStream, Self::Error> {
+    async fn stream_gateways_info(&mut self) -> Result<GatewayInfoStream, ClientError> {
         let stream = stream::iter(self.stream_gateways.clone()).boxed();
         Ok(stream)
     }
@@ -53,7 +52,7 @@ impl Gateways for MockIotConfigClient {
     async fn resolve_region_params(
         &mut self,
         _region: ProtoRegion,
-    ) -> Result<RegionParamsInfo, Self::Error> {
+    ) -> Result<RegionParamsInfo, ClientError> {
         Ok(self.region_params.clone())
     }
 }

--- a/mobile_config/src/boosted_hex_info.rs
+++ b/mobile_config/src/boosted_hex_info.rs
@@ -1,4 +1,4 @@
-use crate::client::{hex_boosting_client::HexBoostingInfoResolver, ClientError};
+use crate::client::hex_boosting_client::HexBoostingInfoResolver;
 use chrono::{DateTime, Duration, Utc};
 use file_store::traits::TimestampDecode;
 use futures::stream::{BoxStream, StreamExt};
@@ -138,7 +138,7 @@ impl BoostedHexes {
     }
 
     pub async fn get_all(
-        hex_service_client: &impl HexBoostingInfoResolver<Error = ClientError>,
+        hex_service_client: &impl HexBoostingInfoResolver,
     ) -> anyhow::Result<Self> {
         let mut map = HashMap::new();
         let mut stream = hex_service_client
@@ -156,7 +156,7 @@ impl BoostedHexes {
     }
 
     pub async fn get_modified(
-        hex_service_client: &impl HexBoostingInfoResolver<Error = ClientError>,
+        hex_service_client: &impl HexBoostingInfoResolver,
         timestamp: DateTime<Utc>,
     ) -> anyhow::Result<Self> {
         let mut map = HashMap::new();

--- a/mobile_config/src/client/carrier_service_client.rs
+++ b/mobile_config/src/client/carrier_service_client.rs
@@ -10,17 +10,16 @@ use helium_proto::{
 use retainer::Cache;
 use std::{str::FromStr, sync::Arc, time::Duration};
 #[async_trait]
-pub trait CarrierServiceVerifier {
-    type Error;
-    async fn payer_key_to_service_provider<'a>(
+pub trait CarrierServiceVerifier: Send + Sync + 'static {
+    async fn payer_key_to_service_provider(
         &self,
         payer: &str,
-    ) -> Result<ServiceProvider, Self::Error>;
+    ) -> Result<ServiceProvider, ClientError>;
 
     async fn list_incentive_promotions(
         &self,
         epoch_start: &DateTime<Utc>,
-    ) -> Result<Vec<ServiceProviderPromotions>, Self::Error>;
+    ) -> Result<Vec<ServiceProviderPromotions>, ClientError>;
 }
 #[derive(Clone)]
 pub struct CarrierServiceClient {
@@ -33,9 +32,7 @@ pub struct CarrierServiceClient {
 
 #[async_trait]
 impl CarrierServiceVerifier for CarrierServiceClient {
-    type Error = ClientError;
-
-    async fn payer_key_to_service_provider<'a>(
+    async fn payer_key_to_service_provider(
         &self,
         payer: &str,
     ) -> Result<ServiceProvider, ClientError> {
@@ -71,7 +68,7 @@ impl CarrierServiceVerifier for CarrierServiceClient {
     async fn list_incentive_promotions(
         &self,
         epoch_start: &DateTime<Utc>,
-    ) -> Result<Vec<ServiceProviderPromotions>, Self::Error> {
+    ) -> Result<Vec<ServiceProviderPromotions>, ClientError> {
         let mut request = mobile_config::CarrierIncentivePromotionListReqV1 {
             timestamp: epoch_start.encode_timestamp(),
             signer: self.signing_key.public_key().into(),

--- a/mobile_config/src/client/hex_boosting_client.rs
+++ b/mobile_config/src/client/hex_boosting_client.rs
@@ -8,7 +8,7 @@ use helium_proto::{
     services::{mobile_config, Channel},
     Message,
 };
-use std::{error::Error, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 #[derive(Clone)]
 pub struct HexBoostingClient {
@@ -31,21 +31,17 @@ impl HexBoostingClient {
 
 #[async_trait::async_trait]
 pub trait HexBoostingInfoResolver: Clone + Send + Sync + 'static {
-    type Error: Error + Send + Sync + 'static;
-
-    async fn stream_boosted_hexes_info(&mut self) -> Result<BoostedHexInfoStream, Self::Error>;
+    async fn stream_boosted_hexes_info(&mut self) -> Result<BoostedHexInfoStream, ClientError>;
 
     async fn stream_modified_boosted_hexes_info(
         &mut self,
         timestamp: DateTime<Utc>,
-    ) -> Result<BoostedHexInfoStream, Self::Error>;
+    ) -> Result<BoostedHexInfoStream, ClientError>;
 }
 
 #[async_trait::async_trait]
 impl HexBoostingInfoResolver for HexBoostingClient {
-    type Error = ClientError;
-
-    async fn stream_boosted_hexes_info(&mut self) -> Result<BoostedHexInfoStream, Self::Error> {
+    async fn stream_boosted_hexes_info(&mut self) -> Result<BoostedHexInfoStream, ClientError> {
         let mut req = mobile_config::BoostedHexInfoStreamReqV1 {
             batch_size: self.batch_size,
             signer: self.signing_key.public_key().into(),
@@ -75,7 +71,7 @@ impl HexBoostingInfoResolver for HexBoostingClient {
     async fn stream_modified_boosted_hexes_info(
         &mut self,
         timestamp: DateTime<Utc>,
-    ) -> Result<BoostedHexInfoStream, Self::Error> {
+    ) -> Result<BoostedHexInfoStream, ClientError> {
         let mut req = mobile_config::BoostedHexModifiedInfoStreamReqV1 {
             batch_size: self.batch_size,
             timestamp: timestamp.timestamp() as u64,

--- a/mobile_config/src/client/sub_dao_client.rs
+++ b/mobile_config/src/client/sub_dao_client.rs
@@ -9,7 +9,7 @@ use helium_proto::{
     },
     Message,
 };
-use std::{error::Error, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 #[derive(Clone)]
 pub struct SubDaoClient {
@@ -30,24 +30,20 @@ impl SubDaoClient {
 
 #[async_trait::async_trait]
 pub trait SubDaoEpochRewardInfoResolver: Clone + Send + Sync + 'static {
-    type Error: Error + Send + Sync + 'static;
-
     async fn resolve_info(
         &self,
         sub_dao: &str,
         epoch: u64,
-    ) -> Result<Option<EpochRewardInfo>, Self::Error>;
+    ) -> Result<Option<EpochRewardInfo>, ClientError>;
 }
 
 #[async_trait::async_trait]
 impl SubDaoEpochRewardInfoResolver for SubDaoClient {
-    type Error = ClientError;
-
     async fn resolve_info(
         &self,
         sub_dao: &str,
         epoch: u64,
-    ) -> Result<Option<EpochRewardInfo>, Self::Error> {
+    ) -> Result<Option<EpochRewardInfo>, ClientError> {
         let mut request = SubDaoEpochRewardInfoReqV1 {
             sub_dao_address: sub_dao.to_string(),
             epoch,

--- a/mobile_verifier/src/lib.rs
+++ b/mobile_verifier/src/lib.rs
@@ -22,8 +22,8 @@ pub use settings::Settings;
 
 use async_trait::async_trait;
 use helium_lib::keypair::Pubkey;
+use mobile_config::client::ClientError;
 use rust_decimal::Decimal;
-use std::error::Error;
 
 pub enum GatewayResolution {
     GatewayNotFound,
@@ -40,22 +40,18 @@ impl GatewayResolution {
 
 #[async_trait::async_trait]
 pub trait GatewayResolver: Clone + Send + Sync + 'static {
-    type Error: Error + Send + Sync + 'static;
-
     async fn resolve_gateway(
         &self,
         address: &helium_crypto::PublicKeyBinary,
-    ) -> Result<GatewayResolution, Self::Error>;
+    ) -> Result<GatewayResolution, ClientError>;
 }
 
 #[async_trait]
 impl GatewayResolver for mobile_config::GatewayClient {
-    type Error = mobile_config::client::ClientError;
-
     async fn resolve_gateway(
         &self,
         address: &helium_crypto::PublicKeyBinary,
-    ) -> Result<GatewayResolution, Self::Error> {
+    ) -> Result<GatewayResolution, ClientError> {
         use mobile_config::client::gateway_client::GatewayInfoResolver;
         use mobile_config::gateway_info::{DeviceType, GatewayInfo};
 
@@ -76,24 +72,20 @@ impl GatewayResolver for mobile_config::GatewayClient {
 
 #[async_trait]
 pub trait IsAuthorized {
-    type Error: std::error::Error + Send + Sync + 'static;
-
     async fn is_authorized(
         &self,
         address: &helium_crypto::PublicKeyBinary,
         role: helium_proto::services::mobile_config::NetworkKeyRole,
-    ) -> Result<bool, Self::Error>;
+    ) -> Result<bool, ClientError>;
 }
 
 #[async_trait]
 impl IsAuthorized for mobile_config::client::AuthorizationClient {
-    type Error = mobile_config::client::ClientError;
-
     async fn is_authorized(
         &self,
         address: &helium_crypto::PublicKeyBinary,
         role: helium_proto::services::mobile_config::NetworkKeyRole,
-    ) -> Result<bool, Self::Error> {
+    ) -> Result<bool, ClientError> {
         use mobile_config::client::authorization_client::AuthorizationVerifier;
         self.verify_authorized_key(address, role).await
     }

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -39,7 +39,7 @@ use mobile_config::{
     client::{
         carrier_service_client::CarrierServiceVerifier,
         hex_boosting_client::HexBoostingInfoResolver,
-        sub_dao_client::SubDaoEpochRewardInfoResolver, ClientError,
+        sub_dao_client::SubDaoEpochRewardInfoResolver,
     },
     sub_dao_epoch_reward_info::EpochRewardInfo,
     EpochInfo,
@@ -73,9 +73,9 @@ pub struct Rewarder<A, B, C> {
 
 impl<A, B, C> Rewarder<A, B, C>
 where
-    A: CarrierServiceVerifier<Error = ClientError> + Send + Sync + 'static,
-    B: HexBoostingInfoResolver<Error = ClientError> + Send + Sync + 'static,
-    C: SubDaoEpochRewardInfoResolver<Error = ClientError> + Send + Sync + 'static,
+    A: CarrierServiceVerifier + 'static,
+    B: HexBoostingInfoResolver,
+    C: SubDaoEpochRewardInfoResolver,
 {
     pub async fn create_managed_task(
         pool: Pool<Postgres>,
@@ -374,9 +374,9 @@ where
 
 impl<A, B, C> ManagedTask for Rewarder<A, B, C>
 where
-    A: CarrierServiceVerifier<Error = ClientError> + Send + Sync + 'static,
-    B: HexBoostingInfoResolver<Error = ClientError> + Send + Sync + 'static,
-    C: SubDaoEpochRewardInfoResolver<Error = ClientError> + Send + Sync + 'static,
+    A: CarrierServiceVerifier,
+    B: HexBoostingInfoResolver,
+    C: SubDaoEpochRewardInfoResolver,
 {
     fn start_task(
         self: Box<Self>,
@@ -393,7 +393,7 @@ where
 
 pub async fn reward_poc_and_dc(
     pool: &Pool<Postgres>,
-    hex_service_client: &impl HexBoostingInfoResolver<Error = ClientError>,
+    hex_service_client: &impl HexBoostingInfoResolver,
     mobile_rewards: FileSinkClient<proto::MobileRewardShare>,
     speedtest_avg_sink: &FileSinkClient<proto::SpeedtestAvg>,
     reward_info: &EpochRewardInfo,
@@ -456,7 +456,7 @@ pub async fn reward_poc_and_dc(
 
 async fn reward_poc(
     pool: &Pool<Postgres>,
-    hex_service_client: &impl HexBoostingInfoResolver<Error = ClientError>,
+    hex_service_client: &impl HexBoostingInfoResolver,
     mobile_rewards: &FileSinkClient<proto::MobileRewardShare>,
     speedtest_avg_sink: &FileSinkClient<proto::SpeedtestAvg>,
     reward_info: &EpochRewardInfo,

--- a/mobile_verifier/src/service_provider/dc_sessions.rs
+++ b/mobile_verifier/src/service_provider/dc_sessions.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, ops::Range};
 
 use chrono::{DateTime, Utc};
-use mobile_config::client::{carrier_service_client::CarrierServiceVerifier, ClientError};
+use mobile_config::client::carrier_service_client::CarrierServiceVerifier;
 use rust_decimal::{Decimal, RoundingStrategy};
 use sqlx::PgPool;
 
@@ -14,7 +14,7 @@ use super::ServiceProviderId;
 
 pub async fn get_dc_sessions(
     pool: &PgPool,
-    carrier_client: &impl CarrierServiceVerifier<Error = ClientError>,
+    carrier_client: &impl CarrierServiceVerifier,
     reward_period: &Range<DateTime<Utc>>,
 ) -> anyhow::Result<ServiceProviderDCSessions> {
     let payer_dc_sessions =
@@ -107,6 +107,7 @@ pub mod tests {
 
     use chrono::Duration;
     use helium_proto::{ServiceProvider, ServiceProviderPromotions};
+    use mobile_config::client::ClientError;
 
     use crate::data_session::HotspotDataSession;
 
@@ -125,9 +126,7 @@ pub mod tests {
 
         #[async_trait::async_trait]
         impl CarrierServiceVerifier for MockClient {
-            type Error = ClientError;
-
-            async fn payer_key_to_service_provider<'a>(
+            async fn payer_key_to_service_provider(
                 &self,
                 _pubkey: &str,
             ) -> Result<ServiceProvider, ClientError> {
@@ -137,7 +136,7 @@ pub mod tests {
             async fn list_incentive_promotions(
                 &self,
                 _epoch_start: &DateTime<Utc>,
-            ) -> Result<Vec<ServiceProviderPromotions>, Self::Error> {
+            ) -> Result<Vec<ServiceProviderPromotions>, ClientError> {
                 Ok(vec![])
             }
         }

--- a/mobile_verifier/src/service_provider/promotions.rs
+++ b/mobile_verifier/src/service_provider/promotions.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use mobile_config::client::{carrier_service_client::CarrierServiceVerifier, ClientError};
+use mobile_config::client::carrier_service_client::CarrierServiceVerifier;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 
@@ -10,7 +10,7 @@ mod proto {
 }
 
 pub async fn get_promotions(
-    client: &impl CarrierServiceVerifier<Error = ClientError>,
+    client: &impl CarrierServiceVerifier,
     epoch_start: &DateTime<Utc>,
 ) -> anyhow::Result<ServiceProviderPromotions> {
     let promos = client.list_incentive_promotions(epoch_start).await?;

--- a/mobile_verifier/tests/integrations/common/mod.rs
+++ b/mobile_verifier/tests/integrations/common/mod.rs
@@ -52,8 +52,6 @@ impl MockHexBoostingClient {
 
 #[async_trait::async_trait]
 impl HexBoostingInfoResolver for MockHexBoostingClient {
-    type Error = ClientError;
-
     async fn stream_boosted_hexes_info(&mut self) -> Result<BoostedHexInfoStream, ClientError> {
         Ok(stream::iter(self.boosted_hexes.clone()).boxed())
     }
@@ -68,13 +66,11 @@ impl HexBoostingInfoResolver for MockHexBoostingClient {
 
 #[async_trait::async_trait]
 impl SubDaoEpochRewardInfoResolver for MockSubDaoRewardsClient {
-    type Error = ClientError;
-
     async fn resolve_info(
         &self,
         _sub_dao: &str,
         _epoch: u64,
-    ) -> Result<Option<EpochRewardInfo>, Self::Error> {
+    ) -> Result<Option<EpochRewardInfo>, ClientError> {
         Ok(self.info.clone())
     }
 }
@@ -215,12 +211,10 @@ pub struct GatewayClientAllOwnersValid;
 
 #[async_trait]
 impl GatewayResolver for GatewayClientAllOwnersValid {
-    type Error = std::convert::Infallible;
-
     async fn resolve_gateway(
         &self,
         _address: &PublicKeyBinary,
-    ) -> Result<GatewayResolution, Self::Error> {
+    ) -> Result<GatewayResolution, ClientError> {
         Ok(GatewayResolution::AssertedLocation(0x8c2681a3064d9ff))
     }
 }

--- a/mobile_verifier/tests/integrations/modeled_coverage.rs
+++ b/mobile_verifier/tests/integrations/modeled_coverage.rs
@@ -12,7 +12,10 @@ use helium_proto::services::{
     poc_mobile::{CoverageObjectValidity, LocationSource, SignalLevel},
 };
 use hextree::Cell;
-use mobile_config::boosted_hex_info::{BoostedHexInfo, BoostedHexes};
+use mobile_config::{
+    boosted_hex_info::{BoostedHexInfo, BoostedHexes},
+    client::ClientError,
+};
 
 use mobile_verifier::{
     banning::BannedRadios,
@@ -189,13 +192,11 @@ struct AllPubKeysAuthed;
 
 #[async_trait::async_trait]
 impl IsAuthorized for AllPubKeysAuthed {
-    type Error = std::convert::Infallible;
-
     async fn is_authorized(
         &self,
         _pub_key: &PublicKeyBinary,
         _role: NetworkKeyRole,
-    ) -> Result<bool, Self::Error> {
+    ) -> Result<bool, ClientError> {
         Ok(true)
     }
 }

--- a/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
+++ b/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
@@ -44,9 +44,7 @@ impl MockCarrierServiceClient {
 
 #[async_trait]
 impl CarrierServiceVerifier for MockCarrierServiceClient {
-    type Error = ClientError;
-
-    async fn payer_key_to_service_provider<'a>(
+    async fn payer_key_to_service_provider(
         &self,
         pubkey: &str,
     ) -> Result<ServiceProvider, ClientError> {
@@ -60,7 +58,7 @@ impl CarrierServiceVerifier for MockCarrierServiceClient {
     async fn list_incentive_promotions(
         &self,
         _epoch_start: &DateTime<Utc>,
-    ) -> Result<Vec<ServiceProviderPromotions>, Self::Error> {
+    ) -> Result<Vec<ServiceProviderPromotions>, ClientError> {
         Ok(self.promotions.clone())
     }
 }

--- a/mobile_verifier/tests/integrations/speedtests.rs
+++ b/mobile_verifier/tests/integrations/speedtests.rs
@@ -10,26 +10,21 @@ use helium_proto::services::{
     mobile_config::DeviceType as MobileDeviceType, poc_mobile::SpeedtestAvgValidity,
 };
 use mobile_config::{
-    client::gateway_client::GatewayInfoResolver,
+    client::{gateway_client::GatewayInfoResolver, ClientError},
     gateway_info::{DeviceType, GatewayInfo, GatewayInfoStream},
 };
 use mobile_verifier::speedtests::SpeedtestDaemon;
 use sqlx::{Pool, Postgres};
-
-#[derive(thiserror::Error, Debug)]
-enum MockError {}
 
 #[derive(Clone)]
 struct MockGatewayInfoResolver {}
 
 #[async_trait::async_trait]
 impl GatewayInfoResolver for MockGatewayInfoResolver {
-    type Error = MockError;
-
     async fn resolve_gateway_info(
         &self,
         address: &PublicKeyBinary,
-    ) -> Result<Option<GatewayInfo>, Self::Error> {
+    ) -> Result<Option<GatewayInfo>, ClientError> {
         Ok(Some(GatewayInfo {
             address: address.clone(),
             metadata: None,
@@ -43,7 +38,7 @@ impl GatewayInfoResolver for MockGatewayInfoResolver {
     async fn stream_gateways_info(
         &mut self,
         _device_types: &[MobileDeviceType],
-    ) -> Result<GatewayInfoStream, Self::Error> {
+    ) -> Result<GatewayInfoStream, ClientError> {
         todo!()
     }
 }


### PR DESCRIPTION
In every occurence where we have a GAT error, the ability to change the Error is not used. As all of the touched traits are for API Clients, and they all return ClienError, we can reduce the amount of generic constraints we need to type by removing them.

In a case where we do want to return an error, it is a simple process to return an applicable ClientError variant.