### PR TITLE
Speedtest iceberg

### DIFF
--- a/mobile_verifier/src/backfill.rs
+++ b/mobile_verifier/src/backfill.rs
@@ -1,0 +1,219 @@
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+use file_store::{
+    file_info::FileInfo, file_info_poller::FileInfoStream, file_source, traits::MsgDecode,
+    BucketClient,
+};
+use file_store_oracles::FileType;
+use futures::StreamExt;
+use helium_iceberg::BoxedDataWriter;
+use sqlx::PgPool;
+use std::time::Duration;
+use task_manager::ManagedTask;
+use tokio::sync::mpsc::Receiver;
+
+pub trait IcebergBackfill: Send + 'static {
+    type FileRecord: MsgDecode + Clone + Send + Sync + 'static;
+    type IcebergRow: serde::Serialize + Send + Sync + 'static;
+
+    const FILE_TYPE: FileType;
+
+    /// Return `Some(row)` to write the record, `None` to skip it.
+    fn convert(record: Self::FileRecord) -> Option<Self::IcebergRow>;
+}
+
+pub struct BackfillOptions {
+    pub process_name: String,
+    pub start_after: DateTime<Utc>,
+    pub stop_after: DateTime<Utc>,
+    pub poll_duration: Option<Duration>,
+    pub idle_timeout: Option<Duration>,
+}
+
+pub struct BackfillPollerServer(Option<Box<dyn ManagedTask>>);
+
+impl BackfillPollerServer {
+    fn noop() -> Self {
+        Self(None)
+    }
+
+    fn active(server: impl ManagedTask + 'static) -> Self {
+        Self(Some(Box::new(server)))
+    }
+}
+
+impl ManagedTask for BackfillPollerServer {
+    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
+        match (*self).0 {
+            Some(task) => task.start_task(shutdown),
+            None => task_manager::spawn(async { anyhow::Ok(()) }),
+        }
+    }
+}
+
+pub struct Backfiller<C: IcebergBackfill> {
+    pool: PgPool,
+    reports: Receiver<FileInfoStream<C::FileRecord>>,
+    writer: Option<BoxedDataWriter<C::IcebergRow>>,
+    done: bool,
+}
+
+impl<C: IcebergBackfill> Backfiller<C> {
+    pub fn new(
+        pool: PgPool,
+        reports: Receiver<FileInfoStream<C::FileRecord>>,
+        writer: Option<BoxedDataWriter<C::IcebergRow>>,
+    ) -> Self {
+        let done = writer.is_none();
+        Self {
+            pool,
+            reports,
+            writer,
+            done,
+        }
+    }
+
+    pub async fn recv(&mut self) -> Option<FileInfoStream<C::FileRecord>> {
+        if self.done {
+            std::future::pending().await
+        } else {
+            self.reports.recv().await
+        }
+    }
+
+    pub async fn handle(
+        &mut self,
+        file: Option<FileInfoStream<C::FileRecord>>,
+    ) -> anyhow::Result<()> {
+        let Some(stream) = file else {
+            tracing::info!("{} backfiller completed", C::FILE_TYPE);
+            self.done = true;
+            return Ok(());
+        };
+        tracing::info!(
+            file = %stream.file_info,
+            age = %file_age(&stream.file_info),
+            "backfilling {} file",
+            C::FILE_TYPE
+        );
+        self.handle_file(stream).await
+    }
+
+    async fn handle_file(&self, file: FileInfoStream<C::FileRecord>) -> anyhow::Result<()> {
+        let Some(ref writer) = self.writer else {
+            return Ok(());
+        };
+
+        let file_info = file.file_info.clone();
+        let write_id = file_info.key.clone();
+        let mut txn = self.pool.begin().await?;
+
+        let all: Vec<_> = file.into_stream(&mut txn).await?.collect().await;
+        let total = all.len();
+
+        let rows: Vec<C::IcebergRow> = all.into_iter().filter_map(C::convert).collect();
+        let written = rows.len();
+
+        writer
+            .write_idempotent(&write_id, rows)
+            .await
+            .with_context(|| format!("writing {} backfill to iceberg", C::FILE_TYPE))?;
+
+        txn.commit().await?;
+        tracing::info!(
+            file = %file_info,
+            written,
+            skipped = total - written,
+            age = %file_age(&file_info),
+            "backfilled {} file",
+            C::FILE_TYPE
+        );
+        Ok(())
+    }
+
+    async fn run(mut self, mut shutdown: triggered::Listener) -> anyhow::Result<()> {
+        tracing::info!("{} backfiller starting", C::FILE_TYPE);
+        loop {
+            if self.done {
+                tracing::info!("{} backfiller complete", C::FILE_TYPE);
+                return Ok(());
+            }
+            tokio::select! {
+                biased;
+                _ = &mut shutdown => {
+                    tracing::info!("{} backfiller shutting down", C::FILE_TYPE);
+                    return Ok(());
+                }
+                file = self.recv() => {
+                    self.handle(file).await?;
+                }
+            }
+        }
+    }
+}
+
+// `create` needs extra bounds because `file_source::continuous_source()` uses
+// `MsgDecodeFileInfoPollerParser`, which requires the error type to be `std::error::Error`
+// and the proto message type to implement `prost::Message + Default`.
+impl<C: IcebergBackfill> Backfiller<C>
+where
+    <C::FileRecord as TryFrom<<C::FileRecord as MsgDecode>::Msg>>::Error: std::error::Error,
+    <C::FileRecord as MsgDecode>::Msg: prost::Message + Default,
+{
+    pub async fn create(
+        pool: PgPool,
+        bucket_client: BucketClient,
+        writer: Option<BoxedDataWriter<C::IcebergRow>>,
+        options: Option<BackfillOptions>,
+    ) -> anyhow::Result<(Self, BackfillPollerServer)> {
+        let (Some(writer), Some(options)) = (writer, options) else {
+            let (_, rx) = tokio::sync::mpsc::channel(1);
+            return Ok((
+                Backfiller::new(pool, rx, None),
+                BackfillPollerServer::noop(),
+            ));
+        };
+
+        let (reports, reports_server) = file_source::continuous_source()
+            .state(pool.clone())
+            .bucket_client(bucket_client)
+            .prefix(C::FILE_TYPE.to_string())
+            .lookback_start_after(options.start_after)
+            .stop_after(options.stop_after)
+            .process_name(options.process_name)
+            .poll_duration_opt(options.poll_duration)
+            .idle_timeout_opt(options.idle_timeout)
+            .create()
+            .await?;
+
+        Ok((
+            Backfiller::new(pool, reports, Some(writer)),
+            BackfillPollerServer::active(reports_server),
+        ))
+    }
+}
+
+impl<C: IcebergBackfill> ManagedTask for Backfiller<C> {
+    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
+        task_manager::spawn(self.run(shutdown))
+    }
+}
+
+fn file_age(file_info: &FileInfo) -> String {
+    let age = chrono::Utc::now().signed_duration_since(file_info.timestamp);
+
+    let total_seconds = age.num_seconds();
+    if total_seconds < 0 {
+        return "in the future".to_string();
+    }
+
+    let days = age.num_days();
+    let hours = age.num_hours() % 24;
+    let minutes = age.num_minutes() % 60;
+
+    match (days, hours, minutes) {
+        (0, 0, m) => format!("{m}m ago"),
+        (0, h, m) => format!("{h}h {m}m ago"),
+        (d, h, _) => format!("{d}d {h}h ago"),
+    }
+}

--- a/mobile_verifier/src/cli/backfill_speedtest.rs
+++ b/mobile_verifier/src/cli/backfill_speedtest.rs
@@ -1,0 +1,75 @@
+use crate::{
+    iceberg,
+    speedtests::{BackfillOptions, SpeedtestBackfiller},
+    Settings,
+};
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use task_manager::TaskManager;
+
+#[derive(Debug, clap::Args)]
+pub struct Cmd {
+    /// Process name for tracking speedtest backfill (avoids conflict with daemon)
+    #[clap(long, default_value = "speedtest-backfill")]
+    process_name: String,
+
+    /// Start processing files after this timestamp.
+    /// Format: RFC 3339 (e.g., 2024-01-01T00:00:00Z)
+    #[clap(long)]
+    start_after: DateTime<Utc>,
+
+    /// Stop processing files when their timestamp is > this value.
+    /// Use this to avoid reprocessing files that the daemon has already handled.
+    /// Format: RFC 3339 (e.g., 2025-02-25T00:00:00Z)
+    #[clap(long)]
+    stop_after: DateTime<Utc>,
+}
+
+impl Cmd {
+    pub async fn run(self, settings: &Settings) -> Result<()> {
+        let iceberg_settings = settings
+            .iceberg_settings
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("iceberg_settings required for speedtest backfill"))?;
+
+        let pool = settings
+            .database
+            .connect("mobile-verifier-speedtest-backfill")
+            .await?;
+        sqlx::migrate!().run(&pool).await?;
+
+        let (_heartbeat_writer, speedtest_writer) =
+            iceberg::get_poc_writers(iceberg_settings).await?;
+
+        tracing::info!(
+            process_name = %self.process_name,
+            start_after = %self.start_after,
+            stop_after = %self.stop_after,
+            "starting speedtest backfill"
+        );
+
+        let opts = BackfillOptions {
+            process_name: self.process_name,
+            start_after: self.start_after,
+            stop_after: self.stop_after,
+            poll_duration: None,
+            idle_timeout: None,
+        };
+
+        let (backfiller, server) = SpeedtestBackfiller::create(
+            pool,
+            settings.buckets.output.connect().await,
+            Some(speedtest_writer),
+            Some(opts),
+        )
+        .await?;
+
+        TaskManager::builder()
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start()
+            .await?;
+        Ok(())
+    }
+}

--- a/mobile_verifier/src/cli/backfill_speedtest.rs
+++ b/mobile_verifier/src/cli/backfill_speedtest.rs
@@ -1,6 +1,7 @@
 use crate::{
+    backfill::BackfillOptions,
     iceberg,
-    speedtests::{BackfillOptions, SpeedtestBackfiller},
+    speedtests::SpeedtestBackfiller,
     Settings,
 };
 use anyhow::Result;

--- a/mobile_verifier/src/cli/backfill_speedtest.rs
+++ b/mobile_verifier/src/cli/backfill_speedtest.rs
@@ -1,9 +1,4 @@
-use crate::{
-    backfill::BackfillOptions,
-    iceberg,
-    speedtests::SpeedtestBackfiller,
-    Settings,
-};
+use crate::{iceberg, speedtests::SpeedtestBackfiller, Settings};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use task_manager::TaskManager;
@@ -28,19 +23,21 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(self, settings: &Settings) -> Result<()> {
-        let iceberg_settings = settings
-            .iceberg_settings
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("iceberg_settings required for speedtest backfill"))?;
-
         let pool = settings
             .database
             .connect("mobile-verifier-speedtest-backfill")
             .await?;
         sqlx::migrate!().run(&pool).await?;
 
-        let (_heartbeat_writer, speedtest_writer) =
-            iceberg::get_poc_writers(iceberg_settings).await?;
+        let iceberg_settings = settings
+            .iceberg_settings
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("iceberg_settings required for speedtest backfill"))?;
+
+        let speedtest_writer = iceberg::PocWriters::from_settings(iceberg_settings)
+            .await?
+            .speedtest
+            .expect("iceberg writer");
 
         tracing::info!(
             process_name = %self.process_name,
@@ -49,7 +46,7 @@ impl Cmd {
             "starting speedtest backfill"
         );
 
-        let opts = BackfillOptions {
+        let opts = crate::backfill::BackfillOptions {
             process_name: self.process_name,
             start_after: self.start_after,
             stop_after: self.stop_after,

--- a/mobile_verifier/src/cli/mod.rs
+++ b/mobile_verifier/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod backfill_speedtest;
 pub mod reward_from_db;
 pub mod server;
 pub mod verify_disktree;

--- a/mobile_verifier/src/cli/server.rs
+++ b/mobile_verifier/src/cli/server.rs
@@ -81,20 +81,14 @@ impl Cmd {
 
         let ingest_bucket_client = settings.buckets.ingest.connect().await;
 
-        let (heartbeat_writer, speedtest_writer, reward_writers) =
+        let (poc_writers, reward_writers) =
             if let Some(ref iceberg_settings) = settings.iceberg_settings {
-                tracing::info!("iceberg settings provided, connecting...");
-                let (heartbeat_writer, speedtest_writer) =
-                    iceberg::get_poc_writers(iceberg_settings).await?;
-                let reward_writers = iceberg::get_reward_writers(iceberg_settings).await?;
                 (
-                    Some(heartbeat_writer),
-                    Some(speedtest_writer),
-                    Some(reward_writers),
+                    iceberg::PocWriters::from_settings(iceberg_settings).await?,
+                    Some(iceberg::get_reward_writers(iceberg_settings).await?),
                 )
             } else {
-                tracing::info!("no iceberg settings provided");
-                (None, None, None)
+                (iceberg::PocWriters::noop(), None)
             };
 
         TaskManager::builder()
@@ -110,7 +104,7 @@ impl Cmd {
                     valid_heartbeats,
                     seniority_updates,
                     usa_and_mexico_geofence,
-                    heartbeat_writer,
+                    poc_writers.heartbeat,
                 )
                 .await?,
             )
@@ -121,7 +115,7 @@ impl Cmd {
                     file_upload.clone(),
                     ingest_bucket_client.clone(),
                     gateway_client.clone(),
-                    speedtest_writer,
+                    poc_writers.speedtest,
                 )
                 .await?,
             )

--- a/mobile_verifier/src/cli/server.rs
+++ b/mobile_verifier/src/cli/server.rs
@@ -81,15 +81,20 @@ impl Cmd {
 
         let ingest_bucket_client = settings.buckets.ingest.connect().await;
 
-        let (heartbeat_writer, reward_writers) =
+        let (heartbeat_writer, speedtest_writer, reward_writers) =
             if let Some(ref iceberg_settings) = settings.iceberg_settings {
                 tracing::info!("iceberg settings provided, connecting...");
-                let writer = iceberg::get_writer(iceberg_settings).await?;
+                let (heartbeat_writer, speedtest_writer) =
+                    iceberg::get_poc_writers(iceberg_settings).await?;
                 let reward_writers = iceberg::get_reward_writers(iceberg_settings).await?;
-                (Some(writer), Some(reward_writers))
+                (
+                    Some(heartbeat_writer),
+                    Some(speedtest_writer),
+                    Some(reward_writers),
+                )
             } else {
                 tracing::info!("no iceberg settings provided");
-                (None, None)
+                (None, None, None)
             };
 
         TaskManager::builder()
@@ -116,6 +121,7 @@ impl Cmd {
                     file_upload.clone(),
                     ingest_bucket_client.clone(),
                     gateway_client.clone(),
+                    speedtest_writer,
                 )
                 .await?,
             )

--- a/mobile_verifier/src/iceberg/mod.rs
+++ b/mobile_verifier/src/iceberg/mod.rs
@@ -19,22 +19,38 @@ pub const REWARDS_NAMESPACE: &str = "rewards";
 pub type HeartbeatWriter = BoxedDataWriter<IcebergHeartbeat>;
 pub type SpeedtestWriter = BoxedDataWriter<IcebergSpeedtest>;
 
-pub async fn get_poc_writers(
-    settings: &helium_iceberg::Settings,
-) -> anyhow::Result<(HeartbeatWriter, SpeedtestWriter)> {
-    let catalog = settings.connect().await.context("connecting to catalog")?;
+pub struct PocWriters {
+    pub heartbeat: Option<HeartbeatWriter>,
+    pub speedtest: Option<SpeedtestWriter>,
+}
 
-    catalog.create_namespace_if_not_exists(NAMESPACE).await?;
+impl PocWriters {
+    pub fn noop() -> Self {
+        Self {
+            heartbeat: None,
+            speedtest: None,
+        }
+    }
 
-    let heartbeat_writer = catalog
-        .create_table_if_not_exists(heartbeat::table_definition()?)
-        .await?;
+    pub async fn from_settings(settings: &helium_iceberg::Settings) -> anyhow::Result<Self> {
+        tracing::info!("iceberg settings provided, connecting...");
+        let catalog = settings.connect().await.context("connecting to catalog")?;
+        catalog.create_namespace_if_not_exists(NAMESPACE).await?;
 
-    let speedtest_writer = catalog
-        .create_table_if_not_exists(speedtest::table_definition()?)
-        .await?;
+        let heartbeat = catalog
+            .create_table_if_not_exists(heartbeat::table_definition()?)
+            .await?
+            .boxed();
+        let speedtest = catalog
+            .create_table_if_not_exists(speedtest::table_definition()?)
+            .await?
+            .boxed();
 
-    Ok((heartbeat_writer.boxed(), speedtest_writer.boxed()))
+        Ok(Self {
+            heartbeat: Some(heartbeat),
+            speedtest: Some(speedtest),
+        })
+    }
 }
 
 pub struct RewardWriters {

--- a/mobile_verifier/src/iceberg/mod.rs
+++ b/mobile_verifier/src/iceberg/mod.rs
@@ -7,25 +7,34 @@ pub mod heartbeat;
 pub mod radio_reward;
 pub mod radio_reward_covered_hex;
 pub mod service_provider_reward;
+pub mod speedtest;
 pub mod unallocated_reward;
 
 pub use heartbeat::IcebergHeartbeat;
+pub use speedtest::IcebergSpeedtest;
 
 pub const NAMESPACE: &str = "poc";
 pub const REWARDS_NAMESPACE: &str = "rewards";
 
 pub type HeartbeatWriter = BoxedDataWriter<IcebergHeartbeat>;
+pub type SpeedtestWriter = BoxedDataWriter<IcebergSpeedtest>;
 
-pub async fn get_writer(settings: &helium_iceberg::Settings) -> anyhow::Result<HeartbeatWriter> {
+pub async fn get_poc_writers(
+    settings: &helium_iceberg::Settings,
+) -> anyhow::Result<(HeartbeatWriter, SpeedtestWriter)> {
     let catalog = settings.connect().await.context("connecting to catalog")?;
 
     catalog.create_namespace_if_not_exists(NAMESPACE).await?;
 
-    let writer = catalog
+    let heartbeat_writer = catalog
         .create_table_if_not_exists(heartbeat::table_definition()?)
         .await?;
 
-    Ok(writer.boxed())
+    let speedtest_writer = catalog
+        .create_table_if_not_exists(speedtest::table_definition()?)
+        .await?;
+
+    Ok((heartbeat_writer.boxed(), speedtest_writer.boxed()))
 }
 
 pub struct RewardWriters {

--- a/mobile_verifier/src/iceberg/speedtest.rs
+++ b/mobile_verifier/src/iceberg/speedtest.rs
@@ -1,0 +1,110 @@
+use chrono::{DateTime, FixedOffset};
+use file_store_oracles::speedtest::CellSpeedtestIngestReport;
+use helium_iceberg::{FieldDefinition, PartitionDefinition, SortFieldDefinition, TableDefinition};
+use serde::{Deserialize, Serialize};
+use trino_rust_client::Trino;
+
+pub use super::NAMESPACE;
+pub const TABLE_NAME: &str = "speedtests";
+
+#[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
+pub struct IcebergSpeedtest {
+    hotspot_pubkey: String,
+    serial: String,
+    received_timestamp: DateTime<FixedOffset>,
+    timestamp: DateTime<FixedOffset>,
+    upload_speed: u64,
+    download_speed: u64,
+    latency: u32,
+}
+
+pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {
+    TableDefinition::builder(NAMESPACE, TABLE_NAME)
+        .with_fields([
+            FieldDefinition::required_string("hotspot_pubkey"),
+            FieldDefinition::required_string("serial"),
+            FieldDefinition::required_timestamptz("received_timestamp"),
+            FieldDefinition::required_timestamptz("timestamp"),
+            FieldDefinition::required_long("upload_speed"),
+            FieldDefinition::required_long("download_speed"),
+            FieldDefinition::required_long("latency"),
+        ])
+        .with_partition(PartitionDefinition::day(
+            "received_timestamp",
+            "received_timestamp_day",
+        ))
+        .with_sort_fields([
+            SortFieldDefinition::ascending("hotspot_pubkey"),
+            SortFieldDefinition::ascending("received_timestamp"),
+        ])
+        .build()
+}
+
+pub async fn get_all(trino: &trino_rust_client::Client) -> anyhow::Result<Vec<IcebergSpeedtest>> {
+    let all = match trino
+        .get_all(format!("SELECT * from {NAMESPACE}.{TABLE_NAME}"))
+        .await
+    {
+        Ok(all) => all.into_vec(),
+        Err(trino_rust_client::error::Error::EmptyData) => vec![],
+        Err(err) => return Err(err.into()),
+    };
+    Ok(all)
+}
+
+impl From<&CellSpeedtestIngestReport> for IcebergSpeedtest {
+    fn from(value: &CellSpeedtestIngestReport) -> Self {
+        Self {
+            hotspot_pubkey: value.report.pubkey.to_string(),
+            serial: value.report.serial.clone(),
+            received_timestamp: value.received_timestamp.into(),
+            timestamp: value.report.timestamp.into(),
+            upload_speed: value.report.upload_speed,
+            download_speed: value.report.download_speed,
+            latency: value.report.latency,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use file_store_oracles::speedtest::CellSpeedtest;
+    use helium_crypto::PublicKeyBinary;
+
+    fn make_report() -> CellSpeedtestIngestReport {
+        let pubkey: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
+            .parse()
+            .unwrap();
+        let speedtest_time = Utc::now() - chrono::Duration::seconds(30);
+        let received_time = Utc::now();
+        CellSpeedtestIngestReport {
+            received_timestamp: received_time,
+            report: CellSpeedtest {
+                pubkey,
+                serial: "test-serial".to_string(),
+                timestamp: speedtest_time,
+                upload_speed: 10_000_000,
+                download_speed: 100_000_000,
+                latency: 25,
+            },
+        }
+    }
+
+    #[test]
+    fn convert_cell_speedtest_ingest_report() {
+        let report = make_report();
+        let iceberg = IcebergSpeedtest::from(&report);
+
+        assert_eq!(iceberg.hotspot_pubkey, report.report.pubkey.to_string());
+        assert_eq!(iceberg.serial, "test-serial");
+        assert_eq!(iceberg.upload_speed, 10_000_000);
+        assert_eq!(iceberg.download_speed, 100_000_000);
+        assert_eq!(iceberg.latency, 25);
+        assert_ne!(
+            iceberg.received_timestamp, iceberg.timestamp,
+            "received_timestamp and measurement timestamp should differ"
+        );
+    }
+}

--- a/mobile_verifier/src/lib.rs
+++ b/mobile_verifier/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate tls_init;
 
+pub mod backfill;
 pub mod banning;
 pub mod boosting_oracles;
 pub mod cell_type;

--- a/mobile_verifier/src/main.rs
+++ b/mobile_verifier/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use mobile_verifier::{
-    cli::{reward_from_db, server, verify_disktree},
+    cli::{backfill_speedtest, reward_from_db, server, verify_disktree},
     Settings,
 };
 use std::path;
@@ -38,6 +38,8 @@ pub enum Cmd {
     /// Go through every cell and ensure it's value can be turned into an Assignment.
     /// NOTE: This can take a very long time. Run with a --release binary.
     VerifyDisktree(verify_disktree::Cmd),
+    /// Backfill historical VerifiedSpeedtest files to the poc.speedtests iceberg table.
+    BackfillSpeedtest(backfill_speedtest::Cmd),
 }
 
 impl Cmd {
@@ -46,6 +48,7 @@ impl Cmd {
             Self::Server(cmd) => cmd.run(&settings).await,
             Self::RewardFromDb(cmd) => cmd.run(&settings).await,
             Self::VerifyDisktree(cmd) => cmd.run(&settings).await,
+            Self::BackfillSpeedtest(cmd) => cmd.run(&settings).await,
         }
     }
 }

--- a/mobile_verifier/src/settings.rs
+++ b/mobile_verifier/src/settings.rs
@@ -78,6 +78,18 @@ pub struct BackfillSettings {
     pub stop_after: DateTime<Utc>,
 }
 
+impl BackfillSettings {
+    pub fn into_options(&self, process_name: impl Into<String>) -> crate::backfill::BackfillOptions {
+        crate::backfill::BackfillOptions {
+            process_name: process_name.into(),
+            start_after: self.start_after,
+            stop_after: self.stop_after,
+            poll_duration: None,
+            idle_timeout: None,
+        }
+    }
+}
+
 fn default_backfill_start_after() -> DateTime<Utc> {
     DateTime::UNIX_EPOCH
 }

--- a/mobile_verifier/src/settings.rs
+++ b/mobile_verifier/src/settings.rs
@@ -50,11 +50,36 @@ pub struct Settings {
     #[serde(with = "humantime_serde", default = "default_data_sets_poll_duration")]
     pub data_sets_poll_duration: Duration,
     pub iceberg_settings: Option<helium_iceberg::Settings>,
+    /// Settings for speedtest Iceberg backfill. Only used when iceberg_settings is configured.
+    /// Backfill processes VerifiedSpeedtest files from `speedtest_backfill.start_after` up to
+    /// `speedtest_backfill.stop_after` (the Iceberg deployment date). When absent, the backfiller
+    /// is a no-op and no file poller is started.
+    #[serde(default)]
+    pub speedtest_backfill: Option<BackfillSettings>,
     // Geofencing settings
     #[serde(default = "default_usa_and_mexico_geofence_regions")]
     pub usa_and_mexico_geofence_regions: PathBuf,
     #[serde(default = "default_fencing_resolution")]
     pub usa_and_mexico_fencing_resolution: u8,
+}
+
+/// Settings controlling the Iceberg backfill window.
+///
+/// Backfill covers [start_after, stop_after). Set stop_after to the date Iceberg
+/// was first enabled in production. Files before that date are written by the
+/// backfiller; files on or after are written by the daemon's real-time path.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct BackfillSettings {
+    /// Start of the backfill window. Defaults to UNIX_EPOCH (backfill all available history).
+    #[serde(default = "default_backfill_start_after")]
+    pub start_after: DateTime<Utc>,
+    /// End of the backfill window (exclusive). Must be set to the Iceberg deployment date
+    /// to prevent the backfiller from overlapping with the daemon's real-time Iceberg writes.
+    pub stop_after: DateTime<Utc>,
+}
+
+fn default_backfill_start_after() -> DateTime<Utc> {
+    DateTime::UNIX_EPOCH
 }
 
 fn default_fencing_resolution() -> u8 {

--- a/mobile_verifier/src/settings.rs
+++ b/mobile_verifier/src/settings.rs
@@ -76,12 +76,20 @@ pub struct BackfillSettings {
     /// End of the backfill window (exclusive). Must be set to the Iceberg deployment date
     /// to prevent the backfiller from overlapping with the daemon's real-time Iceberg writes.
     pub stop_after: DateTime<Utc>,
+    /// Override the process name used to track backfill position in the database.
+    /// Change this to force a full re-backfill without touching the database directly.
+    /// When absent, each backfiller uses its own default name.
+    #[serde(default)]
+    pub process_name: Option<String>,
 }
 
 impl BackfillSettings {
-    pub fn into_options(&self, process_name: impl Into<String>) -> crate::backfill::BackfillOptions {
+    pub fn into_options(&self, default_name: impl Into<String>) -> crate::backfill::BackfillOptions {
         crate::backfill::BackfillOptions {
-            process_name: process_name.into(),
+            process_name: self
+                .process_name
+                .clone()
+                .unwrap_or_else(|| default_name.into()),
             start_after: self.start_after,
             stop_after: self.stop_after,
             poll_duration: None,

--- a/mobile_verifier/src/settings.rs
+++ b/mobile_verifier/src/settings.rs
@@ -84,7 +84,7 @@ pub struct BackfillSettings {
 }
 
 impl BackfillSettings {
-    pub fn into_options(&self, default_name: impl Into<String>) -> crate::backfill::BackfillOptions {
+    pub fn as_options(&self, default_name: impl Into<String>) -> crate::backfill::BackfillOptions {
         crate::backfill::BackfillOptions {
             process_name: self
                 .process_name

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    backfill::{Backfiller, BackfillOptions, IcebergBackfill},
+    backfill::{Backfiller, IcebergBackfill},
     iceberg,
     speedtests_average::{SpeedtestAverage, SPEEDTEST_LAPSE},
     Settings,
@@ -125,13 +125,10 @@ where
             .create()
             .await?;
 
-        let backfill_opts = settings.speedtest_backfill.as_ref().map(|b| BackfillOptions {
-            process_name: "speedtest-backfill".to_string(),
-            start_after: b.start_after,
-            stop_after: b.stop_after,
-            poll_duration: None,
-            idle_timeout: None,
-        });
+        let backfill_opts = settings
+            .speedtest_backfill
+            .as_ref()
+            .map(|b| b.into_options("speedtest-backfill"));
 
         let (speedtest_backfill, backfill_server) = SpeedtestBackfiller::create(
             pool.clone(),

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -1,7 +1,10 @@
 use crate::{
+    iceberg,
+    settings::BackfillSettings,
     speedtests_average::{SpeedtestAverage, SPEEDTEST_LAPSE},
     Settings,
 };
+use anyhow::Context;
 use chrono::{DateTime, Utc};
 use coverage_point_calculator::speedtest::BYTES_PER_MEGABIT;
 use file_store::{
@@ -9,7 +12,7 @@ use file_store::{
     file_upload::FileUpload, BucketClient,
 };
 use file_store_oracles::{
-    speedtest::{CellSpeedtest, CellSpeedtestIngestReport},
+    speedtest::{CellSpeedtest, CellSpeedtestIngestReport, VerifiedSpeedtest},
     traits::{FileSinkCommitStrategy, FileSinkRollTime, FileSinkWriteExt},
     FileType,
 };
@@ -20,7 +23,7 @@ use helium_proto::services::poc_mobile::{
     SpeedtestVerificationResult as SpeedtestResult, VerifiedSpeedtest as VerifiedSpeedtestProto,
 };
 use mobile_config::gateway::client::GatewayInfoResolver;
-use sqlx::{postgres::PgRow, FromRow, Pool, Postgres, Row, Transaction};
+use sqlx::{postgres::PgRow, FromRow, PgPool, PgTransaction, Row};
 use std::{
     collections::HashMap,
     time::{Duration, Instant},
@@ -56,12 +59,217 @@ impl FromRow<'_, PgRow> for Speedtest {
     }
 }
 
+// ── Backfill support types ────────────────────────────────────────────────────
+
+pub struct BackfillOptions {
+    pub process_name: String,
+    pub start_after: DateTime<Utc>,
+    pub stop_after: DateTime<Utc>,
+    pub poll_duration: Option<Duration>,
+    pub idle_timeout: Option<Duration>,
+}
+
+impl BackfillOptions {
+    pub fn from_settings(settings: &BackfillSettings) -> Self {
+        Self {
+            process_name: "speedtest-backfill".to_string(),
+            start_after: settings.start_after,
+            stop_after: settings.stop_after,
+            poll_duration: None,
+            idle_timeout: None,
+        }
+    }
+
+    pub fn poll_duration(mut self, d: Duration) -> Self {
+        self.poll_duration = Some(d);
+        self
+    }
+
+    pub fn idle_timeout(mut self, d: Duration) -> Self {
+        self.idle_timeout = Some(d);
+        self
+    }
+}
+
+/// Wraps a file-source poller server that may or may not exist.
+/// Always implements `ManagedTask` — returns immediately when there is nothing to do.
+pub struct BackfillPollerServer(Option<Box<dyn ManagedTask>>);
+
+impl BackfillPollerServer {
+    fn noop() -> Self {
+        Self(None)
+    }
+
+    fn active(server: impl ManagedTask + 'static) -> Self {
+        Self(Some(Box::new(server)))
+    }
+}
+
+impl ManagedTask for BackfillPollerServer {
+    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
+        match (*self).0 {
+            Some(task) => task.start_task(shutdown),
+            None => task_manager::spawn(async { anyhow::Ok(()) }),
+        }
+    }
+}
+
+// ── SpeedtestBackfiller ───────────────────────────────────────────────────────
+
+/// Reads historical `VerifiedSpeedtest` files from the output bucket and writes
+/// valid speedtests to the `poc.speedtests` iceberg table. When no writer or
+/// options are configured it becomes a no-op whose `recv()` never returns.
+pub struct SpeedtestBackfiller {
+    pool: PgPool,
+    reports: Receiver<FileInfoStream<VerifiedSpeedtest>>,
+    writer: Option<iceberg::SpeedtestWriter>,
+    done: bool,
+}
+
+impl SpeedtestBackfiller {
+    pub fn new(
+        pool: PgPool,
+        reports: Receiver<FileInfoStream<VerifiedSpeedtest>>,
+        writer: Option<iceberg::SpeedtestWriter>,
+    ) -> Self {
+        let done = writer.is_none();
+        Self {
+            pool,
+            reports,
+            writer,
+            done,
+        }
+    }
+
+    pub async fn recv(&mut self) -> Option<FileInfoStream<VerifiedSpeedtest>> {
+        if self.done {
+            std::future::pending().await
+        } else {
+            self.reports.recv().await
+        }
+    }
+
+    pub async fn create(
+        pool: PgPool,
+        bucket_client: BucketClient,
+        writer: Option<iceberg::SpeedtestWriter>,
+        options: Option<BackfillOptions>,
+    ) -> anyhow::Result<(Self, BackfillPollerServer)> {
+        let (Some(writer), Some(options)) = (writer, options) else {
+            let (_, rx) = tokio::sync::mpsc::channel(1);
+            return Ok((
+                SpeedtestBackfiller::new(pool, rx, None),
+                BackfillPollerServer::noop(),
+            ));
+        };
+
+        let (reports, reports_server) = file_source::continuous_source()
+            .state(pool.clone())
+            .bucket_client(bucket_client)
+            .prefix(FileType::VerifiedSpeedtest.to_string())
+            .lookback_start_after(options.start_after)
+            .stop_after(options.stop_after)
+            .process_name(options.process_name)
+            .poll_duration_opt(options.poll_duration)
+            .idle_timeout_opt(options.idle_timeout)
+            .create()
+            .await?;
+
+        Ok((
+            SpeedtestBackfiller::new(pool, reports, Some(writer)),
+            BackfillPollerServer::active(reports_server),
+        ))
+    }
+
+    pub async fn handle(
+        &mut self,
+        file: Option<FileInfoStream<VerifiedSpeedtest>>,
+    ) -> anyhow::Result<()> {
+        let Some(file_info_stream) = file else {
+            tracing::info!("speedtest backfiller completed");
+            self.done = true;
+            return Ok(());
+        };
+        tracing::info!(
+            file = %file_info_stream.file_info,
+            timestamp = %file_info_stream.file_info.timestamp,
+            "backfilling speedtest file"
+        );
+        self.handle_file(file_info_stream).await
+    }
+
+    async fn handle_file(&self, file: FileInfoStream<VerifiedSpeedtest>) -> anyhow::Result<()> {
+        let Some(ref writer) = self.writer else {
+            return Ok(());
+        };
+
+        let file_info = file.file_info.clone();
+        let write_id = file_info.key.clone();
+        let mut txn = self.pool.begin().await?;
+
+        let records = file.into_stream(&mut txn).await?;
+        let all: Vec<_> = records.collect().await;
+        let total = all.len();
+
+        let iceberg_rows: Vec<_> = all
+            .into_iter()
+            .filter(|v| v.result == SpeedtestResult::SpeedtestValid)
+            .map(|v| iceberg::IcebergSpeedtest::from(&v.report))
+            .collect();
+
+        let valid_count = iceberg_rows.len();
+        writer
+            .write_idempotent(&write_id, iceberg_rows)
+            .await
+            .context("writing speedtests to iceberg")?;
+
+        txn.commit().await?;
+        tracing::info!(
+            file = %file_info,
+            valid_count,
+            filtered_count = total - valid_count,
+            "backfilled speedtest file"
+        );
+        Ok(())
+    }
+
+    async fn run(mut self, mut shutdown: triggered::Listener) -> anyhow::Result<()> {
+        tracing::info!("speedtest backfiller starting");
+        loop {
+            if self.done {
+                tracing::info!("speedtest backfiller complete");
+                return Ok(());
+            }
+            tokio::select! {
+                biased;
+                _ = &mut shutdown => {
+                    tracing::info!("speedtest backfiller shutting down");
+                    return Ok(());
+                }
+                file = self.recv() => {
+                    self.handle(file).await?;
+                }
+            }
+        }
+    }
+}
+
+impl ManagedTask for SpeedtestBackfiller {
+    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
+        task_manager::spawn(self.run(shutdown))
+    }
+}
+
+// ── SpeedtestDaemon ───────────────────────────────────────────────────────────
+
 pub struct SpeedtestDaemon<GIR> {
     pool: sqlx::Pool<sqlx::Postgres>,
     gateway_info_resolver: GIR,
     speedtests: Receiver<FileInfoStream<CellSpeedtestIngestReport>>,
     speedtest_avg_file_sink: FileSinkClient<SpeedtestAvgProto>,
     verified_speedtest_file_sink: FileSinkClient<VerifiedSpeedtestProto>,
+    iceberg_writer: Option<iceberg::SpeedtestWriter>,
+    speedtest_backfill: SpeedtestBackfiller,
 }
 
 impl<GIR> SpeedtestDaemon<GIR>
@@ -69,11 +277,12 @@ where
     GIR: GatewayInfoResolver,
 {
     pub async fn create_managed_task(
-        pool: Pool<Postgres>,
+        pool: PgPool,
         settings: &Settings,
         file_upload: FileUpload,
         bucket_client: BucketClient,
         gateway_resolver: GIR,
+        iceberg_writer: Option<iceberg::SpeedtestWriter>,
     ) -> anyhow::Result<impl ManagedTask> {
         let (speedtests_avg, speedtests_avg_server) = SpeedtestAvgProto::file_sink(
             &settings.cache,
@@ -101,18 +310,34 @@ where
             .create()
             .await?;
 
+        let backfill_opts = settings
+            .speedtest_backfill
+            .as_ref()
+            .map(BackfillOptions::from_settings);
+
+        let (speedtest_backfill, backfill_server) = SpeedtestBackfiller::create(
+            pool.clone(),
+            settings.buckets.output.connect().await,
+            iceberg_writer.clone(),
+            backfill_opts,
+        )
+        .await?;
+
         let speedtest_daemon = SpeedtestDaemon::new(
             pool.clone(),
             gateway_resolver,
             speedtests,
             speedtests_avg,
             speedtests_validity,
+            iceberg_writer,
+            speedtest_backfill,
         );
 
         Ok(TaskManager::builder()
             .add_task(speedtests_validity_server)
             .add_task(speedtests_avg_server)
             .add_task(speedtests_server)
+            .add_task(backfill_server)
             .add_task(speedtest_daemon)
             .build())
     }
@@ -123,6 +348,8 @@ where
         speedtests: Receiver<FileInfoStream<CellSpeedtestIngestReport>>,
         speedtest_avg_file_sink: FileSinkClient<SpeedtestAvgProto>,
         verified_speedtest_file_sink: FileSinkClient<VerifiedSpeedtestProto>,
+        iceberg_writer: Option<iceberg::SpeedtestWriter>,
+        speedtest_backfill: SpeedtestBackfiller,
     ) -> Self {
         Self {
             pool,
@@ -130,6 +357,8 @@ where
             speedtests,
             speedtest_avg_file_sink,
             verified_speedtest_file_sink,
+            iceberg_writer,
+            speedtest_backfill,
         }
     }
 
@@ -147,6 +376,11 @@ where
                     metrics::histogram!("speedtest_processing_time")
                         .record(start.elapsed());
                 }
+                // Backfill runs at lowest priority — only fires when ingest has nothing ready.
+                // When iceberg is not configured, recv() returns pending() immediately.
+                file = self.speedtest_backfill.recv() => {
+                    self.speedtest_backfill.handle(file).await?;
+                }
             }
         }
 
@@ -158,8 +392,11 @@ where
         file: FileInfoStream<CellSpeedtestIngestReport>,
     ) -> anyhow::Result<()> {
         tracing::info!("Processing speedtest file {}", file.file_info.key);
+        let write_id = file.file_info.key.clone();
         let mut transaction = self.pool.begin().await?;
         let mut speedtests = file.into_stream(&mut transaction).await?;
+
+        let mut iceberg_records = Vec::new();
 
         while let Some(speedtest_report) = speedtests.next().await {
             let result = self.validate_speedtest(&speedtest_report).await?;
@@ -173,11 +410,19 @@ where
                 .await?;
                 let average = SpeedtestAverage::from(latest_speedtests);
                 average.write(&self.speedtest_avg_file_sink).await?;
+
+                if self.iceberg_writer.is_some() {
+                    iceberg_records.push(iceberg::IcebergSpeedtest::from(&speedtest_report));
+                }
             }
             // write out paper trail of speedtest validity
             self.write_verified_speedtest(speedtest_report, result)
                 .await?;
         }
+
+        iceberg::maybe_write_idempotent(self.iceberg_writer.as_ref(), &write_id, iceberg_records)
+            .await?;
+
         self.speedtest_avg_file_sink.commit().await?;
         self.verified_speedtest_file_sink.commit().await?;
         transaction.commit().await?;
@@ -238,7 +483,7 @@ where
 
 pub async fn save_speedtest(
     speedtest: &CellSpeedtest,
-    exec: &mut Transaction<'_, Postgres>,
+    exec: &mut PgTransaction<'_>,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
         r#"
@@ -261,7 +506,7 @@ pub async fn save_speedtest(
 pub async fn get_latest_speedtests_for_pubkey(
     pubkey: &PublicKeyBinary,
     timestamp: DateTime<Utc>,
-    exec: &mut Transaction<'_, Postgres>,
+    exec: &mut PgTransaction<'_>,
 ) -> Result<Vec<Speedtest>, sqlx::Error> {
     let speedtests = sqlx::query_as::<_, Speedtest>(
         r#"
@@ -285,7 +530,7 @@ pub async fn get_latest_speedtests_for_pubkey(
 
 pub async fn aggregate_epoch_speedtests(
     epoch_end: DateTime<Utc>,
-    exec: &sqlx::Pool<sqlx::Postgres>,
+    exec: &PgPool,
 ) -> Result<EpochSpeedTests, sqlx::Error> {
     let mut speedtests = EpochSpeedTests::new();
     // use latest speedtest which are no older than N hours, defined by SPEEDTEST_LAPSE
@@ -313,7 +558,7 @@ pub async fn aggregate_epoch_speedtests(
 }
 
 pub async fn clear_speedtests(
-    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    tx: &mut PgTransaction<'_>,
     epoch_end: &DateTime<Utc>,
 ) -> Result<(), sqlx::Error> {
     let oldest_ts = *epoch_end - chrono::Duration::hours(SPEEDTEST_LAPSE);

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -128,7 +128,7 @@ where
         let backfill_opts = settings
             .speedtest_backfill
             .as_ref()
-            .map(|b| b.into_options("speedtest-backfill"));
+            .map(|b| b.as_options("speedtest-backfill"));
 
         let (speedtest_backfill, backfill_server) = SpeedtestBackfiller::create(
             pool.clone(),

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -1,10 +1,9 @@
 use crate::{
+    backfill::{Backfiller, BackfillOptions, IcebergBackfill},
     iceberg,
-    settings::BackfillSettings,
     speedtests_average::{SpeedtestAverage, SPEEDTEST_LAPSE},
     Settings,
 };
-use anyhow::Context;
 use chrono::{DateTime, Utc};
 use coverage_point_calculator::speedtest::BYTES_PER_MEGABIT;
 use file_store::{
@@ -59,206 +58,22 @@ impl FromRow<'_, PgRow> for Speedtest {
     }
 }
 
-// ── Backfill support types ────────────────────────────────────────────────────
+// ── Speedtest backfill ────────────────────────────────────────────────────────
 
-pub struct BackfillOptions {
-    pub process_name: String,
-    pub start_after: DateTime<Utc>,
-    pub stop_after: DateTime<Utc>,
-    pub poll_duration: Option<Duration>,
-    pub idle_timeout: Option<Duration>,
-}
+pub struct SpeedtestConverter;
 
-impl BackfillOptions {
-    pub fn from_settings(settings: &BackfillSettings) -> Self {
-        Self {
-            process_name: "speedtest-backfill".to_string(),
-            start_after: settings.start_after,
-            stop_after: settings.stop_after,
-            poll_duration: None,
-            idle_timeout: None,
-        }
-    }
+impl IcebergBackfill for SpeedtestConverter {
+    type FileRecord = VerifiedSpeedtest;
+    type IcebergRow = iceberg::IcebergSpeedtest;
+    const FILE_TYPE: FileType = FileType::VerifiedSpeedtest;
 
-    pub fn poll_duration(mut self, d: Duration) -> Self {
-        self.poll_duration = Some(d);
-        self
-    }
-
-    pub fn idle_timeout(mut self, d: Duration) -> Self {
-        self.idle_timeout = Some(d);
-        self
+    fn convert(record: VerifiedSpeedtest) -> Option<iceberg::IcebergSpeedtest> {
+        (record.result == SpeedtestResult::SpeedtestValid)
+            .then(|| iceberg::IcebergSpeedtest::from(&record.report))
     }
 }
 
-/// Wraps a file-source poller server that may or may not exist.
-/// Always implements `ManagedTask` — returns immediately when there is nothing to do.
-pub struct BackfillPollerServer(Option<Box<dyn ManagedTask>>);
-
-impl BackfillPollerServer {
-    fn noop() -> Self {
-        Self(None)
-    }
-
-    fn active(server: impl ManagedTask + 'static) -> Self {
-        Self(Some(Box::new(server)))
-    }
-}
-
-impl ManagedTask for BackfillPollerServer {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        match (*self).0 {
-            Some(task) => task.start_task(shutdown),
-            None => task_manager::spawn(async { anyhow::Ok(()) }),
-        }
-    }
-}
-
-// ── SpeedtestBackfiller ───────────────────────────────────────────────────────
-
-/// Reads historical `VerifiedSpeedtest` files from the output bucket and writes
-/// valid speedtests to the `poc.speedtests` iceberg table. When no writer or
-/// options are configured it becomes a no-op whose `recv()` never returns.
-pub struct SpeedtestBackfiller {
-    pool: PgPool,
-    reports: Receiver<FileInfoStream<VerifiedSpeedtest>>,
-    writer: Option<iceberg::SpeedtestWriter>,
-    done: bool,
-}
-
-impl SpeedtestBackfiller {
-    pub fn new(
-        pool: PgPool,
-        reports: Receiver<FileInfoStream<VerifiedSpeedtest>>,
-        writer: Option<iceberg::SpeedtestWriter>,
-    ) -> Self {
-        let done = writer.is_none();
-        Self {
-            pool,
-            reports,
-            writer,
-            done,
-        }
-    }
-
-    pub async fn recv(&mut self) -> Option<FileInfoStream<VerifiedSpeedtest>> {
-        if self.done {
-            std::future::pending().await
-        } else {
-            self.reports.recv().await
-        }
-    }
-
-    pub async fn create(
-        pool: PgPool,
-        bucket_client: BucketClient,
-        writer: Option<iceberg::SpeedtestWriter>,
-        options: Option<BackfillOptions>,
-    ) -> anyhow::Result<(Self, BackfillPollerServer)> {
-        let (Some(writer), Some(options)) = (writer, options) else {
-            let (_, rx) = tokio::sync::mpsc::channel(1);
-            return Ok((
-                SpeedtestBackfiller::new(pool, rx, None),
-                BackfillPollerServer::noop(),
-            ));
-        };
-
-        let (reports, reports_server) = file_source::continuous_source()
-            .state(pool.clone())
-            .bucket_client(bucket_client)
-            .prefix(FileType::VerifiedSpeedtest.to_string())
-            .lookback_start_after(options.start_after)
-            .stop_after(options.stop_after)
-            .process_name(options.process_name)
-            .poll_duration_opt(options.poll_duration)
-            .idle_timeout_opt(options.idle_timeout)
-            .create()
-            .await?;
-
-        Ok((
-            SpeedtestBackfiller::new(pool, reports, Some(writer)),
-            BackfillPollerServer::active(reports_server),
-        ))
-    }
-
-    pub async fn handle(
-        &mut self,
-        file: Option<FileInfoStream<VerifiedSpeedtest>>,
-    ) -> anyhow::Result<()> {
-        let Some(file_info_stream) = file else {
-            tracing::info!("speedtest backfiller completed");
-            self.done = true;
-            return Ok(());
-        };
-        tracing::info!(
-            file = %file_info_stream.file_info,
-            timestamp = %file_info_stream.file_info.timestamp,
-            "backfilling speedtest file"
-        );
-        self.handle_file(file_info_stream).await
-    }
-
-    async fn handle_file(&self, file: FileInfoStream<VerifiedSpeedtest>) -> anyhow::Result<()> {
-        let Some(ref writer) = self.writer else {
-            return Ok(());
-        };
-
-        let file_info = file.file_info.clone();
-        let write_id = file_info.key.clone();
-        let mut txn = self.pool.begin().await?;
-
-        let records = file.into_stream(&mut txn).await?;
-        let all: Vec<_> = records.collect().await;
-        let total = all.len();
-
-        let iceberg_rows: Vec<_> = all
-            .into_iter()
-            .filter(|v| v.result == SpeedtestResult::SpeedtestValid)
-            .map(|v| iceberg::IcebergSpeedtest::from(&v.report))
-            .collect();
-
-        let valid_count = iceberg_rows.len();
-        writer
-            .write_idempotent(&write_id, iceberg_rows)
-            .await
-            .context("writing speedtests to iceberg")?;
-
-        txn.commit().await?;
-        tracing::info!(
-            file = %file_info,
-            valid_count,
-            filtered_count = total - valid_count,
-            "backfilled speedtest file"
-        );
-        Ok(())
-    }
-
-    async fn run(mut self, mut shutdown: triggered::Listener) -> anyhow::Result<()> {
-        tracing::info!("speedtest backfiller starting");
-        loop {
-            if self.done {
-                tracing::info!("speedtest backfiller complete");
-                return Ok(());
-            }
-            tokio::select! {
-                biased;
-                _ = &mut shutdown => {
-                    tracing::info!("speedtest backfiller shutting down");
-                    return Ok(());
-                }
-                file = self.recv() => {
-                    self.handle(file).await?;
-                }
-            }
-        }
-    }
-}
-
-impl ManagedTask for SpeedtestBackfiller {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        task_manager::spawn(self.run(shutdown))
-    }
-}
+pub type SpeedtestBackfiller = Backfiller<SpeedtestConverter>;
 
 // ── SpeedtestDaemon ───────────────────────────────────────────────────────────
 
@@ -310,10 +125,13 @@ where
             .create()
             .await?;
 
-        let backfill_opts = settings
-            .speedtest_backfill
-            .as_ref()
-            .map(BackfillOptions::from_settings);
+        let backfill_opts = settings.speedtest_backfill.as_ref().map(|b| BackfillOptions {
+            process_name: "speedtest-backfill".to_string(),
+            start_after: b.start_after,
+            stop_after: b.stop_after,
+            poll_duration: None,
+            idle_timeout: None,
+        });
 
         let (speedtest_backfill, backfill_server) = SpeedtestBackfiller::create(
             pool.clone(),

--- a/mobile_verifier/tests/integrations/common/mod.rs
+++ b/mobile_verifier/tests/integrations/common/mod.rs
@@ -438,6 +438,7 @@ impl<V: AsStringKeyedMapKey + Clone> AsStringKeyedMap<V> for Vec<V> {
 pub async fn setup_iceberg() -> anyhow::Result<IcebergTestHarness> {
     let harness = IcebergTestHarness::new_with_tables([
         mobile_verifier::iceberg::heartbeat::table_definition()?,
+        mobile_verifier::iceberg::speedtest::table_definition()?,
     ])
     .await?;
     Ok(harness)

--- a/mobile_verifier/tests/integrations/main.rs
+++ b/mobile_verifier/tests/integrations/main.rs
@@ -12,3 +12,4 @@ mod rewarder_poc_dc;
 mod rewarder_sp_rewards;
 mod seniority;
 mod speedtests;
+mod speedtests_iceberg;

--- a/mobile_verifier/tests/integrations/speedtests.rs
+++ b/mobile_verifier/tests/integrations/speedtests.rs
@@ -15,8 +15,13 @@ use mobile_config::{
         service::info::{DeviceType, GatewayInfo, GatewayInfoStream},
     },
 };
-use mobile_verifier::speedtests::SpeedtestDaemon;
+use mobile_verifier::speedtests::{SpeedtestBackfiller, SpeedtestDaemon};
 use sqlx::{Pool, Postgres};
+
+fn noop_backfiller(pool: Pool<Postgres>) -> SpeedtestBackfiller {
+    let (_, rx) = tokio::sync::mpsc::channel(1);
+    SpeedtestBackfiller::new(pool, rx, None)
+}
 
 #[derive(Clone)]
 struct MockGatewayInfoResolver {}
@@ -69,11 +74,13 @@ async fn speedtests_average_should_only_include_last_48_hours(
     // Drop the daemon when it's done running to close the channel
     {
         let daemon = SpeedtestDaemon::new(
-            pool,
+            pool.clone(),
             gateway_info_resolver,
             rx,
             speedtest_avg_client,
             verified_client,
+            None,
+            noop_backfiller(pool),
         );
 
         daemon.process_file(stream).await?;
@@ -99,11 +106,13 @@ async fn speedtest_upload_exceeds_300megabits_ps_limit(pool: Pool<Postgres>) -> 
         "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6".parse()?;
 
     let daemon = SpeedtestDaemon::new(
-        pool,
+        pool.clone(),
         gateway_info_resolver,
         rx,
         speedtest_avg_client,
         verified_client,
+        None,
+        noop_backfiller(pool),
     );
 
     let speedtest_report = CellSpeedtestIngestReport {
@@ -137,11 +146,13 @@ async fn speedtest_download_exceeds_300_megabits_ps_limit(
         "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6".parse()?;
 
     let daemon = SpeedtestDaemon::new(
-        pool,
+        pool.clone(),
         gateway_info_resolver,
         rx,
         speedtest_avg_client,
         verified_client,
+        None,
+        noop_backfiller(pool),
     );
 
     // Create speedtest with download speed > 300Mbits
@@ -176,11 +187,13 @@ async fn speedtest_both_speeds_exceed_300_megabits_ps_limit(
         "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6".parse()?;
 
     let daemon = SpeedtestDaemon::new(
-        pool,
+        pool.clone(),
         gateway_info_resolver,
         rx,
         speedtest_avg_client,
         verified_client,
+        None,
+        noop_backfiller(pool),
     );
 
     // Create speedtest with both speeds > 300Mbits
@@ -215,11 +228,13 @@ async fn speedtest_within_300_megabits_ps_limit_should_be_valid(
         "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6".parse()?;
 
     let daemon = SpeedtestDaemon::new(
-        pool,
+        pool.clone(),
         gateway_info_resolver,
         rx,
         speedtest_avg_client,
         verified_client,
+        None,
+        noop_backfiller(pool),
     );
 
     // Create speedtest with both speeds within 300Mbits limit
@@ -254,11 +269,13 @@ async fn speedtest_exactly_300_megabits_ps_limit_should_be_valid(
         "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6".parse()?;
 
     let daemon = SpeedtestDaemon::new(
-        pool,
+        pool.clone(),
         gateway_info_resolver,
         rx,
         speedtest_avg_client,
         verified_client,
+        None,
+        noop_backfiller(pool),
     );
 
     // Create speedtest with speeds exactly at 300Mbits limit
@@ -357,11 +374,13 @@ async fn invalid_speedtests_should_not_affect_average(pool: Pool<Postgres>) -> a
     // Drop the daemon when it's done running to close the channel
     {
         let daemon = SpeedtestDaemon::new(
-            pool,
+            pool.clone(),
             gateway_info_resolver,
             rx,
             speedtest_avg_client,
             verified_client,
+            None,
+            noop_backfiller(pool),
         );
 
         daemon.process_file(stream).await?;

--- a/mobile_verifier/tests/integrations/speedtests_iceberg.rs
+++ b/mobile_verifier/tests/integrations/speedtests_iceberg.rs
@@ -7,8 +7,9 @@ use helium_proto::services::poc_mobile::{
     VerifiedSpeedtest as VerifiedSpeedtestProto,
 };
 use mobile_verifier::{
+    backfill::BackfillOptions,
     iceberg::{self, speedtest::IcebergSpeedtest},
-    speedtests::{BackfillOptions, SpeedtestBackfiller},
+    speedtests::SpeedtestBackfiller,
 };
 use sqlx::PgPool;
 

--- a/mobile_verifier/tests/integrations/speedtests_iceberg.rs
+++ b/mobile_verifier/tests/integrations/speedtests_iceberg.rs
@@ -1,0 +1,312 @@
+use chrono::{DateTime, Duration, SubsecRound, Utc};
+use file_store::aws_local::AwsLocal;
+use file_store_oracles::{speedtest::CellSpeedtestIngestReport, FileType};
+use helium_crypto::PublicKeyBinary;
+use helium_proto::services::poc_mobile::{
+    SpeedtestIngestReportV1, SpeedtestReqV1, SpeedtestVerificationResult,
+    VerifiedSpeedtest as VerifiedSpeedtestProto,
+};
+use mobile_verifier::{
+    iceberg::{self, speedtest::IcebergSpeedtest},
+    speedtests::{BackfillOptions, SpeedtestBackfiller},
+};
+use sqlx::PgPool;
+
+const TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+fn test_backfill_options(
+    process_name: &str,
+    start_after: DateTime<Utc>,
+    stop_after: DateTime<Utc>,
+) -> BackfillOptions {
+    BackfillOptions {
+        process_name: process_name.to_string(),
+        start_after,
+        stop_after,
+        poll_duration: Some(std::time::Duration::from_millis(100)),
+        idle_timeout: Some(std::time::Duration::from_millis(500)),
+    }
+}
+
+fn make_iceberg_speedtest(seed: u8) -> IcebergSpeedtest {
+    let pubkey = PublicKeyBinary::from(vec![seed, seed, seed]);
+    let now = Utc::now().trunc_subsecs(3);
+    let received = now + Duration::seconds(1);
+    let report = CellSpeedtestIngestReport {
+        received_timestamp: received,
+        report: file_store_oracles::speedtest::CellSpeedtest {
+            pubkey,
+            serial: "test-serial".to_string(),
+            timestamp: now,
+            upload_speed: 10_000_000,
+            download_speed: 100_000_000,
+            latency: 25,
+        },
+    };
+    IcebergSpeedtest::from(&report)
+}
+
+fn make_verified_speedtest_proto(
+    timestamp: DateTime<Utc>,
+    result: SpeedtestVerificationResult,
+) -> VerifiedSpeedtestProto {
+    let pubkey: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
+        .parse()
+        .unwrap();
+    let ts_ms = timestamp.timestamp_millis() as u64;
+    let ts_s = timestamp.timestamp() as u64;
+    VerifiedSpeedtestProto {
+        report: Some(SpeedtestIngestReportV1 {
+            received_timestamp: ts_ms,
+            report: Some(SpeedtestReqV1 {
+                pub_key: pubkey.as_ref().to_vec(),
+                serial: "test-serial".to_string(),
+                timestamp: ts_s,
+                upload_speed: 10_000_000,
+                download_speed: 100_000_000,
+                latency: 25,
+                signature: vec![],
+            }),
+        }),
+        result: result as i32,
+        timestamp: ts_ms,
+    }
+}
+
+// ── Pure write tests (no DB needed) ──────────────────────────────────────────
+
+#[tokio::test]
+async fn write_single_speedtest() -> anyhow::Result<()> {
+    let harness = crate::common::setup_iceberg().await?;
+    let writer = harness
+        .get_table_writer::<IcebergSpeedtest>(iceberg::speedtest::TABLE_NAME)
+        .await?;
+
+    let record = make_iceberg_speedtest(1);
+
+    writer
+        .write_idempotent("test_single", vec![record.clone()])
+        .await?;
+
+    let all = iceberg::speedtest::get_all(harness.trino()).await?;
+    assert_eq!(all, vec![record]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn write_multiple_speedtests() -> anyhow::Result<()> {
+    let harness = crate::common::setup_iceberg().await?;
+    let writer = harness
+        .get_table_writer::<IcebergSpeedtest>(iceberg::speedtest::TABLE_NAME)
+        .await?;
+
+    let records: Vec<IcebergSpeedtest> = (1u8..=5).map(make_iceberg_speedtest).collect();
+
+    writer.write_idempotent("test_multiple", records).await?;
+
+    let all = iceberg::speedtest::get_all(harness.trino()).await?;
+    assert_eq!(all.len(), 5);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn idempotent_write_deduplicates() -> anyhow::Result<()> {
+    let harness = crate::common::setup_iceberg().await?;
+    let writer = harness
+        .get_table_writer::<IcebergSpeedtest>(iceberg::speedtest::TABLE_NAME)
+        .await?;
+
+    let record = make_iceberg_speedtest(1);
+
+    writer
+        .write_idempotent("same_id", vec![record.clone()])
+        .await?;
+    writer
+        .write_idempotent("same_id", vec![record.clone()])
+        .await?;
+
+    let all = iceberg::speedtest::get_all(harness.trino()).await?;
+    assert_eq!(all.len(), 1, "second write with same id should be a no-op");
+
+    Ok(())
+}
+
+// ── Backfill tests (DB needed for file-tracking state) ────────────────────────
+
+#[sqlx::test]
+async fn backfill_writes_speedtests_to_iceberg(pool: PgPool) -> anyhow::Result<()> {
+    let harness = crate::common::setup_iceberg().await?;
+    let writer = harness
+        .get_table_writer::<IcebergSpeedtest>(iceberg::speedtest::TABLE_NAME)
+        .await?;
+
+    let awsl = AwsLocal::new().await;
+    awsl.create_bucket().await?;
+
+    let base_time = Utc::now() - Duration::hours(1);
+    let start_time = base_time - Duration::minutes(1);
+    let file1_time = base_time;
+    let file2_time = base_time + Duration::minutes(5);
+    let end_time = base_time + Duration::days(42);
+
+    awsl.put_protos_at_time(
+        FileType::VerifiedSpeedtest.to_string(),
+        vec![make_verified_speedtest_proto(
+            file1_time,
+            SpeedtestVerificationResult::SpeedtestValid,
+        )],
+        file1_time,
+    )
+    .await?;
+
+    awsl.put_protos_at_time(
+        FileType::VerifiedSpeedtest.to_string(),
+        vec![make_verified_speedtest_proto(
+            file2_time,
+            SpeedtestVerificationResult::SpeedtestValid,
+        )],
+        file2_time,
+    )
+    .await?;
+
+    let opts = test_backfill_options("test-backfill", start_time, end_time);
+    let (backfiller, server) =
+        SpeedtestBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts)).await?;
+
+    tokio::time::timeout(
+        TEST_TIMEOUT,
+        task_manager::TaskManager::builder()
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start(),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("backfill timed out after {:?}", TEST_TIMEOUT))??;
+
+    let rows = iceberg::speedtest::get_all(harness.trino()).await?;
+    assert_eq!(rows.len(), 2, "expected 2 speedtests in iceberg");
+
+    awsl.cleanup().await?;
+    Ok(())
+}
+
+#[sqlx::test]
+async fn backfill_filters_invalid_speedtests(pool: PgPool) -> anyhow::Result<()> {
+    let harness = crate::common::setup_iceberg().await?;
+    let writer = harness
+        .get_table_writer::<IcebergSpeedtest>(iceberg::speedtest::TABLE_NAME)
+        .await?;
+
+    let awsl = AwsLocal::new().await;
+    awsl.create_bucket().await?;
+
+    let base_time = Utc::now() - Duration::hours(1);
+    let start_time = base_time - Duration::minutes(1);
+    let file_time = base_time;
+    let end_time = base_time + Duration::days(42);
+
+    awsl.put_protos_at_time(
+        FileType::VerifiedSpeedtest.to_string(),
+        vec![
+            make_verified_speedtest_proto(file_time, SpeedtestVerificationResult::SpeedtestValid),
+            make_verified_speedtest_proto(
+                file_time,
+                SpeedtestVerificationResult::SpeedtestValueOutOfBounds,
+            ),
+            make_verified_speedtest_proto(
+                file_time,
+                SpeedtestVerificationResult::SpeedtestGatewayNotFound,
+            ),
+        ],
+        file_time,
+    )
+    .await?;
+
+    let opts = test_backfill_options("test-backfill-filter", start_time, end_time);
+    let (backfiller, server) =
+        SpeedtestBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts)).await?;
+
+    tokio::time::timeout(
+        TEST_TIMEOUT,
+        task_manager::TaskManager::builder()
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start(),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("backfill timed out after {:?}", TEST_TIMEOUT))??;
+
+    let rows = iceberg::speedtest::get_all(harness.trino()).await?;
+    assert_eq!(
+        rows.len(),
+        1,
+        "only valid speedtests should be written to iceberg"
+    );
+
+    awsl.cleanup().await?;
+    Ok(())
+}
+
+#[sqlx::test]
+async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
+    let harness = crate::common::setup_iceberg().await?;
+    let writer = harness
+        .get_table_writer::<IcebergSpeedtest>(iceberg::speedtest::TABLE_NAME)
+        .await?;
+
+    let awsl = AwsLocal::new().await;
+    awsl.create_bucket().await?;
+
+    let base_time = Utc::now() - Duration::hours(2);
+    let start_time = base_time - Duration::minutes(1);
+    let file1_time = base_time;
+    let file2_time = base_time + Duration::minutes(30);
+    let stop_time = base_time + Duration::minutes(45);
+    let file3_time = base_time + Duration::hours(1); // should be skipped
+
+    for (time, label) in [
+        (file1_time, "file1"),
+        (file2_time, "file2"),
+        (file3_time, "file3"),
+    ] {
+        awsl.put_protos_at_time(
+            FileType::VerifiedSpeedtest.to_string(),
+            vec![make_verified_speedtest_proto(
+                time,
+                SpeedtestVerificationResult::SpeedtestValid,
+            )],
+            time,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("failed to put {label}: {e}"));
+    }
+
+    let opts = test_backfill_options("test-backfill-stop", start_time, stop_time);
+    let (backfiller, server) =
+        SpeedtestBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts)).await?;
+
+    tokio::time::timeout(
+        TEST_TIMEOUT,
+        task_manager::TaskManager::builder()
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start(),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("backfill timed out after {:?}", TEST_TIMEOUT))??;
+
+    let rows = iceberg::speedtest::get_all(harness.trino()).await?;
+    assert_eq!(
+        rows.len(),
+        2,
+        "expected 2 speedtests (file3 after stop_after should be skipped)"
+    );
+
+    awsl.cleanup().await?;
+    Ok(())
+}


### PR DESCRIPTION
Start writing speedtests to iceberg.
Along with adding the backfill machinery for verified speedtests.

I went back and forth on the standalone backfill commands. Thought we could maybe use it to test out the fast append stuff.

Backfill specific settings are separate from iceberg settings, and they will be separate for upcoming backfills of other types so they can be enabled/disabled independently.

The difference in construction between the `PocWriters` and the `RewardWriters` seemed a bit odd to me at first, but what I've been telling myself is that the `PocWriters` are independent of one another and the `RewardWriters` work as a unit. So there's a difference between each field being optional versus the entire struct being optional. 

I made each backfill process_name overrideable in case we want to change the settings and start from a new place without needing to make a new release. 

### Questions
I'm starting to notice that we have some differences in how we treat public keys. For example.
|||
|---|---|
| `speedtest` | `hotspot_pubkey` |
|`heartbeat`|`hotspot_pubkey`|
| `radio_reward_covered_hex` | `hotspot_key`|
|`radio_reward`|`hotspot_key`|
|`gateway_reward`|`hotspot_key`|
|`service_provider_reward`|`rewardable_entity_key`|

Do we want to try and consolidate some of these...

(service provider reward is an outlier for many reasons, I'm mostly going after the suffix of `key` vs `pubkey` vs `pub_key` (that could potentially sneak it's way in if we're no vigilant)).