### PR TITLE
Add filter for boosted hexes to remove any not started or started aft…

### DIFF
--- a/mobile_config/src/hex_boosting_service.rs
+++ b/mobile_config/src/hex_boosting_service.rs
@@ -3,7 +3,7 @@ use crate::{
     key_cache::KeyCache,
     telemetry, verify_public_key, GrpcResult, GrpcStreamResult,
 };
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use file_store::traits::{MsgVerify, TimestampDecode, TimestampEncode};
 use futures::{
     stream::{Stream, StreamExt, TryStreamExt},
@@ -25,14 +25,21 @@ pub struct HexBoostingService {
     key_cache: KeyCache,
     metadata_pool: Pool<Postgres>,
     signing_key: Arc<Keypair>,
+    activation_cutoff: DateTime<Utc>,
 }
 
 impl HexBoostingService {
-    pub fn new(key_cache: KeyCache, metadata_pool: Pool<Postgres>, signing_key: Keypair) -> Self {
+    pub fn new(
+        key_cache: KeyCache,
+        metadata_pool: Pool<Postgres>,
+        signing_key: Keypair,
+        activation_cutoff: DateTime<Utc>,
+    ) -> Self {
         Self {
             key_cache,
             metadata_pool,
             signing_key: Arc::new(signing_key),
+            activation_cutoff,
         }
     }
 
@@ -67,11 +74,12 @@ impl mobile_config::HexBoosting for HexBoostingService {
         let pool = self.metadata_pool.clone();
         let signing_key = self.signing_key.clone();
         let batch_size = request.batch_size;
+        let activation_cutoff = self.activation_cutoff;
 
         let (tx, rx) = tokio::sync::mpsc::channel(100);
 
         tokio::spawn(async move {
-            let stream = boosted_hex_info::db::all_info_stream(&pool);
+            let stream = boosted_hex_info::db::all_info_stream(&pool, activation_cutoff);
             stream_multi_info(stream, tx.clone(), signing_key.clone(), batch_size).await
         });
 
@@ -95,6 +103,7 @@ impl mobile_config::HexBoosting for HexBoostingService {
         let pool = self.metadata_pool.clone();
         let signing_key = self.signing_key.clone();
         let batch_size = request.batch_size;
+        let activation_cutoff = self.activation_cutoff;
         let ts = request
             .timestamp
             .to_timestamp()
@@ -104,7 +113,7 @@ impl mobile_config::HexBoosting for HexBoostingService {
         let (tx, rx) = tokio::sync::mpsc::channel(100);
 
         tokio::spawn(async move {
-            let stream = boosted_hex_info::db::modified_info_stream(&pool, ts);
+            let stream = boosted_hex_info::db::modified_info_stream(&pool, activation_cutoff, ts);
             stream_multi_info(stream, tx.clone(), signing_key.clone(), batch_size).await
         });
 

--- a/mobile_config/src/main.rs
+++ b/mobile_config/src/main.rs
@@ -113,6 +113,7 @@ impl Daemon {
             key_cache.clone(),
             metadata_pool.clone(),
             settings.signing_keypair()?,
+            settings.boosted_hex_activation_cutoff,
         );
 
         let sub_dao_svc = SubDaoService::new(

--- a/mobile_config/src/settings.rs
+++ b/mobile_config/src/settings.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use chrono::{DateTime, Utc};
 use config::{Config, Environment, File};
 use serde::Deserialize;
 use std::{net::SocketAddr, path::Path, str::FromStr};
@@ -30,6 +31,12 @@ pub struct Settings {
     )]
     pub mobile_radio_tracker_interval: std::time::Duration,
     pub metrics: poc_metrics::Settings,
+    #[serde(default = "default_boosted_hex_activation_cutoff")]
+    pub boosted_hex_activation_cutoff: DateTime<Utc>,
+}
+
+fn default_boosted_hex_activation_cutoff() -> DateTime<Utc> {
+    DateTime::from_str("2025-07-01T00:00:00Z").unwrap()
 }
 
 fn default_mobile_radio_tracker_interval() -> std::time::Duration {


### PR DESCRIPTION
https://github.com/helium/helium-release-proposals/blob/main/releases/20250812-core-devs.md#1-removal-of-unstarted-boosted-hexes-from-the-mobile-network

Updating mobile-config to not return any boosted hexes that are not started or started after `2025-07-01`.  Chose this implementation and it closely resembles how it would work if hexes were not on chain