### PR TITLE
Loosen FileType restrction for aws_local testing

### DIFF
--- a/aws_local/src/lib.rs
+++ b/aws_local/src/lib.rs
@@ -3,7 +3,7 @@ use aws_config::BehaviorVersion;
 use aws_sdk_s3::Client;
 use chrono::Utc;
 use file_store::traits::MsgBytes;
-use file_store::{file_sink, file_upload, FileType, Settings};
+use file_store::{file_sink, file_upload, Settings};
 use std::env;
 use std::path::Path;
 use std::sync::Arc;
@@ -76,7 +76,7 @@ impl AwsLocal {
     pub async fn put_proto_to_aws<T: prost::Message + MsgBytes>(
         &self,
         items: Vec<T>,
-        file_type: FileType,
+        file_type: impl ToString,
         metric_name: &'static str,
     ) -> Result<String> {
         let tmp_dir = TempDir::new()?;


### PR DESCRIPTION
Match the function requirements of `file_sink::FileSinkBuilder::new`  where `file_type` can be anything that `impl ToString`. 

This allows projects outside Oracles to use `aws_local` to test with  file types that may only be local to their project.