### PR TITLE
Add new Iceberg BatchedWriter that auto handles batches and is durabl…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3784,6 +3784,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrow-array",
+ "arrow-ipc",
  "arrow-json",
  "arrow-schema",
  "async-trait",
@@ -3799,11 +3800,14 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "task-manager",
+ "tempfile",
  "thiserror 1.0.69",
  "tls-init",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "triggered",
  "trino-rust-client",
  "uuid",
 ]

--- a/helium_iceberg/Cargo.toml
+++ b/helium_iceberg/Cargo.toml
@@ -32,11 +32,14 @@ uuid = { workspace = true, features = ["v7"] }
 
 # Arrow dependencies
 arrow-array = "57"
+arrow-ipc = "57"
 arrow-json = "57"
 arrow-schema = "57"
 parquet = "57"
 
+task-manager = { path = "../task_manager" }
 tls-init = { path = "../tls_init" }
+triggered = { workspace = true }
 
 # Test harness dependencies (optional)
 trino-rust-client = { version = "0.9", optional = true }
@@ -45,4 +48,5 @@ derive_builder = { workspace = true, optional = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 rand = { workspace = true }
+tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/helium_iceberg/src/batched_writer/mod.rs
+++ b/helium_iceberg/src/batched_writer/mod.rs
@@ -22,7 +22,7 @@
 mod spool;
 
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 use task_manager::{ManagedTask, TaskFuture};
@@ -176,6 +176,12 @@ where
     T: Serialize + Send + Sync + 'static,
 {
     pub async fn run(mut self, shutdown: triggered::Listener) -> Result<()> {
+        let table_label = {
+            let guard = self.table.table.read().await;
+            let id = guard.identifier();
+            format!("{}.{}", id.namespace().to_url_string(), id.name())
+        };
+
         Spool::replay_dir(&self.config.spool_dir, &self.table).await?;
         let mut spool = Spool::create(&self.config.spool_dir, &self.table).await?;
 
@@ -187,13 +193,11 @@ where
             tokio::select! {
                 biased;
                 _ = shutdown.clone() => {
-                    spool.flush_to_iceberg(&self.table).await?;
+                    log_flush(&mut spool, &self.table, &table_label, "shutdown").await?;
                     break;
                 }
                 _ = timer.tick() => {
-                    if !spool.is_empty() {
-                        spool.flush_to_iceberg(&self.table).await?;
-                    }
+                    log_flush(&mut spool, &self.table, &table_label, "timeout").await?;
                 }
                 msg = self.receiver.recv() => match msg {
                     Some(BatchMessage::Queue(records, ack)) => {
@@ -211,18 +215,19 @@ where
                         let append_ok = append_res.is_ok();
                         let _ = ack.send(append_res);
                         if append_ok && spool.record_count() >= self.config.max_batch_size {
-                            spool.flush_to_iceberg(&self.table).await?;
+                            log_flush(&mut spool, &self.table, &table_label, "size").await?;
                             timer.reset();
                         }
                     }
                     Some(BatchMessage::Flush(ack)) => {
-                        let res = spool.flush_to_iceberg(&self.table).await;
+                        let res = log_flush(&mut spool, &self.table, &table_label, "manual").await;
                         let _ = ack.send(res);
                         timer.reset();
                     }
                     None => {
                         // All handles dropped. Drain and exit.
-                        spool.flush_to_iceberg(&self.table).await?;
+                        log_flush(&mut spool, &self.table, &table_label, "channel_closed")
+                            .await?;
                         break;
                     }
                 }
@@ -240,4 +245,33 @@ where
     fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> TaskFuture {
         task_manager::spawn((*self).run(shutdown))
     }
+}
+
+/// Flush the spool to Iceberg and emit an info log on success. No-op
+/// (and no log) when the spool has no buffered records — empty
+/// timer/shutdown ticks shouldn't show up in logs.
+async fn log_flush<T>(
+    spool: &mut Spool,
+    table: &IcebergTable<T>,
+    table_label: &str,
+    reason: &'static str,
+) -> Result<()>
+where
+    T: Serialize + Send + Sync + 'static,
+{
+    if spool.is_empty() {
+        return Ok(());
+    }
+    let records = spool.record_count();
+    let started = Instant::now();
+    spool.flush_to_iceberg(table).await?;
+    let duration_ms = started.elapsed().as_millis() as u64;
+    tracing::info!(
+        table = table_label,
+        reason,
+        records,
+        duration_ms,
+        "flushed batch to iceberg",
+    );
+    Ok(())
 }

--- a/helium_iceberg/src/batched_writer/mod.rs
+++ b/helium_iceberg/src/batched_writer/mod.rs
@@ -1,0 +1,243 @@
+//! Batching layer over [`IcebergTable`] with on-disk spooling.
+//!
+//! Callers `queue` records into a `BatchedWriter` handle; a background
+//! [`BatchedWriterTask`] accumulates them in an Arrow-IPC spool file on
+//! disk and commits to Iceberg when either the size or time threshold is
+//! reached, on explicit `flush()`, or on shutdown. On startup, any
+//! leftover spool files from a prior run are replayed before the writer
+//! accepts new traffic.
+//!
+//! `queue` and `queue_all` await a per-message ack so they don't return
+//! until the records have been pushed through `BufWriter` to the kernel
+//! page cache. After they return, the records survive a process abort
+//! (only a kernel crash or hardware failure loses them). The Iceberg
+//! commit itself is still asynchronous — call `flush()` when you need
+//! that synchronization point.
+//!
+//! The spool gives us crash recovery between flushes without a separate
+//! WAL: queue → disk → kernel page cache; on restart, replay reads the
+//! file back and commits before resuming. See [`spool`] for the file
+//! lifecycle and truncation handling.
+
+mod spool;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::Serialize;
+use task_manager::{ManagedTask, TaskFuture};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::{self, MissedTickBehavior};
+
+use crate::iceberg_table::{records_to_batch, IcebergTable};
+use crate::{Error, Result};
+use spool::Spool;
+
+const DEFAULT_MAX_BATCH_SIZE: usize = 10_000;
+const DEFAULT_BATCH_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_CHANNEL_SIZE: usize = 100;
+
+/// Configuration for [`BatchedWriter`].
+///
+/// `spool_dir` is required; the other knobs default to 10_000 records /
+/// 60 s timeout / 100-message channel. There is no `Default` impl
+/// because there's no sensible default for `spool_dir`.
+#[derive(Debug, Clone)]
+pub struct BatchedWriterConfig {
+    pub max_batch_size: usize,
+    pub batch_timeout: Duration,
+    pub channel_size: usize,
+    pub spool_dir: PathBuf,
+}
+
+impl BatchedWriterConfig {
+    pub fn new(spool_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            max_batch_size: DEFAULT_MAX_BATCH_SIZE,
+            batch_timeout: DEFAULT_BATCH_TIMEOUT,
+            channel_size: DEFAULT_CHANNEL_SIZE,
+            spool_dir: spool_dir.into(),
+        }
+    }
+
+    pub fn with_max_batch_size(mut self, n: usize) -> Self {
+        self.max_batch_size = n;
+        self
+    }
+
+    pub fn with_batch_timeout(mut self, d: Duration) -> Self {
+        self.batch_timeout = d;
+        self
+    }
+
+    pub fn with_channel_size(mut self, n: usize) -> Self {
+        self.channel_size = n;
+        self
+    }
+}
+
+enum BatchMessage<T> {
+    /// `ack` fires once the records have been appended to the spool and
+    /// pushed to the kernel page cache (BufWriter::flush). Caller waits
+    /// on it before returning from `queue` / `queue_all`.
+    Queue(Vec<T>, oneshot::Sender<Result<()>>),
+    Flush(oneshot::Sender<Result<()>>),
+}
+
+/// Cloneable handle over a batched, spooled writer to an [`IcebergTable`].
+///
+/// `queue` and `queue_all` send the records to the background task and
+/// wait for an ack — they return only after the records are durable in
+/// the kernel page cache. The Iceberg commit itself is still
+/// asynchronous; `flush` is the synchronization point for that.
+pub struct BatchedWriter<T> {
+    sender: mpsc::Sender<BatchMessage<T>>,
+}
+
+// Manual `Clone`: deriving would add a spurious `T: Clone` bound even
+// though `mpsc::Sender<_>` is `Clone` regardless of `T`.
+impl<T> Clone for BatchedWriter<T> {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+        }
+    }
+}
+
+impl<T> BatchedWriter<T>
+where
+    T: Serialize + Send + Sync + 'static,
+{
+    /// Build the handle and the background task. Caller registers the
+    /// task with `TaskManager` (or spawns `task.run(shutdown)` directly).
+    /// Spool replay happens inside `task.run`, not here.
+    pub fn new(
+        table: IcebergTable<T>,
+        config: BatchedWriterConfig,
+    ) -> (Self, BatchedWriterTask<T>) {
+        let (sender, receiver) = mpsc::channel(config.channel_size);
+        let task = BatchedWriterTask {
+            table,
+            receiver,
+            config,
+        };
+        (Self { sender }, task)
+    }
+
+    /// Queue a single record. Returns once the record is appended to
+    /// the on-disk spool (kernel page cache) — survives a process abort.
+    /// Named `queue` (not `write`) to make it obvious that no Iceberg
+    /// commit has happened yet.
+    pub async fn queue(&self, record: T) -> Result<()> {
+        self.queue_all(vec![record]).await
+    }
+
+    /// Queue many records as a single message so they're converted to
+    /// one `RecordBatch` together (cheaper than per-record). Returns
+    /// once the records are appended to the on-disk spool. Mirrors
+    /// `FileSinkClient::write_all`.
+    pub async fn queue_all(&self, records: Vec<T>) -> Result<()> {
+        if records.is_empty() {
+            return Ok(());
+        }
+        let (ack_tx, ack_rx) = oneshot::channel();
+        self.sender
+            .send(BatchMessage::Queue(records, ack_tx))
+            .await
+            .map_err(|_| Error::Writer("batched writer task closed".into()))?;
+        ack_rx
+            .await
+            .map_err(|_| Error::Writer("batched writer task closed before queue ack".into()))?
+    }
+
+    /// Force an immediate flush and wait for the result. Returns the
+    /// success/failure of the underlying Iceberg commit.
+    pub async fn flush(&self) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(BatchMessage::Flush(tx))
+            .await
+            .map_err(|_| Error::Writer("batched writer task closed".into()))?;
+        rx.await
+            .map_err(|_| Error::Writer("batched writer task closed before flush ack".into()))?
+    }
+}
+
+/// Background task that drains the queue, manages the on-disk spool, and
+/// commits batches to Iceberg.
+pub struct BatchedWriterTask<T> {
+    table: IcebergTable<T>,
+    receiver: mpsc::Receiver<BatchMessage<T>>,
+    config: BatchedWriterConfig,
+}
+
+impl<T> BatchedWriterTask<T>
+where
+    T: Serialize + Send + Sync + 'static,
+{
+    pub async fn run(mut self, shutdown: triggered::Listener) -> Result<()> {
+        Spool::replay_dir(&self.config.spool_dir, &self.table).await?;
+        let mut spool = Spool::create(&self.config.spool_dir, &self.table).await?;
+
+        let mut timer = time::interval(self.config.batch_timeout);
+        timer.set_missed_tick_behavior(MissedTickBehavior::Burst);
+        timer.tick().await; // discard the immediate first tick
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown.clone() => {
+                    spool.flush_to_iceberg(&self.table).await?;
+                    break;
+                }
+                _ = timer.tick() => {
+                    if !spool.is_empty() {
+                        spool.flush_to_iceberg(&self.table).await?;
+                    }
+                }
+                msg = self.receiver.recv() => match msg {
+                    Some(BatchMessage::Queue(records, ack)) => {
+                        // Ack as soon as the records are on disk — don't
+                        // make the caller wait for any size-triggered
+                        // Iceberg commit that follows.
+                        let append_res = (async {
+                            let batch = {
+                                let guard = self.table.table.read().await;
+                                records_to_batch(&guard, &records)?
+                            };
+                            spool.append(batch).await
+                        })
+                        .await;
+                        let append_ok = append_res.is_ok();
+                        let _ = ack.send(append_res);
+                        if append_ok && spool.record_count() >= self.config.max_batch_size {
+                            spool.flush_to_iceberg(&self.table).await?;
+                            timer.reset();
+                        }
+                    }
+                    Some(BatchMessage::Flush(ack)) => {
+                        let res = spool.flush_to_iceberg(&self.table).await;
+                        let _ = ack.send(res);
+                        timer.reset();
+                    }
+                    None => {
+                        // All handles dropped. Drain and exit.
+                        spool.flush_to_iceberg(&self.table).await?;
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<T> ManagedTask for BatchedWriterTask<T>
+where
+    T: Serialize + Send + Sync + 'static,
+{
+    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> TaskFuture {
+        task_manager::spawn((*self).run(shutdown))
+    }
+}

--- a/helium_iceberg/src/batched_writer/mod.rs
+++ b/helium_iceberg/src/batched_writer/mod.rs
@@ -193,11 +193,11 @@ where
             tokio::select! {
                 biased;
                 _ = shutdown.clone() => {
-                    log_flush(&mut spool, &self.table, &table_label, "shutdown").await?;
+                    flush_to_iceberg(&mut spool, &self.table, &table_label, "shutdown").await?;
                     break;
                 }
                 _ = timer.tick() => {
-                    log_flush(&mut spool, &self.table, &table_label, "timeout").await?;
+                    flush_to_iceberg(&mut spool, &self.table, &table_label, "timeout").await?;
                 }
                 msg = self.receiver.recv() => match msg {
                     Some(BatchMessage::Queue(records, ack)) => {
@@ -215,18 +215,18 @@ where
                         let append_ok = append_res.is_ok();
                         let _ = ack.send(append_res);
                         if append_ok && spool.record_count() >= self.config.max_batch_size {
-                            log_flush(&mut spool, &self.table, &table_label, "size").await?;
+                            flush_to_iceberg(&mut spool, &self.table, &table_label, "size").await?;
                             timer.reset();
                         }
                     }
                     Some(BatchMessage::Flush(ack)) => {
-                        let res = log_flush(&mut spool, &self.table, &table_label, "manual").await;
+                        let res = flush_to_iceberg(&mut spool, &self.table, &table_label, "manual").await;
                         let _ = ack.send(res);
                         timer.reset();
                     }
                     None => {
                         // All handles dropped. Drain and exit.
-                        log_flush(&mut spool, &self.table, &table_label, "channel_closed")
+                        flush_to_iceberg(&mut spool, &self.table, &table_label, "channel_closed")
                             .await?;
                         break;
                     }
@@ -250,7 +250,7 @@ where
 /// Flush the spool to Iceberg and emit an info log on success. No-op
 /// (and no log) when the spool has no buffered records — empty
 /// timer/shutdown ticks shouldn't show up in logs.
-async fn log_flush<T>(
+async fn flush_to_iceberg<T>(
     spool: &mut Spool,
     table: &IcebergTable<T>,
     table_label: &str,

--- a/helium_iceberg/src/batched_writer/spool.rs
+++ b/helium_iceberg/src/batched_writer/spool.rs
@@ -1,0 +1,325 @@
+//! On-disk spool for `BatchedWriter`.
+//!
+//! Records arriving via `BatchedWriter::queue` are converted to
+//! `RecordBatch` and appended to a per-task Arrow-IPC stream file in
+//! `spool_dir`. The buffer lives on disk, not in memory, so a crash
+//! between queue and flush is recoverable: on the next startup,
+//! `Spool::replay_dir` reads any leftover files for the same table and
+//! commits them to Iceberg before the writer accepts new work.
+//!
+//! The IPC stream format is chosen because each batch is length-prefixed
+//! — a partial trailing batch from a hard kill is detectable on read and
+//! discarded, so the well-formed prefix still replays cleanly.
+//!
+//! Files are opened lazily: a fresh `Spool` and a `Spool` immediately
+//! after a successful flush both have no open file. The next `append`
+//! opens one. This keeps clean shutdowns from leaving zero-record files
+//! behind in the spool directory.
+
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arrow_array::RecordBatch;
+use arrow_ipc::{reader::StreamReader, writer::StreamWriter};
+use arrow_schema::SchemaRef;
+use iceberg::arrow::schema_to_arrow_schema;
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::iceberg_table::IcebergTable;
+use crate::{Error, Result};
+
+const SPOOL_FILE_EXT: &str = "arrow";
+
+pub(super) struct Spool {
+    spool_dir: PathBuf,
+    table_prefix: String,
+    schema: SchemaRef,
+    /// `None` until the first append after construction or after a
+    /// successful flush.
+    open: Option<OpenFile>,
+}
+
+struct OpenFile {
+    path: PathBuf,
+    writer: StreamWriter<BufWriter<File>>,
+    record_count: usize,
+}
+
+impl Spool {
+    /// Construct a Spool bound to `table` in `spool_dir`. Doesn't open
+    /// a file yet — the first `append` does.
+    pub(super) async fn create<T>(spool_dir: &Path, table: &IcebergTable<T>) -> Result<Self>
+    where
+        T: Serialize + Send + Sync + 'static,
+    {
+        let schema = arrow_schema_for(table).await?;
+        let table_prefix = table_prefix_for(table).await?;
+
+        tokio::fs::create_dir_all(spool_dir)
+            .await
+            .map_err(|e| Error::Writer(format!("create spool dir: {e}")))?;
+
+        Ok(Self {
+            spool_dir: spool_dir.to_path_buf(),
+            table_prefix,
+            schema,
+            open: None,
+        })
+    }
+
+    pub(super) fn record_count(&self) -> usize {
+        self.open.as_ref().map(|o| o.record_count).unwrap_or(0)
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.record_count() == 0
+    }
+
+    /// Append a `RecordBatch` and push it through the BufWriter so it
+    /// reaches the kernel page cache. Doesn't fsync — see
+    /// `flush_to_iceberg` for that. Pushing past BufWriter on every
+    /// append makes the batch recoverable across a process abort, even
+    /// without an explicit shutdown.
+    pub(super) async fn append(&mut self, batch: RecordBatch) -> Result<()> {
+        if batch.num_rows() == 0 {
+            return Ok(());
+        }
+        let added = batch.num_rows();
+
+        let mut open = match self.open.take() {
+            Some(o) => o,
+            None => {
+                let (path, writer) =
+                    open_new_writer(&self.spool_dir, &self.table_prefix, self.schema.clone())
+                        .await?;
+                OpenFile {
+                    path,
+                    writer,
+                    record_count: 0,
+                }
+            }
+        };
+
+        let writer = open.writer;
+        let (writer, write_res) =
+            tokio::task::spawn_blocking(move || -> (_, std::io::Result<()>) {
+                let mut writer = writer;
+                let res = (|| {
+                    writer
+                        .write(&batch)
+                        .map_err(|e| std::io::Error::other(e.to_string()))?;
+                    writer.get_mut().flush()
+                })();
+                (writer, res)
+            })
+            .await
+            .map_err(|e| Error::Writer(format!("join error: {e}")))?;
+
+        open.writer = writer;
+        write_res.map_err(|e| Error::Writer(format!("spool append: {e}")))?;
+        open.record_count += added;
+        self.open = Some(open);
+        Ok(())
+    }
+
+    /// Close the current writer, fsync, read all batches back, commit
+    /// them as a single Iceberg snapshot, and delete the file. Leaves
+    /// the spool with no open file — the next append opens a fresh one.
+    /// No-op if no file is open.
+    pub(super) async fn flush_to_iceberg<T>(&mut self, table: &IcebergTable<T>) -> Result<()>
+    where
+        T: Serialize + Send + Sync + 'static,
+    {
+        let Some(open) = self.open.take() else {
+            return Ok(());
+        };
+        let OpenFile {
+            path,
+            writer,
+            record_count,
+        } = open;
+
+        if record_count == 0 {
+            // Empty open file (shouldn't normally happen — append only
+            // creates a file when there are rows to write — but guard
+            // anyway). Drop the writer and remove the file.
+            drop(writer);
+            let _ = tokio::fs::remove_file(&path).await;
+            return Ok(());
+        }
+
+        let path_for_finish = path.clone();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut writer = writer;
+            writer.finish().map_err(Error::Arrow)?;
+            let buf = writer.into_inner().map_err(Error::Arrow)?;
+            let file = buf
+                .into_inner()
+                .map_err(|e| Error::Writer(format!("flush bufwriter: {e}")))?;
+            file.sync_data()
+                .map_err(|e| Error::Writer(format!("fsync {}: {e}", path_for_finish.display())))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| Error::Writer(format!("join error: {e}")))??;
+
+        let path_for_read = path.clone();
+        let batches = tokio::task::spawn_blocking(move || read_all_batches(&path_for_read))
+            .await
+            .map_err(|e| Error::Writer(format!("join error: {e}")))??;
+
+        table.write_record_batches(batches).await?;
+
+        tokio::fs::remove_file(&path)
+            .await
+            .map_err(|e| Error::Writer(format!("remove {}: {e}", path.display())))?;
+
+        Ok(())
+    }
+
+    /// Replay every leftover spool file in `spool_dir` belonging to
+    /// `table`. Each file: read its batches, commit to Iceberg, then
+    /// remove. Truncated trailing batches are dropped silently (kill -9
+    /// mid-append). Schema mismatch surfaces from
+    /// `IcebergTable::write_record_batches`.
+    pub(super) async fn replay_dir<T>(spool_dir: &Path, table: &IcebergTable<T>) -> Result<()>
+    where
+        T: Serialize + Send + Sync + 'static,
+    {
+        if !spool_dir.exists() {
+            return Ok(());
+        }
+        let prefix = table_prefix_for(table).await?;
+        let paths = collect_spool_files(spool_dir, &prefix).await?;
+
+        for path in paths {
+            tracing::info!(path = %path.display(), "replaying spool file");
+            let path_for_read = path.clone();
+            let batches = tokio::task::spawn_blocking(move || read_all_batches(&path_for_read))
+                .await
+                .map_err(|e| Error::Writer(format!("join error: {e}")))??;
+
+            if batches.is_empty() {
+                tracing::info!(path = %path.display(), "spool file empty, removing");
+            } else {
+                let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+                tracing::info!(
+                    path = %path.display(),
+                    batches = batches.len(),
+                    records = total,
+                    "committing replayed batches",
+                );
+                table.write_record_batches(batches).await?;
+            }
+
+            tokio::fs::remove_file(&path)
+                .await
+                .map_err(|e| Error::Writer(format!("remove {}: {e}", path.display())))?;
+        }
+        Ok(())
+    }
+}
+
+async fn arrow_schema_for<T>(table: &IcebergTable<T>) -> Result<SchemaRef> {
+    let guard = table.table.read().await;
+    let iceberg_schema = guard.metadata().current_schema();
+    let arrow_schema = schema_to_arrow_schema(iceberg_schema).map_err(Error::Iceberg)?;
+    Ok(Arc::new(arrow_schema))
+}
+
+async fn table_prefix_for<T>(table: &IcebergTable<T>) -> Result<String> {
+    let guard = table.table.read().await;
+    let identifier = guard.identifier();
+    let namespace = identifier.namespace().to_url_string();
+    let name = identifier.name();
+    Ok(format!("{}__{}", sanitize(&namespace), sanitize(name)))
+}
+
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+async fn open_new_writer(
+    spool_dir: &Path,
+    prefix: &str,
+    schema: SchemaRef,
+) -> Result<(PathBuf, StreamWriter<BufWriter<File>>)> {
+    let filename = format!("{prefix}__{}.{SPOOL_FILE_EXT}", Uuid::now_v7());
+    let path = spool_dir.join(filename);
+    let path_for_create = path.clone();
+    let writer = tokio::task::spawn_blocking(move || -> Result<_> {
+        let file = File::create(&path_for_create)
+            .map_err(|e| Error::Writer(format!("create {}: {e}", path_for_create.display())))?;
+        let buf = BufWriter::new(file);
+        StreamWriter::try_new(buf, &schema).map_err(Error::Arrow)
+    })
+    .await
+    .map_err(|e| Error::Writer(format!("join error: {e}")))??;
+    Ok((path, writer))
+}
+
+fn read_all_batches(path: &Path) -> Result<Vec<RecordBatch>> {
+    let file =
+        File::open(path).map_err(|e| Error::Writer(format!("open {}: {e}", path.display())))?;
+    let reader = match StreamReader::try_new(BufReader::new(file), None) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "spool file has unreadable header, treating as empty",
+            );
+            return Ok(Vec::new());
+        }
+    };
+    let mut batches = Vec::new();
+    for batch in reader {
+        match batch {
+            Ok(b) => batches.push(b),
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "stopping replay early at malformed batch (likely truncated tail)",
+                );
+                break;
+            }
+        }
+    }
+    Ok(batches)
+}
+
+async fn collect_spool_files(spool_dir: &Path, prefix: &str) -> Result<Vec<PathBuf>> {
+    let mut entries = tokio::fs::read_dir(spool_dir)
+        .await
+        .map_err(|e| Error::Writer(format!("read_dir {}: {e}", spool_dir.display())))?;
+    let mut paths = Vec::new();
+    let prefix_full = format!("{prefix}__");
+    let suffix = format!(".{SPOOL_FILE_EXT}");
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .map_err(|e| Error::Writer(format!("next_entry: {e}")))?
+    {
+        let path = entry.path();
+        let Some(filename) = path.file_name().and_then(|f| f.to_str()) else {
+            continue;
+        };
+        if filename.starts_with(&prefix_full) && filename.ends_with(&suffix) {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}

--- a/helium_iceberg/src/iceberg_table.rs
+++ b/helium_iceberg/src/iceberg_table.rs
@@ -74,11 +74,22 @@ impl<T> IcebergTable<T> {
 
     async fn write_and_commit(
         &self,
-        batch: RecordBatch,
+        batches: Vec<RecordBatch>,
         snapshot_properties: HashMap<String, String>,
     ) -> Result {
-        let data_files = write_data_files(&self.table, batch).await?;
+        let data_files = write_data_files(&self.table, batches).await?;
         self.commit_files(data_files, snapshot_properties).await
+    }
+
+    /// Commit one or more pre-built `RecordBatch`es as a single Iceberg
+    /// snapshot. All batches must share the table's current schema. Used
+    /// by `BatchedWriter` after replaying its on-disk spool so we don't
+    /// re-serialize through arrow-json on the way back to Iceberg.
+    pub async fn write_record_batches(&self, batches: Vec<RecordBatch>) -> Result {
+        if batches.iter().all(|b| b.num_rows() == 0) {
+            return Ok(());
+        }
+        self.write_and_commit(batches, HashMap::new()).await
     }
 
     async fn commit_files(
@@ -124,7 +135,7 @@ impl<T: Serialize + Send + Sync + 'static> DataWriter<T> for IcebergTable<T> {
         let table = self.table.read().await;
         let batch = records_to_batch(&table, &records)?;
         drop(table);
-        self.write_and_commit(batch, HashMap::new()).await
+        self.write_and_commit(vec![batch], HashMap::new()).await
     }
 
     async fn write_idempotent(&self, id: &str, records: Vec<T>) -> Result {
@@ -144,7 +155,7 @@ impl<T: Serialize + Send + Sync + 'static> DataWriter<T> for IcebergTable<T> {
         drop(table);
 
         let props = HashMap::from([(WRITE_ID_PROPERTY.to_string(), id.to_string())]);
-        self.write_and_commit(batch, props).await
+        self.write_and_commit(vec![batch], props).await
     }
 }
 
@@ -158,7 +169,7 @@ pub(crate) async fn reload_table(catalog: &Catalog, table: &RwLock<Table>) -> Re
     Ok(())
 }
 
-fn records_to_batch<T: Serialize>(table: &Table, records: &[T]) -> Result<RecordBatch> {
+pub(crate) fn records_to_batch<T: Serialize>(table: &Table, records: &[T]) -> Result<RecordBatch> {
     let iceberg_schema = table.metadata().current_schema();
     let arrow_schema = schema_to_arrow_schema(iceberg_schema).map_err(Error::Iceberg)?;
 
@@ -178,7 +189,7 @@ fn records_to_batch<T: Serialize>(table: &Table, records: &[T]) -> Result<Record
 
 async fn write_data_files(
     table: &RwLock<Table>,
-    batch: RecordBatch,
+    batches: Vec<RecordBatch>,
 ) -> Result<Vec<iceberg::spec::DataFile>> {
     let table_guard = table.read().await;
     let schema = table_guard.metadata().current_schema().clone();
@@ -215,15 +226,19 @@ async fn write_data_files(
         RecordBatchPartitionSplitter::try_new_with_computed_values(schema, partition_spec)
             .map_err(Error::Iceberg)?;
 
-    let partitioned_batches = splitter.split(&batch).map_err(Error::Iceberg)?;
-
     let mut fanout_writer = FanoutWriter::new(data_file_writer_builder);
 
-    for (partition_key, partition_batch) in partitioned_batches {
-        fanout_writer
-            .write(partition_key, partition_batch)
-            .await
-            .map_err(Error::Iceberg)?;
+    for batch in batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let partitioned_batches = splitter.split(&batch).map_err(Error::Iceberg)?;
+        for (partition_key, partition_batch) in partitioned_batches {
+            fanout_writer
+                .write(partition_key, partition_batch)
+                .await
+                .map_err(Error::Iceberg)?;
+        }
     }
 
     fanout_writer.close().await.map_err(Error::Iceberg)

--- a/helium_iceberg/src/lib.rs
+++ b/helium_iceberg/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate tls_init;
 
+mod batched_writer;
 mod catalog;
 mod error;
 mod iceberg_table;
@@ -10,6 +11,7 @@ mod writer;
 #[cfg(feature = "test-harness")]
 pub mod test_harness;
 
+pub use batched_writer::{BatchedWriter, BatchedWriterConfig, BatchedWriterTask};
 pub use catalog::Catalog;
 pub use error::{Error, Result};
 pub use iceberg_table::IcebergTable;

--- a/helium_iceberg/tests/batched_writer.rs
+++ b/helium_iceberg/tests/batched_writer.rs
@@ -1,0 +1,293 @@
+//! End-to-end tests for `BatchedWriter`.
+//!
+//! These run against the real Polaris + Trino + S3 harness provided by
+//! `helium_iceberg::test_harness`. They cover:
+//!
+//! - Size-triggered flushes
+//! - Time-triggered flushes
+//! - Manual `flush()`
+//! - Graceful shutdown drain
+//! - Crash-recovery replay (records spooled to disk before a hard abort
+//!   are committed when a fresh task starts up against the same spool dir)
+
+use std::time::Duration;
+
+use chrono::{DateTime, DurationRound, FixedOffset, Utc};
+use helium_iceberg::{
+    BatchedWriter, BatchedWriterConfig, FieldDefinition, IcebergTable, IcebergTestHarness,
+    PartitionDefinition, TableDefinition,
+};
+use serde::{Deserialize, Serialize};
+use tempfile::TempDir;
+use trino_rust_client::Trino;
+
+const NAMESPACE: &str = "default";
+const TABLE: &str = "people";
+
+#[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
+struct Person {
+    name: String,
+    age: u32,
+    inserted: DateTime<FixedOffset>,
+}
+
+#[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
+struct Count {
+    c: i64,
+}
+
+fn utc_now() -> DateTime<FixedOffset> {
+    // Iceberg truncates to microseconds; round so equality holds against
+    // what Trino returns.
+    Utc::now()
+        .duration_trunc(chrono::Duration::microseconds(1))
+        .expect("round timestamp")
+        .into()
+}
+
+fn person_table_def() -> anyhow::Result<TableDefinition> {
+    Ok(TableDefinition::builder(NAMESPACE, TABLE)
+        .with_fields([
+            FieldDefinition::required_string("name"),
+            FieldDefinition::required_int("age"),
+            FieldDefinition::required_timestamptz("inserted"),
+        ])
+        .with_partition(PartitionDefinition::day("inserted", "inserted_day"))
+        .build()?)
+}
+
+async fn fresh_table(harness: &IcebergTestHarness) -> anyhow::Result<IcebergTable<Person>> {
+    Ok(
+        IcebergTable::<Person>::from_catalog(harness.iceberg_catalog().clone(), NAMESPACE, TABLE)
+            .await?,
+    )
+}
+
+async fn count_in_iceberg(harness: &IcebergTestHarness) -> anyhow::Result<i64> {
+    let counts: Vec<Count> = harness
+        .trino()
+        .get_all::<Count>(format!("SELECT count(*) AS c FROM {NAMESPACE}.{TABLE}"))
+        .await?
+        .into_vec();
+    Ok(counts.first().map(|c| c.c).unwrap_or(0))
+}
+
+async fn count_spool_files(spool_dir: &std::path::Path) -> anyhow::Result<usize> {
+    if !spool_dir.exists() {
+        return Ok(0);
+    }
+    let mut entries = tokio::fs::read_dir(spool_dir).await?;
+    let mut count = 0;
+    while entries.next_entry().await?.is_some() {
+        count += 1;
+    }
+    Ok(count)
+}
+
+fn person(n: usize) -> Person {
+    Person {
+        name: format!("p{n:03}"),
+        age: n as u32,
+        inserted: utc_now(),
+    }
+}
+
+#[tokio::test]
+async fn flushes_when_size_threshold_reached() -> anyhow::Result<()> {
+    let harness = IcebergTestHarness::new_with_tables([person_table_def()?]).await?;
+    let spool_dir = TempDir::new()?;
+
+    let table = fresh_table(&harness).await?;
+    let config = BatchedWriterConfig::new(spool_dir.path())
+        .with_max_batch_size(5)
+        .with_batch_timeout(Duration::from_secs(3600));
+
+    let (writer, task) = BatchedWriter::new(table, config);
+    let (trigger, listener) = triggered::trigger();
+    let handle = tokio::spawn(task.run(listener));
+
+    for i in 0..5 {
+        writer.queue(person(i)).await?;
+    }
+
+    // Size-triggered flush is async; poll briefly until visible.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if count_in_iceberg(&harness).await? == 5 {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("size-triggered flush did not commit 5 rows in time");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    trigger.trigger();
+    drop(writer);
+    handle.await??;
+
+    assert_eq!(count_spool_files(spool_dir.path()).await?, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn flushes_on_batch_timeout() -> anyhow::Result<()> {
+    let harness = IcebergTestHarness::new_with_tables([person_table_def()?]).await?;
+    let spool_dir = TempDir::new()?;
+
+    let table = fresh_table(&harness).await?;
+    let config = BatchedWriterConfig::new(spool_dir.path())
+        .with_max_batch_size(10_000)
+        .with_batch_timeout(Duration::from_millis(150));
+
+    let (writer, task) = BatchedWriter::new(table, config);
+    let (trigger, listener) = triggered::trigger();
+    let handle = tokio::spawn(task.run(listener));
+
+    writer
+        .queue_all(vec![person(0), person(1), person(2)])
+        .await?;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if count_in_iceberg(&harness).await? == 3 {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timeout-triggered flush did not commit 3 rows in time");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    trigger.trigger();
+    drop(writer);
+    handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn flush_method_commits_immediately() -> anyhow::Result<()> {
+    let harness = IcebergTestHarness::new_with_tables([person_table_def()?]).await?;
+    let spool_dir = TempDir::new()?;
+
+    let table = fresh_table(&harness).await?;
+    let config = BatchedWriterConfig::new(spool_dir.path())
+        .with_max_batch_size(10_000)
+        .with_batch_timeout(Duration::from_secs(3600));
+
+    let (writer, task) = BatchedWriter::new(table, config);
+    let (trigger, listener) = triggered::trigger();
+    let handle = tokio::spawn(task.run(listener));
+
+    writer
+        .queue_all(vec![person(0), person(1), person(2)])
+        .await?;
+    writer.flush().await?;
+
+    // After `flush().await?` returns, the rows must already be visible —
+    // no polling required.
+    assert_eq!(count_in_iceberg(&harness).await?, 3);
+
+    trigger.trigger();
+    drop(writer);
+    handle.await??;
+
+    assert_eq!(count_spool_files(spool_dir.path()).await?, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn shutdown_drains_partial_buffer() -> anyhow::Result<()> {
+    let harness = IcebergTestHarness::new_with_tables([person_table_def()?]).await?;
+    let spool_dir = TempDir::new()?;
+
+    let table = fresh_table(&harness).await?;
+    let config = BatchedWriterConfig::new(spool_dir.path())
+        .with_max_batch_size(10_000)
+        .with_batch_timeout(Duration::from_secs(3600));
+
+    let (writer, task) = BatchedWriter::new(table, config);
+    let (trigger, listener) = triggered::trigger();
+    let handle = tokio::spawn(task.run(listener));
+
+    writer.queue_all(vec![person(0), person(1)]).await?;
+    // `queue_all` returning means the records are already in the spool —
+    // no extra wait needed before signalling shutdown.
+
+    trigger.trigger();
+    drop(writer);
+    handle.await??;
+
+    assert_eq!(count_in_iceberg(&harness).await?, 2);
+    assert_eq!(count_spool_files(spool_dir.path()).await?, 0);
+    Ok(())
+}
+
+/// Records that landed in the spool but were never flushed to Iceberg
+/// (process aborted, no graceful shutdown) must be replayed by the next
+/// task that starts up against the same `spool_dir`.
+#[tokio::test]
+async fn replays_leftover_spool_on_startup() -> anyhow::Result<()> {
+    let harness = IcebergTestHarness::new_with_tables([person_table_def()?]).await?;
+    let spool_dir = TempDir::new()?;
+
+    let people = vec![person(0), person(1), person(2)];
+
+    // Phase 1: spool records, then abort the task without flushing.
+    {
+        let table = fresh_table(&harness).await?;
+        let config = BatchedWriterConfig::new(spool_dir.path())
+            .with_max_batch_size(10_000)
+            .with_batch_timeout(Duration::from_secs(3600));
+        let (writer, task) = BatchedWriter::new(table, config);
+        let (_trigger, listener) = triggered::trigger();
+        let handle = tokio::spawn(task.run(listener));
+
+        // `queue_all` returns only after the records are appended to
+        // the spool (kernel page cache via per-append BufWriter::flush),
+        // so by the time it resolves they survive an abort.
+        writer.queue_all(people.clone()).await?;
+
+        // Abort first, *then* drop the handle. Dropping the writer first
+        // would close the channel and trigger the graceful drain branch.
+        handle.abort();
+        let _ = handle.await;
+        drop(writer);
+    }
+
+    // Iceberg should still be empty: no flush happened in phase 1.
+    assert_eq!(count_in_iceberg(&harness).await?, 0);
+    // The spool file is still there waiting for replay.
+    assert!(count_spool_files(spool_dir.path()).await? >= 1);
+
+    // Phase 2: fresh task replays before accepting new work.
+    {
+        let table = fresh_table(&harness).await?;
+        let config = BatchedWriterConfig::new(spool_dir.path())
+            .with_max_batch_size(10_000)
+            .with_batch_timeout(Duration::from_secs(3600));
+        let (writer, task) = BatchedWriter::new(table, config);
+        let (trigger, listener) = triggered::trigger();
+        let handle = tokio::spawn(task.run(listener));
+
+        // `flush()` is processed by the run-loop *after* `replay_dir`,
+        // so when this returns the replayed records are committed.
+        writer.flush().await?;
+
+        trigger.trigger();
+        drop(writer);
+        handle.await??;
+    }
+
+    let mut expected = people;
+    expected.sort_by(|a, b| a.name.cmp(&b.name));
+    let queried: Vec<Person> = harness
+        .trino()
+        .get_all::<Person>(format!("SELECT * FROM {NAMESPACE}.{TABLE} ORDER BY name"))
+        .await?
+        .into_vec();
+    assert_eq!(queried, expected);
+
+    assert_eq!(count_spool_files(spool_dir.path()).await?, 0);
+    Ok(())
+}


### PR DESCRIPTION
## Add `BatchedWriter` to `helium_iceberg` with crash-recovery spooling

### Summary

Introduces `BatchedWriter<T>` — a batching layer over `IcebergTable<T>` that accumulates records, spools them to disk, and commits them to Iceberg in larger snapshots. Designed for streaming-ingestion call sites that today either commit per record (snapshot churn) or hand-roll their own buffering.

Records are durably spooled in Arrow-IPC stream format on the way in, so a process abort between flushes is recoverable: on next startup the new task replays any leftover spool files for its table before accepting new traffic.

### Public API

```rust
let (writer, task) = BatchedWriter::new(
    table,
    BatchedWriterConfig::new(spool_dir)
        .with_max_batch_size(10_000)
        .with_batch_timeout(Duration::from_secs(60)),
);

// Register `task` with TaskManager (impl ManagedTask), or spawn `task.run(shutdown)`.

writer.queue(record).await?;          // returns once on disk (kernel page cache)
writer.queue_all(records).await?;     // batch variant
writer.flush().await?;                // forces an Iceberg commit, waits for result
```

- `queue` / `queue_all` are **ack'd**: they don't return until the records have been pushed through the spool's `BufWriter` to the kernel page cache. After they return, the records survive a process abort.
- The task triggers an Iceberg commit when the spool reaches `max_batch_size`, when `batch_timeout` elapses, on explicit `flush()`, on `triggered::Listener` shutdown, or on channel close.
- Each commit emits an info log: `flushed batch to iceberg table="ns.tbl" reason="size" records=10000 duration_ms=842`. Reasons: `"size"`, `"timeout"`, `"manual"`, `"shutdown"`, `"channel_closed"`.

### How the spool works

- One `{namespace}__{table}__{uuid_v7}.arrow` file per task, opened lazily on first append (so a clean shutdown with nothing buffered leaves the dir empty).
- **Append path**: `T → RecordBatch → StreamWriter::write → BufWriter::flush` (kernel page cache). Wrapped in `spawn_blocking` because `arrow-ipc` is sync-only.
- **Flush path**: `StreamWriter::finish → File::sync_data` (the only fsync) → read all batches back via `StreamReader` → `IcebergTable::write_record_batches` → delete file.
- **Replay path**: scan the dir for files matching the table's prefix, read each, commit, delete. Truncated trailing batches (kill -9 mid-append) are detected and dropped via the IPC stream's length-prefix framing.

### Files changed

| File | Change |
| --- | --- |
| `helium_iceberg/src/batched_writer/mod.rs` | New: `BatchedWriter`, `BatchedWriterConfig`, `BatchedWriterTask`, `ManagedTask` impl, run loop, log helper. |
| `helium_iceberg/src/batched_writer/spool.rs` | New: `Spool` — Arrow-IPC stream lifecycle, append, flush, replay. |
| `helium_iceberg/src/iceberg_table.rs` | `write_data_files` now accepts `Vec<RecordBatch>` so one snapshot can absorb many spool batches; new `IcebergTable::write_record_batches` skips the arrow-json round-trip; `records_to_batch` promoted to `pub(crate)`. |
| `helium_iceberg/src/lib.rs` | Re-export the new types. |
| `helium_iceberg/Cargo.toml` | Add `arrow-ipc`, `task-manager`, `triggered`; `tempfile` as dev-dep. |
| `helium_iceberg/tests/batched_writer.rs` | New: 5 integration tests against the Polaris/Trino/S3 harness. |

### Design decisions

- **Non-idempotent only.** A batch aggregates records from many submissions; idempotency stays on `IcebergTable` directly via `write_idempotent`.
- **Separate API, not `DataWriter<T>`.** `write_idempotent` doesn't fit batching semantics, so we don't pretend to.
- **`ManagedTask` integration.** Mirrors `FileSink` — fits the workspace shutdown story.
- **`spool_dir` is required.** No `Default` impl; the builder's `BatchedWriterConfig::new(spool_dir)` is the entry point.
