### PR TITLE
Add metric when we throttle route stream updates

### DIFF
--- a/iot_config/src/lib.rs
+++ b/iot_config/src/lib.rs
@@ -47,6 +47,7 @@ pub async fn broadcast_update<T: std::fmt::Debug>(
     sender: broadcast::Sender<T>,
 ) -> Result<(), broadcast::error::SendError<T>> {
     while !enqueue_update(sender.len()) {
+        telemetry::route_stream_throttle();
         tokio::time::sleep(tokio::time::Duration::from_millis(25)).await
     }
     sender.send(message).map(|_| ()).map_err(|err| {

--- a/iot_config/src/telemetry.rs
+++ b/iot_config/src/telemetry.rs
@@ -1,5 +1,7 @@
 const RPC_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "grpc-request");
 const STREAM_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "grpc-stream");
+const STREAM_THROTTLE_COUNT_METRIC: &str =
+    concat!(env!("CARGO_PKG_NAME"), "-", "grpc-stream-throttle");
 const REGION_HEX_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "region-hexes");
 const REGION_LOOKUP_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "region-lookup");
 const SKF_ADD_COUNT_METRIC: &str = concat!(env!("CARGO_PKG_NAME"), "-", "skfs-added");
@@ -75,4 +77,8 @@ pub fn route_stream_subscribe() {
 
 pub fn route_stream_unsubscribe() {
     metrics::gauge!(STREAM_METRIC).decrement(1.0);
+}
+
+pub fn route_stream_throttle() {
+    metrics::counter!(STREAM_THROTTLE_COUNT_METRIC).increment(1);
 }


### PR DESCRIPTION
Broadcast channels will drop messages if one of the consumers falls  behind. We cannot miss updates for downstream HPR. This is why we check  how full the broadcast channel is before queueing a message. 

Simply sleeping before adding a message means it’s theoretically  possible for messages to be queued out of order. 

Before we spend resources trying to tackle this potential case, we  should add a way to check how common it might be.