### PR TITLE
Stop writing out speedtest_avg files during rewarding

### DIFF
--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -287,7 +287,6 @@ where
             &self.pool,
             &self.hex_service_client,
             self.mobile_rewards.clone(),
-            &self.speedtest_averages,
             &reward_info,
             price_info.clone(),
         )
@@ -395,7 +394,6 @@ pub async fn reward_poc_and_dc(
     pool: &Pool<Postgres>,
     hex_service_client: &impl HexBoostingInfoResolver,
     mobile_rewards: FileSinkClient<proto::MobileRewardShare>,
-    speedtest_avg_sink: &FileSinkClient<proto::SpeedtestAvg>,
     reward_info: &EpochRewardInfo,
     price_info: PriceInfo,
 ) -> anyhow::Result<CalculatedPocRewardShares> {
@@ -432,7 +430,6 @@ pub async fn reward_poc_and_dc(
         pool,
         hex_service_client,
         &mobile_rewards,
-        speedtest_avg_sink,
         reward_info,
         reward_shares,
     )
@@ -458,15 +455,12 @@ async fn reward_poc(
     pool: &Pool<Postgres>,
     hex_service_client: &impl HexBoostingInfoResolver,
     mobile_rewards: &FileSinkClient<proto::MobileRewardShare>,
-    speedtest_avg_sink: &FileSinkClient<proto::SpeedtestAvg>,
     reward_info: &EpochRewardInfo,
     reward_shares: DataTransferAndPocAllocatedRewardBuckets,
 ) -> anyhow::Result<(Decimal, CalculatedPocRewardShares)> {
     let heartbeats = HeartbeatReward::validated(pool, &reward_info.epoch_period);
     let speedtest_averages =
         SpeedtestAverages::aggregate_epoch_averages(reward_info.epoch_period.end, pool).await?;
-
-    speedtest_averages.write_all(speedtest_avg_sink).await?;
 
     let boosted_hexes = BoostedHexes::get_all(hex_service_client).await?;
 

--- a/mobile_verifier/src/speedtests_average.rs
+++ b/mobile_verifier/src/speedtests_average.rs
@@ -211,17 +211,6 @@ pub struct SpeedtestAverages {
 }
 
 impl SpeedtestAverages {
-    pub async fn write_all(
-        &self,
-        sink: &FileSinkClient<proto::SpeedtestAvg>,
-    ) -> anyhow::Result<()> {
-        for speedtest in self.averages.values() {
-            speedtest.write(sink).await?;
-        }
-
-        Ok(())
-    }
-
     pub fn get_average(&self, pub_key: &PublicKeyBinary) -> Option<SpeedtestAverage> {
         self.averages.get(pub_key).cloned()
     }

--- a/mobile_verifier/tests/integrations/hex_boosting.rs
+++ b/mobile_verifier/tests/integrations/hex_boosting.rs
@@ -52,7 +52,6 @@ async fn update_assignments(pool: &PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -139,7 +138,6 @@ async fn test_poc_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
         &pool,
         &hex_boosting_client,
         mobile_rewards_client,
-        &speedtest_avg_client,
         &reward_info,
         price_info,
     )
@@ -210,7 +208,6 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
     // thresholds for the radios have not been met
     // the end result is that no boosting takes place, the radios are awarded non boosted reward values
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
     let now = Utc::now();
     let epoch = (now - ChronoDuration::hours(24))..now;
     let boost_period_length = Duration::days(30);
@@ -297,7 +294,6 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
         &pool,
         &hex_boosting_client,
         mobile_rewards_client,
-        &speedtest_avg_client,
         &reward_info,
         price_info,
     )
@@ -330,7 +326,6 @@ async fn test_poc_boosted_hexes_thresholds_not_met(pool: PgPool) -> anyhow::Resu
 #[sqlx::test]
 async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -428,7 +423,6 @@ async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Res
         &pool,
         &MockHexBoostingClient::new(boosted_hexes),
         mobile_rewards_client,
-        &speedtest_avg_client,
         &reward_info,
         default_price_info(),
     )
@@ -508,7 +502,6 @@ async fn test_poc_with_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Res
 #[sqlx::test]
 async fn test_expired_boosted_hex(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
     let boost_period_length = Duration::days(30);
@@ -569,7 +562,6 @@ async fn test_expired_boosted_hex(pool: PgPool) -> anyhow::Result<()> {
         &pool,
         &MockHexBoostingClient::new(boosted_hexes),
         mobile_rewards_client,
-        &speedtest_avg_client,
         &reward_info,
         default_price_info(),
     )
@@ -606,7 +598,6 @@ async fn test_expired_boosted_hex(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn test_reduced_location_score_with_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
     let boost_period_length = Duration::days(30);
@@ -673,7 +664,6 @@ async fn test_reduced_location_score_with_boosted_hexes(pool: PgPool) -> anyhow:
         &pool,
         &MockHexBoostingClient::new(boosted_hexes),
         mobile_rewards_client,
-        &speedtest_avg_client,
         &reward_info,
         default_price_info(),
     )
@@ -744,7 +734,6 @@ async fn test_distance_from_asserted_removes_boosting_but_not_location_trust(
     pool: PgPool,
 ) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
     let boost_period_length = Duration::days(30);
@@ -814,7 +803,6 @@ async fn test_distance_from_asserted_removes_boosting_but_not_location_trust(
         &pool,
         &MockHexBoostingClient::new(boosted_hexes),
         mobile_rewards_client,
-        &speedtest_avg_client,
         &reward_info,
         default_price_info(),
     )
@@ -883,7 +871,6 @@ async fn test_distance_from_asserted_removes_boosting_but_not_location_trust(
 #[sqlx::test]
 async fn test_poc_with_wifi_and_multi_coverage_boosted_hexes(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -978,7 +965,6 @@ async fn test_poc_with_wifi_and_multi_coverage_boosted_hexes(pool: PgPool) -> an
         &pool,
         &MockHexBoostingClient::new(boosted_hexes),
         mobile_rewards_client,
-        &speedtest_avg_client,
         &reward_info,
         default_price_info(),
     )

--- a/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
+++ b/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
@@ -44,7 +44,6 @@ const PAYER_1: &str = "11eX55faMbqZB7jzN4p67m6w7ScPMH6ubnvCjCPLh72J49PaJEL";
 #[sqlx::test]
 async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -64,7 +63,6 @@ async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
         &pool,
         &hex_boosting_client,
         mobile_rewards_client,
-        &speedtest_avg_client,
         &reward_info,
         price_info,
     )
@@ -117,7 +115,6 @@ async fn test_poc_and_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn test_qualified_wifi_poc_rewards(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -152,7 +149,6 @@ async fn test_qualified_wifi_poc_rewards(pool: PgPool) -> anyhow::Result<()> {
         &pool,
         &hex_boosting_client,
         mobile_rewards_client,
-        &speedtest_avg_client,
         &reward_info,
         price_info,
     )
@@ -190,7 +186,6 @@ async fn test_qualified_wifi_poc_rewards(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -214,7 +209,6 @@ async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
         &pool,
         &hex_boosting_client,
         mobile_rewards_client,
-        &speedtest_avg_client,
         &reward_info,
         price_info.clone(),
     )
@@ -226,7 +220,6 @@ async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
 
     // ==============================================================
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     // SP ban radio, zeroed rewards are filtered out
     let mut txn = pool.begin().await?;
@@ -237,7 +230,6 @@ async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
         &pool,
         &hex_boosting_client,
         mobile_rewards_client,
-        &speedtest_avg_client,
         &reward_info,
         price_info,
     )
@@ -253,7 +245,6 @@ async fn test_sp_banned_radio(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn test_all_banned_radio(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -287,7 +278,6 @@ async fn test_all_banned_radio(pool: PgPool) -> anyhow::Result<()> {
         &pool,
         &hex_boosting_client,
         mobile_rewards_client,
-        &speedtest_avg_client,
         &reward_info,
         price_info,
     )
@@ -309,7 +299,6 @@ async fn test_all_banned_radio(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn test_data_banned_radio_still_receives_poc(pool: PgPool) -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-    let (speedtest_avg_client, _speedtest_avg_server) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
 
@@ -342,7 +331,6 @@ async fn test_data_banned_radio_still_receives_poc(pool: PgPool) -> anyhow::Resu
         &pool,
         &hex_boosting_client,
         mobile_rewards_client,
-        &speedtest_avg_client,
         &reward_info,
         price_info,
     )


### PR DESCRIPTION
Talking with @riobah , writing out speedtest_avg files during rewarding that are limited to the end of the epoch is causing confusion and now that `radio_reward_v2` includes the speedtest_avg there is no need to write them out anymore.