### PR TITLE
AwsLocal and Iceberg harness updates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -221,7 +221,8 @@ jobs:
       - name: Run tests
         env:
           DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres # trufflehog:ignore
-          AWSLOCAL_ENDPOINT: http://rustfs:9000
+          AWSLOCAL_HOST: rustfs
+          AWSLOCAL_PORT: 9000
           S3_QUALIFIED_HOST: rustfs
           S3_LOCAL_HOST: rustfs
           CATALOG_QUALIFIED_HOST: polaris

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,7 +3136,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "triggered",
- "uuid",
 ]
 
 [[package]]

--- a/aws_local/src/README.md
+++ b/aws_local/src/README.md
@@ -1,1 +1,0 @@
-It helps to run tests with [RustFS](https://github.com/rustfs/rustfs), an S3-compatible object storage server.

--- a/file_store/Cargo.toml
+++ b/file_store/Cargo.toml
@@ -30,7 +30,6 @@ derive_builder = { workspace = true }
 retainer = { workspace = true }
 task-manager = { path = "../task_manager" }
 tls-init = { path = "../tls_init" }
-uuid = { workspace = true }
 tempfile = { workspace = true }
 
 aws-config = { workspace = true }

--- a/file_store/src/aws_local.rs
+++ b/file_store/src/aws_local.rs
@@ -1,6 +1,5 @@
 use crate::{without_caching, BucketClient, GzippedFramedFile};
 use chrono::{DateTime, Utc};
-use std::env;
 use uuid::Uuid;
 
 #[derive(thiserror::Error, Debug)]
@@ -14,13 +13,6 @@ impl AwsLocalError {
 }
 
 pub type Result<T> = std::result::Result<T, AwsLocalError>;
-
-pub const AWSLOCAL_ENDPOINT_ENV: &str = "AWSLOCAL_ENDPOINT";
-pub const AWSLOCAL_DEFAULT_ENDPOINT: &str = "http://localhost:4566";
-
-pub fn aws_local_default_endpoint() -> String {
-    env::var(AWSLOCAL_ENDPOINT_ENV).unwrap_or_else(|_| AWSLOCAL_DEFAULT_ENDPOINT.to_string())
-}
 
 pub fn gen_bucket_name() -> String {
     format!("mvr-{}-{}", Uuid::new_v4(), Utc::now().timestamp_millis())
@@ -164,7 +156,8 @@ impl AwsLocal {
 #[derive(Debug, Clone, Default)]
 pub struct AwsLocalBuilder {
     region: Option<String>,
-    endpoint: Option<String>,
+    host: Option<String>,
+    port: Option<u16>,
     bucket: Option<String>,
     access_key_id: Option<String>,
     secret_access_key: Option<String>,
@@ -176,8 +169,13 @@ impl AwsLocalBuilder {
         self
     }
 
-    pub fn endpoint(mut self, endpoint: String) -> Self {
-        self.endpoint = Some(endpoint);
+    pub fn host(mut self, host: String) -> Self {
+        self.host = Some(host);
+        self
+    }
+
+    pub fn port(mut self, port: u16) -> Self {
+        self.port = Some(port);
         self
     }
 
@@ -204,7 +202,11 @@ impl AwsLocalBuilder {
     }
 
     pub async fn build(self) -> AwsLocal {
-        let endpoint = self.endpoint.unwrap_or_else(aws_local_default_endpoint);
+        let endpoint = format!(
+            "http://{}:{}",
+            self.host.unwrap_or_else(env_defaults::awslocal_host),
+            self.port.unwrap_or_else(env_defaults::awslocal_port)
+        );
 
         let client = without_caching(BucketClient::new(
             self.bucket.unwrap_or_else(gen_bucket_name),
@@ -255,5 +257,32 @@ impl AwsLocal {
     #[allow(unsafe_code)]
     pub unsafe fn drop_without_bucket_delete(mut self) {
         self.gaurd_drop = false;
+    }
+}
+
+pub mod env_defaults {
+    const AWSLOCAL_HOST_ENV: &str = "AWSLOCAL_HOST";
+    const AWSLOCAL_PORT_ENV: &str = "AWSLOCAL_PORT";
+
+    pub fn awslocal_host() -> String {
+        env_str(AWSLOCAL_HOST_ENV, "localhost")
+    }
+
+    pub fn awslocal_port() -> u16 {
+        env_port(AWSLOCAL_PORT_ENV, 4566)
+    }
+
+    // ======= Helpers ====================
+    fn to_u16(port: String, label: &str) -> u16 {
+        port.parse::<u16>()
+            .unwrap_or_else(|val| panic!("u16 parseable {label} port: {val}"))
+    }
+    fn env_str(var: &str, default: &str) -> String {
+        std::env::var(var).unwrap_or_else(|_| default.to_string())
+    }
+    fn env_port(var: &str, default: u16) -> u16 {
+        std::env::var(var)
+            .map(|port| to_u16(port, var))
+            .unwrap_or(default)
     }
 }

--- a/file_store/src/aws_local.rs
+++ b/file_store/src/aws_local.rs
@@ -1,6 +1,5 @@
 use crate::{without_caching, BucketClient, GzippedFramedFile};
 use chrono::{DateTime, Utc};
-use uuid::Uuid;
 
 #[derive(thiserror::Error, Debug)]
 #[error("aws local error: {0}")]
@@ -13,10 +12,6 @@ impl AwsLocalError {
 }
 
 pub type Result<T> = std::result::Result<T, AwsLocalError>;
-
-pub fn gen_bucket_name() -> String {
-    format!("mvr-{}-{}", Uuid::new_v4(), Utc::now().timestamp_millis())
-}
 
 // Interacts with an S3-compatible object storage (RustFS).
 pub struct AwsLocal {
@@ -257,6 +252,35 @@ impl AwsLocal {
     #[allow(unsafe_code)]
     pub unsafe fn drop_without_bucket_delete(mut self) {
         self.gaurd_drop = false;
+    }
+}
+
+fn gen_bucket_name() -> String {
+    // Get current timestamp in milliseconds
+    let now = chrono::Utc::now();
+    let timestamp = now.timestamp_millis();
+
+    // Extract only the function name (last part after ::) from thread name
+    let test_name = std::thread::current()
+        .name()
+        .and_then(|name| name.split("::").last())
+        .map(|name| {
+            name.chars()
+                .take(32) // Limit test name portion to 32 chars
+                .map(|c| {
+                    if c.is_alphanumeric() || c == '-' {
+                        c
+                    } else {
+                        '-'
+                    }
+                })
+                .collect::<String>()
+        })
+        .filter(|name| !name.is_empty());
+
+    match test_name {
+        Some(name) => format!("{}-{}", name, timestamp),
+        None => format!("test-{}", timestamp),
     }
 }
 

--- a/helium_iceberg/src/test_harness.rs
+++ b/helium_iceberg/src/test_harness.rs
@@ -113,6 +113,7 @@ pub struct IcebergTestHarness {
     trino: trino_rust_client::Client,
     iceberg_catalog: Catalog,
     table_namespaces: Mutex<HashMap<String, String>>,
+    pub config: HarnessConfig,
 }
 
 impl IcebergTestHarness {
@@ -172,6 +173,7 @@ impl IcebergTestHarness {
             trino,
             iceberg_catalog,
             table_namespaces: Mutex::new(HashMap::default()),
+            config,
         })
     }
 
@@ -256,6 +258,28 @@ impl IcebergTestHarness {
         let creator = TableCreator::new(self.iceberg_catalog.clone());
         creator.create_table_if_not_exists::<()>(definition).await?;
         Ok(())
+    }
+
+    pub fn as_settings(&self) -> Settings {
+        Settings {
+            catalog_uri: self.config.catalog_local_url(),
+            catalog_name: self.catalog_name().to_owned(),
+            warehouse: Some(self.catalog_name().to_owned()),
+            auth: AuthConfig {
+                credential: Some(self.config.catalog_oauth2_credential.to_owned()),
+                scope: Some(self.config.catalog_oauth2_scope.to_owned()),
+                ..Default::default()
+            },
+            s3: S3Config {
+                endpoint: Some(self.config.s3_local_url()),
+                access_key_id: Some(self.config.s3_access_key.to_owned()),
+                secret_access_key: Some(self.config.s3_access_key.to_owned()),
+                region: Some(self.config.s3_region.to_owned()),
+                path_style_access: Some(true),
+                disable_config_load: Some(true),
+            },
+            properties: Default::default(),
+        }
     }
 }
 
@@ -396,27 +420,27 @@ impl HarnessConfig {
         HarnessConfigBuilder::default()
     }
 
-    fn s3_local_url(&self) -> String {
+    pub fn s3_local_url(&self) -> String {
         self.s3_host_local.with_path("")
     }
 
-    fn s3_qualified_url(&self) -> String {
+    pub fn s3_qualified_url(&self) -> String {
         self.s3_host_qualified.with_path("")
     }
 
-    fn catalog_management_local_url(&self) -> String {
+    pub fn catalog_management_local_url(&self) -> String {
         self.catalog_host_local.with_path("/api/management/v1")
     }
 
-    fn catalog_local_url(&self) -> String {
+    pub fn catalog_local_url(&self) -> String {
         self.catalog_host_local.with_path("/api/catalog")
     }
 
-    fn catalog_qualified_url(&self) -> String {
+    pub fn catalog_qualified_url(&self) -> String {
         self.catalog_host_qualified.with_path("/api/catalog")
     }
 
-    fn trino_client_builder(&self) -> ClientBuilder {
+    pub fn trino_client_builder(&self) -> ClientBuilder {
         ClientBuilder::new(&self.trino_user, &self.trino_host).port(self.trino_port)
     }
 }
@@ -680,12 +704,16 @@ impl TestHost {
         self.port = port;
     }
 
-    fn with_path(&self, path: &str) -> String {
+    pub fn with_path(&self, path: &str) -> String {
         format!("http://{}:{}{path}", self.host, self.port)
+    }
+
+    pub fn endpoint(&self) -> String {
+        format!("http://{}:{}", self.host, self.port)
     }
 }
 
-mod env_defaults {
+pub mod env_defaults {
     use crate::test_harness::TestHost;
 
     const S3_LOCAL_HOST_ENV: &str = "S3_LOCAL_HOST";


### PR DESCRIPTION
mirror the setup we have in `helium_iceberg` where each part of the
configuration is configurable through the environment.

Allows for settings a different port without having to also make the
host configurable downstream.

Allow for getting configuration used for Iceberg test harness for
external projects that need the same values in their own configuration
for testing.