### PR TITLE
Crypto Provider fix 🤞 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 dependencies = [
  "backtrace",
 ]
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -751,9 +751,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.8.2"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd9b83179adf8998576317ce47785948bcff399ec5b15f4dfbdedd44ddf5b92"
+checksum = "8bc1b40fb26027769f16960d2f4a6bc20c4bb755d403e552c8c1a73af433c246"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -781,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.4"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68c2194a190e1efc999612792e25b1ab3abfefe4306494efaaabc25933c0cbe"
+checksum = "d025db5d9f52cbc413b167136afb3d8aeea708c0d8884783cf6253be5e22f6f2"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -833,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.9"
+version = "1.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2090e664216c78e766b6bac10fe74d2f451c02441d43484cd76ac9a295075f7"
+checksum = "c034a1bc1d70e16e7f4e4caf7e9f7693e4c9c24cd91cf17c2a0b21abaebc7c8b"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -858,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.98.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029e89cae7e628553643aecb3a3f054a0a0912ff0fd1f5d6a0b4fda421dce64b"
+checksum = "2c230530df49ed3f2b7b4d9c8613b72a04cdac6452eede16d587fc62addfabac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.76.0"
+version = "1.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bf26698dd6d238ef1486bdda46f22a589dc813368ba868dc3d94c8d27b56ba"
+checksum = "357a841807f6b52cb26123878b3326921e2a25faca412fabdd32bd35b7edd5d3"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.77.0"
+version = "1.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cd07ed1edd939fae854a22054299ae3576500f4e0fadc560ca44f9c6ea1664"
+checksum = "67e05f33b6c9026fecfe9b3b6740f34d41bc6ff641a6a32dabaab60209245b75"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -936,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.78.0"
+version = "1.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f7766d2344f56d10d12f3c32993da36d78217f32594fe4fb8e57a538c1cdea"
+checksum = "e7d835f123f307cafffca7b9027c14979f1d403b417d8541d67cf252e8a21e35"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -959,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
+checksum = "084c34162187d39e3740cb635acd73c4e3a551a36146ad6fe8883c929c9f876c"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -998,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.5"
+version = "0.63.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab9472f7a8ec259ddb5681d2ef1cb1cf16c0411890063e67cdc7b62562cc496"
+checksum = "56d2df0314b8e307995a3b86d44565dfe9de41f876901a7d71886c756a25979f"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -1018,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.10"
+version = "0.60.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604c7aec361252b8f1c871a7641d5e0ba3a7f5a586e51b66bc9510a5519594d9"
+checksum = "182b03393e8c677347fb5705a04a9392695d47d20ef0a2f8cfe28c8e6b9b9778"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -1029,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.2"
+version = "0.62.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c82ba4cab184ea61f6edaafc1072aad3c2a17dcf4c0fce19ac5694b90d8b5f"
+checksum = "7c4dacf2d38996cf729f55e7a762b30918229917eca115de45dfa8dfb97796c9"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -1050,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.6"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f108f1ca850f3feef3009bdcc977be201bca9a91058864d9de0684e64514bee0"
+checksum = "147e8eea63a40315d704b97bf9bc9b8c1402ae94f89d5ad6f7550d963309da1b"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1073,15 +1073,16 @@ dependencies = [
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.26.2",
  "tower 0.5.2",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.4"
+version = "0.61.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16e040799d29c17412943bdbf488fd75db04112d0c0d4b9290bacf5ae0014b9"
+checksum = "eaa31b350998e703e9826b2104dd6f63be0508666e1aba88137af060e8944047"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -1107,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.4"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aaec682eb189e43c8a19c3dab2fe54590ad5f2cc2d26ab27608a20f2acf81c"
+checksum = "4fa63ad37685ceb7762fa4d73d06f1d5493feb88e3f27259b9ed277f4c01b185"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1131,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.3"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852b9226cb60b78ce9369022c0df678af1cac231c882d5da97a0c4e03be6e67"
+checksum = "07f5e0fc8a6b3f2303f331b94504bbf754d85488f402d6f1dd7a6080f99afe56"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -1193,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
+checksum = "b069d19bf01e46298eaedd7c6f283fe565a59263e53eebec945f3e6398f42390"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1358,8 +1359,8 @@ dependencies = [
  "byteorder",
  "helium-proto",
  "prost",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rust_decimal",
  "serde",
  "sha2 0.10.9",
@@ -1393,7 +1394,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -1642,18 +1643,18 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2177,6 +2178,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994091bae428316ad612b1d563e7bd917141ba942963f65251bb07c0f31cc55"
 
 [[package]]
+name = "ctor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,6 +2331,7 @@ dependencies = [
  "serde",
  "sqlx",
  "thiserror 1.0.69",
+ "tls-init",
  "tokio",
  "tracing",
  "url",
@@ -2330,7 +2348,7 @@ dependencies = [
  "config",
  "helium-crypto",
  "humantime-serde",
- "reqwest 0.12.15",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2504,6 +2522,21 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dtor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -2749,6 +2782,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c1ddb9231d8554c2d6bdf4cfaabf0c59251658c68b6c95cd52dd0c513a912a"
+dependencies = [
+ "getrandom 0.3.2",
+ "libm",
+ "rand 0.9.1",
+ "siphasher 1.0.1",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2829,6 +2874,7 @@ dependencies = [
  "task-manager",
  "tempfile",
  "thiserror 1.0.69",
+ "tls-init",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2941,9 +2987,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -3186,6 +3232,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "governor"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3239,7 +3297,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.11.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -3258,7 +3316,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.11.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -3402,8 +3460,8 @@ dependencies = [
 
 [[package]]
 name = "helium-lib"
-version = "0.1.1"
-source = "git+https://github.com/helium/helium-wallet-rs?branch=master#754b08fcf6a5d6b96ce28bf79e27bf78b0418c4c"
+version = "0.2.0"
+source = "git+https://github.com/helium/helium-wallet-rs?branch=master#e21e0f688fddeac9e8c8f26a57a55cea0f89ab9a"
 dependencies = [
  "anchor-client",
  "anchor-lang",
@@ -3470,9 +3528,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -3493,6 +3551,7 @@ dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
  "sqlx",
+ "tls-init",
 ]
 
 [[package]]
@@ -3736,7 +3795,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 0.26.10",
 ]
 
 [[package]]
@@ -3766,11 +3824,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -3778,7 +3853,9 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.0",
  "tokio",
@@ -3979,9 +4056,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -4010,13 +4087,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.3",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4037,7 +4115,7 @@ name = "ingest"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "backon",
+ "backon 1.5.2",
  "base64 0.22.1",
  "bs58",
  "chrono",
@@ -4062,6 +4140,7 @@ dependencies = [
  "sha2 0.10.9",
  "task-manager",
  "thiserror 1.0.69",
+ "tls-init",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4101,12 +4180,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "iot-config"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "backon",
+ "backon 0.4.0",
  "base64 0.22.1",
  "bs58",
  "chrono",
@@ -4137,6 +4227,7 @@ dependencies = [
  "sqlx",
  "task-manager",
  "thiserror 1.0.69",
+ "tls-init",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4175,6 +4266,7 @@ dependencies = [
  "sqlx",
  "task-manager",
  "thiserror 1.0.69",
+ "tls-init",
  "tokio",
  "tonic",
  "tracing",
@@ -4224,6 +4316,7 @@ dependencies = [
  "sqlx",
  "task-manager",
  "thiserror 1.0.69",
+ "tls-init",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4240,6 +4333,16 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -4495,9 +4598,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libflate"
@@ -4526,7 +4629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4648,6 +4751,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4742,7 +4851,7 @@ checksum = "83a4c4718a371ddfb7806378f23617876eea8b82e5ff1324516bcd283249d9ea"
 dependencies = [
  "base64 0.21.7",
  "hyper 0.14.32",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "indexmap 1.9.3",
  "ipnet",
  "metrics",
@@ -4884,6 +4993,7 @@ dependencies = [
  "sqlx",
  "task-manager",
  "thiserror 1.0.69",
+ "tls-init",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4913,6 +5023,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "tls-init",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -4942,7 +5053,7 @@ dependencies = [
  "mobile-config",
  "poc-metrics",
  "prost",
- "reqwest 0.12.15",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4950,6 +5061,7 @@ dependencies = [
  "sqlx",
  "task-manager",
  "thiserror 1.0.69",
+ "tls-init",
  "tokio",
  "tonic",
  "tracing",
@@ -5007,6 +5119,7 @@ dependencies = [
  "task-manager",
  "tempfile",
  "thiserror 1.0.69",
+ "tls-init",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5274,28 +5387,29 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -5509,9 +5623,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "percentage"
@@ -5529,7 +5643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap 2.11.3",
 ]
 
 [[package]]
@@ -5628,6 +5742,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tls-init",
  "tokio",
  "tonic",
  "tower 0.4.13",
@@ -5643,7 +5758,7 @@ dependencies = [
  "futures",
  "metrics",
  "metrics-exporter-prometheus",
- "reqwest 0.12.15",
+ "reqwest 0.12.23",
  "serde",
  "thiserror 1.0.69",
  "tokio",
@@ -5721,6 +5836,7 @@ dependencies = [
  "task-manager",
  "temp-env",
  "thiserror 1.0.69",
+ "tls-init",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5835,7 +5951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5857,7 +5973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -5944,9 +6060,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.7"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -5955,8 +6071,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.31",
- "socket2 0.5.9",
- "thiserror 2.0.12",
+ "socket2 0.6.0",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "web-time",
@@ -5964,12 +6080,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.11"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
+ "fastbloom",
  "getrandom 0.3.2",
+ "lru-slab",
  "rand 0.9.1",
  "ring",
  "rustc-hash 2.1.1",
@@ -5977,7 +6095,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6256,7 +6374,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6276,47 +6394,43 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
+ "hyper-tls 0.6.0",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
- "once_cell",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls 0.23.31",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-native-tls",
  "tokio-util",
  "tower 0.5.2",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.10",
- "windows-registry",
 ]
 
 [[package]]
@@ -6378,6 +6492,7 @@ dependencies = [
  "sqlx",
  "task-manager",
  "thiserror 1.0.69",
+ "tls-init",
  "tokio",
  "tonic",
  "tracing",
@@ -6670,7 +6785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "schannel",
  "security-framework 2.11.1",
 ]
@@ -6697,15 +6812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6717,9 +6823,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+checksum = "be59af91596cac372a6942530653ad0c3a246cdd491aaa9dcaee47f88d67d5a0"
 dependencies = [
  "core-foundation 0.10.0",
  "core-foundation-sys",
@@ -6732,7 +6838,7 @@ dependencies = [
  "rustls-webpki 0.103.4",
  "security-framework 3.2.0",
  "security-framework-sys",
- "webpki-root-certs 0.26.11",
+ "webpki-root-certs",
  "windows-sys 0.59.0",
 ]
 
@@ -6899,10 +7005,11 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -6925,10 +7032,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6937,14 +7053,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7142,6 +7259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7158,9 +7281,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
@@ -7205,6 +7328,7 @@ dependencies = [
  "spl-token 8.0.0",
  "sqlx",
  "thiserror 1.0.69",
+ "tls-init",
  "tokio",
  "tracing",
 ]
@@ -7262,7 +7386,7 @@ dependencies = [
  "spl-token-2022 7.0.0",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "zstd",
 ]
 
@@ -7367,7 +7491,7 @@ dependencies = [
  "ark-serialize",
  "bytemuck",
  "solana-define-syscall",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -7391,7 +7515,7 @@ dependencies = [
  "dashmap",
  "futures",
  "futures-util",
- "indexmap 2.9.0",
+ "indexmap 2.11.3",
  "indicatif",
  "log",
  "quinn",
@@ -7422,7 +7546,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "solana-udp-client",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
 ]
 
@@ -7538,7 +7662,7 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "futures-util",
- "indexmap 2.9.0",
+ "indexmap 2.11.3",
  "log",
  "rand 0.8.5",
  "rayon",
@@ -7548,7 +7672,7 @@ dependencies = [
  "solana-net-utils",
  "solana-time-utils",
  "solana-transaction-error",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
 ]
 
@@ -7568,16 +7692,16 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.20"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411f8a1fcbc3781bdc6ee3457bb6275eab8a7bd05154f1e73ecfdbba508d1ea4"
+checksum = "be0f4b325ca71954295690acab6e2bc6a969ff0d3b028b20ba41f7906bd4044a"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
  "solana-define-syscall",
  "subtle",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -7591,9 +7715,9 @@ dependencies = [
 
 [[package]]
 name = "solana-define-syscall"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf784bb2cb3e02cac9801813c30187344228d2ae952534902108f6150573a33d"
+checksum = "2ae3e2abcf541c8122eafe9a625d4d194b4023c20adde1e251f94e056bb1aee2"
 
 [[package]]
 name = "solana-derivation-path"
@@ -7651,7 +7775,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c5fd2662ae7574810904585fd443545ed2b568dbd304b25a31e79ccc76e81b"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
  "solana-hash",
  "solana-pubkey",
 ]
@@ -7687,7 +7811,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-system-interface",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -8029,7 +8153,7 @@ dependencies = [
  "solana-cluster-type",
  "solana-sha256-hasher",
  "solana-time-utils",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -8281,7 +8405,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-vote-interface",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "wasm-bindgen",
 ]
 
@@ -8375,7 +8499,7 @@ dependencies = [
  "solana-timings",
  "solana-transaction-context",
  "solana-type-overrides",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -8424,7 +8548,7 @@ dependencies = [
  "solana-pubkey",
  "solana-rpc-client-api",
  "solana-signature",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -8459,7 +8583,7 @@ dependencies = [
  "solana-streamer",
  "solana-tls-utils",
  "solana-transaction-error",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
 ]
 
@@ -8610,7 +8734,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-version",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -8627,7 +8751,7 @@ dependencies = [
  "solana-pubkey",
  "solana-rpc-client",
  "solana-sdk-ids",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -8720,7 +8844,7 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error",
  "solana-validator-exit",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "wasm-bindgen",
 ]
 
@@ -8772,7 +8896,7 @@ dependencies = [
  "borsh 1.5.7",
  "libsecp256k1",
  "solana-define-syscall",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -8972,7 +9096,7 @@ dependencies = [
  "futures-util",
  "governor",
  "histogram",
- "indexmap 2.9.0",
+ "indexmap 2.11.3",
  "itertools 0.12.1",
  "libc",
  "log",
@@ -8999,7 +9123,7 @@ dependencies = [
  "solana-tls-utils",
  "solana-transaction-error",
  "solana-transaction-metrics-tracker",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-util",
  "x509-parser",
@@ -9151,7 +9275,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "futures-util",
- "indexmap 2.9.0",
+ "indexmap 2.11.3",
  "indicatif",
  "log",
  "rayon",
@@ -9172,7 +9296,7 @@ dependencies = [
  "solana-signer",
  "solana-transaction",
  "solana-transaction-error",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
 ]
 
@@ -9287,7 +9411,7 @@ dependencies = [
  "spl-token-2022 7.0.0",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -9310,7 +9434,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -9362,7 +9486,7 @@ dependencies = [
  "solana-net-utils",
  "solana-streamer",
  "solana-transaction-error",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
 ]
 
@@ -9442,7 +9566,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "subtle",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -9591,7 +9715,7 @@ dependencies = [
  "solana-program-option",
  "solana-pubkey",
  "solana-zk-sdk",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -9696,7 +9820,7 @@ dependencies = [
  "solana-rent",
  "solana-sdk-ids",
  "solana-sysvar",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -9752,7 +9876,7 @@ dependencies = [
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -9778,7 +9902,7 @@ dependencies = [
  "solana-program",
  "solana-zk-sdk",
  "spl-pod",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -9800,7 +9924,7 @@ checksum = "0e3597628b0d2fe94e7900fd17cdb4cfbb31ee35c66f82809d27d86e44b2848b"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-zk-sdk",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -9918,7 +10042,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.3",
  "hashlink",
- "indexmap 2.9.0",
+ "indexmap 2.11.3",
  "log",
  "memchr",
  "once_cell",
@@ -9929,7 +10053,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -10016,7 +10140,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tracing",
  "uuid",
  "whoami",
@@ -10056,7 +10180,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tracing",
  "uuid",
  "whoami",
@@ -10082,7 +10206,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tracing",
  "url",
  "uuid",
@@ -10294,11 +10418,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -10314,9 +10438,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10399,21 +10523,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls-init"
+version = "0.1.0"
+dependencies = [
+ "ctor",
+ "hyper-rustls 0.27.5",
+ "rustls 0.23.31",
+ "rustls-webpki 0.103.4",
+ "tokio-rustls 0.26.2",
+]
+
+[[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio 1.0.3",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.9",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10427,7 +10564,7 @@ dependencies = [
  "bytemuck",
  "miette",
  "pin-project-lite",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-util",
  "tracing",
@@ -10502,9 +10639,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -10549,7 +10686,7 @@ version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.11.3",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -10656,7 +10793,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.9.0",
+ "indexmap 2.11.3",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",
@@ -10675,9 +10812,12 @@ checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.9.0",
  "bytes",
+ "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
+ "iri-string",
  "pin-project-lite",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10845,7 +10985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -10961,9 +11101,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -11189,15 +11329,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.2",
-]
-
-[[package]]
-name = "webpki-root-certs"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
@@ -11292,7 +11423,7 @@ dependencies = [
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.0",
+ "windows-strings",
 ]
 
 [[package]]
@@ -11324,30 +11455,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link",
 ]
@@ -11436,27 +11547,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -11478,12 +11573,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11500,12 +11589,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11526,22 +11609,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -11562,12 +11633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11584,12 +11649,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -11610,12 +11669,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11632,12 +11685,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -11736,7 +11783,7 @@ dependencies = [
  "csv",
  "flate2",
  "helium-crypto",
- "indexmap 2.9.0",
+ "indexmap 2.11.3",
  "prost",
  "prost-build",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,6 +1272,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,8 @@ sqlx = { version = "0.8", default-features = false, features = [
   "chrono",
   "migrate",
   "macros",
-  "runtime-tokio-rustls",
+  "runtime-tokio",
+  "tls-rustls-aws-lc-rs",
 ] }
 helium-crypto = { version = "0.9.3", default-features = false }
 hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
@@ -72,7 +73,8 @@ hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", fe
 reqwest = { version = "0", default-features = false, features = [
   "gzip",
   "json",
-  "rustls-tls",
+  "http2",
+  "default-tls",
 ] }
 humantime = "2"
 humantime-serde = "1"
@@ -127,7 +129,10 @@ helium-proto = { git = "https://github.com/helium/proto", branch = "master", fea
 beacon = { git = "https://github.com/helium/proto", branch = "master" }
 # Pickup versions from above
 prost = "*"
-tonic = { version = "*", features = ["tls-ring", "tls-native-roots"] }
+tonic = { version = "*", features = ["tls-aws-lc", "tls-native-roots"] }
+
+### TLS
+# TODO(mj): add notes about including tls-init in workspaces that needt tls
 
 [patch.crates-io]
 anchor-lang = { git = "https://github.com/madninja/anchor.git", branch = "madninja/const_pubkey" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,25 @@ prost = "*"
 tonic = { version = "*", features = ["tls-aws-lc", "tls-native-roots"] }
 
 ### TLS
-# TODO(mj): add notes about including tls-init in workspaces that needt tls
+# Updates to `rustls` now support multiple CryptoProvider backends. Namely
+# `aws-lc-rs` (default) and `ring` (legacy).
+#
+# Until more crates have updated to default to `aws-lc-rs` we need to ensure
+# that a single CryptoProvider backend is installed. Because of our heavy
+# reliance on aws crates, we've chosen `aws-lc-rs`. Also because `rustls` has
+# recently chosen that as it's default.
+#
+# If you're crate needs to use tls, add the following.
+# // Cargo.toml
+# tls-init = { path = "../tls_init" }
+#
+# // lib.rs
+# `extern crate tls_init;`
+#
+# `tls_init` uses `ctor` to run a constructor when the code is loaded a single
+# time. We need to `extern` the crate to prevent the linker from optimizing the
+# codepath away because there are no direct calls into the workspace.
+
 
 [patch.crates-io]
 anchor-lang = { git = "https://github.com/madninja/anchor.git", branch = "madninja/const_pubkey" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "task_manager",
   "hex_assignments",
   "aws_local",
+  "tls_init",
 ]
 resolver = "2"
 

--- a/db_store/Cargo.toml
+++ b/db_store/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true }
 http = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+tls-init = { path = "../tls_init" }
 
 aws-config = { workspace = true }
 aws-sdk-sts = { workspace = true }

--- a/db_store/src/lib.rs
+++ b/db_store/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 use std::str::FromStr;
 mod error;
 mod iam_auth_pool;

--- a/db_store/src/lib.rs
+++ b/db_store/src/lib.rs
@@ -86,3 +86,6 @@ where
         Ok(std::mem::replace(&mut self.value, new_val))
     }
 }
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/file_store/Cargo.toml
+++ b/file_store/Cargo.toml
@@ -47,6 +47,7 @@ uuid = { workspace = true }
 h3o = { workspace = true }
 task-manager = { path = "../task_manager" }
 humantime-serde = { workspace = true }
+tls-init = { path = "../tls_init" }
 
 aws-config = { workspace = true }
 aws-sdk-s3 = { workspace = true }

--- a/file_store/src/lib.rs
+++ b/file_store/src/lib.rs
@@ -47,3 +47,6 @@ use futures::stream::BoxStream;
 pub type Stream<T> = BoxStream<'static, Result<T>>;
 pub type FileInfoStream = Stream<FileInfo>;
 pub type BytesMutStream = Stream<BytesMut>;
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/file_store/src/lib.rs
+++ b/file_store/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 pub mod cli;
 pub mod coverage;
 pub mod entropy_report;

--- a/hex_assignments/Cargo.toml
+++ b/hex_assignments/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 hextree = { workspace = true }
-sqlx = { version = "*", features = ["runtime-tokio-rustls"] }
+sqlx = { workspace = true }
 rust_decimal = { workspace = true }
 rust_decimal_macros = { workspace = true }
 helium-proto = { workspace = true }

--- a/hex_assignments/Cargo.toml
+++ b/hex_assignments/Cargo.toml
@@ -16,3 +16,4 @@ helium-proto = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 derive_builder = { workspace = true }
+tls-init = { path = "../tls_init" }

--- a/hex_assignments/src/lib.rs
+++ b/hex_assignments/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 pub mod assignment;
 pub mod footfall;
 pub mod landtype;

--- a/hex_assignments/src/lib.rs
+++ b/hex_assignments/src/lib.rs
@@ -84,6 +84,9 @@ pub struct HexBoostData {
 }
 
 #[cfg(test)]
+tls_init::include_tls_tests!();
+
+#[cfg(test)]
 mod tests {
 
     use assignment::HexAssignments;

--- a/ingest/Cargo.toml
+++ b/ingest/Cargo.toml
@@ -39,6 +39,7 @@ task-manager = { path = "../task_manager" }
 rand = { workspace = true }
 custom-tracing = { path = "../custom_tracing", features = ["grpc"] }
 humantime-serde = { workspace = true }
+tls-init = { path = "../tls_init" }
 
 [dev-dependencies]
 backon = "1"

--- a/ingest/Cargo.toml
+++ b/ingest/Cargo.toml
@@ -41,4 +41,4 @@ custom-tracing = { path = "../custom_tracing", features = ["grpc"] }
 humantime-serde = { workspace = true }
 
 [dev-dependencies]
-backon = "0"
+backon = "1"

--- a/ingest/src/lib.rs
+++ b/ingest/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 pub mod server_iot;
 pub mod server_mobile;
 pub mod settings;

--- a/ingest/src/lib.rs
+++ b/ingest/src/lib.rs
@@ -5,3 +5,6 @@ pub mod server_mobile;
 pub mod settings;
 
 pub use settings::{Mode, Settings};
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/iot_config/Cargo.toml
+++ b/iot_config/Cargo.toml
@@ -41,6 +41,7 @@ tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 triggered = { workspace = true }
+tls-init = { path = "../tls_init" }
 
 custom-tracing = { path = "../custom_tracing", features = ["grpc"] }
 db-store = { path = "../db_store" }

--- a/iot_config/src/lib.rs
+++ b/iot_config/src/lib.rs
@@ -82,3 +82,6 @@ impl From<u64> for EpochInfo {
         }
     }
 }
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/iot_config/src/lib.rs
+++ b/iot_config/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 pub mod admin;
 pub mod admin_service;
 pub mod client;

--- a/iot_packet_verifier/Cargo.toml
+++ b/iot_packet_verifier/Cargo.toml
@@ -41,3 +41,4 @@ iot-config = { path = "../iot_config" }
 poc-metrics = { path = "../metrics" }
 solana = { path = "../solana" }
 task-manager = { path = "../task_manager" }
+tls-init = { path = "../tls_init" }

--- a/iot_packet_verifier/src/lib.rs
+++ b/iot_packet_verifier/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 pub mod balances;
 pub mod burner;
 pub mod daemon;

--- a/iot_packet_verifier/src/lib.rs
+++ b/iot_packet_verifier/src/lib.rs
@@ -6,3 +6,6 @@ pub mod daemon;
 pub mod pending;
 pub mod settings;
 pub mod verifier;
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/iot_verifier/Cargo.toml
+++ b/iot_verifier/Cargo.toml
@@ -57,3 +57,4 @@ price = { path = "../price" }
 reward-scheduler = { path = "../reward_scheduler" }
 solana = { path = "../solana" }
 task-manager = { path = "../task_manager" }
+tls-init = { path = "../tls_init" }

--- a/iot_verifier/src/lib.rs
+++ b/iot_verifier/src/lib.rs
@@ -52,3 +52,6 @@ impl PriceInfo {
 pub fn resolve_subdao_pubkey() -> SolPubkey {
     solana::SubDao::Iot.key()
 }
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/iot_verifier/src/lib.rs
+++ b/iot_verifier/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 pub mod entropy;
 pub mod entropy_loader;
 pub mod gateway_cache;

--- a/mobile_config/Cargo.toml
+++ b/mobile_config/Cargo.toml
@@ -51,6 +51,7 @@ file-store = { path = "../file_store" }
 poc-metrics = { path = "../metrics" }
 solana = { path = "../solana" }
 task-manager = { path = "../task_manager" }
+tls-init = { path = "../tls_init" }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/mobile_config/src/lib.rs
+++ b/mobile_config/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 use base64::Engine;
 use chrono::{DateTime, Duration, Utc};
 use helium_crypto::{Keypair, PublicKey};

--- a/mobile_config/src/lib.rs
+++ b/mobile_config/src/lib.rs
@@ -134,3 +134,6 @@ where
         .map(Arc::new)
         .map_err(serde::de::Error::custom)
 }
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/mobile_config_cli/Cargo.toml
+++ b/mobile_config_cli/Cargo.toml
@@ -26,4 +26,5 @@ tokio-stream = {workspace = true}
 tonic = {workspace = true}
 tracing = {workspace = true}
 custom-tracing = { path = "../custom_tracing" }
+tls-init = { path = "../tls_init" }
 

--- a/mobile_config_cli/src/lib.rs
+++ b/mobile_config_cli/src/lib.rs
@@ -110,3 +110,6 @@ impl Display for NetworkKeyRole {
         }
     }
 }
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/mobile_config_cli/src/lib.rs
+++ b/mobile_config_cli/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 pub mod client;
 pub mod cmds;
 

--- a/mobile_packet_verifier/Cargo.toml
+++ b/mobile_packet_verifier/Cargo.toml
@@ -43,6 +43,7 @@ file-store = { path = "../file_store" }
 mobile-config = { path = "../mobile_config" }
 poc-metrics = { path = "../metrics" }
 task-manager = { path = "../task_manager" }
+tls-init = { path = "../tls_init" }
 
 [dev-dependencies]
 reqwest = { workspace = true }

--- a/mobile_packet_verifier/src/lib.rs
+++ b/mobile_packet_verifier/src/lib.rs
@@ -74,3 +74,6 @@ mod tests {
         assert_eq!(2, bytes_to_dc(20_001));
     }
 }
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/mobile_packet_verifier/src/lib.rs
+++ b/mobile_packet_verifier/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 use helium_crypto::PublicKeyBinary;
 use helium_proto::services::mobile_config::NetworkKeyRole;
 use mobile_config::client::{

--- a/mobile_verifier/Cargo.toml
+++ b/mobile_verifier/Cargo.toml
@@ -7,9 +7,9 @@ edition.workspace = true
 authors.workspace = true
 
 [dependencies]
+tls-init = { path = "../tls_init" }
 async-compression = { version = "0", features = ["tokio", "gzip"] }
 regex = "1"
-
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }

--- a/mobile_verifier/src/lib.rs
+++ b/mobile_verifier/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 pub mod banning;
 pub mod boosting_oracles;
 pub mod cell_type;

--- a/mobile_verifier/src/lib.rs
+++ b/mobile_verifier/src/lib.rs
@@ -117,3 +117,6 @@ impl PriceInfo {
 pub fn resolve_subdao_pubkey() -> SolPubkey {
     solana::SubDao::Mobile.key()
 }
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/poc_entropy/Cargo.toml
+++ b/poc_entropy/Cargo.toml
@@ -36,3 +36,4 @@ helium-crypto = { workspace = true }
 file-store = { path = "../file_store" }
 poc-metrics = { path = "../metrics" }
 custom-tracing = { path = "../custom_tracing", features = ["grpc"] }
+tls-init = { path = "../tls_init" }

--- a/poc_entropy/src/lib.rs
+++ b/poc_entropy/src/lib.rs
@@ -5,3 +5,6 @@ pub mod server;
 pub mod settings;
 
 pub use settings::Settings;
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/poc_entropy/src/lib.rs
+++ b/poc_entropy/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 pub mod entropy_generator;
 pub mod server;
 pub mod settings;

--- a/price/Cargo.toml
+++ b/price/Cargo.toml
@@ -34,6 +34,7 @@ file-store = { path = "../file_store" }
 poc-metrics = { path = "../metrics" }
 solana = { path = "../solana" }
 task-manager = { path = "../task_manager" }
+tls-init = { path = "../tls_init" }
 
 [dev-dependencies]
 temp-env = "0.3.6"

--- a/price/src/lib.rs
+++ b/price/src/lib.rs
@@ -9,3 +9,6 @@ pub mod settings;
 pub use price_generator::PriceGenerator;
 pub use price_tracker::PriceTracker;
 pub use settings::Settings;
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/price/src/lib.rs
+++ b/price/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 pub mod cli;
 pub mod metrics;
 pub mod price_generator;

--- a/reward_index/Cargo.toml
+++ b/reward_index/Cargo.toml
@@ -42,3 +42,4 @@ db-store = { path = "../db_store" }
 file-store = { path = "../file_store" }
 poc-metrics = { path = "../metrics" }
 task-manager = { path = "../task_manager" }
+tls-init = { path = "../tls_init" }

--- a/reward_index/src/lib.rs
+++ b/reward_index/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 pub mod db;
 pub mod extract;
 pub mod indexer;

--- a/reward_index/src/lib.rs
+++ b/reward_index/src/lib.rs
@@ -8,3 +8,6 @@ pub mod telemetry;
 
 pub use indexer::Indexer;
 pub use settings::Settings;
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -26,3 +26,4 @@ spl-token = { version = "8" }
 sqlx = { workspace = true }
 
 helium-lib = { git = "https://github.com/helium/helium-wallet-rs", branch = "master" }
+tls-init = { path = "../tls_init" }

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -107,3 +107,6 @@ where
     let keypair = read_keypair(&mut s.as_bytes()).map_err(serde::de::Error::custom)?;
     Ok(keypair)
 }
+
+#[cfg(test)]
+tls_init::include_tls_tests!();

--- a/solana/src/lib.rs
+++ b/solana/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate tls_init;
+
 use helium_lib::{
     solana_client::client_error::ClientError,
     solana_sdk::{

--- a/tls_init/Cargo.toml
+++ b/tls_init/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tls-init"
+version = "0.1.0"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+
+[dependencies]
+rustls = { version = "0.23", default-features = true }
+ctor = "0.5"
+rustls-webpki = { version = "0.103", default-features = false, features = [
+    "aws-lc-rs",
+] }
+
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "aws-lc-rs",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "http2",
+    "tls12",
+    "aws-lc-rs",
+] }

--- a/tls_init/src/lib.rs
+++ b/tls_init/src/lib.rs
@@ -1,0 +1,8 @@
+pub use rustls;
+
+#[ctor::ctor]
+fn _install_tls_provider() {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install aws-lc-rs crypto provider");
+}

--- a/tls_init/src/lib.rs
+++ b/tls_init/src/lib.rs
@@ -1,3 +1,23 @@
+//! ### TLS
+//! Updates to `rustls` now support multiple CryptoProvider backends. Namely
+//! `aws-lc-rs` (default) and `ring` (legacy).
+//!
+//! Until more crates have updated to default to `aws-lc-rs` we need to ensure
+//! that a single CryptoProvider backend is installed. Because of our heavy
+//! reliance on aws crates, we've chosen `aws-lc-rs`. Also because `rustls` has
+//! recently chosen that as it's default.
+//!
+//! If you're crate needs to use tls, add the following.
+//! // Cargo.toml
+//! tls-init = { path = "../tls_init" }
+//!
+//! // lib.rs
+//! `extern crate tls_init;`
+//!
+//! `tls_init` uses `ctor` to run a constructor when the code is loaded a single
+//! time. We need to `extern` the crate to prevent the linker from optimizing the
+//! codepath away because there are no direct calls into the workspace.
+
 pub use rustls;
 
 #[ctor::ctor]
@@ -7,6 +27,11 @@ fn _install_tls_provider() {
         .expect("failed to install aws-lc-rs crypto provider");
 }
 
+/// Include the following macro in your src/lib.rs to hopefully prevent
+/// transient dependencies from installing another CryptoProvider backend.
+///
+/// #[cfg(test)]
+/// tls_init::include_tls_tests!();
 #[macro_export]
 macro_rules! include_tls_tests {
     () => {

--- a/tls_init/src/lib.rs
+++ b/tls_init/src/lib.rs
@@ -6,3 +6,23 @@ fn _install_tls_provider() {
         .install_default()
         .expect("failed to install aws-lc-rs crypto provider");
 }
+
+#[macro_export]
+macro_rules! include_tls_tests {
+    () => {
+        mod tls_init_tests {
+            #[test]
+            fn rustls_provider_is_set() {
+                let provider = $crate::rustls::crypto::CryptoProvider::get_default();
+
+                assert!(
+                    provider.is_some(),
+                    "No default Crypto Provider set (likely no or multiple providers)"
+                );
+                if let Some(p) = provider {
+                    assert_eq!(format!("{:?}", p.key_provider), "AwsLcRs");
+                }
+            }
+        }
+    };
+}


### PR DESCRIPTION
Do it with me now. *loooooooong sigh*

Okay, rust depedencies are a headache, we know this.

Updating AWS deps in https://github.com/helium/oracles/pull/1019 brought in a lot of newer stuff.
At this point, we're specifically concerned with `rustls`.

The default provider `<0.23` was `ring`. `0.24` defaults to `aws-lc-rs`. It's faster, more compliant, all that good stuff.

But this poses a problem to us, what to use when both `aws-lc-rs` and `ring` are present in the dependency tree?
If they both try to install themselves as the global `CryptoProvider`, that's no good. 
The state of rust deps that depend on TLS is slowly moving over to `aws-lc-rs`, but not quite there. So we have to make the decision in our runtime.

## The option I don't like
We could manually install `aws-lc-rs` in the `main()` function if every bin we build.

```rs
#[tokio::main]
async fn main() -> anyhow::Result<()> {
  rustls::crypto::aws_lc_rs::default_provider().install_default();

  // ...
}
```

But this won't enable for tests, and we won't know if there's a conflicting backend installed until runtime.
And we would need to handle the case where someone installed before our main function could run.

I didn't do that.

## The option I did

A new workspace was added, `tls-init`.

It uses `ctor` to run a constructor function when the crate is included anywhere.
```rs
#[ctor::ctor]
fn _install_tls_provider() {
    rustls::crypto::aws_lc_rs::default_provider()
        .install_default()
        .expect("failed to install aws-lc-rs crypto provider");
}
```

It will only run a single time no matter how many times it's included, so we don't need to worry about multiple levels of dependencies including `tls-init`.

For any crate that uses TLS we need to include it in `Cargo.toml`
```toml
[dependencies]
tls-init = { path = "../tls_init" }
```

And include the crate in `lib.rs`.
```rs
extern crate tls_init;
```

`extern`ing the crate is required so the linker doesn't optimize the dependency away.

Now, when any workspace is loaded or depended on that requires TLS, the first thing that happens is we install `aws-lc-rs` as the `CryptoProvider` backend.

#### Can we be sure?

I'm not sure how to be totally sure.
But `tls_init` also provides a test that can be included in workspaces that will hopefully catch if another dependency includes `ring` and it tries to be installed as the backend.

```rs
#[cfg(test)]
tls_init::include_tls_tests!();
```

This inlines the tests into the workspace to run alongside all of it's dependencies.

## Other

`backon` was updated because there was a breaking change between `0.4` and `0.5`. But weirdly, not `>1`. Also it was easy, and a dev-dependency.