### PR TITLE
Add new metrics to track poc, data transfer, and mapper rewards

### DIFF
--- a/mobile_verifier/src/telemetry.rs
+++ b/mobile_verifier/src/telemetry.rs
@@ -5,6 +5,9 @@ use sqlx::{Pool, Postgres};
 
 const LAST_REWARDED_END_TIME: &str = "last_rewarded_end_time";
 const DATA_TRANSFER_REWARDS_SCALE: &str = "data_transfer_rewards_scale";
+const POC_REWARDED_RADIOS: &str = "poc_rewarded_radios";
+const DATA_TRANSFER_REWARDED_GATEWAYS: &str = "data_transfer_rewarded_gateways";
+const MAPPERS_REWARDED: &str = "mappers_rewarded";
 
 pub async fn initialize(db: &Pool<Postgres>) -> anyhow::Result<()> {
     let next_reward_epoch = rewarder::next_reward_epoch(db).await?;
@@ -19,4 +22,16 @@ pub fn last_rewarded_end_time(timestamp: DateTime<Utc>) {
 
 pub fn data_transfer_rewards_scale(scale: f64) {
     metrics::gauge!(DATA_TRANSFER_REWARDS_SCALE).set(scale);
+}
+
+pub fn poc_rewarded_radios(count: u64) {
+    metrics::gauge!(POC_REWARDED_RADIOS).set(count as f64);
+}
+
+pub fn data_transfer_rewarded_gateways(count: u64) {
+    metrics::gauge!(DATA_TRANSFER_REWARDED_GATEWAYS).set(count as f64);
+}
+
+pub fn mappers_rewarded(count: u64) {
+    metrics::gauge!(MAPPERS_REWARDED).set(count as f64);
 }


### PR DESCRIPTION
- poc_rewarded_radios - count of radios that earned PoC
- data_transfer_rewarded_gateways - count of gateways that earned data transfer rewards
- mappers_rewarded - count of mappers that earned rewards

All 3 are gauges output during reward calculation