### PR TITLE
cast helium_proto::UnknownEnumValue to file-store error

### DIFF
--- a/file_store/src/error.rs
+++ b/file_store/src/error.rs
@@ -1,3 +1,4 @@
+use helium_proto::UnknownEnumValue;
 use thiserror::Error;
 
 pub type Result<T = ()> = std::result::Result<T, Error>;
@@ -10,6 +11,8 @@ pub enum Error {
     Encode(#[from] EncodeError),
     #[error("decode error")]
     Decode(#[from] DecodeError),
+    #[error("unknown enum value")]
+    UnknownEnumValue(#[from] UnknownEnumValue),
     #[error("not found")]
     NotFound(String),
     #[error("crypto error")]


### PR DESCRIPTION
This fixes an error for project uses file-store.

```
error[E0277]: `?` couldn't convert the error to `file_store::Error`
   --> cas/src/etl/verified_hotspot_data_transfer_session.rs:117:53
    |
117 |             status: ReportStatus::try_from(v.status)?,
    |                     --------------------------------^ the trait `From<UnknownEnumValue>` is not implemented for `file_store::Error`
    |                     |
    |                     this can't be annotated with `?` because it has type `Result<_, UnknownEnumValue>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
              `file_store::Error` implements `From<Box<dyn derive_more::Error + std::marker::Send + Sync>>`
              `file_store::Error` implements `From<EncodeError>`
              `file_store::Error` implements `From<FileInfoPollerConfigBuilderError>`
              `file_store::Error` implements `From<aws_sdk_s3::error_meta::Error>`
              `file_store::Error` implements `From<config::error::ConfigError>`
              `file_store::Error` implements `From<csv::error::Error>`
              `file_store::Error` implements `From<file_store::error::DecodeError>`
              `file_store::Error` implements `From<file_store::error::EncodeError>`
            and 7 others
```