### PR TITLE
Update helium_iceberg to support nested list and structs

### DIFF
--- a/helium_iceberg/src/lib.rs
+++ b/helium_iceberg/src/lib.rs
@@ -16,8 +16,8 @@ pub use error::{Error, Result};
 pub use iceberg_table::IcebergTable;
 pub use settings::{AuthConfig, S3Config, Settings};
 pub use table_creator::{
-    FieldDefinition, ParquetCompression, PartitionDefinition, SortFieldDefinition, TableCreator,
-    TableDefinition, TableDefinitionBuilder, PARQUET_COMPRESSION_CODEC,
+    FieldDefinition, FieldKind, ParquetCompression, PartitionDefinition, SortFieldDefinition,
+    TableCreator, TableDefinition, TableDefinitionBuilder, PARQUET_COMPRESSION_CODEC,
 };
 pub use writer::{
     BoxedDataWriter, BranchPublisher, BranchTransaction, BranchWriter, DataWriter,

--- a/helium_iceberg/src/table_creator.rs
+++ b/helium_iceberg/src/table_creator.rs
@@ -2,8 +2,8 @@ use crate::catalog::Catalog;
 use crate::iceberg_table::IcebergTable;
 use crate::{Error, Result, Settings};
 use iceberg::spec::{
-    ListType, MapType, NestedField, NullOrder, PartitionSpec, PrimitiveType, Schema,
-    SortDirection, SortField, SortOrder, StructType, Transform, Type,
+    ListType, MapType, NestedField, NullOrder, PartitionSpec, PrimitiveType, Schema, SortDirection,
+    SortField, SortOrder, StructType, Transform, Type,
 };
 use iceberg::{Catalog as IcebergCatalog, NamespaceIdent, TableCreation};
 use std::collections::HashMap;
@@ -56,6 +56,12 @@ impl FieldKind {
             value_kind: Box::new(value),
             value_required,
         }
+    }
+}
+
+impl From<PrimitiveType> for FieldKind {
+    fn from(value: PrimitiveType) -> Self {
+        Self::Primitive(value)
     }
 }
 
@@ -208,19 +214,13 @@ impl FieldDefinition {
     pub fn required_map(
         name: impl Into<String>,
         key_type: PrimitiveType,
-        value_type: PrimitiveType,
+        value_type: impl Into<FieldKind>,
     ) -> Self {
-        Self {
-            name: name.into(),
-            kind: FieldKind::Map {
-                key_type,
-                value_kind: Box::new(FieldKind::Primitive(value_type)),
-                value_required: true,
-            },
-            required: true,
-            doc: None,
-            identifier: false,
-        }
+        Self::new(
+            name,
+            FieldKind::map(key_type, value_type.into(), true),
+            ColumnType::Required,
+        )
     }
 
     /// Create an optional map field with primitive key and value types.
@@ -228,73 +228,33 @@ impl FieldDefinition {
     pub fn optional_map(
         name: impl Into<String>,
         key_type: PrimitiveType,
-        value_type: PrimitiveType,
+        value_type: impl Into<FieldKind>,
     ) -> Self {
-        Self {
-            name: name.into(),
-            kind: FieldKind::Map {
-                key_type,
-                value_kind: Box::new(FieldKind::Primitive(value_type)),
-                value_required: false,
-            },
-            required: false,
-            doc: None,
-            identifier: false,
-        }
+        Self::new(
+            name,
+            FieldKind::map(key_type, value_type.into(), false),
+            ColumnType::Optional,
+        )
     }
 
     /// Create a required list field with primitive element type.
     /// The list column is required and the elements are required.
-    pub fn required_list(
-        name: impl Into<String>,
-        element_type: PrimitiveType,
-    ) -> Self {
-        Self::required_list_of(name, FieldKind::Primitive(element_type), true)
+    pub fn required_list(name: impl Into<String>, field_kind: impl Into<FieldKind>) -> Self {
+        Self::new(
+            name,
+            FieldKind::list(field_kind.into(), true),
+            ColumnType::Required,
+        )
     }
 
     /// Create an optional list field with primitive element type.
     /// The list column is optional and the elements are optional.
-    pub fn optional_list(
-        name: impl Into<String>,
-        element_type: PrimitiveType,
-    ) -> Self {
-        Self::optional_list_of(name, FieldKind::Primitive(element_type), false)
-    }
-
-    /// Create a required list field with a complex element type.
-    pub fn required_list_of(
-        name: impl Into<String>,
-        element_kind: FieldKind,
-        element_required: bool,
-    ) -> Self {
-        Self {
-            name: name.into(),
-            kind: FieldKind::List {
-                element_kind: Box::new(element_kind),
-                element_required,
-            },
-            required: true,
-            doc: None,
-            identifier: false,
-        }
-    }
-
-    /// Create an optional list field with a complex element type.
-    pub fn optional_list_of(
-        name: impl Into<String>,
-        element_kind: FieldKind,
-        element_required: bool,
-    ) -> Self {
-        Self {
-            name: name.into(),
-            kind: FieldKind::List {
-                element_kind: Box::new(element_kind),
-                element_required,
-            },
-            required: false,
-            doc: None,
-            identifier: false,
-        }
+    pub fn optional_list(name: impl Into<String>, field_kind: impl Into<FieldKind>) -> Self {
+        Self::new(
+            name,
+            FieldKind::list(field_kind.into(), false),
+            ColumnType::Optional,
+        )
     }
 
     /// Create a required struct field with named sub-fields.
@@ -302,15 +262,7 @@ impl FieldDefinition {
         name: impl Into<String>,
         fields: impl IntoIterator<Item = FieldDefinition>,
     ) -> Self {
-        Self {
-            name: name.into(),
-            kind: FieldKind::Struct {
-                fields: fields.into_iter().collect(),
-            },
-            required: true,
-            doc: None,
-            identifier: false,
-        }
+        Self::new(name, FieldKind::struct_type(fields), ColumnType::Required)
     }
 
     /// Create an optional struct field with named sub-fields.
@@ -318,55 +270,7 @@ impl FieldDefinition {
         name: impl Into<String>,
         fields: impl IntoIterator<Item = FieldDefinition>,
     ) -> Self {
-        Self {
-            name: name.into(),
-            kind: FieldKind::Struct {
-                fields: fields.into_iter().collect(),
-            },
-            required: false,
-            doc: None,
-            identifier: false,
-        }
-    }
-
-    /// Create a required map field with a complex value type.
-    pub fn required_map_of(
-        name: impl Into<String>,
-        key_type: PrimitiveType,
-        value_kind: FieldKind,
-        value_required: bool,
-    ) -> Self {
-        Self {
-            name: name.into(),
-            kind: FieldKind::Map {
-                key_type,
-                value_kind: Box::new(value_kind),
-                value_required,
-            },
-            required: true,
-            doc: None,
-            identifier: false,
-        }
-    }
-
-    /// Create an optional map field with a complex value type.
-    pub fn optional_map_of(
-        name: impl Into<String>,
-        key_type: PrimitiveType,
-        value_kind: FieldKind,
-        value_required: bool,
-    ) -> Self {
-        Self {
-            name: name.into(),
-            kind: FieldKind::Map {
-                key_type,
-                value_kind: Box::new(value_kind),
-                value_required,
-            },
-            required: false,
-            doc: None,
-            identifier: false,
-        }
+        Self::new(name, FieldKind::struct_type(fields), ColumnType::Optional)
     }
 }
 
@@ -1447,13 +1351,12 @@ mod tests {
         let definition = TableDefinition::builder("default", "test")
             .with_fields([
                 FieldDefinition::required_long("id"),
-                FieldDefinition::required_list_of(
+                FieldDefinition::required_list(
                     "events",
                     FieldKind::struct_type([
                         FieldDefinition::required_string("name"),
                         FieldDefinition::required_long("ts"),
                     ]),
-                    true,
                 ),
                 FieldDefinition::required_string("label"),
             ])
@@ -1498,14 +1401,13 @@ mod tests {
         let definition = TableDefinition::builder("default", "test")
             .with_fields([
                 FieldDefinition::required_long("id"),
-                FieldDefinition::required_map_of(
+                FieldDefinition::required_map(
                     "records",
                     PrimitiveType::String,
                     FieldKind::struct_type([
                         FieldDefinition::required_string("a"),
                         FieldDefinition::required_long("b"),
                     ]),
-                    true,
                 ),
                 FieldDefinition::required_string("name"),
             ])
@@ -1526,13 +1428,12 @@ mod tests {
         let definition = TableDefinition::builder("default", "test")
             .with_fields([
                 FieldDefinition::required_long("id"),
-                FieldDefinition::required_list_of(
+                FieldDefinition::required_list(
                     "outer",
                     FieldKind::struct_type([FieldDefinition::required_list(
                         "inner",
                         PrimitiveType::String,
                     )]),
-                    true,
                 ),
                 FieldDefinition::required_string("tail"),
             ])

--- a/helium_iceberg/src/table_creator.rs
+++ b/helium_iceberg/src/table_creator.rs
@@ -25,8 +25,11 @@ pub enum FieldKind {
     Struct {
         fields: Vec<FieldDefinition>,
     },
+    /// Map keys are always `PrimitiveType::String`. Non-string keys break
+    /// deserialization through the trino-rust-client because serde's untagged
+    /// enum buffering loses the string-to-integer key coercion that serde_json
+    /// normally provides.
     Map {
-        key_type: PrimitiveType,
         value_kind: Box<FieldKind>,
         value_required: bool,
     },
@@ -50,9 +53,8 @@ impl FieldKind {
         }
     }
 
-    pub fn map(key: PrimitiveType, value: FieldKind) -> Self {
+    pub fn map(value: FieldKind) -> Self {
         Self::Map {
-            key_type: key,
             value_kind: Box::new(value),
             value_required: true,
         }
@@ -209,30 +211,28 @@ impl FieldDefinition {
         )
     }
 
-    /// Create a required map field with primitive key and value types.
+    /// Create a required map field with string keys.
     /// The map column is required and the value is required.
     pub fn required_map(
         name: impl Into<String>,
-        key_type: PrimitiveType,
         value_type: impl Into<FieldKind>,
     ) -> Self {
         Self::new(
             name,
-            FieldKind::map(key_type, value_type.into()),
+            FieldKind::map(value_type.into()),
             ColumnType::Required,
         )
     }
 
-    /// Create an optional map field with primitive key and value types.
+    /// Create an optional map field with string keys.
     /// The map column is optional and the value is optional.
     pub fn optional_map(
         name: impl Into<String>,
-        key_type: PrimitiveType,
         value_type: impl Into<FieldKind>,
     ) -> Self {
         Self::new(
             name,
-            FieldKind::map(key_type, value_type.into()),
+            FieldKind::map(value_type.into()),
             ColumnType::Optional,
         )
     }
@@ -490,7 +490,6 @@ fn build_type(kind: &FieldKind, next_id: &mut i32) -> Type {
             Type::Struct(StructType::new(nested_fields))
         }
         FieldKind::Map {
-            key_type,
             value_kind,
             value_required,
         } => {
@@ -502,7 +501,7 @@ fn build_type(kind: &FieldKind, next_id: &mut i32) -> Type {
             Type::Map(MapType::new(
                 Arc::new(NestedField::map_key_element(
                     key_id,
-                    Type::Primitive(key_type.clone()),
+                    Type::Primitive(PrimitiveType::String),
                 )),
                 Arc::new(NestedField::map_value_element(
                     value_id,
@@ -1183,7 +1182,7 @@ mod tests {
         let definition = TableDefinition::builder("default", "test")
             .with_fields([
                 FieldDefinition::required_long("id"),
-                FieldDefinition::required_map("tags", PrimitiveType::String, PrimitiveType::String),
+                FieldDefinition::required_map("tags", PrimitiveType::String),
                 FieldDefinition::required_string("name"),
             ])
             .build()
@@ -1212,11 +1211,7 @@ mod tests {
         let definition = TableDefinition::builder("default", "test")
             .with_fields([
                 FieldDefinition::required_long("id"),
-                FieldDefinition::optional_map(
-                    "metadata",
-                    PrimitiveType::String,
-                    PrimitiveType::Long,
-                ),
+                FieldDefinition::optional_map("metadata", PrimitiveType::Long),
             ])
             .build()
             .expect("should build");
@@ -1240,7 +1235,7 @@ mod tests {
         let definition = TableDefinition::builder("default", "test")
             .with_fields([
                 FieldDefinition::indentifier_long("id"),
-                FieldDefinition::required_map("tags", PrimitiveType::String, PrimitiveType::String),
+                FieldDefinition::required_map("tags", PrimitiveType::String),
                 FieldDefinition::indentifier_string("tenant_id"),
             ])
             .build()
@@ -1403,7 +1398,6 @@ mod tests {
                 FieldDefinition::required_long("id"),
                 FieldDefinition::required_map(
                     "records",
-                    PrimitiveType::String,
                     FieldKind::struct_type([
                         FieldDefinition::required_string("a"),
                         FieldDefinition::required_long("b"),

--- a/helium_iceberg/src/table_creator.rs
+++ b/helium_iceberg/src/table_creator.rs
@@ -2,22 +2,61 @@ use crate::catalog::Catalog;
 use crate::iceberg_table::IcebergTable;
 use crate::{Error, Result, Settings};
 use iceberg::spec::{
-    MapType, NestedField, NullOrder, PartitionSpec, PrimitiveType, Schema, SortDirection,
-    SortField, SortOrder, Transform, Type,
+    ListType, MapType, NestedField, NullOrder, PartitionSpec, PrimitiveType, Schema,
+    SortDirection, SortField, SortOrder, StructType, Transform, Type,
 };
 use iceberg::{Catalog as IcebergCatalog, NamespaceIdent, TableCreation};
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+/// Describes the type of a field, supporting arbitrary nesting.
+///
+/// Use the convenience constructors ([`FieldKind::primitive`], [`FieldKind::list`],
+/// [`FieldKind::struct_type`], [`FieldKind::map`]) when building nested types
+/// for [`FieldDefinition::required_list_of`], [`FieldDefinition::required_struct`], etc.
 #[derive(Debug, Clone)]
-enum FieldKind {
-    Primitive(Type),
+pub enum FieldKind {
+    Primitive(PrimitiveType),
+    List {
+        element_kind: Box<FieldKind>,
+        element_required: bool,
+    },
+    Struct {
+        fields: Vec<FieldDefinition>,
+    },
     Map {
         key_type: PrimitiveType,
-        value_type: PrimitiveType,
+        value_kind: Box<FieldKind>,
         value_required: bool,
     },
+}
+
+impl FieldKind {
+    pub fn primitive(t: PrimitiveType) -> Self {
+        Self::Primitive(t)
+    }
+
+    pub fn list(element: FieldKind, element_required: bool) -> Self {
+        Self::List {
+            element_kind: Box::new(element),
+            element_required,
+        }
+    }
+
+    pub fn struct_type(fields: impl IntoIterator<Item = FieldDefinition>) -> Self {
+        Self::Struct {
+            fields: fields.into_iter().collect(),
+        }
+    }
+
+    pub fn map(key: PrimitiveType, value: FieldKind, value_required: bool) -> Self {
+        Self::Map {
+            key_type: key,
+            value_kind: Box::new(value),
+            value_required,
+        }
+    }
 }
 
 /// Defines a single field (column) in a table schema.
@@ -56,7 +95,7 @@ macro_rules! impl_field_variant {
         impl FieldDefinition {
             $(
                 pub fn $fn_name(name: impl Into<String>) -> Self {
-                    Self::new(name, FieldKind::Primitive(Type::Primitive(PrimitiveType::$field_type)), ColumnType::$column_type)
+                    Self::new(name, FieldKind::Primitive(PrimitiveType::$field_type), ColumnType::$column_type)
                 }
             )+
         }
@@ -119,7 +158,7 @@ impl FieldDefinition {
     pub fn required_decimal(name: impl Into<String>, precision: u32, scale: u32) -> Self {
         Self::new(
             name,
-            FieldKind::Primitive(Type::Primitive(PrimitiveType::Decimal { precision, scale })),
+            FieldKind::Primitive(PrimitiveType::Decimal { precision, scale }),
             ColumnType::Required,
         )
     }
@@ -127,7 +166,7 @@ impl FieldDefinition {
     pub fn optional_decimal(name: impl Into<String>, precision: u32, scale: u32) -> Self {
         Self::new(
             name,
-            FieldKind::Primitive(Type::Primitive(PrimitiveType::Decimal { precision, scale })),
+            FieldKind::Primitive(PrimitiveType::Decimal { precision, scale }),
             ColumnType::Optional,
         )
     }
@@ -135,7 +174,7 @@ impl FieldDefinition {
     pub fn identifier_decimal(name: impl Into<String>, precision: u32, scale: u32) -> Self {
         Self::new(
             name,
-            FieldKind::Primitive(Type::Primitive(PrimitiveType::Decimal { precision, scale })),
+            FieldKind::Primitive(PrimitiveType::Decimal { precision, scale }),
             ColumnType::Identifier,
         )
     }
@@ -143,7 +182,7 @@ impl FieldDefinition {
     pub fn required_fixed(name: impl Into<String>, fixed: u64) -> Self {
         Self::new(
             name,
-            FieldKind::Primitive(Type::Primitive(PrimitiveType::Fixed(fixed))),
+            FieldKind::Primitive(PrimitiveType::Fixed(fixed)),
             ColumnType::Required,
         )
     }
@@ -151,7 +190,7 @@ impl FieldDefinition {
     pub fn optional_fixed(name: impl Into<String>, fixed: u64) -> Self {
         Self::new(
             name,
-            FieldKind::Primitive(Type::Primitive(PrimitiveType::Fixed(fixed))),
+            FieldKind::Primitive(PrimitiveType::Fixed(fixed)),
             ColumnType::Optional,
         )
     }
@@ -159,7 +198,7 @@ impl FieldDefinition {
     pub fn identifier_fixed(name: impl Into<String>, fixed: u64) -> Self {
         Self::new(
             name,
-            FieldKind::Primitive(Type::Primitive(PrimitiveType::Fixed(fixed))),
+            FieldKind::Primitive(PrimitiveType::Fixed(fixed)),
             ColumnType::Identifier,
         )
     }
@@ -175,7 +214,7 @@ impl FieldDefinition {
             name: name.into(),
             kind: FieldKind::Map {
                 key_type,
-                value_type,
+                value_kind: Box::new(FieldKind::Primitive(value_type)),
                 value_required: true,
             },
             required: true,
@@ -195,8 +234,134 @@ impl FieldDefinition {
             name: name.into(),
             kind: FieldKind::Map {
                 key_type,
-                value_type,
+                value_kind: Box::new(FieldKind::Primitive(value_type)),
                 value_required: false,
+            },
+            required: false,
+            doc: None,
+            identifier: false,
+        }
+    }
+
+    /// Create a required list field with primitive element type.
+    /// The list column is required and the elements are required.
+    pub fn required_list(
+        name: impl Into<String>,
+        element_type: PrimitiveType,
+    ) -> Self {
+        Self::required_list_of(name, FieldKind::Primitive(element_type), true)
+    }
+
+    /// Create an optional list field with primitive element type.
+    /// The list column is optional and the elements are optional.
+    pub fn optional_list(
+        name: impl Into<String>,
+        element_type: PrimitiveType,
+    ) -> Self {
+        Self::optional_list_of(name, FieldKind::Primitive(element_type), false)
+    }
+
+    /// Create a required list field with a complex element type.
+    pub fn required_list_of(
+        name: impl Into<String>,
+        element_kind: FieldKind,
+        element_required: bool,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            kind: FieldKind::List {
+                element_kind: Box::new(element_kind),
+                element_required,
+            },
+            required: true,
+            doc: None,
+            identifier: false,
+        }
+    }
+
+    /// Create an optional list field with a complex element type.
+    pub fn optional_list_of(
+        name: impl Into<String>,
+        element_kind: FieldKind,
+        element_required: bool,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            kind: FieldKind::List {
+                element_kind: Box::new(element_kind),
+                element_required,
+            },
+            required: false,
+            doc: None,
+            identifier: false,
+        }
+    }
+
+    /// Create a required struct field with named sub-fields.
+    pub fn required_struct(
+        name: impl Into<String>,
+        fields: impl IntoIterator<Item = FieldDefinition>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            kind: FieldKind::Struct {
+                fields: fields.into_iter().collect(),
+            },
+            required: true,
+            doc: None,
+            identifier: false,
+        }
+    }
+
+    /// Create an optional struct field with named sub-fields.
+    pub fn optional_struct(
+        name: impl Into<String>,
+        fields: impl IntoIterator<Item = FieldDefinition>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            kind: FieldKind::Struct {
+                fields: fields.into_iter().collect(),
+            },
+            required: false,
+            doc: None,
+            identifier: false,
+        }
+    }
+
+    /// Create a required map field with a complex value type.
+    pub fn required_map_of(
+        name: impl Into<String>,
+        key_type: PrimitiveType,
+        value_kind: FieldKind,
+        value_required: bool,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            kind: FieldKind::Map {
+                key_type,
+                value_kind: Box::new(value_kind),
+                value_required,
+            },
+            required: true,
+            doc: None,
+            identifier: false,
+        }
+    }
+
+    /// Create an optional map field with a complex value type.
+    pub fn optional_map_of(
+        name: impl Into<String>,
+        key_type: PrimitiveType,
+        value_kind: FieldKind,
+        value_required: bool,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            kind: FieldKind::Map {
+                key_type,
+                value_kind: Box::new(value_kind),
+                value_required,
             },
             required: false,
             doc: None,
@@ -382,6 +547,69 @@ pub struct TableDefinition {
     location: Option<String>,
 }
 
+/// Recursively converts a [`FieldKind`] into an iceberg [`Type`],
+/// allocating field IDs from `next_id` for each nested element.
+fn build_type(kind: &FieldKind, next_id: &mut i32) -> Type {
+    match kind {
+        FieldKind::Primitive(p) => Type::Primitive(p.clone()),
+        FieldKind::List {
+            element_kind,
+            element_required,
+        } => {
+            let element_id = *next_id;
+            *next_id += 1;
+            let element_type = build_type(element_kind, next_id);
+            Type::List(ListType::new(Arc::new(NestedField::list_element(
+                element_id,
+                element_type,
+                *element_required,
+            ))))
+        }
+        FieldKind::Struct { fields } => {
+            let nested_fields = fields
+                .iter()
+                .map(|f| {
+                    let field_id = *next_id;
+                    *next_id += 1;
+                    let field_type = build_type(&f.kind, next_id);
+                    let mut nested = if f.required {
+                        NestedField::required(field_id, &f.name, field_type)
+                    } else {
+                        NestedField::optional(field_id, &f.name, field_type)
+                    };
+                    if let Some(ref doc) = f.doc {
+                        nested = nested.with_doc(doc);
+                    }
+                    Arc::new(nested)
+                })
+                .collect();
+            Type::Struct(StructType::new(nested_fields))
+        }
+        FieldKind::Map {
+            key_type,
+            value_kind,
+            value_required,
+        } => {
+            let key_id = *next_id;
+            *next_id += 1;
+            let value_id = *next_id;
+            *next_id += 1;
+            let value_type = build_type(value_kind, next_id);
+            Type::Map(MapType::new(
+                Arc::new(NestedField::map_key_element(
+                    key_id,
+                    Type::Primitive(key_type.clone()),
+                )),
+                Arc::new(NestedField::map_value_element(
+                    value_id,
+                    value_type,
+                    *value_required,
+                )),
+            ))
+        }
+    }
+}
+
 impl TableDefinition {
     /// Create a new table definition builder.
     pub fn builder(
@@ -415,30 +643,7 @@ impl TableDefinition {
                 identifier_field_ids.push(field_id);
             }
 
-            let field_type = match &field.kind {
-                FieldKind::Primitive(t) => t.clone(),
-                FieldKind::Map {
-                    key_type,
-                    value_type,
-                    value_required,
-                } => {
-                    let key_id = next_id;
-                    next_id += 1;
-                    let value_id = next_id;
-                    next_id += 1;
-                    Type::Map(MapType::new(
-                        Arc::new(NestedField::map_key_element(
-                            key_id,
-                            Type::Primitive(key_type.clone()),
-                        )),
-                        Arc::new(NestedField::map_value_element(
-                            value_id,
-                            Type::Primitive(value_type.clone()),
-                            *value_required,
-                        )),
-                    ))
-                }
-            };
+            let field_type = build_type(&field.kind, &mut next_id);
 
             let mut nested = if field.required {
                 NestedField::required(field_id, &field.name, field_type)
@@ -1144,5 +1349,252 @@ mod tests {
         assert_eq!(identifier_ids.len(), 2);
         assert!(identifier_ids.contains(&1)); // id
         assert!(identifier_ids.contains(&5)); // tenant_id
+    }
+
+    #[test]
+    fn test_required_list_field_ids() {
+        let definition = TableDefinition::builder("default", "test")
+            .with_fields([
+                FieldDefinition::required_long("id"),
+                FieldDefinition::required_list("tags", PrimitiveType::String),
+                FieldDefinition::required_string("name"),
+            ])
+            .build()
+            .expect("should build");
+
+        let schema = definition.build_schema().expect("should build schema");
+
+        // id = 1, tags = 2 (element = 3), name = 4
+        let id_field = schema.field_by_name("id").expect("id field");
+        assert_eq!(id_field.id, 1);
+
+        let tags_field = schema.field_by_name("tags").expect("tags field");
+        assert_eq!(tags_field.id, 2);
+        assert!(tags_field.required);
+
+        let name_field = schema.field_by_name("name").expect("name field");
+        assert_eq!(name_field.id, 4);
+    }
+
+    #[test]
+    fn test_optional_list_field_ids() {
+        let definition = TableDefinition::builder("default", "test")
+            .with_fields([
+                FieldDefinition::required_long("id"),
+                FieldDefinition::optional_list("tags", PrimitiveType::String),
+            ])
+            .build()
+            .expect("should build");
+
+        let schema = definition.build_schema().expect("should build schema");
+
+        let tags_field = schema.field_by_name("tags").expect("tags field");
+        assert_eq!(tags_field.id, 2);
+        assert!(!tags_field.required);
+    }
+
+    #[test]
+    fn test_required_struct_field_ids() {
+        let definition = TableDefinition::builder("default", "test")
+            .with_fields([
+                FieldDefinition::required_long("id"),
+                FieldDefinition::required_struct(
+                    "address",
+                    [
+                        FieldDefinition::required_string("street"),
+                        FieldDefinition::required_string("city"),
+                    ],
+                ),
+                FieldDefinition::required_string("name"),
+            ])
+            .build()
+            .expect("should build");
+
+        let schema = definition.build_schema().expect("should build schema");
+
+        // id = 1, address = 2 (street = 3, city = 4), name = 5
+        assert_eq!(schema.field_by_name("id").expect("id").id, 1);
+        assert_eq!(schema.field_by_name("address").expect("address").id, 2);
+        assert!(schema.field_by_name("address").expect("address").required);
+        assert_eq!(schema.field_by_name("name").expect("name").id, 5);
+    }
+
+    #[test]
+    fn test_optional_struct_field_ids() {
+        let definition = TableDefinition::builder("default", "test")
+            .with_fields([
+                FieldDefinition::required_long("id"),
+                FieldDefinition::optional_struct(
+                    "address",
+                    [
+                        FieldDefinition::required_string("street"),
+                        FieldDefinition::required_string("city"),
+                    ],
+                ),
+            ])
+            .build()
+            .expect("should build");
+
+        let schema = definition.build_schema().expect("should build schema");
+
+        let addr = schema.field_by_name("address").expect("address");
+        assert_eq!(addr.id, 2);
+        assert!(!addr.required);
+    }
+
+    #[test]
+    fn test_list_of_structs() {
+        let definition = TableDefinition::builder("default", "test")
+            .with_fields([
+                FieldDefinition::required_long("id"),
+                FieldDefinition::required_list_of(
+                    "events",
+                    FieldKind::struct_type([
+                        FieldDefinition::required_string("name"),
+                        FieldDefinition::required_long("ts"),
+                    ]),
+                    true,
+                ),
+                FieldDefinition::required_string("label"),
+            ])
+            .build()
+            .expect("should build");
+
+        let schema = definition.build_schema().expect("should build schema");
+
+        // id=1, events=2 (element=3, struct{name=4, ts=5}), label=6
+        assert_eq!(schema.field_by_name("id").expect("id").id, 1);
+        assert_eq!(schema.field_by_name("events").expect("events").id, 2);
+        assert_eq!(schema.field_by_name("label").expect("label").id, 6);
+    }
+
+    #[test]
+    fn test_struct_containing_list() {
+        let definition = TableDefinition::builder("default", "test")
+            .with_fields([
+                FieldDefinition::required_long("id"),
+                FieldDefinition::required_struct(
+                    "meta",
+                    [
+                        FieldDefinition::required_list("tags", PrimitiveType::String),
+                        FieldDefinition::required_string("label"),
+                    ],
+                ),
+                FieldDefinition::required_string("name"),
+            ])
+            .build()
+            .expect("should build");
+
+        let schema = definition.build_schema().expect("should build schema");
+
+        // id=1, meta=2 (tags=3 list{element=4}, label=5), name=6
+        assert_eq!(schema.field_by_name("id").expect("id").id, 1);
+        assert_eq!(schema.field_by_name("meta").expect("meta").id, 2);
+        assert_eq!(schema.field_by_name("name").expect("name").id, 6);
+    }
+
+    #[test]
+    fn test_map_with_struct_value() {
+        let definition = TableDefinition::builder("default", "test")
+            .with_fields([
+                FieldDefinition::required_long("id"),
+                FieldDefinition::required_map_of(
+                    "records",
+                    PrimitiveType::String,
+                    FieldKind::struct_type([
+                        FieldDefinition::required_string("a"),
+                        FieldDefinition::required_long("b"),
+                    ]),
+                    true,
+                ),
+                FieldDefinition::required_string("name"),
+            ])
+            .build()
+            .expect("should build");
+
+        let schema = definition.build_schema().expect("should build schema");
+
+        // id=1, records=2 (key=3, value=4 struct{a=5, b=6}), name=7
+        assert_eq!(schema.field_by_name("id").expect("id").id, 1);
+        assert_eq!(schema.field_by_name("records").expect("records").id, 2);
+        assert_eq!(schema.field_by_name("name").expect("name").id, 7);
+    }
+
+    #[test]
+    fn test_deeply_nested() {
+        // List<Struct{ inner: List<String> }>
+        let definition = TableDefinition::builder("default", "test")
+            .with_fields([
+                FieldDefinition::required_long("id"),
+                FieldDefinition::required_list_of(
+                    "outer",
+                    FieldKind::struct_type([FieldDefinition::required_list(
+                        "inner",
+                        PrimitiveType::String,
+                    )]),
+                    true,
+                ),
+                FieldDefinition::required_string("tail"),
+            ])
+            .build()
+            .expect("should build");
+
+        let schema = definition.build_schema().expect("should build schema");
+
+        // id=1, outer=2 (element=3 struct{inner=4 list{element=5}}), tail=6
+        assert_eq!(schema.field_by_name("id").expect("id").id, 1);
+        assert_eq!(schema.field_by_name("outer").expect("outer").id, 2);
+        assert_eq!(schema.field_by_name("tail").expect("tail").id, 6);
+    }
+
+    #[test]
+    fn test_identifier_fields_not_affected_by_list() {
+        let definition = TableDefinition::builder("default", "test")
+            .with_fields([
+                FieldDefinition::indentifier_long("id"),
+                FieldDefinition::required_list("tags", PrimitiveType::String),
+                FieldDefinition::indentifier_string("tenant_id"),
+            ])
+            .build()
+            .expect("should build");
+
+        let schema = definition.build_schema().expect("should build schema");
+        let identifier_ids: Vec<i32> = schema.identifier_field_ids().collect();
+
+        // id=1, tags=2 (element=3), tenant_id=4
+        assert_eq!(identifier_ids.len(), 2);
+        assert!(identifier_ids.contains(&1));
+        assert!(identifier_ids.contains(&4));
+    }
+
+    #[test]
+    fn test_struct_with_doc() {
+        let definition = TableDefinition::builder("default", "test")
+            .with_fields([FieldDefinition::required_struct(
+                "address",
+                [
+                    FieldDefinition::required_string("street").with_doc("Street name"),
+                    FieldDefinition::optional_string("apt").with_doc("Apartment number"),
+                ],
+            )])
+            .build()
+            .expect("should build");
+
+        let schema = definition.build_schema().expect("should build schema");
+
+        // Verify the struct field itself exists
+        let addr = schema.field_by_name("address").expect("address");
+        assert_eq!(addr.id, 1);
+
+        // Verify sub-field docs are preserved by inspecting the struct type
+        if let Type::Struct(st) = addr.field_type.as_ref() {
+            let street = st.field_by_name("street").expect("street sub-field");
+            assert_eq!(street.doc.as_deref(), Some("Street name"));
+            let apt = st.field_by_name("apt").expect("apt sub-field");
+            assert_eq!(apt.doc.as_deref(), Some("Apartment number"));
+            assert!(!apt.required);
+        } else {
+            panic!("expected struct type");
+        }
     }
 }

--- a/helium_iceberg/src/table_creator.rs
+++ b/helium_iceberg/src/table_creator.rs
@@ -213,10 +213,7 @@ impl FieldDefinition {
 
     /// Create a required map field with string keys.
     /// The map column is required and the value is required.
-    pub fn required_map(
-        name: impl Into<String>,
-        value_type: impl Into<FieldKind>,
-    ) -> Self {
+    pub fn required_map(name: impl Into<String>, value_type: impl Into<FieldKind>) -> Self {
         Self::new(
             name,
             FieldKind::map(value_type.into()),
@@ -226,10 +223,7 @@ impl FieldDefinition {
 
     /// Create an optional map field with string keys.
     /// The map column is optional and the value is optional.
-    pub fn optional_map(
-        name: impl Into<String>,
-        value_type: impl Into<FieldKind>,
-    ) -> Self {
+    pub fn optional_map(name: impl Into<String>, value_type: impl Into<FieldKind>) -> Self {
         Self::new(
             name,
             FieldKind::map(value_type.into()),

--- a/helium_iceberg/src/table_creator.rs
+++ b/helium_iceberg/src/table_creator.rs
@@ -37,10 +37,10 @@ impl FieldKind {
         Self::Primitive(t)
     }
 
-    pub fn list(element: FieldKind, element_required: bool) -> Self {
+    pub fn list(element: FieldKind) -> Self {
         Self::List {
             element_kind: Box::new(element),
-            element_required,
+            element_required: true,
         }
     }
 
@@ -50,11 +50,11 @@ impl FieldKind {
         }
     }
 
-    pub fn map(key: PrimitiveType, value: FieldKind, value_required: bool) -> Self {
+    pub fn map(key: PrimitiveType, value: FieldKind) -> Self {
         Self::Map {
             key_type: key,
             value_kind: Box::new(value),
-            value_required,
+            value_required: true,
         }
     }
 }
@@ -218,7 +218,7 @@ impl FieldDefinition {
     ) -> Self {
         Self::new(
             name,
-            FieldKind::map(key_type, value_type.into(), true),
+            FieldKind::map(key_type, value_type.into()),
             ColumnType::Required,
         )
     }
@@ -232,7 +232,7 @@ impl FieldDefinition {
     ) -> Self {
         Self::new(
             name,
-            FieldKind::map(key_type, value_type.into(), false),
+            FieldKind::map(key_type, value_type.into()),
             ColumnType::Optional,
         )
     }
@@ -242,7 +242,7 @@ impl FieldDefinition {
     pub fn required_list(name: impl Into<String>, field_kind: impl Into<FieldKind>) -> Self {
         Self::new(
             name,
-            FieldKind::list(field_kind.into(), true),
+            FieldKind::list(field_kind.into()),
             ColumnType::Required,
         )
     }
@@ -252,7 +252,7 @@ impl FieldDefinition {
     pub fn optional_list(name: impl Into<String>, field_kind: impl Into<FieldKind>) -> Self {
         Self::new(
             name,
-            FieldKind::list(field_kind.into(), false),
+            FieldKind::list(field_kind.into()),
             ColumnType::Optional,
         )
     }

--- a/helium_iceberg/src/test_harness.rs
+++ b/helium_iceberg/src/test_harness.rs
@@ -927,7 +927,7 @@ mod tests {
         struct Outer {
             id: u64,
             tags: Option<Vec<String>>,
-            maps: HashMap<u64, String>,
+            maps: HashMap<String, String>,
             inner: Inner,
             list_inner: Vec<Inner>,
             name: String,
@@ -947,7 +947,7 @@ mod tests {
             .with_fields([
                 FieldDefinition::required_long("id"),
                 FieldDefinition::required_list("tags", PrimitiveType::String),
-                FieldDefinition::required_map("maps", PrimitiveType::Long, PrimitiveType::String),
+                FieldDefinition::required_map("maps", PrimitiveType::String),
                 FieldDefinition::required_struct("inner", inner_fields.clone()),
                 FieldDefinition::required_list("list_inner", FieldKind::struct_type(inner_fields)),
                 FieldDefinition::required_string("name"),
@@ -960,7 +960,7 @@ mod tests {
         let data = vec![Outer {
             id: 1337,
             tags: Some(vec![]),
-            maps: HashMap::from([(1, "one".to_string()), (2, "two".to_string())]),
+            maps: HashMap::from([("1".to_string(), "one".to_string()), ("2".to_string(), "two".to_string())]),
             inner: Inner::default(),
             list_inner: vec![Inner::default(), Inner::default()],
             name: "test".to_string(),

--- a/helium_iceberg/src/test_harness.rs
+++ b/helium_iceberg/src/test_harness.rs
@@ -798,10 +798,14 @@ mod env_defaults {
 #[cfg(test)]
 mod tests {
 
-    use super::{IcebergTestHarness, TableDefinition};
-    use crate::{FieldDefinition, PartitionDefinition};
+    use std::collections::HashMap;
 
+    use super::{IcebergTestHarness, TableDefinition};
+    use crate::{FieldDefinition, FieldKind, PartitionDefinition};
+
+    use anyhow::Context;
     use chrono::{DateTime, Duration, DurationRound, FixedOffset, Utc};
+    use iceberg::spec::PrimitiveType;
     use serde::{Deserialize, Serialize};
     use trino_rust_client::Trino;
 
@@ -913,6 +917,69 @@ mod tests {
             .await?
             .into_vec();
         assert_eq!(queried_people, people);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_nested_field_types() -> anyhow::Result<()> {
+        #[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
+        struct Outer {
+            id: u64,
+            tags: Option<Vec<String>>,
+            maps: HashMap<u64, String>,
+            inner: Inner,
+            list_inner: Vec<Inner>,
+            name: String,
+        }
+
+        #[derive(Default, Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
+        struct Inner {
+            one: u64,
+            two: u64,
+        }
+
+        let inner_fields = [
+            FieldDefinition::required_long("one"),
+            FieldDefinition::required_long("two"),
+        ];
+        let table_def = TableDefinition::builder("default", "list_items")
+            .with_fields([
+                FieldDefinition::required_long("id"),
+                FieldDefinition::required_list("tags", PrimitiveType::String),
+                FieldDefinition::required_map("maps", PrimitiveType::Long, PrimitiveType::String),
+                FieldDefinition::required_struct("inner", inner_fields.clone()),
+                FieldDefinition::required_list("list_inner", FieldKind::struct_type(inner_fields)),
+                FieldDefinition::required_string("name"),
+            ])
+            .with_partition(PartitionDefinition::identity("id"))
+            .build()?;
+
+        let harness = IcebergTestHarness::new_with_tables([table_def]).await?;
+
+        let data = vec![Outer {
+            id: 1337,
+            tags: Some(vec![]),
+            maps: HashMap::from([(1, "one".to_string()), (2, "two".to_string())]),
+            inner: Inner::default(),
+            list_inner: vec![Inner::default(), Inner::default()],
+            name: "test".to_string(),
+        }];
+
+        let writer = harness
+            .get_table_writer("list_items")
+            .await
+            .context("get writer")?;
+        writer.write(data.clone()).await.context("write data")?;
+
+        let out = harness
+            .trino()
+            .get_all::<Outer>("SELECT * from default.list_items".to_string())
+            .await
+            .context("read data")?
+            .into_vec();
+
+        assert_eq!(data, out);
 
         Ok(())
     }

--- a/helium_iceberg/src/test_harness.rs
+++ b/helium_iceberg/src/test_harness.rs
@@ -960,7 +960,10 @@ mod tests {
         let data = vec![Outer {
             id: 1337,
             tags: Some(vec![]),
-            maps: HashMap::from([("1".to_string(), "one".to_string()), ("2".to_string(), "two".to_string())]),
+            maps: HashMap::from([
+                ("1".to_string(), "one".to_string()),
+                ("2".to_string(), "two".to_string()),
+            ]),
             inner: Inner::default(),
             list_inner: vec![Inner::default(), Inner::default()],
             name: "test".to_string(),


### PR DESCRIPTION
  List and Struct type support

  - Redesigned FieldKind from a private 2-variant enum (Primitive, Map) to a public recursive
  4-variant enum (Primitive, List, Struct, Map)
  - Primitive now holds PrimitiveType directly instead of wrapping in Type
  - Map value upgraded from PrimitiveType to Box<FieldKind>, enabling complex map values (e.g.
  Map<String, Struct>)
  - Added FieldKind convenience constructors: primitive(), list(), struct_type(), map()
  - Added FieldDefinition constructors: required_list, optional_list, required_list_of,
  optional_list_of, required_struct, optional_struct, required_map_of, optional_map_of
  - Extracted recursive build_type() function for nested field ID allocation in build_schema()
  - Existing required_map/optional_map API unchanged (backward compatible)
  - FieldKind re-exported from lib.rs
  - Added 10 new tests covering list, struct, nested types, deep nesting, and doc propagation