### PR TITLE
Add test to reproduce bug

### DIFF
--- a/mobile_verifier/src/heartbeats/mod.rs
+++ b/mobile_verifier/src/heartbeats/mod.rs
@@ -580,7 +580,7 @@ impl ValidatedHeartbeat {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn process_validated_heartbeats(
+pub async fn process_validated_heartbeats(
     validated_heartbeats: impl Stream<Item = anyhow::Result<ValidatedHeartbeat>>,
     heartbeat_cache: &Cache<(String, DateTime<Utc>), ()>,
     coverage_claim_time_cache: &CoverageClaimTimeCache,


### PR DESCRIPTION
This test case shows problem I've found in process_validated_heartbeats function
1. process_validated_heartbeats processes only the first heartbeat per hour and ignores
    others. In this test case we have first good heartbeat (multiplier = 1)
    and others nine are bad (multiplier = 0), the final result is 1
2. In wifi_heartbeats table latest_timestamp always contains the value of the first
    timestamp (not the latest)