### PR TITLE
Remove Generics around HexAssignments

### DIFF
--- a/hex_assignments/src/assignment.rs
+++ b/hex_assignments/src/assignment.rs
@@ -1,5 +1,3 @@
-use super::HexAssignment;
-use anyhow::Result;
 use helium_proto::services::poc_mobile::OracleBoostingAssignment as ProtoAssignment;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -77,16 +75,6 @@ impl fmt::Display for Assignment {
 }
 
 impl HexAssignments {
-    pub fn builder(cell: hextree::Cell) -> HexAssignmentsBuilder {
-        HexAssignmentsBuilder {
-            cell,
-            footfall: None,
-            landtype: None,
-            urbanized: None,
-            service_provider_override: None,
-        }
-    }
-
     pub fn boosting_multiplier(&self) -> Decimal {
         let HexAssignments {
             footfall,
@@ -121,59 +109,5 @@ impl HexAssignments {
             //HRP-20250409 - all footfall C hexes are 0.03 multiplier
             (C, _, _, _) => dec!(0.03),
         }
-    }
-}
-
-pub struct HexAssignmentsBuilder {
-    cell: hextree::Cell,
-    footfall: Option<Result<Assignment>>,
-    landtype: Option<Result<Assignment>>,
-    urbanized: Option<Result<Assignment>>,
-    service_provider_override: Option<Result<Assignment>>,
-}
-
-impl HexAssignmentsBuilder {
-    pub fn footfall(mut self, footfall: &impl HexAssignment) -> Self {
-        self.footfall = Some(footfall.assignment(self.cell));
-        self
-    }
-
-    pub fn landtype(mut self, landtype: &impl HexAssignment) -> Self {
-        self.landtype = Some(landtype.assignment(self.cell));
-        self
-    }
-
-    pub fn urbanized(mut self, urbanized: &impl HexAssignment) -> Self {
-        self.urbanized = Some(urbanized.assignment(self.cell));
-        self
-    }
-
-    pub fn service_provider_override(
-        mut self,
-        service_provider_override: &impl HexAssignment,
-    ) -> Self {
-        self.service_provider_override = Some(service_provider_override.assignment(self.cell));
-        self
-    }
-
-    pub fn build(self) -> anyhow::Result<HexAssignments> {
-        let Some(footfall) = self.footfall else {
-            anyhow::bail!("footfall assignment not set");
-        };
-        let Some(landtype) = self.landtype else {
-            anyhow::bail!("landtype assignment not set");
-        };
-        let Some(urbanized) = self.urbanized else {
-            anyhow::bail!("urbanized assignment not set");
-        };
-        let Some(service_provider_override) = self.service_provider_override else {
-            anyhow::bail!("service_provider_override assignment not set");
-        };
-        Ok(HexAssignments {
-            footfall: footfall?,
-            urbanized: urbanized?,
-            landtype: landtype?,
-            service_provider_override: service_provider_override?,
-        })
     }
 }

--- a/hex_assignments/src/footfall.rs
+++ b/hex_assignments/src/footfall.rs
@@ -3,6 +3,7 @@ use hextree::disktree::DiskTreeMap;
 
 use super::{Assignment, HexAssignment};
 
+#[derive(Default)]
 pub struct Footfall {
     pub footfall: Option<DiskTreeMap>,
     pub timestamp: Option<DateTime<Utc>>,
@@ -14,12 +15,6 @@ impl Footfall {
             footfall,
             timestamp: None,
         }
-    }
-}
-
-impl Default for Footfall {
-    fn default() -> Self {
-        Self::new(None)
     }
 }
 

--- a/hex_assignments/src/landtype.rs
+++ b/hex_assignments/src/landtype.rs
@@ -3,6 +3,7 @@ use hextree::disktree::DiskTreeMap;
 
 use super::{Assignment, HexAssignment};
 
+#[derive(Default)]
 pub struct Landtype {
     pub landtype: Option<DiskTreeMap>,
     pub timestamp: Option<DateTime<Utc>>,
@@ -14,12 +15,6 @@ impl Landtype {
             landtype,
             timestamp: None,
         }
-    }
-}
-
-impl Default for Landtype {
-    fn default() -> Self {
-        Self::new(None)
     }
 }
 

--- a/hex_assignments/src/service_provider_override.rs
+++ b/hex_assignments/src/service_provider_override.rs
@@ -3,6 +3,7 @@ use hextree::disktree::DiskTreeMap;
 
 use super::{Assignment, HexAssignment};
 
+#[derive(Default)]
 pub struct ServiceProviderOverride {
     pub service_provider_override: Option<DiskTreeMap>,
     pub timestamp: Option<DateTime<Utc>>,
@@ -14,12 +15,6 @@ impl ServiceProviderOverride {
             service_provider_override,
             timestamp: None,
         }
-    }
-}
-
-impl Default for ServiceProviderOverride {
-    fn default() -> Self {
-        Self::new(None)
     }
 }
 

--- a/hex_assignments/src/urbanization.rs
+++ b/hex_assignments/src/urbanization.rs
@@ -3,6 +3,7 @@ use hextree::disktree::DiskTreeMap;
 
 use super::{Assignment, HexAssignment};
 
+#[derive(Default)]
 pub struct Urbanization {
     pub urbanized: Option<DiskTreeMap>,
     pub timestamp: Option<DateTime<Utc>>,
@@ -14,12 +15,6 @@ impl Urbanization {
             urbanized,
             timestamp: None,
         }
-    }
-}
-
-impl Default for Urbanization {
-    fn default() -> Self {
-        Self::new(None)
     }
 }
 

--- a/mobile_verifier/src/boosting_oracles/data_sets.rs
+++ b/mobile_verifier/src/boosting_oracles/data_sets.rs
@@ -34,7 +34,7 @@ use crate::{
 use hex_assignments::{
     assignment::HexAssignments, footfall::Footfall, landtype::Landtype,
     service_provider_override::ServiceProviderOverride, urbanization::Urbanization, HexAssignment,
-    HexBoostData,
+    HexBoostData, HexBoostDataAssignmentsExt,
 };
 
 #[async_trait::async_trait]
@@ -187,24 +187,18 @@ impl DataSet for ServiceProviderOverride {
     }
 }
 
-pub fn is_hex_boost_data_ready<A, B, C, D>(h: &HexBoostData<A, B, C, D>) -> bool
-where
-    A: DataSet,
-    B: DataSet,
-    C: DataSet,
-    D: DataSet,
-{
+pub fn is_hex_boost_data_ready(h: &HexBoostData) -> bool {
     h.urbanization.is_ready()
         && h.footfall.is_ready()
         && h.landtype.is_ready()
         && h.service_provider_override.is_ready()
 }
 
-pub struct DataSetDownloaderDaemon<A, B, C, D, T> {
+pub struct DataSetDownloaderDaemon {
     pool: PgPool,
-    data_sets: HexBoostData<A, B, C, D>,
+    data_sets: HexBoostData,
     store: FileStore,
-    data_set_processor: T,
+    data_set_processor: FileSinkClient<proto::OracleBoostingReportV1>,
     data_set_directory: PathBuf,
     new_coverage_object_notification: NewCoverageObjectNotification,
     poll_duration: Duration,
@@ -244,14 +238,7 @@ impl DataSetStatus {
     }
 }
 
-impl<A, B, C, D, T> ManagedTask for DataSetDownloaderDaemon<A, B, C, D, T>
-where
-    A: DataSet,
-    B: DataSet,
-    C: DataSet,
-    D: DataSet,
-    T: DataSetProcessor,
-{
+impl ManagedTask for DataSetDownloaderDaemon {
     fn start_task(
         self: Box<Self>,
         shutdown: triggered::Listener,
@@ -272,15 +259,7 @@ where
     }
 }
 
-impl
-    DataSetDownloaderDaemon<
-        Footfall,
-        Landtype,
-        Urbanization,
-        ServiceProviderOverride,
-        FileSinkClient<proto::OracleBoostingReportV1>,
-    >
-{
+impl DataSetDownloaderDaemon {
     pub async fn create_managed_task(
         pool: PgPool,
         settings: &Settings,
@@ -298,20 +277,9 @@ impl
             )
             .await?;
 
-        let urbanization = Urbanization::new(None);
-        let footfall = Footfall::new(None);
-        let landtype = Landtype::new(None);
-        let service_provider_override = ServiceProviderOverride::new(None);
-        let hex_boost_data = HexBoostData::builder()
-            .footfall(footfall)
-            .landtype(landtype)
-            .urbanization(urbanization)
-            .service_provider_override(service_provider_override)
-            .build()?;
-
         let data_set_downloader = Self::new(
             pool,
-            hex_boost_data,
+            HexBoostData::default(),
             FileStore::from_settings(&settings.data_sets).await?,
             oracle_boosting_reports,
             settings.data_sets_directory.clone(),
@@ -326,19 +294,12 @@ impl
     }
 }
 
-impl<A, B, C, D, T> DataSetDownloaderDaemon<A, B, C, D, T>
-where
-    A: DataSet,
-    B: DataSet,
-    C: DataSet,
-    D: DataSet,
-    T: DataSetProcessor,
-{
+impl DataSetDownloaderDaemon {
     pub fn new(
         pool: PgPool,
-        data_sets: HexBoostData<A, B, C, D>,
+        data_sets: HexBoostData,
         store: FileStore,
-        data_set_processor: T,
+        data_set_processor: FileSinkClient<proto::OracleBoostingReportV1>,
         data_set_directory: PathBuf,
         new_coverage_object_notification: NewCoverageObjectNotification,
         poll_duration: Duration,
@@ -578,23 +539,13 @@ pub trait DataSetProcessor: Send + Sync + 'static {
     async fn set_all_oracle_boosting_assignments(
         &self,
         pool: &PgPool,
-        data_sets: &HexBoostData<
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-        >,
+        data_sets: &impl HexBoostDataAssignmentsExt,
     ) -> anyhow::Result<()>;
 
     async fn set_unassigned_oracle_boosting_assignments(
         &self,
         pool: &PgPool,
-        data_sets: &HexBoostData<
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-        >,
+        data_sets: &impl HexBoostDataAssignmentsExt,
     ) -> anyhow::Result<()>;
 }
 
@@ -603,12 +554,7 @@ impl DataSetProcessor for FileSinkClient<proto::OracleBoostingReportV1> {
     async fn set_all_oracle_boosting_assignments(
         &self,
         pool: &PgPool,
-        data_sets: &HexBoostData<
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-        >,
+        data_sets: &impl HexBoostDataAssignmentsExt,
     ) -> anyhow::Result<()> {
         let assigned_coverage_objs =
             AssignedCoverageObjects::assign_hex_stream(db::fetch_all_hexes(pool), data_sets)
@@ -621,12 +567,7 @@ impl DataSetProcessor for FileSinkClient<proto::OracleBoostingReportV1> {
     async fn set_unassigned_oracle_boosting_assignments(
         &self,
         pool: &PgPool,
-        data_sets: &HexBoostData<
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-        >,
+        data_sets: &impl HexBoostDataAssignmentsExt,
     ) -> anyhow::Result<()> {
         let assigned_coverage_objs = AssignedCoverageObjects::assign_hex_stream(
             db::fetch_hexes_with_null_assignments(pool),
@@ -646,12 +587,7 @@ impl DataSetProcessor for NopDataSetProcessor {
     async fn set_all_oracle_boosting_assignments(
         &self,
         _pool: &PgPool,
-        _data_sets: &HexBoostData<
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-        >,
+        _data_sets: &impl HexBoostDataAssignmentsExt,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -659,12 +595,7 @@ impl DataSetProcessor for NopDataSetProcessor {
     async fn set_unassigned_oracle_boosting_assignments(
         &self,
         _pool: &PgPool,
-        _data_sets: &HexBoostData<
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-        >,
+        _data_sets: &impl HexBoostDataAssignmentsExt,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -817,12 +748,7 @@ pub struct AssignedCoverageObjects {
 impl AssignedCoverageObjects {
     pub async fn assign_hex_stream(
         stream: impl Stream<Item = sqlx::Result<UnassignedHex>>,
-        data_sets: &HexBoostData<
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-        >,
+        data_sets: &impl HexBoostDataAssignmentsExt,
     ) -> anyhow::Result<Self> {
         let mut coverage_objs = HashMap::<uuid::Uuid, Vec<AssignedHex>>::new();
         let mut stream = pin!(stream);
@@ -920,28 +846,15 @@ pub struct UnassignedHex {
 }
 
 impl UnassignedHex {
-    fn assign(
-        self,
-        data_sets: &HexBoostData<
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-            impl HexAssignment,
-        >,
-    ) -> anyhow::Result<AssignedHex> {
+    fn assign(self, data_sets: &impl HexBoostDataAssignmentsExt) -> anyhow::Result<AssignedHex> {
         let cell = hextree::Cell::try_from(self.hex)?;
-        let assignments = HexAssignments::builder(cell)
-            .footfall(&data_sets.footfall)
-            .landtype(&data_sets.landtype)
-            .urbanized(&data_sets.urbanization)
-            .service_provider_override(&data_sets.service_provider_override)
-            .build()?;
+
         Ok(AssignedHex {
             uuid: self.uuid,
             hex: self.hex,
             signal_level: self.signal_level,
             signal_power: self.signal_power,
-            assignments,
+            assignments: data_sets.assignments(cell)?,
         })
     }
 }

--- a/mobile_verifier/tests/integrations/common/mod.rs
+++ b/mobile_verifier/tests/integrations/common/mod.rs
@@ -11,7 +11,8 @@ use helium_proto::services::poc_mobile::{
     OracleBoostingHexAssignment, OracleBoostingReportV1, PromotionReward, RadioReward,
     RadioRewardV2, ServiceProviderReward, SpeedtestAvg, SubscriberReward, UnallocatedReward,
 };
-use hex_assignments::{Assignment, HexAssignment, HexBoostData};
+use hex_assignments::{Assignment, HexAssignment, HexBoostDataAssignmentsExt};
+use hextree::Cell;
 use mobile_config::{
     boosted_hex_info::{BoostedHexInfo, BoostedHexInfoStream},
     client::sub_dao_client::SubDaoEpochRewardInfoResolver,
@@ -24,7 +25,11 @@ use mobile_verifier::{
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use rust_decimal_macros::dec;
 use sqlx::PgPool;
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+    sync::Arc,
+};
 use tokio::{sync::RwLock, time::Timeout};
 use tonic::async_trait;
 
@@ -126,54 +131,78 @@ impl RadioRewardV2Ext for RadioRewardV2 {
     }
 }
 
-pub fn mock_hex_boost_data_default(
-) -> HexBoostData<Assignment, Assignment, Assignment, impl HexAssignment> {
-    HexBoostData::builder()
-        .urbanization(Assignment::A)
-        .footfall(Assignment::A)
-        .landtype(Assignment::A)
-        .service_provider_override(Assignment::C)
-        .build()
-        .unwrap()
+pub struct MockHexBoostDataAssignment {
+    footfall: Assignment,
+    urbanized: Assignment,
+    landtype: Assignment,
+    service_provider_override: Assignment,
 }
 
-pub fn mock_hex_boost_data_bad(
-) -> HexBoostData<Assignment, Assignment, Assignment, impl HexAssignment> {
-    HexBoostData::builder()
-        .urbanization(Assignment::C)
-        .footfall(Assignment::C)
-        .landtype(Assignment::C)
-        .service_provider_override(Assignment::C)
-        .build()
-        .unwrap()
+pub fn mock_hex_boost_data_default() -> impl HexBoostDataAssignmentsExt {
+    MockHexBoostDataAssignment {
+        footfall: Assignment::A,
+        landtype: Assignment::A,
+        urbanized: Assignment::A,
+        service_provider_override: Assignment::C,
+    }
 }
 
-type MockAssignmentMap = HashMap<hextree::Cell, Assignment>;
+pub fn mock_hex_boost_data_bad() -> impl HexBoostDataAssignmentsExt {
+    MockHexBoostDataAssignment {
+        footfall: Assignment::C,
+        landtype: Assignment::C,
+        urbanized: Assignment::C,
+        service_provider_override: Assignment::C,
+    }
+}
 
-#[allow(dead_code)]
-pub fn mock_hex_boost_data(
-    footfall: MockAssignmentMap,
-    urbanized: MockAssignmentMap,
-    landtype: MockAssignmentMap,
-    service_provider_override: MockAssignmentMap,
-) -> HexBoostData<MockAssignmentMap, MockAssignmentMap, MockAssignmentMap, MockAssignmentMap> {
-    HexBoostData::builder()
-        .footfall(footfall)
-        .urbanization(urbanized)
-        .landtype(landtype)
-        .service_provider_override(service_provider_override)
-        .build()
-        .unwrap()
+impl HexBoostDataAssignmentsExt for MockHexBoostDataAssignment {
+    fn footfall_assignment(&self, _cell: Cell) -> anyhow::Result<Assignment> {
+        Ok(self.footfall)
+    }
+
+    fn landtype_assignment(&self, _cell: Cell) -> anyhow::Result<Assignment> {
+        Ok(self.landtype)
+    }
+
+    fn urbanization_assignment(&self, _cell: Cell) -> anyhow::Result<Assignment> {
+        Ok(self.urbanized)
+    }
+
+    fn service_provider_override_assignment(&self, _cell: Cell) -> anyhow::Result<Assignment> {
+        Ok(self.service_provider_override)
+    }
+}
+
+#[derive(Default)]
+pub struct MockHexBoostDataColl {
+    pub footfall: HashMap<Cell, Assignment>,
+    pub urbanized: HashMap<Cell, Assignment>,
+    pub landtype: HashMap<Cell, Assignment>,
+    pub service_provider_override: HashSet<Cell>,
+}
+
+impl HexBoostDataAssignmentsExt for MockHexBoostDataColl {
+    fn footfall_assignment(&self, cell: Cell) -> anyhow::Result<Assignment> {
+        self.footfall.assignment(cell)
+    }
+
+    fn landtype_assignment(&self, cell: Cell) -> anyhow::Result<Assignment> {
+        self.landtype.assignment(cell)
+    }
+
+    fn urbanization_assignment(&self, cell: Cell) -> anyhow::Result<Assignment> {
+        self.urbanized.assignment(cell)
+    }
+
+    fn service_provider_override_assignment(&self, cell: Cell) -> anyhow::Result<Assignment> {
+        self.service_provider_override.assignment(cell)
+    }
 }
 
 pub async fn set_unassigned_oracle_boosting_assignments(
     pool: &PgPool,
-    data_sets: &HexBoostData<
-        impl HexAssignment,
-        impl HexAssignment,
-        impl HexAssignment,
-        impl HexAssignment,
-    >,
+    data_sets: &impl HexBoostDataAssignmentsExt,
 ) -> anyhow::Result<Vec<OracleBoostingReportV1>> {
     let assigned_coverage_objs = AssignedCoverageObjects::assign_hex_stream(
         mobile_verifier::boosting_oracles::data_sets::db::fetch_hexes_with_null_assignments(pool),


### PR DESCRIPTION
We can remove some amount of indirection in hex boosting by reifying generics to types that are already supported.