### PR TITLE
Update UsageStatsReqV1 timestamp to ms

### DIFF
--- a/file_store/src/usage_counts.rs
+++ b/file_store/src/usage_counts.rs
@@ -52,25 +52,25 @@ impl MsgDecode for RadioUsageStatsReq {
 
 impl MsgTimestamp<Result<DateTime<Utc>>> for HexUsageStatsReqV1 {
     fn timestamp(&self) -> Result<DateTime<Utc>> {
-        self.timestamp.to_timestamp()
+        self.timestamp.to_timestamp_millis()
     }
 }
 
 impl MsgTimestamp<u64> for HexUsageStatsReq {
     fn timestamp(&self) -> u64 {
-        self.timestamp.encode_timestamp()
+        self.timestamp.encode_timestamp_millis()
     }
 }
 
 impl MsgTimestamp<Result<DateTime<Utc>>> for RadioUsageStatsReqV1 {
     fn timestamp(&self) -> Result<DateTime<Utc>> {
-        self.timestamp.to_timestamp()
+        self.timestamp.to_timestamp_millis()
     }
 }
 
 impl MsgTimestamp<u64> for RadioUsageStatsReq {
     fn timestamp(&self) -> u64 {
-        self.timestamp.encode_timestamp()
+        self.timestamp.encode_timestamp_millis()
     }
 }
 
@@ -78,8 +78,8 @@ impl TryFrom<HexUsageStatsReqV1> for HexUsageStatsReq {
     type Error = Error;
     fn try_from(v: HexUsageStatsReqV1) -> Result<Self> {
         let timestamp = v.timestamp()?;
-        let epoch_start_timestamp = v.epoch_start_timestamp.to_timestamp()?;
-        let epoch_end_timestamp = v.epoch_end_timestamp.to_timestamp()?;
+        let epoch_start_timestamp = v.epoch_start_timestamp.to_timestamp_millis()?;
+        let epoch_end_timestamp = v.epoch_end_timestamp.to_timestamp_millis()?;
         let hex = CellIndex::try_from(v.hex).map_err(|_| {
             DecodeError::FileStreamTryDecode(format!("invalid CellIndex {}", v.hex))
         })?;
@@ -101,8 +101,8 @@ impl TryFrom<HexUsageStatsReqV1> for HexUsageStatsReq {
 impl From<HexUsageStatsReq> for HexUsageStatsReqV1 {
     fn from(v: HexUsageStatsReq) -> Self {
         let timestamp = v.timestamp();
-        let epoch_start_timestamp = v.epoch_start_timestamp.encode_timestamp();
-        let epoch_end_timestamp = v.epoch_end_timestamp.encode_timestamp();
+        let epoch_start_timestamp = v.epoch_start_timestamp.encode_timestamp_millis();
+        let epoch_end_timestamp = v.epoch_end_timestamp.encode_timestamp_millis();
 
         HexUsageStatsReqV1 {
             hex: v.hex.into(),
@@ -124,8 +124,8 @@ impl TryFrom<RadioUsageStatsReqV1> for RadioUsageStatsReq {
     type Error = Error;
     fn try_from(v: RadioUsageStatsReqV1) -> Result<Self> {
         let timestamp = v.timestamp()?;
-        let epoch_start_timestamp = v.epoch_start_timestamp.to_timestamp()?;
-        let epoch_end_timestamp = v.epoch_end_timestamp.to_timestamp()?;
+        let epoch_start_timestamp = v.epoch_start_timestamp.to_timestamp_millis()?;
+        let epoch_end_timestamp = v.epoch_end_timestamp.to_timestamp_millis()?;
         Ok(Self {
             hotspot_pubkey: v.hotspot_pubkey.into(),
             service_provider_user_count: v.service_provider_user_count,
@@ -144,8 +144,8 @@ impl TryFrom<RadioUsageStatsReqV1> for RadioUsageStatsReq {
 impl From<RadioUsageStatsReq> for RadioUsageStatsReqV1 {
     fn from(v: RadioUsageStatsReq) -> Self {
         let timestamp = v.timestamp();
-        let epoch_start_timestamp = v.epoch_start_timestamp.encode_timestamp();
-        let epoch_end_timestamp = v.epoch_end_timestamp.encode_timestamp();
+        let epoch_start_timestamp = v.epoch_start_timestamp.encode_timestamp_millis();
+        let epoch_end_timestamp = v.epoch_end_timestamp.encode_timestamp_millis();
 
         RadioUsageStatsReqV1 {
             hotspot_pubkey: v.hotspot_pubkey.into(),


### PR DESCRIPTION
Fixing issue where timestamp should be in milliseconds instead of seconds [see here](https://github.com/helium/proto/blob/master/src/service/poc_mobile.proto#L29).