### PR TITLE
remove BackfillSettings and Backfiller from speedtest

### DIFF
--- a/mobile_verifier/src/settings.rs
+++ b/mobile_verifier/src/settings.rs
@@ -50,56 +50,11 @@ pub struct Settings {
     #[serde(with = "humantime_serde", default = "default_data_sets_poll_duration")]
     pub data_sets_poll_duration: Duration,
     pub iceberg_settings: Option<helium_iceberg::Settings>,
-    /// Settings for speedtest Iceberg backfill. Only used when iceberg_settings is configured.
-    /// Backfill processes VerifiedSpeedtest files from `speedtest_backfill.start_after` up to
-    /// `speedtest_backfill.stop_after` (the Iceberg deployment date). When absent, the backfiller
-    /// is a no-op and no file poller is started.
-    #[serde(default)]
-    pub speedtest_backfill: Option<BackfillSettings>,
     // Geofencing settings
     #[serde(default = "default_usa_and_mexico_geofence_regions")]
     pub usa_and_mexico_geofence_regions: PathBuf,
     #[serde(default = "default_fencing_resolution")]
     pub usa_and_mexico_fencing_resolution: u8,
-}
-
-/// Settings controlling the Iceberg backfill window.
-///
-/// Backfill covers [start_after, stop_after). Set stop_after to the date Iceberg
-/// was first enabled in production. Files before that date are written by the
-/// backfiller; files on or after are written by the daemon's real-time path.
-#[derive(Debug, Deserialize, Serialize)]
-pub struct BackfillSettings {
-    /// Start of the backfill window. Defaults to UNIX_EPOCH (backfill all available history).
-    #[serde(default = "default_backfill_start_after")]
-    pub start_after: DateTime<Utc>,
-    /// End of the backfill window (exclusive). Must be set to the Iceberg deployment date
-    /// to prevent the backfiller from overlapping with the daemon's real-time Iceberg writes.
-    pub stop_after: DateTime<Utc>,
-    /// Override the process name used to track backfill position in the database.
-    /// Change this to force a full re-backfill without touching the database directly.
-    /// When absent, each backfiller uses its own default name.
-    #[serde(default)]
-    pub process_name: Option<String>,
-}
-
-impl BackfillSettings {
-    pub fn as_options(&self, default_name: impl Into<String>) -> crate::backfill::BackfillOptions {
-        crate::backfill::BackfillOptions {
-            process_name: self
-                .process_name
-                .clone()
-                .unwrap_or_else(|| default_name.into()),
-            start_after: self.start_after,
-            stop_after: self.stop_after,
-            poll_duration: None,
-            idle_timeout: None,
-        }
-    }
-}
-
-fn default_backfill_start_after() -> DateTime<Utc> {
-    DateTime::UNIX_EPOCH
 }
 
 fn default_fencing_resolution() -> u8 {

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -84,7 +84,6 @@ pub struct SpeedtestDaemon<GIR> {
     speedtest_avg_file_sink: FileSinkClient<SpeedtestAvgProto>,
     verified_speedtest_file_sink: FileSinkClient<VerifiedSpeedtestProto>,
     iceberg_writer: Option<iceberg::SpeedtestWriter>,
-    speedtest_backfill: SpeedtestBackfiller,
 }
 
 impl<GIR> SpeedtestDaemon<GIR>
@@ -125,19 +124,6 @@ where
             .create()
             .await?;
 
-        let backfill_opts = settings
-            .speedtest_backfill
-            .as_ref()
-            .map(|b| b.as_options("speedtest-backfill"));
-
-        let (speedtest_backfill, backfill_server) = SpeedtestBackfiller::create(
-            pool.clone(),
-            settings.buckets.output.connect().await,
-            iceberg_writer.clone(),
-            backfill_opts,
-        )
-        .await?;
-
         let speedtest_daemon = SpeedtestDaemon::new(
             pool.clone(),
             gateway_resolver,
@@ -145,14 +131,12 @@ where
             speedtests_avg,
             speedtests_validity,
             iceberg_writer,
-            speedtest_backfill,
         );
 
         Ok(TaskManager::builder()
             .add_task(speedtests_validity_server)
             .add_task(speedtests_avg_server)
             .add_task(speedtests_server)
-            .add_task(backfill_server)
             .add_task(speedtest_daemon)
             .build())
     }
@@ -164,7 +148,6 @@ where
         speedtest_avg_file_sink: FileSinkClient<SpeedtestAvgProto>,
         verified_speedtest_file_sink: FileSinkClient<VerifiedSpeedtestProto>,
         iceberg_writer: Option<iceberg::SpeedtestWriter>,
-        speedtest_backfill: SpeedtestBackfiller,
     ) -> Self {
         Self {
             pool,
@@ -173,7 +156,6 @@ where
             speedtest_avg_file_sink,
             verified_speedtest_file_sink,
             iceberg_writer,
-            speedtest_backfill,
         }
     }
 
@@ -190,11 +172,6 @@ where
                     self.process_file(file).await?;
                     metrics::histogram!("speedtest_processing_time")
                         .record(start.elapsed());
-                }
-                // Backfill runs at lowest priority — only fires when ingest has nothing ready.
-                // When iceberg is not configured, recv() returns pending() immediately.
-                file = self.speedtest_backfill.recv() => {
-                    self.speedtest_backfill.handle(file).await?;
                 }
             }
         }

--- a/mobile_verifier/tests/integrations/speedtests.rs
+++ b/mobile_verifier/tests/integrations/speedtests.rs
@@ -15,13 +15,8 @@ use mobile_config::{
         service::info::{DeviceType, GatewayInfo, GatewayInfoStream},
     },
 };
-use mobile_verifier::speedtests::{SpeedtestBackfiller, SpeedtestDaemon};
+use mobile_verifier::speedtests::SpeedtestDaemon;
 use sqlx::{Pool, Postgres};
-
-fn noop_backfiller(pool: Pool<Postgres>) -> SpeedtestBackfiller {
-    let (_, rx) = tokio::sync::mpsc::channel(1);
-    SpeedtestBackfiller::new(pool, rx, None)
-}
 
 #[derive(Clone)]
 struct MockGatewayInfoResolver {}
@@ -80,7 +75,6 @@ async fn speedtests_average_should_only_include_last_48_hours(
             speedtest_avg_client,
             verified_client,
             None,
-            noop_backfiller(pool),
         );
 
         daemon.process_file(stream).await?;
@@ -112,7 +106,6 @@ async fn speedtest_upload_exceeds_300megabits_ps_limit(pool: Pool<Postgres>) -> 
         speedtest_avg_client,
         verified_client,
         None,
-        noop_backfiller(pool),
     );
 
     let speedtest_report = CellSpeedtestIngestReport {
@@ -152,7 +145,6 @@ async fn speedtest_download_exceeds_300_megabits_ps_limit(
         speedtest_avg_client,
         verified_client,
         None,
-        noop_backfiller(pool),
     );
 
     // Create speedtest with download speed > 300Mbits
@@ -193,7 +185,6 @@ async fn speedtest_both_speeds_exceed_300_megabits_ps_limit(
         speedtest_avg_client,
         verified_client,
         None,
-        noop_backfiller(pool),
     );
 
     // Create speedtest with both speeds > 300Mbits
@@ -234,7 +225,6 @@ async fn speedtest_within_300_megabits_ps_limit_should_be_valid(
         speedtest_avg_client,
         verified_client,
         None,
-        noop_backfiller(pool),
     );
 
     // Create speedtest with both speeds within 300Mbits limit
@@ -275,7 +265,6 @@ async fn speedtest_exactly_300_megabits_ps_limit_should_be_valid(
         speedtest_avg_client,
         verified_client,
         None,
-        noop_backfiller(pool),
     );
 
     // Create speedtest with speeds exactly at 300Mbits limit
@@ -380,7 +369,6 @@ async fn invalid_speedtests_should_not_affect_average(pool: Pool<Postgres>) -> a
             speedtest_avg_client,
             verified_client,
             None,
-            noop_backfiller(pool),
         );
 
         daemon.process_file(stream).await?;


### PR DESCRIPTION
With the fast_append writing flow, we don't need to be as worried about threading writes from multiple places into the same tables when we know the data will not overlap. Let's go back to simplifying our Daemons, and running backfill as the oneshots that they are.