### PR TITLE
migrate lazy_static -> std::sync::LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,7 +1440,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rust_decimal",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -1580,11 +1580,9 @@ dependencies = [
  "http 0.2.12",
  "http-serde",
  "humantime-serde",
- "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
  "mobile-config",
- "once_cell",
  "poc-metrics",
  "prost",
  "rand 0.8.5",
@@ -2862,7 +2860,6 @@ dependencies = [
  "helium-proto",
  "hex-literal",
  "http 0.2.12",
- "lazy_static",
  "metrics",
  "poc-metrics",
  "prost",
@@ -4256,9 +4253,7 @@ dependencies = [
  "humantime-serde",
  "iot-config",
  "itertools 0.14.0",
- "lazy_static",
  "metrics",
- "once_cell",
  "poc-metrics",
  "price",
  "prost",
@@ -4895,7 +4890,6 @@ dependencies = [
  "http-serde",
  "humantime",
  "humantime-serde",
- "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
  "poc-metrics",
@@ -5011,11 +5005,9 @@ dependencies = [
  "http-serde",
  "humantime",
  "humantime-serde",
- "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
  "mobile-config",
- "once_cell",
  "poc-metrics",
  "price",
  "proptest",
@@ -5358,7 +5350,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -5866,7 +5858,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -5886,7 +5878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -6402,10 +6394,8 @@ dependencies = [
  "helium-crypto",
  "helium-proto",
  "humantime-serde",
- "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
- "once_cell",
  "poc-metrics",
  "prost",
  "rand 0.8.5",
@@ -11230,7 +11220,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11699,7 +11689,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "twox-hash",
  "xorf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,6 @@ triggered = "0"
 futures = "*"
 futures-util = "*"
 prost = "0.12"
-once_cell = "1"
-lazy_static = "1"
 config = { version = "0", default-features = false, features = ["toml"] }
 h3o = { version = "0", features = ["serde"] }
 xorf = { version = "0", features = ["serde"] }

--- a/boost_manager/Cargo.toml
+++ b/boost_manager/Cargo.toml
@@ -20,12 +20,10 @@ serde_json = { workspace = true }
 sqlx = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }
-lazy_static = { workspace = true }
 triggered = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 prost = { workspace = true }
-once_cell = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }

--- a/file_store/Cargo.toml
+++ b/file_store/Cargo.toml
@@ -23,7 +23,6 @@ futures-util = { workspace = true }
 prost = { workspace = true }
 bytes = "*"
 regex = "1"
-lazy_static = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
 helium-proto = { workspace = true }

--- a/file_store/src/file_info.rs
+++ b/file_store/src/file_info.rs
@@ -1,9 +1,8 @@
 use crate::{error::DecodeError, traits::TimestampDecode, Error, Result};
 use chrono::{DateTime, Utc};
-use lazy_static::lazy_static;
 use regex::Regex;
 use serde::Serialize;
-use std::{fmt, io, os::unix::fs::MetadataExt, path::Path, str::FromStr};
+use std::{fmt, io, os::unix::fs::MetadataExt, path::Path, str::FromStr, sync::LazyLock};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct FileInfo {
@@ -13,9 +12,7 @@ pub struct FileInfo {
     pub size: usize,
 }
 
-lazy_static! {
-    static ref RE: Regex = Regex::new(r"([a-z,\d,_]+)\.(\d+)(\.gz)?").unwrap();
-}
+static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"([a-z,\d,_]+)\.(\d+)(\.gz)?").unwrap());
 
 impl FromStr for FileInfo {
     type Err = Error;

--- a/iot_verifier/Cargo.toml
+++ b/iot_verifier/Cargo.toml
@@ -26,9 +26,7 @@ helium-proto = { workspace = true }
 http-serde = { workspace = true }
 humantime-serde = { workspace = true }
 itertools = { workspace = true }
-lazy_static = { workspace = true }
 metrics = { workspace = true }
-once_cell = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
 retainer = { workspace = true }

--- a/iot_verifier/src/hex_density.rs
+++ b/iot_verifier/src/hex_density.rs
@@ -1,10 +1,13 @@
 use file_store::SCALING_PRECISION;
 use h3o::{CellIndex, Resolution};
 use itertools::Itertools;
-use lazy_static::lazy_static;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
-use std::{cmp, collections::HashMap, sync::Arc};
+use std::{
+    cmp,
+    collections::HashMap,
+    sync::{Arc, LazyLock},
+};
 use tokio::sync::RwLock;
 
 pub struct HexResConfig {
@@ -48,21 +51,19 @@ const SCALING_RES: [Resolution; 10] = [
     Resolution::Four,
 ];
 
-lazy_static! {
-    static ref HIP104_RES_CONFIG: HashMap<Resolution, HexResConfig> = {
-        // Hex resolutions 0 - 3 and 11 and 12 are currently ignored when calculating density;
-        // For completeness sake their on-chain settings are N=2, TGT=100_000, MAX=100_000
-        let mut configs = HashMap::new();
-        configs.insert(Resolution::Four, HexResConfig::new(2, 500, 1000));
-        configs.insert(Resolution::Five, HexResConfig::new(4, 100, 200));
-        configs.insert(Resolution::Six, HexResConfig::new(4, 25, 50));
-        configs.insert(Resolution::Seven, HexResConfig::new(4, 5, 10));
-        configs.insert(Resolution::Eight, HexResConfig::new(2, 1, 1));
-        configs.insert(Resolution::Nine, HexResConfig::new(2, 1, 1));
-        configs.insert(Resolution::Ten, HexResConfig::new(2, 1, 1));
-        configs
-    };
-}
+static HIP104_RES_CONFIG: LazyLock<HashMap<Resolution, HexResConfig>> = LazyLock::new(|| {
+    // Hex resolutions 0 - 3 and 11 and 12 are currently ignored when calculating density;
+    // For completeness sake their on-chain settings are N=2, TGT=100_000, MAX=100_000
+    let mut configs = HashMap::new();
+    configs.insert(Resolution::Four, HexResConfig::new(2, 500, 1000));
+    configs.insert(Resolution::Five, HexResConfig::new(4, 100, 200));
+    configs.insert(Resolution::Six, HexResConfig::new(4, 25, 50));
+    configs.insert(Resolution::Seven, HexResConfig::new(4, 5, 10));
+    configs.insert(Resolution::Eight, HexResConfig::new(2, 1, 1));
+    configs.insert(Resolution::Nine, HexResConfig::new(2, 1, 1));
+    configs.insert(Resolution::Ten, HexResConfig::new(2, 1, 1));
+    configs
+});
 
 #[derive(Debug, Clone)]
 pub struct HexDensityMap(Arc<RwLock<HashMap<u64, Decimal>>>);

--- a/iot_verifier/src/runner.rs
+++ b/iot_verifier/src/runner.rs
@@ -59,7 +59,6 @@ use helium_proto::services::poc_lora::{
     LoraInvalidWitnessReportV1, LoraPocV1, VerificationStatus,
 };
 use iot_config::{client::Gateways, gateway_info::GatewayInfo};
-use lazy_static::lazy_static;
 use rust_decimal::{Decimal, MathematicalOps};
 use rust_decimal_macros::dec;
 use sqlx::PgPool;
@@ -76,10 +75,8 @@ const WITNESS_REDUNDANCY: u32 = 4;
 const POC_REWARD_DECAY_RATE: Decimal = dec!(0.8);
 const HIP15_TX_REWARD_UNIT_CAP: Decimal = Decimal::TWO;
 
-lazy_static! {
-    /// the duration in which a beaconer or witnesser must have a valid opposite report from
-    static ref RECIPROCITY_WINDOW: ChronoDuration = ChronoDuration::hours(48);
-}
+/// the duration in which a beaconer or witnesser must have a valid opposite report from
+static RECIPROCITY_WINDOW: ChronoDuration = ChronoDuration::hours(48);
 
 pub struct Runner<G> {
     pub pool: PgPool,
@@ -556,9 +553,8 @@ where
             .witness_updater
             .get_last_witness(&beacon_report.report.pub_key)
             .await?;
-        Ok(last_witness.is_some_and(|lw| {
-            beacon_report.received_timestamp - lw.timestamp < *RECIPROCITY_WINDOW
-        }))
+        Ok(last_witness
+            .is_some_and(|lw| beacon_report.received_timestamp - lw.timestamp < RECIPROCITY_WINDOW))
     }
 
     // witness recropocity checks require that a witnesser must have a prior valid beacon report within
@@ -589,7 +585,7 @@ where
         let last_beacon_recip =
             LastBeaconReciprocity::get(&self.pool, &report.report.pub_key).await?;
         Ok(last_beacon_recip
-            .is_some_and(|lw| report.received_timestamp - lw.timestamp < *RECIPROCITY_WINDOW))
+            .is_some_and(|lw| report.received_timestamp - lw.timestamp < RECIPROCITY_WINDOW))
     }
 }
 

--- a/iot_verifier/tests/integrations/runner_tests.rs
+++ b/iot_verifier/tests/integrations/runner_tests.rs
@@ -19,15 +19,15 @@ use iot_verifier::{
     gateway_cache::GatewayCache, gateway_updater::GatewayUpdater, poc_report::Report,
     region_cache::RegionCache, runner::Runner, tx_scaler::Server as DensityScaler,
 };
-use lazy_static::lazy_static;
+
 use sqlx::PgPool;
+use std::sync::LazyLock;
 use std::{self, str::FromStr, time::Duration};
 
-lazy_static! {
-    static ref BEACON_INTERVAL: Duration = Duration::from_secs(21600);
-    static ref BEACON_INTERVAL_PLUS_TWO_HOURS: Duration =
-        *BEACON_INTERVAL + Duration::from_secs(2 * 60 * 60);
-}
+static BEACON_INTERVAL: Duration = Duration::from_secs(21600);
+static BEACON_INTERVAL_PLUS_TWO_HOURS: LazyLock<Duration> =
+    LazyLock::new(|| BEACON_INTERVAL + Duration::from_secs(2 * 60 * 60));
+
 #[derive(Debug, Clone)]
 pub struct MockIotConfigClient {
     resolve_gateway: GatewayInfo,
@@ -136,7 +136,7 @@ impl TestContext {
 
 #[sqlx::test]
 async fn valid_beacon_and_witness(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     let now = ctx.entropy_ts;
 
     // test with a valid beacon and a valid witness
@@ -203,7 +203,7 @@ async fn valid_beacon_and_witness(pool: PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn confirm_valid_reports_unmodified(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     let now = ctx.entropy_ts;
 
     // test with a valid beacon and a valid witness
@@ -266,7 +266,7 @@ async fn confirm_valid_reports_unmodified(pool: PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn confirm_invalid_reports_unmodified(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     let now = Utc::now();
 
     // test with an invalid beacon and a valid witness
@@ -316,7 +316,7 @@ async fn confirm_invalid_reports_unmodified(pool: PgPool) -> anyhow::Result<()> 
 async fn confirm_valid_beacon_invalid_witness_reports_unmodified(
     pool: PgPool,
 ) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     let now = ctx.entropy_ts;
 
     // test with an valid beacon and an  invalid witness
@@ -377,7 +377,7 @@ async fn confirm_valid_beacon_invalid_witness_reports_unmodified(
 
 #[sqlx::test]
 async fn valid_beacon_irregular_schedule_with_witness(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     let now = ctx.entropy_ts;
 
     // submit a valid beacon and a valid witness
@@ -482,7 +482,7 @@ async fn valid_beacon_irregular_schedule_with_witness(pool: PgPool) -> anyhow::R
 
 #[sqlx::test]
 async fn valid_beacon_irregular_schedule_no_witness(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     let now = ctx.entropy_ts;
 
     // submit a valid beacon and no witnesses
@@ -568,7 +568,7 @@ async fn valid_beacon_irregular_schedule_no_witness(pool: PgPool) -> anyhow::Res
 
 #[sqlx::test]
 async fn invalid_beacon_irregular_schedule_with_witness(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     let now = ctx.entropy_ts;
 
     // submit an invalid beacon and a valid witness
@@ -684,7 +684,7 @@ async fn invalid_beacon_irregular_schedule_with_witness(pool: PgPool) -> anyhow:
 
 #[sqlx::test]
 async fn valid_beacon_gateway_not_found(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     let now = ctx.entropy_ts;
     //
     // test with a valid beacon and an invalid witness
@@ -750,7 +750,7 @@ async fn valid_beacon_gateway_not_found(pool: PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn invalid_witness_no_metadata(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     let now = ctx.entropy_ts;
     //
     // test with a valid beacon and an invalid witness
@@ -826,7 +826,7 @@ async fn invalid_witness_no_metadata(pool: PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn invalid_beacon_no_gateway_found(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     let now = Utc::now();
     //
     // test with an invalid beacon & 1 witness
@@ -888,7 +888,7 @@ async fn invalid_beacon_no_gateway_found(pool: PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn invalid_beacon_gateway_not_found_no_witnesses(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     //
     // test with an invalid beacon, no witnesses
     // beacon is invalid as GW is unknown
@@ -916,7 +916,7 @@ async fn invalid_beacon_gateway_not_found_no_witnesses(pool: PgPool) -> anyhow::
 
 #[sqlx::test]
 async fn invalid_beacon_bad_payload(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     //
     // test with an invalid beacon, no witnesses
     // the beacon will have an invalid payload, resulting in an error
@@ -948,7 +948,7 @@ async fn invalid_beacon_bad_payload(pool: PgPool) -> anyhow::Result<()> {
 
 #[sqlx::test]
 async fn valid_beacon_and_witness_no_beacon_reciprocity(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     let now = ctx.entropy_ts;
 
     // test with a valid beacon and a valid witness
@@ -1007,7 +1007,7 @@ async fn valid_beacon_and_witness_no_beacon_reciprocity(pool: PgPool) -> anyhow:
 
 #[sqlx::test]
 async fn valid_beacon_and_witness_no_witness_reciprocity(pool: PgPool) -> anyhow::Result<()> {
-    let mut ctx = TestContext::setup(pool.clone(), *BEACON_INTERVAL).await?;
+    let mut ctx = TestContext::setup(pool.clone(), BEACON_INTERVAL).await?;
     let now = ctx.entropy_ts;
 
     // test with a valid beacon and a valid witness

--- a/mobile_config/Cargo.toml
+++ b/mobile_config/Cargo.toml
@@ -24,7 +24,6 @@ http = { workspace = true }
 http-serde = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
-lazy_static = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 prost = { workspace = true }

--- a/mobile_config/src/boosted_hex_info.rs
+++ b/mobile_config/src/boosted_hex_info.rs
@@ -9,10 +9,6 @@ use std::{collections::HashMap, convert::TryFrom, num::NonZeroU32};
 
 pub type BoostedHexInfoStream = BoxStream<'static, BoostedHexInfo>;
 
-lazy_static::lazy_static! {
-    static ref PERIOD_IN_SECONDS: Duration = Duration::seconds(60 * 60 * 24 * 30);
-}
-
 #[derive(Clone, Debug)]
 pub struct BoostedHexInfo {
     pub location: Cell,

--- a/mobile_config/src/gateway_info.rs
+++ b/mobile_config/src/gateway_info.rs
@@ -369,7 +369,7 @@ pub(crate) mod db {
     };
     use helium_crypto::PublicKeyBinary;
     use sqlx::{types::Json, PgExecutor, Row};
-    use std::{collections::HashMap, str::FromStr};
+    use std::{collections::HashMap, str::FromStr, sync::LazyLock};
 
     const GET_METADATA_SQL: &str = r#"
             select kta.entity_key, infos.location::bigint, infos.device_type,
@@ -389,10 +389,10 @@ pub(crate) mod db {
     const GET_TRACKED_RADIOS_SQL: &str =
         "SELECT entity_key, last_changed_at FROM mobile_radio_tracker where entity_key = any($1::bytea[])";
 
-    lazy_static::lazy_static! {
-        static ref BATCH_METADATA_SQL: String = format!("{GET_METADATA_SQL} {BATCH_SQL_WHERE_SNIPPET}");
-        static ref DEVICE_TYPES_METADATA_SQL: String = format!("{GET_METADATA_SQL} {DEVICE_TYPES_WHERE_SNIPPET}");
-    }
+    static BATCH_METADATA_SQL: LazyLock<String> =
+        LazyLock::new(|| format!("{GET_METADATA_SQL} {BATCH_SQL_WHERE_SNIPPET}"));
+    static DEVICE_TYPES_METADATA_SQL: LazyLock<String> =
+        LazyLock::new(|| format!("{GET_METADATA_SQL} {DEVICE_TYPES_WHERE_SNIPPET}"));
 
     pub async fn get_batch_tracked_radios(
         db: impl PgExecutor<'_>,

--- a/mobile_verifier/Cargo.toml
+++ b/mobile_verifier/Cargo.toml
@@ -27,10 +27,8 @@ hextree = { workspace = true }
 http-serde = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
-lazy_static = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
-once_cell = { workspace = true }
 price = { path = "../price" }
 prost = { workspace = true }
 rand = { workspace = true }

--- a/reward_index/Cargo.toml
+++ b/reward_index/Cargo.toml
@@ -18,12 +18,10 @@ serde_json = { workspace = true }
 sqlx = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }
-lazy_static = { workspace = true }
 triggered = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 prost = { workspace = true }
-once_cell = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
`LazyLock` was stabilized in `1.80`, we can drop our dependency on `lazy_static`. This frees us up from having to keep the dependency up to date with libraries that are still using it.

This PR is preparing for further updates to aws dependencies