### PR TITLE
Make `sqlx` optional for `file-store`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
   "solana",
   "task_manager",
   "hex_assignments",
-  "aws_local"
+  "aws_local",
 ]
 resolver = "2"
 
@@ -64,7 +64,7 @@ sqlx = { version = "0.8", default-features = false, features = [
   "macros",
   "runtime-tokio-rustls",
 ] }
-helium-crypto = { version = "0.9.2", features = ["multisig", "sqlx-postgres"] }
+helium-crypto = { version = "0.9.2", default-features = false }
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
   "disktree",
 ] }

--- a/file_store/Cargo.toml
+++ b/file_store/Cargo.toml
@@ -7,48 +7,48 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-anyhow = {workspace = true}
-clap = {workspace = true}
-config = {workspace = true}
-serde =  {workspace = true}
-serde_json = {workspace = true}
-thiserror = {workspace = true}
+anyhow = { workspace = true }
+clap = { workspace = true }
+config = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
-tokio-stream = {workspace = true}
-triggered = {workspace = true}
-async-compression = {version = "0", features = ["tokio", "gzip"]}
-futures = {workspace = true}
-futures-util = {workspace = true}
-prost = {workspace = true}
+tokio-stream = { workspace = true }
+triggered = { workspace = true }
+async-compression = { version = "0", features = ["tokio", "gzip"] }
+futures = { workspace = true }
+futures-util = { workspace = true }
+prost = { workspace = true }
 bytes = "*"
 regex = "1"
-lazy_static = {workspace = true}
+lazy_static = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
-helium-proto = {workspace = true}
-helium-crypto = {workspace = true}
+helium-proto = { workspace = true }
+helium-crypto = { workspace = true }
 csv = "*"
-http = {workspace = true}
-aws-config = {workspace = true} 
-aws-sdk-s3 = {workspace = true}
-aws-types = {workspace = true, optional = true}
-strum = {version = "0", features = ["derive"]}
+http = { workspace = true }
+aws-config = { workspace = true }
+aws-sdk-s3 = { workspace = true }
+aws-types = { workspace = true, optional = true }
+strum = { version = "0", features = ["derive"] }
 strum_macros = "0"
-sha2 = {workspace = true}
-metrics = {workspace = true }
-blake3 = {workspace = true}
+sha2 = { workspace = true }
+metrics = { workspace = true }
+blake3 = { workspace = true }
 poc-metrics = { path = "../metrics" }
-rust_decimal = {workspace = true}
-rust_decimal_macros = {workspace = true}
-base64 = {workspace = true}
-beacon = {workspace = true}
-sqlx = {workspace = true, optional = true}
-async-trait = {workspace = true}
-derive_builder = {workspace = true}
-retainer = {workspace = true}
-uuid = {workspace = true}
-h3o = {workspace = true}
+rust_decimal = { workspace = true }
+rust_decimal_macros = { workspace = true }
+base64 = { workspace = true }
+beacon = { workspace = true }
+sqlx = { workspace = true, optional = true }
+async-trait = { workspace = true }
+derive_builder = { workspace = true }
+retainer = { workspace = true }
+uuid = { workspace = true }
+h3o = { workspace = true }
 task-manager = { path = "../task_manager" }
 
 [dev-dependencies]


### PR DESCRIPTION
`sqlx` found it's way into the main compilation path of `file-store`, even though it was marked as optional.

This PR follows the pattern in `helium-crypto-rs` is hiding all `sqlx` related impls behind `#[cfg(feature = 'sqlx-postgres')]`.

The `sqlx-postgres` feature is default enabled for `file-store`. 
To test this, making a sample rust project with a `file-store` dependency will show that `sqlx` is not included unless it's asked for.

```toml
[dependencies]
file-store = { path = "../oracles/file_store", default-features = false }
```

```sh
> sqlx-test git:(master) ✗ cargo tree -i sqlx                 
error: package ID specification `sqlx` did not match any packages
```
