### PR TITLE
Add reward_override_entity_key to subscriber mapping activity

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -120,7 +120,7 @@ jobs:
             - 5432:5432
       localstack:
         image: localstack/localstack:latest
-        environment:
+        env:
           SERVICES: s3
           EAGER_SERVICE_LOADING: 1
         ports:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://www.github.com/helium/proto.git?branch=add-entity-key-to-mapping-act-req#422859ca0b1219183b518537b3f071a99f335608"
+source = "git+https://www.github.com/helium/proto.git?branch=add-entity-key-to-mapping-act-req#695506da8d34e18e173b5f2f9ede7db364b5ca9d"
 dependencies = [
  "bytes",
  "prost",
@@ -5866,7 +5866,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -5886,7 +5886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.101",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,17 +1430,17 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 [[package]]
 name = "beacon"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#ddc23d5b19b56d4725f94005e6f89bf8fc516043"
+source = "git+https://github.com/helium/proto?branch=master#be78e091a37f2707c5ac97d118589beb671e4a91"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
  "helium-proto",
  "prost",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rust_decimal",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.9.9",
  "thiserror 1.0.69",
 ]
 
@@ -5358,7 +5358,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -5866,7 +5866,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -5886,7 +5886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -10807,7 +10807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -11699,7 +11699,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.9.9",
  "thiserror 1.0.69",
  "twox-hash",
  "xorf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://www.github.com/helium/proto.git?branch=add-entity-key-to-mapping-act-req#695506da8d34e18e173b5f2f9ede7db364b5ca9d"
+source = "git+https://github.com/helium/proto?branch=master#be78e091a37f2707c5ac97d118589beb671e4a91"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,8 +1436,8 @@ dependencies = [
  "byteorder",
  "helium-proto",
  "prost",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
  "rust_decimal",
  "serde",
  "sha2 0.10.9",
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://www.github.com/helium/proto.git?branch=add-entity-key-to-mapping-act-req#a2b9b139ae9efa3fe0fe04fc772cbd17d0384344"
+source = "git+https://www.github.com/helium/proto.git?branch=add-entity-key-to-mapping-act-req#422859ca0b1219183b518537b3f071a99f335608"
 dependencies = [
  "bytes",
  "prost",
@@ -5866,7 +5866,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -5886,7 +5886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -10807,7 +10807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -11230,7 +11230,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#ddc23d5b19b56d4725f94005e6f89bf8fc516043"
+source = "git+https://www.github.com/helium/proto.git?branch=add-entity-key-to-mapping-act-req#a2b9b139ae9efa3fe0fe04fc772cbd17d0384344"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ helium-crypto = { version = "0.9.2", features = ["multisig", "sqlx-postgres"] }
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
   "disktree",
 ] }
-helium-proto = { git = "https://github.com/helium/proto", branch = "add-entity-key-to-mapping-act-req", features = [
+helium-proto = { git = "https://github.com/helium/proto", branch = "master", features = [
   "services",
 ] }
 beacon = { git = "https://github.com/helium/proto", branch = "master" }
@@ -132,5 +132,5 @@ anchor-lang = { git = "https://github.com/madninja/anchor.git", branch = "madnin
 # helium-proto = { path = "../proto" }
 # beacon = { path = "../proto/beacon" }
 
-[patch.'https://github.com/helium/proto']
-helium-proto = { git = "https://www.github.com/helium/proto.git", branch = "add-entity-key-to-mapping-act-req" }
+# [patch.'https://github.com/helium/proto']
+# helium-proto = { git = "https://www.github.com/helium/proto.git", branch = "bbalser/deprecate-radio-reward-v1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ helium-crypto = { version = "0.9.2", features = ["multisig", "sqlx-postgres"] }
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
   "disktree",
 ] }
-helium-proto = { git = "https://github.com/helium/proto", branch = "master", features = [
+helium-proto = { git = "https://github.com/helium/proto", branch = "add-entity-key-to-mapping-act-req", features = [
   "services",
 ] }
 beacon = { git = "https://github.com/helium/proto", branch = "master" }
@@ -132,5 +132,5 @@ anchor-lang = { git = "https://github.com/madninja/anchor.git", branch = "madnin
 # helium-proto = { path = "../proto" }
 # beacon = { path = "../proto/beacon" }
 
-# [patch.'https://github.com/helium/proto']
-# helium-proto = { git = "https://www.github.com/helium/proto.git", branch = "bbalser/deprecate-radio-reward-v1" }
+[patch.'https://github.com/helium/proto']
+helium-proto = { git = "https://www.github.com/helium/proto.git", branch = "add-entity-key-to-mapping-act-req" }

--- a/aws_local/src/lib.rs
+++ b/aws_local/src/lib.rs
@@ -11,7 +11,7 @@ use tokio::sync::Mutex;
 use tonic::transport::Uri;
 use uuid::Uuid;
 
-pub const AWSLOCAL_DEFAULT_ENDPOINT: &str = "http://localhost:4566";
+pub const AWSLOCAL_DEFAULT_ENDPOINT: &str = "http://localstack:4566";
 
 pub fn gen_bucket_name() -> String {
     format!("mvr-{}-{}", Uuid::new_v4(), Utc::now().timestamp_millis())

--- a/aws_local/src/lib.rs
+++ b/aws_local/src/lib.rs
@@ -11,7 +11,7 @@ use tokio::sync::Mutex;
 use tonic::transport::Uri;
 use uuid::Uuid;
 
-pub const AWSLOCAL_DEFAULT_ENDPOINT: &str = "http://0.0.0.0:4566";
+pub const AWSLOCAL_DEFAULT_ENDPOINT: &str = "http://localhost:4566";
 
 pub fn gen_bucket_name() -> String {
     format!("mvr-{}-{}", Uuid::new_v4(), Utc::now().timestamp_millis())

--- a/aws_local/src/lib.rs
+++ b/aws_local/src/lib.rs
@@ -11,7 +11,7 @@ use tokio::sync::Mutex;
 use tonic::transport::Uri;
 use uuid::Uuid;
 
-pub const AWSLOCAL_DEFAULT_ENDPOINT: &str = "http://127.0.0.1:4566";
+pub const AWSLOCAL_DEFAULT_ENDPOINT: &str = "http://0.0.0.0:4566";
 
 pub fn gen_bucket_name() -> String {
     format!("mvr-{}-{}", Uuid::new_v4(), Utc::now().timestamp_millis())

--- a/mobile_verifier/migrations/51_add_ent_key_to_subscr_map_act.sql
+++ b/mobile_verifier/migrations/51_add_ent_key_to_subscr_map_act.sql
@@ -1,0 +1,1 @@
+ALTER TABLE subscriber_mapping_activity ADD COLUMN entity_key text;

--- a/mobile_verifier/migrations/51_add_ent_key_to_subscr_map_act.sql
+++ b/mobile_verifier/migrations/51_add_ent_key_to_subscr_map_act.sql
@@ -1,1 +1,1 @@
-ALTER TABLE subscriber_mapping_activity ADD COLUMN entity_key text;
+ALTER TABLE subscriber_mapping_activity ADD COLUMN reward_override_entity_key text;

--- a/mobile_verifier/migrations/51_add_ent_key_to_subscr_map_act.sql
+++ b/mobile_verifier/migrations/51_add_ent_key_to_subscr_map_act.sql
@@ -1,1 +1,1 @@
-ALTER TABLE subscriber_mapping_activity ADD COLUMN reward_override_entity_key text;
+ALTER TABLE IF EXISTS subscriber_mapping_activity ADD COLUMN IF NOT EXISTS reward_override_entity_key TEXT;

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -230,7 +230,9 @@ impl MapperShares {
                         subscriber_id: mas.subscriber_id,
                         discovery_location_amount,
                         verification_mapping_amount,
-                        entity_key: mas.entity_key.unwrap_or("".to_string()),
+                        reward_override_entity_key: mas
+                            .reward_override_entity_key
+                            .unwrap_or("".to_string()),
                     })),
                 },
             )
@@ -832,7 +834,7 @@ mod test {
                 subscriber_id: n.encode_to_vec(),
                 discovery_reward_shares: 30,
                 verification_reward_shares: 30,
-                entity_key: None,
+                reward_override_entity_key: None,
             })
         }
 

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -230,6 +230,7 @@ impl MapperShares {
                         subscriber_id: mas.subscriber_id,
                         discovery_location_amount,
                         verification_mapping_amount,
+                        entity_key: mas.entity_key.unwrap_or("".to_string()),
                     })),
                 },
             )
@@ -831,6 +832,7 @@ mod test {
                 subscriber_id: n.encode_to_vec(),
                 discovery_reward_shares: 30,
                 verification_reward_shares: 30,
+                entity_key: None,
             })
         }
 

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -232,7 +232,7 @@ impl MapperShares {
                         verification_mapping_amount,
                         reward_override_entity_key: mas
                             .reward_override_entity_key
-                            .unwrap_or("".to_string()),
+                            .unwrap_or_default(),
                     })),
                 },
             )

--- a/mobile_verifier/src/subscriber_mapping_activity.rs
+++ b/mobile_verifier/src/subscriber_mapping_activity.rs
@@ -195,8 +195,7 @@ where
     if let Some(rek) = &activity.reward_override_entity_key {
         // use UTF8(key_serialization) as bytea
         if !verify_entity(entity_verifier, &rek.clone().into_bytes()).await? {
-            // TODO change to InvalidRewardOverrideEntityKey
-            return Ok(SubscriberReportVerificationStatus::InvalidSubscriberId);
+            return Ok(SubscriberReportVerificationStatus::InvalidRewardOverrideEntityKey);
         };
     }
     Ok(SubscriberReportVerificationStatus::Valid)

--- a/mobile_verifier/src/subscriber_mapping_activity.rs
+++ b/mobile_verifier/src/subscriber_mapping_activity.rs
@@ -247,7 +247,7 @@ pub struct SubscriberMappingActivity {
     pub verification_reward_shares: u64,
     pub received_timestamp: DateTime<Utc>,
     pub carrier_pub_key: PublicKeyBinary,
-    pub entity_key: Option<String>,
+    pub reward_override_entity_key: Option<String>,
 }
 
 impl TryFrom<SubscriberMappingActivityIngestReportV1> for SubscriberMappingActivity {
@@ -258,10 +258,10 @@ impl TryFrom<SubscriberMappingActivityIngestReportV1> for SubscriberMappingActiv
             .report
             .ok_or_else(|| anyhow::anyhow!("SubscriberMappingActivityReqV1 not found"))?;
 
-        let entity_key = if report.entity_key.is_empty() {
+        let reward_override_entity_key = if report.reward_override_entity_key.is_empty() {
             None
         } else {
-            Some(report.entity_key)
+            Some(report.reward_override_entity_key)
         };
 
         Ok(Self {
@@ -270,7 +270,7 @@ impl TryFrom<SubscriberMappingActivityIngestReportV1> for SubscriberMappingActiv
             verification_reward_shares: report.verification_reward_shares,
             received_timestamp: value.received_timestamp.to_timestamp_millis()?,
             carrier_pub_key: PublicKeyBinary::from(report.carrier_pub_key),
-            entity_key,
+            reward_override_entity_key,
         })
     }
 }
@@ -283,5 +283,5 @@ pub struct SubscriberMappingShares {
     #[sqlx(try_from = "i64")]
     pub verification_reward_shares: u64,
 
-    pub entity_key: Option<String>,
+    pub reward_override_entity_key: Option<String>,
 }

--- a/mobile_verifier/src/subscriber_mapping_activity.rs
+++ b/mobile_verifier/src/subscriber_mapping_activity.rs
@@ -247,6 +247,7 @@ pub struct SubscriberMappingActivity {
     pub verification_reward_shares: u64,
     pub received_timestamp: DateTime<Utc>,
     pub carrier_pub_key: PublicKeyBinary,
+    pub entity_key: Option<String>,
 }
 
 impl TryFrom<SubscriberMappingActivityIngestReportV1> for SubscriberMappingActivity {
@@ -257,12 +258,19 @@ impl TryFrom<SubscriberMappingActivityIngestReportV1> for SubscriberMappingActiv
             .report
             .ok_or_else(|| anyhow::anyhow!("SubscriberMappingActivityReqV1 not found"))?;
 
+        let entity_key = if report.entity_key.is_empty() {
+            None
+        } else {
+            Some(report.entity_key)
+        };
+
         Ok(Self {
             subscriber_id: report.subscriber_id,
             discovery_reward_shares: report.discovery_reward_shares,
             verification_reward_shares: report.verification_reward_shares,
             received_timestamp: value.received_timestamp.to_timestamp_millis()?,
             carrier_pub_key: PublicKeyBinary::from(report.carrier_pub_key),
+            entity_key,
         })
     }
 }
@@ -274,4 +282,6 @@ pub struct SubscriberMappingShares {
     pub discovery_reward_shares: u64,
     #[sqlx(try_from = "i64")]
     pub verification_reward_shares: u64,
+
+    pub entity_key: Option<String>,
 }

--- a/mobile_verifier/src/subscriber_mapping_activity.rs
+++ b/mobile_verifier/src/subscriber_mapping_activity.rs
@@ -285,3 +285,36 @@ pub struct SubscriberMappingShares {
 
     pub reward_override_entity_key: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SubscriberMappingActivity;
+    use helium_proto::services::poc_mobile::SubscriberMappingActivityIngestReportV1;
+
+    #[test]
+    fn try_from_subscriber_mapping_activity_check_entity_key() {
+        // Make sure reward_override_entity_key empty string transforms to None
+        let smair = SubscriberMappingActivityIngestReportV1 {
+            received_timestamp: 1,
+            report: Some({
+                helium_proto::services::poc_mobile::SubscriberMappingActivityReqV1 {
+                    subscriber_id: vec![10],
+                    discovery_reward_shares: 2,
+                    verification_reward_shares: 3,
+                    timestamp: 4,
+                    carrier_pub_key: vec![11],
+                    signature: vec![12],
+                    reward_override_entity_key: "".to_string(),
+                }
+            }),
+        };
+        let mut smair2 = smair.clone();
+        smair2.report.as_mut().unwrap().reward_override_entity_key = "key".to_string();
+
+        let res = SubscriberMappingActivity::try_from(smair).unwrap();
+        assert!(res.reward_override_entity_key.is_none());
+
+        let res = SubscriberMappingActivity::try_from(smair2).unwrap();
+        assert_eq!(res.reward_override_entity_key, Some("key".to_string()));
+    }
+}

--- a/mobile_verifier/tests/integrations/common/mod.rs
+++ b/mobile_verifier/tests/integrations/common/mod.rs
@@ -19,7 +19,9 @@ use mobile_config::{
     sub_dao_epoch_reward_info::EpochRewardInfo,
 };
 use mobile_verifier::{
-    boosting_oracles::AssignedCoverageObjects, GatewayResolution, GatewayResolver, PriceInfo,
+    boosting_oracles::AssignedCoverageObjects,
+    subscriber_mapping_activity::SubscriberMappingShares, GatewayResolution, GatewayResolver,
+    PriceInfo,
 };
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use rust_decimal_macros::dec;
@@ -444,6 +446,12 @@ impl AsStringKeyedMapKey for SubscriberReward {
 impl AsStringKeyedMapKey for PromotionReward {
     fn key(&self) -> String {
         self.entity.to_owned()
+    }
+}
+impl AsStringKeyedMapKey for SubscriberMappingShares {
+    fn key(&self) -> String {
+        use helium_proto::Message;
+        String::decode(self.subscriber_id.as_bytes()).expect("decode subscriber id")
     }
 }
 

--- a/mobile_verifier/tests/integrations/rewarder_mappers.rs
+++ b/mobile_verifier/tests/integrations/rewarder_mappers.rs
@@ -84,6 +84,7 @@ async fn seed_mapping_data(
             discovery_reward_shares: 30,
             verification_reward_shares: 0,
             carrier_pub_key: PublicKeyBinary::from_str(HOTSPOT_1).unwrap(),
+            entity_key: None,
         },
         SubscriberMappingActivity {
             received_timestamp: ts - ChronoDuration::hours(2),
@@ -91,6 +92,7 @@ async fn seed_mapping_data(
             discovery_reward_shares: 30,
             verification_reward_shares: 0,
             carrier_pub_key: PublicKeyBinary::from_str(HOTSPOT_1).unwrap(),
+            entity_key: None,
         },
         SubscriberMappingActivity {
             received_timestamp: ts - ChronoDuration::hours(1),
@@ -98,6 +100,7 @@ async fn seed_mapping_data(
             discovery_reward_shares: 30,
             verification_reward_shares: 0,
             carrier_pub_key: PublicKeyBinary::from_str(HOTSPOT_1).unwrap(),
+            entity_key: None,
         },
         SubscriberMappingActivity {
             received_timestamp: ts - ChronoDuration::hours(1),
@@ -105,6 +108,7 @@ async fn seed_mapping_data(
             discovery_reward_shares: 30,
             verification_reward_shares: 0,
             carrier_pub_key: PublicKeyBinary::from_str(HOTSPOT_1).unwrap(),
+            entity_key: None,
         },
     ];
 

--- a/mobile_verifier/tests/integrations/rewarder_mappers.rs
+++ b/mobile_verifier/tests/integrations/rewarder_mappers.rs
@@ -84,7 +84,7 @@ async fn seed_mapping_data(
             discovery_reward_shares: 30,
             verification_reward_shares: 0,
             carrier_pub_key: PublicKeyBinary::from_str(HOTSPOT_1).unwrap(),
-            entity_key: None,
+            reward_override_entity_key: None,
         },
         SubscriberMappingActivity {
             received_timestamp: ts - ChronoDuration::hours(2),
@@ -92,7 +92,7 @@ async fn seed_mapping_data(
             discovery_reward_shares: 30,
             verification_reward_shares: 0,
             carrier_pub_key: PublicKeyBinary::from_str(HOTSPOT_1).unwrap(),
-            entity_key: None,
+            reward_override_entity_key: None,
         },
         SubscriberMappingActivity {
             received_timestamp: ts - ChronoDuration::hours(1),
@@ -100,7 +100,7 @@ async fn seed_mapping_data(
             discovery_reward_shares: 30,
             verification_reward_shares: 0,
             carrier_pub_key: PublicKeyBinary::from_str(HOTSPOT_1).unwrap(),
-            entity_key: None,
+            reward_override_entity_key: None,
         },
         SubscriberMappingActivity {
             received_timestamp: ts - ChronoDuration::hours(1),
@@ -108,7 +108,7 @@ async fn seed_mapping_data(
             discovery_reward_shares: 30,
             verification_reward_shares: 0,
             carrier_pub_key: PublicKeyBinary::from_str(HOTSPOT_1).unwrap(),
-            entity_key: None,
+            reward_override_entity_key: None,
         },
     ];
 

--- a/mobile_verifier/tests/integrations/rewarder_mappers.rs
+++ b/mobile_verifier/tests/integrations/rewarder_mappers.rs
@@ -96,16 +96,6 @@ async fn reward_mapper_check_entity_key_db(pool: PgPool) {
         sub_3.reward_override_entity_key,
         Some("entity key".to_string())
     );
-
-    let sub_map = rewardable_mapping_activity.as_keyed_map();
-    let sub_1 = sub_map.get(SUBSCRIBER_1).expect("sub 1");
-    let sub_3 = sub_map.get(SUBSCRIBER_3).expect("sub 3");
-
-    assert!(sub_1.reward_override_entity_key.is_none());
-    assert_eq!(
-        sub_3.reward_override_entity_key,
-        Some("entity key".to_string())
-    );
 }
 
 async fn seed_mapping_data(

--- a/mobile_verifier/tests/integrations/rewarder_mappers.rs
+++ b/mobile_verifier/tests/integrations/rewarder_mappers.rs
@@ -87,19 +87,23 @@ async fn reward_mapper_check_entity_key_db(pool: PgPool) {
     .await
     .unwrap();
 
-    assert!(rewardable_mapping_activity
-        .iter()
-        .find(|v| v.subscriber_id == SUBSCRIBER_1.to_string().encode_to_vec())
-        .unwrap()
-        .reward_override_entity_key
-        .is_none(),);
+    let sub_map = rewardable_mapping_activity.as_keyed_map();
+    let sub_1 = sub_map.get(SUBSCRIBER_1).expect("sub 1");
+    let sub_3 = sub_map.get(SUBSCRIBER_3).expect("sub 3");
 
+    assert!(sub_1.reward_override_entity_key.is_none());
     assert_eq!(
-        rewardable_mapping_activity
-            .iter()
-            .find(|v| v.subscriber_id == SUBSCRIBER_3.to_string().encode_to_vec())
-            .unwrap()
-            .reward_override_entity_key,
+        sub_3.reward_override_entity_key,
+        Some("entity key".to_string())
+    );
+
+    let sub_map = rewardable_mapping_activity.as_keyed_map();
+    let sub_1 = sub_map.get(SUBSCRIBER_1).expect("sub 1");
+    let sub_3 = sub_map.get(SUBSCRIBER_3).expect("sub 3");
+
+    assert!(sub_1.reward_override_entity_key.is_none());
+    assert_eq!(
+        sub_3.reward_override_entity_key,
         Some("entity key".to_string())
     );
 }

--- a/mobile_verifier/tests/integrations/subscriber_map_act_daemon.rs
+++ b/mobile_verifier/tests/integrations/subscriber_map_act_daemon.rs
@@ -1,0 +1,125 @@
+use async_trait::async_trait;
+use aws_local::{gen_bucket_name, AwsLocal, AWSLOCAL_DEFAULT_ENDPOINT};
+use chrono::DateTime;
+use file_store::{
+    file_info_poller::LookbackBehavior,
+    file_sink::{FileSinkClient, Message},
+    file_source, FileType,
+};
+use helium_crypto::PublicKeyBinary;
+use helium_proto::services::{
+    mobile_config::NetworkKeyRole,
+    poc_mobile::{
+        SubscriberMappingActivityIngestReportV1, SubscriberMappingActivityReqV1,
+        SubscriberReportVerificationStatus, SubscriberVerifiedMappingEventVerificationStatus,
+    },
+};
+use mobile_config::client::{
+    authorization_client::AuthorizationVerifier, entity_client::EntityVerifier, ClientError,
+};
+use mobile_verifier::subscriber_mapping_activity::SubscriberMappingActivityDaemon;
+
+use sqlx::PgPool;
+use std::string::ToString;
+use triggered::trigger;
+
+struct AuthVer;
+#[async_trait]
+impl AuthorizationVerifier for AuthVer {
+    async fn verify_authorized_key(
+        &self,
+        _: &PublicKeyBinary,
+        _: NetworkKeyRole,
+    ) -> Result<bool, ClientError> {
+        Ok(true)
+    }
+}
+
+struct EntVer;
+
+#[async_trait]
+impl EntityVerifier for EntVer {
+    async fn verify_rewardable_entity(&self, _: &[u8]) -> Result<bool, ClientError> {
+        Ok(true)
+    }
+}
+
+pub async fn put_subscriber_reports_to_aws(
+    awsl: &AwsLocal,
+    reports: Vec<SubscriberMappingActivityIngestReportV1>,
+) {
+    awsl.put_proto_to_aws(
+        reports,
+        FileType::SubscriberMappingActivityIngestReport,
+        concat!(
+            env!("CARGO_PKG_NAME"),
+            "_subscriber_mapping_activity_ingest_report"
+        ),
+    )
+    .await
+    .unwrap();
+}
+
+#[sqlx::test]
+async fn test_process_map_act_ingest_report_file(pool: PgPool) {
+    let bucket_name = gen_bucket_name();
+    let awsl = AwsLocal::new(AWSLOCAL_DEFAULT_ENDPOINT, &bucket_name).await;
+
+    let (stream_receiver, stream_server) = file_source::Continuous::prost_source()
+        .state(pool.clone())
+        .store(awsl.file_store.clone())
+        .lookback(LookbackBehavior::StartAfter(DateTime::UNIX_EPOCH))
+        .prefix(FileType::SubscriberMappingActivityIngestReport.to_string())
+        .poll_duration(std::time::Duration::from_millis(300))
+        .create()
+        .await
+        .unwrap();
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(10);
+    let file_sink_client = FileSinkClient::new(tx, "nope");
+
+    let subs_daemon = SubscriberMappingActivityDaemon::new(
+        pool,
+        AuthVer,
+        EntVer,
+        stream_receiver,
+        file_sink_client,
+    );
+    let (_trigger, listener) = trigger();
+    let act_req = {
+        helium_proto::services::poc_mobile::SubscriberMappingActivityReqV1 {
+            subscriber_id: vec![10],
+            discovery_reward_shares: 2,
+            verification_reward_shares: 3,
+            timestamp: 4,
+            carrier_pub_key: vec![11],
+            signature: vec![12],
+            reward_override_entity_key: "something".to_string(),
+        }
+    };
+    put_subscriber_reports_to_aws(
+        &awsl,
+        vec![SubscriberMappingActivityIngestReportV1 {
+            received_timestamp: 1,
+            report: Some(act_req.clone()),
+        }],
+    )
+    .await;
+
+    let _future = stream_server.start(listener.clone()).await.unwrap();
+    let _handle = tokio::spawn(subs_daemon.run(listener.clone()));
+
+    let res = rx.recv().await.unwrap();
+    match res {
+        Message::Data(_, ref verifier_map_act) => {
+            assert_eq!(
+                verifier_map_act.status(),
+                SubscriberReportVerificationStatus::Valid
+            );
+            let report = verifier_map_act.report.clone().unwrap().report.unwrap();
+            dbg!(&report);
+            assert_eq!(report, act_req)
+        }
+        _ => panic!("Expected Data message, got {:?}", res),
+    };
+}

--- a/reward_index/src/extract.rs
+++ b/reward_index/src/extract.rs
@@ -55,13 +55,21 @@ pub fn mobile_reward(
             },
             r.dc_transfer_reward,
         )),
-        MobileReward::SubscriberReward(r) => Ok((
-            RewardKey {
-                key: bs58::encode(&r.subscriber_id).into_string(),
-                reward_type: RewardType::MobileSubscriber,
-            },
-            r.discovery_location_amount + r.verification_mapping_amount,
-        )),
+        MobileReward::SubscriberReward(r) => {
+            let key = if r.reward_override_entity_key.is_empty() {
+                bs58::encode(&r.subscriber_id).into_string()
+            } else {
+                r.reward_override_entity_key
+            };
+
+            Ok((
+                RewardKey {
+                    key,
+                    reward_type: RewardType::MobileSubscriber,
+                },
+                r.discovery_location_amount + r.verification_mapping_amount,
+            ))
+        }
         MobileReward::ServiceProviderReward(r) => {
             let sp = ServiceProvider::try_from(r.service_provider_id)
                 .map_err(|_| ExtractError::ServiceProviderDecode(r.service_provider_id))?;

--- a/reward_index/src/extract.rs
+++ b/reward_index/src/extract.rs
@@ -56,7 +56,7 @@ pub fn mobile_reward(
             r.dc_transfer_reward,
         )),
         MobileReward::SubscriberReward(r) => {
-            let key = if r.reward_override_entity_key.is_empty() {
+            let key = if r.reward_override_entity_key.trim().is_empty() {
                 bs58::encode(&r.subscriber_id).into_string()
             } else {
                 r.reward_override_entity_key

--- a/reward_index/tests/integrations/mobile.rs
+++ b/reward_index/tests/integrations/mobile.rs
@@ -150,6 +150,7 @@ async fn subscriber_reward(pool: PgPool) -> anyhow::Result<()> {
                 subscriber_id: vec![1],
                 discovery_location_amount: 1,
                 verification_mapping_amount: 2,
+                entity_key: "".into(),
             },
         )),
     }]);

--- a/reward_index/tests/integrations/mobile.rs
+++ b/reward_index/tests/integrations/mobile.rs
@@ -150,7 +150,7 @@ async fn subscriber_reward(pool: PgPool) -> anyhow::Result<()> {
                 subscriber_id: vec![1],
                 discovery_location_amount: 1,
                 verification_mapping_amount: 2,
-                entity_key: "".into(),
+                reward_override_entity_key: "".into(),
             },
         )),
     }]);

--- a/reward_index/tests/integrations/mobile.rs
+++ b/reward_index/tests/integrations/mobile.rs
@@ -141,7 +141,7 @@ async fn radio_reward_v1_is_ignored(pool: PgPool) -> anyhow::Result<()> {
 }
 
 #[sqlx::test]
-async fn subscriber_reward(pool: PgPool) -> anyhow::Result<()> {
+async fn subscriber_reward_empty_reward_override(pool: PgPool) -> anyhow::Result<()> {
     let rewards = bytes_mut_stream(vec![MobileRewardShare {
         start_period: Utc::now().timestamp_millis() as u64,
         end_period: Utc::now().timestamp_millis() as u64,
@@ -167,6 +167,38 @@ async fn subscriber_reward(pool: PgPool) -> anyhow::Result<()> {
     )
     .await?;
     assert_eq!(reward.rewards, 3);
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn subscriber_reward_with_reward_override(pool: PgPool) -> anyhow::Result<()> {
+    let reward_override_entity_key = "new_address".to_string();
+    let rewards = bytes_mut_stream(vec![MobileRewardShare {
+        start_period: Utc::now().timestamp_millis() as u64,
+        end_period: Utc::now().timestamp_millis() as u64,
+        reward: Some(mobile_reward_share::Reward::SubscriberReward(
+            SubscriberReward {
+                subscriber_id: vec![1],
+                discovery_location_amount: 3,
+                verification_mapping_amount: 4,
+                reward_override_entity_key: reward_override_entity_key.clone(),
+            },
+        )),
+    }]);
+
+    let mut txn = pool.begin().await?;
+    let manifest_time = Utc::now();
+    handle_mobile_rewards(&mut txn, rewards, "unallocated-key", &manifest_time).await?;
+    txn.commit().await?;
+
+    let reward = common::get_reward(
+        &pool,
+        &reward_override_entity_key,
+        RewardType::MobileSubscriber,
+    )
+    .await?;
+    assert_eq!(reward.rewards, 7);
 
     Ok(())
 }


### PR DESCRIPTION
- Handle `reward_override_entity_key` in SubscriberMappingActivityIngestReportV1 report.
- Add `reward_override_entity_key` field to the `subscriber_mapping_activity` table
- Add `reward_override_entity_key` to SubscriberReward proto
- Handle `reward_override_entity_key` in reward_index (override the key/address in reward_index table)