### PR TITLE
FileInfoPollerConfigBuilder add builder setter

### DIFF
--- a/file_store/src/file_info_poller.rs
+++ b/file_store/src/file_info_poller.rs
@@ -110,6 +110,18 @@ pub enum LookbackBehavior {
     Max(Duration),
 }
 
+impl From<DateTime<Utc>> for LookbackBehavior {
+    fn from(value: DateTime<Utc>) -> Self {
+        LookbackBehavior::StartAfter(value)
+    }
+}
+
+impl From<Duration> for LookbackBehavior {
+    fn from(value: Duration) -> Self {
+        LookbackBehavior::Max(value)
+    }
+}
+
 #[derive(Debug, Clone, Builder)]
 #[builder(pattern = "owned")]
 pub struct FileInfoPollerConfig<Message, State, Store, Parser> {
@@ -119,6 +131,7 @@ pub struct FileInfoPollerConfig<Message, State, Store, Parser> {
     store: Store,
     prefix: String,
     parser: Parser,
+    #[builder(setter(into))]
     lookback: LookbackBehavior,
     #[builder(default = "DEFAULT_OFFSET_DURATION")]
     offset: Duration,

--- a/file_store/src/mobile_ban.rs
+++ b/file_store/src/mobile_ban.rs
@@ -306,7 +306,7 @@ pub async fn report_source<State: FileInfoPollerState>(
     crate::file_source::continuous_source()
         .state(pool)
         .file_store(client, bucket)
-        .lookback(start_after)
+        .lookback_start_after(start_after)
         .prefix(crate::FileType::MobileBanReport.to_string())
         .create()
         .await
@@ -324,7 +324,7 @@ pub async fn verified_report_source<State: FileInfoPollerState>(
     crate::file_source::continuous_source()
         .state(pool)
         .file_store(client, bucket)
-        .lookback(start_after)
+        .lookback_start_after(start_after)
         .prefix(crate::FileType::VerifiedMobileBanReport.to_string())
         .create()
         .await

--- a/file_store/src/mobile_ban.rs
+++ b/file_store/src/mobile_ban.rs
@@ -5,9 +5,7 @@ use helium_crypto::PublicKeyBinary;
 
 use crate::{
     error::DecodeError,
-    file_info_poller::{
-        FileInfoPollerServer, FileInfoPollerState, FileInfoStream, LookbackBehavior,
-    },
+    file_info_poller::{FileInfoPollerServer, FileInfoPollerState, FileInfoStream},
     file_sink::FileSinkClient,
     traits::{FileSinkWriteExt, MsgDecode, TimestampDecode, TimestampEncode},
     Error, FileSink,
@@ -308,7 +306,7 @@ pub async fn report_source<State: FileInfoPollerState>(
     crate::file_source::continuous_source()
         .state(pool)
         .file_store(client, bucket)
-        .lookback(LookbackBehavior::StartAfter(start_after))
+        .lookback(start_after)
         .prefix(crate::FileType::MobileBanReport.to_string())
         .create()
         .await
@@ -326,7 +324,7 @@ pub async fn verified_report_source<State: FileInfoPollerState>(
     crate::file_source::continuous_source()
         .state(pool)
         .file_store(client, bucket)
-        .lookback(LookbackBehavior::StartAfter(start_after))
+        .lookback(start_after)
         .prefix(crate::FileType::VerifiedMobileBanReport.to_string())
         .create()
         .await

--- a/iot_packet_verifier/src/daemon.rs
+++ b/iot_packet_verifier/src/daemon.rs
@@ -165,7 +165,7 @@ impl Cmd {
         let (report_files, report_files_server) = file_source::continuous_source()
             .state(pool.clone())
             .file_store(file_store_client, settings.ingest_bucket.clone())
-            .lookback(settings.start_after)
+            .lookback_start_after(settings.start_after)
             .prefix(FileType::IotPacketReport.to_string())
             .create()
             .await?;

--- a/iot_packet_verifier/src/daemon.rs
+++ b/iot_packet_verifier/src/daemon.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use file_store::{
-    file_info_poller::{FileInfoStream, LookbackBehavior},
+    file_info_poller::FileInfoStream,
     file_sink::FileSinkClient,
     file_source, file_upload,
     iot_packet::PacketRouterPacketReport,
@@ -165,7 +165,7 @@ impl Cmd {
         let (report_files, report_files_server) = file_source::continuous_source()
             .state(pool.clone())
             .file_store(file_store_client, settings.ingest_bucket.clone())
-            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .lookback(settings.start_after)
             .prefix(FileType::IotPacketReport.to_string())
             .create()
             .await?;

--- a/iot_verifier/src/main.rs
+++ b/iot_verifier/src/main.rs
@@ -3,7 +3,6 @@ use crate::entropy_loader::EntropyLoader;
 use anyhow::Result;
 use clap::Parser;
 use file_store::{
-    file_info_poller::LookbackBehavior,
     file_source, file_upload,
     traits::{FileSinkCommitStrategy, FileSinkRollTime, FileSinkWriteExt},
     FileType,
@@ -169,7 +168,7 @@ impl Server {
             .state(pool.clone())
             .file_store(file_store_client.clone(), settings.buckets.entropy.clone())
             .prefix(FileType::EntropyReport.to_string())
-            .lookback(LookbackBehavior::Max(max_lookback_age))
+            .lookback_max(max_lookback_age)
             .poll_duration(entropy_interval)
             .offset(entropy_interval * 2)
             .create()
@@ -202,7 +201,7 @@ impl Server {
                 settings.buckets.packet_ingest.clone(),
             )
             .prefix(FileType::IotValidPacket.to_string())
-            .lookback(LookbackBehavior::Max(max_lookback_age))
+            .lookback_max(max_lookback_age)
             .poll_duration(packet_interval)
             .offset(packet_interval * 2)
             .create()

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -196,7 +196,7 @@ impl Cmd {
                 Utc.timestamp_millis_opt(0).unwrap(),
             ))
             .prefix(FileType::DataTransferSessionIngestReport.to_string())
-            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .lookback(settings.start_after)
             .create()
             .await?;
 

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -7,9 +7,8 @@ use crate::{
     MobileConfigClients, MobileConfigResolverExt,
 };
 use anyhow::{bail, Result};
-use chrono::{TimeZone, Utc};
 use file_store::{
-    file_info_poller::{FileInfoStream, LookbackBehavior},
+    file_info_poller::FileInfoStream,
     file_sink::FileSinkClient,
     file_source, file_upload,
     mobile_session::DataTransferSessionIngestReport,
@@ -192,11 +191,8 @@ impl Cmd {
         let (reports, reports_server) = file_source::continuous_source()
             .state(pool.clone())
             .file_store(file_store_client.clone(), settings.ingest_bucket.clone())
-            .lookback(LookbackBehavior::StartAfter(
-                Utc.timestamp_millis_opt(0).unwrap(),
-            ))
             .prefix(FileType::DataTransferSessionIngestReport.to_string())
-            .lookback(settings.start_after)
+            .lookback_start_after(settings.start_after)
             .create()
             .await?;
 

--- a/mobile_verifier/src/banning/sp_boosted_rewards_bans.rs
+++ b/mobile_verifier/src/banning/sp_boosted_rewards_bans.rs
@@ -2,9 +2,7 @@ use std::collections::HashSet;
 
 use chrono::{DateTime, TimeZone, Utc};
 use file_store::{
-    file_info_poller::{
-        FileInfoPollerConfigBuilder, FileInfoStream, LookbackBehavior, ProstFileInfoPollerParser,
-    },
+    file_info_poller::{FileInfoPollerConfigBuilder, FileInfoStream, ProstFileInfoPollerParser},
     file_sink::FileSinkClient,
     file_upload::FileUpload,
     traits::{FileSinkCommitStrategy, FileSinkRollTime, FileSinkWriteExt},
@@ -162,7 +160,7 @@ where
             .parser(ProstFileInfoPollerParser)
             .state(pool.clone())
             .file_store(file_store_client, bucket)
-            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .lookback(settings.start_after)
             .prefix(FileType::SPBoostedRewardsBannedRadioIngestReport.to_string())
             .create()
             .await?;

--- a/mobile_verifier/src/banning/sp_boosted_rewards_bans.rs
+++ b/mobile_verifier/src/banning/sp_boosted_rewards_bans.rs
@@ -160,7 +160,7 @@ where
             .parser(ProstFileInfoPollerParser)
             .state(pool.clone())
             .file_store(file_store_client, bucket)
-            .lookback(settings.start_after)
+            .lookback_start_after(settings.start_after)
             .prefix(FileType::SPBoostedRewardsBannedRadioIngestReport.to_string())
             .create()
             .await?;

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -99,7 +99,7 @@ impl CoverageDaemon {
         let (coverage_objs, coverage_objs_server) = file_source::continuous_source()
             .state(pool.clone())
             .file_store(file_store_client, bucket)
-            .lookback(settings.start_after)
+            .lookback_start_after(settings.start_after)
             .prefix(FileType::CoverageObjectIngestReport.to_string())
             .create()
             .await?;

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -6,7 +6,7 @@ use crate::{
 use chrono::{DateTime, Utc};
 use file_store::{
     coverage::{self, CoverageObjectIngestReport},
-    file_info_poller::{FileInfoStream, LookbackBehavior},
+    file_info_poller::FileInfoStream,
     file_sink::FileSinkClient,
     file_source,
     file_upload::FileUpload,
@@ -99,7 +99,7 @@ impl CoverageDaemon {
         let (coverage_objs, coverage_objs_server) = file_source::continuous_source()
             .state(pool.clone())
             .file_store(file_store_client, bucket)
-            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .lookback(settings.start_after)
             .prefix(FileType::CoverageObjectIngestReport.to_string())
             .create()
             .await?;

--- a/mobile_verifier/src/data_session.rs
+++ b/mobile_verifier/src/data_session.rs
@@ -1,8 +1,6 @@
 use chrono::{DateTime, Utc};
 use file_store::{
-    file_info_poller::{FileInfoStream, LookbackBehavior},
-    file_source,
-    mobile_transfer::ValidDataTransferSession,
+    file_info_poller::FileInfoStream, file_source, mobile_transfer::ValidDataTransferSession,
     FileType,
 };
 use futures::{
@@ -41,7 +39,7 @@ impl DataSessionIngestor {
         let (data_session_ingest, data_session_ingest_server) = file_source::continuous_source()
             .state(pool.clone())
             .file_store(file_store_client, bucket)
-            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .lookback(settings.start_after)
             .prefix(FileType::ValidDataTransferSession.to_string())
             .create()
             .await?;

--- a/mobile_verifier/src/data_session.rs
+++ b/mobile_verifier/src/data_session.rs
@@ -39,7 +39,7 @@ impl DataSessionIngestor {
         let (data_session_ingest, data_session_ingest_server) = file_source::continuous_source()
             .state(pool.clone())
             .file_store(file_store_client, bucket)
-            .lookback(settings.start_after)
+            .lookback_start_after(settings.start_after)
             .prefix(FileType::ValidDataTransferSession.to_string())
             .create()
             .await?;

--- a/mobile_verifier/src/heartbeats/wifi.rs
+++ b/mobile_verifier/src/heartbeats/wifi.rs
@@ -7,11 +7,8 @@ use crate::{
 };
 use chrono::{DateTime, Duration, Utc};
 use file_store::{
-    file_info_poller::{FileInfoStream, LookbackBehavior},
-    file_sink::FileSinkClient,
-    file_source,
-    wifi_heartbeat::WifiHeartbeatIngestReport,
-    FileType,
+    file_info_poller::FileInfoStream, file_sink::FileSinkClient, file_source,
+    wifi_heartbeat::WifiHeartbeatIngestReport, FileType,
 };
 use futures::{stream::StreamExt, TryFutureExt};
 use helium_proto::services::poc_mobile as proto;
@@ -54,7 +51,7 @@ where
         let (wifi_heartbeats, wifi_heartbeats_server) = file_source::continuous_source()
             .state(pool.clone())
             .file_store(file_store_client, bucket)
-            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .lookback(settings.start_after)
             .prefix(FileType::WifiHeartbeatIngestReport.to_string())
             .create()
             .await?;

--- a/mobile_verifier/src/heartbeats/wifi.rs
+++ b/mobile_verifier/src/heartbeats/wifi.rs
@@ -51,7 +51,7 @@ where
         let (wifi_heartbeats, wifi_heartbeats_server) = file_source::continuous_source()
             .state(pool.clone())
             .file_store(file_store_client, bucket)
-            .lookback(settings.start_after)
+            .lookback_start_after(settings.start_after)
             .prefix(FileType::WifiHeartbeatIngestReport.to_string())
             .create()
             .await?;

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -87,7 +87,7 @@ where
         let (speedtests, speedtests_server) = file_source::continuous_source()
             .state(pool.clone())
             .file_store(file_store_client, bucket)
-            .lookback(settings.start_after)
+            .lookback_start_after(settings.start_after)
             .prefix(FileType::CellSpeedtestIngestReport.to_string())
             .create()
             .await?;

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use file_store::{
-    file_info_poller::{FileInfoStream, LookbackBehavior},
+    file_info_poller::FileInfoStream,
     file_sink::FileSinkClient,
     file_source,
     file_upload::FileUpload,
@@ -87,7 +87,7 @@ where
         let (speedtests, speedtests_server) = file_source::continuous_source()
             .state(pool.clone())
             .file_store(file_store_client, bucket)
-            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .lookback(settings.start_after)
             .prefix(FileType::CellSpeedtestIngestReport.to_string())
             .create()
             .await?;

--- a/mobile_verifier/src/subscriber_mapping_activity.rs
+++ b/mobile_verifier/src/subscriber_mapping_activity.rs
@@ -73,7 +73,7 @@ where
         let (stream_reciever, stream_server) = file_source::Continuous::prost_source()
             .state(pool.clone())
             .file_store(file_store_client, bucket)
-            .lookback(settings.start_after)
+            .lookback_start_after(settings.start_after)
             .prefix(FileType::SubscriberMappingActivityIngestReport.to_string())
             .create()
             .await?;

--- a/mobile_verifier/src/subscriber_mapping_activity.rs
+++ b/mobile_verifier/src/subscriber_mapping_activity.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Instant};
 
 use chrono::{DateTime, Utc};
 use file_store::{
-    file_info_poller::{FileInfoStream, LookbackBehavior},
+    file_info_poller::FileInfoStream,
     file_sink::FileSinkClient,
     file_source,
     file_upload::FileUpload,
@@ -73,7 +73,7 @@ where
         let (stream_reciever, stream_server) = file_source::Continuous::prost_source()
             .state(pool.clone())
             .file_store(file_store_client, bucket)
-            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .lookback(settings.start_after)
             .prefix(FileType::SubscriberMappingActivityIngestReport.to_string())
             .create()
             .await?;

--- a/mobile_verifier/src/unique_connections/ingestor.rs
+++ b/mobile_verifier/src/unique_connections/ingestor.rs
@@ -77,7 +77,7 @@ where
             file_source::continuous_source()
                 .state(pool.clone())
                 .file_store(file_store_client, bucket)
-                .lookback(settings.start_after)
+                .lookback_start_after(settings.start_after)
                 .prefix(FileType::UniqueConnectionsReport.to_string())
                 .create()
                 .await?;

--- a/mobile_verifier/src/unique_connections/ingestor.rs
+++ b/mobile_verifier/src/unique_connections/ingestor.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use file_store::{
-    file_info_poller::{FileInfoStream, LookbackBehavior},
+    file_info_poller::FileInfoStream,
     file_sink::FileSinkClient,
     file_source,
     file_upload::FileUpload,
@@ -77,7 +77,7 @@ where
             file_source::continuous_source()
                 .state(pool.clone())
                 .file_store(file_store_client, bucket)
-                .lookback(LookbackBehavior::StartAfter(settings.start_after))
+                .lookback(settings.start_after)
                 .prefix(FileType::UniqueConnectionsReport.to_string())
                 .create()
                 .await?;

--- a/mobile_verifier/tests/integrations/subscriber_map_act_daemon.rs
+++ b/mobile_verifier/tests/integrations/subscriber_map_act_daemon.rs
@@ -69,7 +69,7 @@ async fn test_process_map_act_ingest_report_file(pool: PgPool) {
     let (stream_receiver, stream_server) = file_source::Continuous::prost_source()
         .state(pool.clone())
         .store(awsl.file_store.clone())
-        .lookback(LookbackBehavior::StartAfter(DateTime::UNIX_EPOCH))
+        .lookback(DateTime::UNIX_EPOCH)
         .prefix(FileType::SubscriberMappingActivityIngestReport.to_string())
         .poll_duration(std::time::Duration::from_millis(300))
         .create()

--- a/reward_index/src/main.rs
+++ b/reward_index/src/main.rs
@@ -61,7 +61,7 @@ impl Server {
             .state(pool.clone())
             .file_store(file_store_client.clone(), settings.input_bucket.clone())
             .prefix(FileType::RewardManifest.to_string())
-            .lookback(settings.start_after)
+            .lookback_start_after(settings.start_after)
             .poll_duration(settings.interval)
             .offset(settings.interval * 2)
             .create()

--- a/reward_index/src/main.rs
+++ b/reward_index/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
-use file_store::{file_info_poller::LookbackBehavior, file_source, FileType};
+use file_store::{file_source, FileType};
 use reward_index::{settings::Settings, telemetry, Indexer};
 use std::path::PathBuf;
 use task_manager::TaskManager;
@@ -61,7 +61,7 @@ impl Server {
             .state(pool.clone())
             .file_store(file_store_client.clone(), settings.input_bucket.clone())
             .prefix(FileType::RewardManifest.to_string())
-            .lookback(LookbackBehavior::StartAfter(settings.start_after))
+            .lookback(settings.start_after)
             .poll_duration(settings.interval)
             .offset(settings.interval * 2)
             .create()


### PR DESCRIPTION
Add new setters that are prefixed with `lookback_` to make them discoverable when setting `lookback`, and it’s a nice place to hang some documentation