### PR TITLE
Backfill use BatchedWriter

### DIFF
--- a/mobile_verifier/src/backfill.rs
+++ b/mobile_verifier/src/backfill.rs
@@ -6,7 +6,12 @@ use file_store::{
 };
 use file_store_oracles::FileType;
 use futures::StreamExt;
-use helium_iceberg::BoxedDataWriter;
+use helium_iceberg::{BatchedWriter, BoxedDataWriter};
+
+enum BackfillWriter<T> {
+    Boxed(BoxedDataWriter<T>),
+    Batched(BatchedWriter<T>),
+}
 use sqlx::PgPool;
 use std::time::{Duration, Instant};
 use task_manager::ManagedTask;
@@ -54,7 +59,7 @@ impl ManagedTask for BackfillPollerServer {
 pub struct Backfiller<C: IcebergBackfill> {
     pool: PgPool,
     reports: Receiver<FileInfoStream<C::FileRecord>>,
-    writer: Option<BoxedDataWriter<C::IcebergRow>>,
+    writer: Option<BackfillWriter<C::IcebergRow>>,
     done: bool,
 }
 
@@ -68,7 +73,7 @@ impl<C: IcebergBackfill> Backfiller<C> {
         Self {
             pool,
             reports,
-            writer,
+            writer: writer.map(BackfillWriter::Boxed),
             done,
         }
     }
@@ -116,10 +121,19 @@ impl<C: IcebergBackfill> Backfiller<C> {
         let rows: Vec<C::IcebergRow> = all.into_iter().filter_map(C::convert).collect();
         let written = rows.len();
 
-        writer
-            .write_idempotent(&write_id, rows)
-            .await
-            .with_context(|| format!("writing {} backfill to iceberg", C::FILE_TYPE))?;
+        match writer {
+            BackfillWriter::Boxed(w) => w
+                .write_idempotent(&write_id, rows)
+                .await
+                .with_context(|| format!("writing {} backfill to iceberg", C::FILE_TYPE))?,
+            BackfillWriter::Batched(w) => {
+                if !rows.is_empty() {
+                    w.queue_all(rows)
+                        .await
+                        .with_context(|| format!("queueing {} backfill", C::FILE_TYPE))?;
+                }
+            }
+        }
 
         txn.commit().await?;
         tracing::info!(
@@ -193,6 +207,45 @@ where
             Backfiller::new(pool, reports, Some(writer)),
             BackfillPollerServer::active(reports_server),
         ))
+    }
+
+    /// Like `create`, but writes go through a `BatchedWriter` (on-disk spool +
+    /// size/time-bounded snapshots) instead of per-file `write_idempotent`.
+    /// Caller is responsible for registering the `BatchedWriterTask` returned
+    /// alongside the writer with the `TaskManager`.
+    pub async fn create_batched(
+        pool: PgPool,
+        bucket_client: BucketClient,
+        writer: Option<BatchedWriter<C::IcebergRow>>,
+        options: Option<BackfillOptions>,
+    ) -> anyhow::Result<(Self, BackfillPollerServer)> {
+        let (Some(writer), Some(options)) = (writer, options) else {
+            let (_, rx) = tokio::sync::mpsc::channel(1);
+            return Ok((
+                Backfiller::new(pool, rx, None),
+                BackfillPollerServer::noop(),
+            ));
+        };
+
+        let (reports, reports_server) = file_source::continuous_source()
+            .state(pool.clone())
+            .bucket_client(bucket_client)
+            .prefix(C::FILE_TYPE.to_string())
+            .lookback_start_after(options.start_after)
+            .stop_after(options.stop_after)
+            .process_name(options.process_name)
+            .poll_duration_opt(options.poll_duration)
+            .idle_timeout_opt(options.idle_timeout)
+            .create()
+            .await?;
+
+        let backfiller = Backfiller {
+            pool,
+            reports,
+            writer: Some(BackfillWriter::Batched(writer)),
+            done: false,
+        };
+        Ok((backfiller, BackfillPollerServer::active(reports_server)))
     }
 }
 

--- a/mobile_verifier/src/backfill.rs
+++ b/mobile_verifier/src/backfill.rs
@@ -7,14 +7,9 @@ use file_store::{
 use file_store_oracles::FileType;
 use futures::StreamExt;
 use helium_iceberg::{
-    BatchedWriter, BatchedWriterConfig, BatchedWriterTask, BoxedDataWriter, Catalog,
-    TableDefinition,
+    BatchedWriter, BatchedWriterConfig, BatchedWriterTask, Catalog, TableDefinition,
 };
 
-enum BackfillWriter<T> {
-    Boxed(BoxedDataWriter<T>),
-    Batched(BatchedWriter<T>),
-}
 use sqlx::PgPool;
 use std::time::{Duration, Instant};
 use task_manager::ManagedTask;
@@ -62,7 +57,7 @@ impl ManagedTask for BackfillPollerServer {
 pub struct Backfiller<C: IcebergBackfill> {
     pool: PgPool,
     reports: Receiver<FileInfoStream<C::FileRecord>>,
-    writer: Option<BackfillWriter<C::IcebergRow>>,
+    writer: Option<BatchedWriter<C::IcebergRow>>,
     done: bool,
 }
 
@@ -70,13 +65,13 @@ impl<C: IcebergBackfill> Backfiller<C> {
     pub fn new(
         pool: PgPool,
         reports: Receiver<FileInfoStream<C::FileRecord>>,
-        writer: Option<BoxedDataWriter<C::IcebergRow>>,
+        writer: Option<BatchedWriter<C::IcebergRow>>,
     ) -> Self {
         let done = writer.is_none();
         Self {
             pool,
             reports,
-            writer: writer.map(BackfillWriter::Boxed),
+            writer,
             done,
         }
     }
@@ -115,7 +110,6 @@ impl<C: IcebergBackfill> Backfiller<C> {
         let start = Instant::now();
 
         let file_info = file.file_info.clone();
-        let write_id = file_info.key.clone();
         let mut txn = self.pool.begin().await?;
 
         let all: Vec<_> = file.into_stream(&mut txn).await?.collect().await;
@@ -124,18 +118,11 @@ impl<C: IcebergBackfill> Backfiller<C> {
         let rows: Vec<C::IcebergRow> = all.into_iter().filter_map(C::convert).collect();
         let written = rows.len();
 
-        match writer {
-            BackfillWriter::Boxed(w) => w
-                .write_idempotent(&write_id, rows)
+        if !rows.is_empty() {
+            writer
+                .queue_all(rows)
                 .await
-                .with_context(|| format!("writing {} backfill to iceberg", C::FILE_TYPE))?,
-            BackfillWriter::Batched(w) => {
-                if !rows.is_empty() {
-                    w.queue_all(rows)
-                        .await
-                        .with_context(|| format!("queueing {} backfill", C::FILE_TYPE))?;
-                }
-            }
+                .with_context(|| format!("queuing {} backfill", C::FILE_TYPE))?;
         }
 
         txn.commit().await?;
@@ -180,38 +167,6 @@ where
     <C::FileRecord as TryFrom<<C::FileRecord as MsgDecode>::Msg>>::Error: std::error::Error,
     <C::FileRecord as MsgDecode>::Msg: prost::Message + Default,
 {
-    pub async fn create(
-        pool: PgPool,
-        bucket_client: BucketClient,
-        writer: Option<BoxedDataWriter<C::IcebergRow>>,
-        options: Option<BackfillOptions>,
-    ) -> anyhow::Result<(Self, BackfillPollerServer)> {
-        let (Some(writer), Some(options)) = (writer, options) else {
-            let (_, rx) = tokio::sync::mpsc::channel(1);
-            return Ok((
-                Backfiller::new(pool, rx, None),
-                BackfillPollerServer::noop(),
-            ));
-        };
-
-        let (reports, reports_server) = file_source::continuous_source()
-            .state(pool.clone())
-            .bucket_client(bucket_client)
-            .prefix(C::FILE_TYPE.to_string())
-            .lookback_start_after(options.start_after)
-            .stop_after(options.stop_after)
-            .process_name(options.process_name)
-            .poll_duration_opt(options.poll_duration)
-            .idle_timeout_opt(options.idle_timeout)
-            .create()
-            .await?;
-
-        Ok((
-            Backfiller::new(pool, reports, Some(writer)),
-            BackfillPollerServer::active(reports_server),
-        ))
-    }
-
     /// Like `create`, but writes go through a `BatchedWriter` (on-disk spool +
     /// size/time-bounded snapshots) instead of per-file `write_idempotent`.
     /// Caller is responsible for registering the `BatchedWriterTask` returned
@@ -245,7 +200,7 @@ where
         let backfiller = Backfiller {
             pool,
             reports,
-            writer: Some(BackfillWriter::Batched(writer)),
+            writer: Some(writer),
             done: false,
         };
         Ok((backfiller, BackfillPollerServer::active(reports_server)))
@@ -277,21 +232,6 @@ fn file_age(file_info: &FileInfo) -> String {
     }
 }
 
-pub async fn batched_writer_for_table<T>(
-    catalog: Catalog,
-    table_def: TableDefinition,
-    config: BatchedWriterConfig,
-) -> anyhow::Result<(BatchedWriter<T>, BatchedWriterTask<T>)>
-where
-    T: serde::Serialize + Send + Sync + 'static,
-{
-    catalog
-        .create_namespace_if_not_exists(table_def.namespace())
-        .await?;
-    let table = catalog.create_table_if_not_exists(table_def).await?;
-    Ok(BatchedWriter::new(table, config))
-}
-
 #[async_trait::async_trait]
 pub trait BatchedWriterExt: Sized {
     async fn batched_writer(
@@ -311,6 +251,10 @@ where
         table_def: TableDefinition,
         config: BatchedWriterConfig,
     ) -> anyhow::Result<(BatchedWriter<Self>, BatchedWriterTask<Self>)> {
-        batched_writer_for_table(catalog, table_def, config).await
+        catalog
+            .create_namespace_if_not_exists(table_def.namespace())
+            .await?;
+        let table = catalog.create_table_if_not_exists(table_def).await?;
+        Ok(BatchedWriter::new(table, config))
     }
 }

--- a/mobile_verifier/src/backfill.rs
+++ b/mobile_verifier/src/backfill.rs
@@ -6,7 +6,10 @@ use file_store::{
 };
 use file_store_oracles::FileType;
 use futures::StreamExt;
-use helium_iceberg::{BatchedWriter, BoxedDataWriter};
+use helium_iceberg::{
+    BatchedWriter, BatchedWriterConfig, BatchedWriterTask, BoxedDataWriter, Catalog,
+    TableDefinition,
+};
 
 enum BackfillWriter<T> {
     Boxed(BoxedDataWriter<T>),
@@ -271,5 +274,43 @@ fn file_age(file_info: &FileInfo) -> String {
         (0, 0, m) => format!("{m}m ago"),
         (0, h, m) => format!("{h}h {m}m ago"),
         (d, h, _) => format!("{d}d {h}h ago"),
+    }
+}
+
+pub async fn batched_writer_for_table<T>(
+    catalog: Catalog,
+    table_def: TableDefinition,
+    config: BatchedWriterConfig,
+) -> anyhow::Result<(BatchedWriter<T>, BatchedWriterTask<T>)>
+where
+    T: serde::Serialize + Send + Sync + 'static,
+{
+    catalog
+        .create_namespace_if_not_exists(table_def.namespace())
+        .await?;
+    let table = catalog.create_table_if_not_exists(table_def).await?;
+    Ok(BatchedWriter::new(table, config))
+}
+
+#[async_trait::async_trait]
+pub trait BatchedWriterExt: Sized {
+    async fn batched_writer(
+        catalog: Catalog,
+        table_def: TableDefinition,
+        config: BatchedWriterConfig,
+    ) -> anyhow::Result<(BatchedWriter<Self>, BatchedWriterTask<Self>)>;
+}
+
+#[async_trait::async_trait]
+impl<T> BatchedWriterExt for T
+where
+    T: serde::Serialize + Send + Sync + 'static,
+{
+    async fn batched_writer(
+        catalog: Catalog,
+        table_def: TableDefinition,
+        config: BatchedWriterConfig,
+    ) -> anyhow::Result<(BatchedWriter<Self>, BatchedWriterTask<Self>)> {
+        batched_writer_for_table(catalog, table_def, config).await
     }
 }

--- a/mobile_verifier/src/cli/backfill_ban.rs
+++ b/mobile_verifier/src/cli/backfill_ban.rs
@@ -1,6 +1,12 @@
-use crate::{banning::BanBackfiller, iceberg, Settings};
+use crate::{
+    backfill::BatchedWriterExt,
+    banning::BanBackfiller,
+    iceberg::{self, IcebergBan},
+    Settings,
+};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
+use helium_iceberg::BatchedWriterConfig;
 use task_manager::TaskManager;
 
 #[derive(Debug, clap::Args)]
@@ -34,10 +40,12 @@ impl Cmd {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("iceberg_settings required for ban backfill"))?;
 
-        let ban_writer = iceberg::PocWriters::from_settings(iceberg_settings)
-            .await?
-            .ban
-            .ok_or_else(|| anyhow::anyhow!("iceberg_settings required for ban backfill"))?;
+        let (writer, writer_task) = IcebergBan::batched_writer(
+            iceberg_settings.connect().await?,
+            iceberg::ban::table_definition()?,
+            BatchedWriterConfig::new(settings.cache.join("iceberg-spool/ban-backfill")),
+        )
+        .await?;
 
         tracing::info!(
             process_name = %self.process_name,
@@ -54,15 +62,16 @@ impl Cmd {
             idle_timeout: None,
         };
 
-        let (backfiller, server) = BanBackfiller::create(
+        let (backfiller, server) = BanBackfiller::create_batched(
             pool,
             settings.buckets.output.connect().await,
-            Some(ban_writer),
+            Some(writer),
             Some(opts),
         )
         .await?;
 
         TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()

--- a/mobile_verifier/src/cli/backfill_speedtest.rs
+++ b/mobile_verifier/src/cli/backfill_speedtest.rs
@@ -1,6 +1,7 @@
 use crate::{iceberg, speedtests::SpeedtestBackfiller, Settings};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
+use helium_iceberg::{BatchedTableWriterExt, BatchedWriter, BatchedWriterConfig, IcebergTable};
 use task_manager::TaskManager;
 
 #[derive(Debug, clap::Args)]
@@ -34,10 +35,13 @@ impl Cmd {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("iceberg_settings required for speedtest backfill"))?;
 
-        let speedtest_writer = iceberg::PocWriters::from_settings(iceberg_settings)
+        let catalog = iceberg_settings.connect().await?;
+        let (writer, writer_task) = catalog
+            .create_namespace_table_if_not_exists(iceberg::speedtest::table_definition()?)
             .await?
-            .speedtest
-            .expect("iceberg writer");
+            .batched_writer(BatchedWriterConfig::new(
+                settings.cache.join("iceberg-spool/speedtest-backfill"),
+            ));
 
         tracing::info!(
             process_name = %self.process_name,
@@ -54,15 +58,16 @@ impl Cmd {
             idle_timeout: None,
         };
 
-        let (backfiller, server) = SpeedtestBackfiller::create(
+        let (backfiller, server) = SpeedtestBackfiller::create_batched(
             pool,
             settings.buckets.output.connect().await,
-            Some(speedtest_writer),
+            Some(writer),
             Some(opts),
         )
         .await?;
 
         TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()

--- a/mobile_verifier/src/cli/backfill_speedtest.rs
+++ b/mobile_verifier/src/cli/backfill_speedtest.rs
@@ -1,7 +1,12 @@
-use crate::{iceberg, speedtests::SpeedtestBackfiller, Settings};
+use crate::{
+    backfill::BatchedWriterExt,
+    iceberg::{self, IcebergSpeedtest},
+    speedtests::SpeedtestBackfiller,
+    Settings,
+};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use helium_iceberg::{BatchedTableWriterExt, BatchedWriter, BatchedWriterConfig, IcebergTable};
+use helium_iceberg::BatchedWriterConfig;
 use task_manager::TaskManager;
 
 #[derive(Debug, clap::Args)]
@@ -35,13 +40,12 @@ impl Cmd {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("iceberg_settings required for speedtest backfill"))?;
 
-        let catalog = iceberg_settings.connect().await?;
-        let (writer, writer_task) = catalog
-            .create_namespace_table_if_not_exists(iceberg::speedtest::table_definition()?)
-            .await?
-            .batched_writer(BatchedWriterConfig::new(
-                settings.cache.join("iceberg-spool/speedtest-backfill"),
-            ));
+        let (writer, writer_task) = IcebergSpeedtest::batched_writer(
+            iceberg_settings.connect().await?,
+            iceberg::speedtest::table_definition()?,
+            BatchedWriterConfig::new(settings.cache.join("iceberg-spool/speedtest-backfill")),
+        )
+        .await?;
 
         tracing::info!(
             process_name = %self.process_name,

--- a/mobile_verifier/src/cli/backfill_speedtest_avg.rs
+++ b/mobile_verifier/src/cli/backfill_speedtest_avg.rs
@@ -1,6 +1,12 @@
-use crate::{iceberg, speedtests_average::SpeedtestAvgBackfiller, Settings};
+use crate::{
+    backfill::BatchedWriterExt,
+    iceberg::{self, IcebergSpeedtestAvg},
+    speedtests_average::SpeedtestAvgBackfiller,
+    Settings,
+};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
+use helium_iceberg::BatchedWriterConfig;
 use task_manager::TaskManager;
 
 #[derive(Debug, clap::Args)]
@@ -33,10 +39,12 @@ impl Cmd {
             anyhow::anyhow!("iceberg_settings required for speedtest_avg backfill")
         })?;
 
-        let speedtest_avg_writer = iceberg::PocWriters::from_settings(iceberg_settings)
-            .await?
-            .speedtest_avg
-            .expect("iceberg writer");
+        let (writer, writer_task) = IcebergSpeedtestAvg::batched_writer(
+            iceberg_settings.connect().await?,
+            iceberg::speedtest_avg::table_definition()?,
+            BatchedWriterConfig::new(settings.cache.join("iceberg-spool/speedtest-avg-backfill")),
+        )
+        .await?;
 
         tracing::info!(
             process_name = %self.process_name,
@@ -53,15 +61,16 @@ impl Cmd {
             idle_timeout: None,
         };
 
-        let (backfiller, server) = SpeedtestAvgBackfiller::create(
+        let (backfiller, server) = SpeedtestAvgBackfiller::create_batched(
             pool,
             settings.buckets.output.connect().await,
-            Some(speedtest_avg_writer),
+            Some(writer),
             Some(opts),
         )
         .await?;
 
         TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()

--- a/mobile_verifier/src/cli/backfill_unique_connections.rs
+++ b/mobile_verifier/src/cli/backfill_unique_connections.rs
@@ -1,6 +1,12 @@
-use crate::{iceberg, unique_connections::UniqueConnectionsBackfiller, Settings};
+use crate::{
+    backfill::BatchedWriterExt,
+    iceberg::{self, IcebergUniqueConnections},
+    unique_connections::UniqueConnectionsBackfiller,
+    Settings,
+};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
+use helium_iceberg::BatchedWriterConfig;
 use task_manager::TaskManager;
 
 #[derive(Debug, clap::Args)]
@@ -33,12 +39,16 @@ impl Cmd {
             anyhow::anyhow!("iceberg_settings required for unique connections backfill")
         })?;
 
-        let unique_connections_writer = iceberg::PocWriters::from_settings(iceberg_settings)
-            .await?
-            .unique_connections
-            .ok_or_else(|| {
-                anyhow::anyhow!("iceberg_settings required for unique_connections backfill")
-            })?;
+        let (writer, writer_task) = IcebergUniqueConnections::batched_writer(
+            iceberg_settings.connect().await?,
+            iceberg::unique_connections::table_definition()?,
+            BatchedWriterConfig::new(
+                settings
+                    .cache
+                    .join("iceberg-spool/unique-connections-backfill"),
+            ),
+        )
+        .await?;
 
         tracing::info!(
             process_name = %self.process_name,
@@ -55,15 +65,16 @@ impl Cmd {
             idle_timeout: None,
         };
 
-        let (backfiller, server) = UniqueConnectionsBackfiller::create(
+        let (backfiller, server) = UniqueConnectionsBackfiller::create_batched(
             pool,
             settings.buckets.output.connect().await,
-            Some(unique_connections_writer),
+            Some(writer),
             Some(opts),
         )
         .await?;
 
         TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()

--- a/mobile_verifier/tests/integrations/banning_iceberg.rs
+++ b/mobile_verifier/tests/integrations/banning_iceberg.rs
@@ -165,9 +165,11 @@ async fn idempotent_write_deduplicates() -> anyhow::Result<()> {
 #[sqlx::test]
 async fn backfill_writes_bans_to_iceberg(pool: PgPool) -> anyhow::Result<()> {
     let harness = crate::common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer::<IcebergBan>(iceberg::ban::TABLE_NAME)
-        .await?;
+    let (writer, writer_task, _spool_dir) = crate::common::make_batched_writer::<IcebergBan>(
+        &harness,
+        iceberg::ban::table_definition()?,
+    )
+    .await?;
 
     let awsl = AwsLocal::new().await;
     awsl.create_bucket().await?;
@@ -200,11 +202,12 @@ async fn backfill_writes_bans_to_iceberg(pool: PgPool) -> anyhow::Result<()> {
 
     let opts = test_backfill_options("test-backfill", start_time, end_time);
     let (backfiller, server) =
-        BanBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts)).await?;
+        BanBackfiller::create_batched(pool, awsl.bucket_client(), Some(writer), Some(opts)).await?;
 
     tokio::time::timeout(
         TEST_TIMEOUT,
         task_manager::TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()
@@ -223,9 +226,11 @@ async fn backfill_writes_bans_to_iceberg(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn backfill_filters_invalid_bans(pool: PgPool) -> anyhow::Result<()> {
     let harness = crate::common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer::<IcebergBan>(iceberg::ban::TABLE_NAME)
-        .await?;
+    let (writer, writer_task, _spool_dir) = crate::common::make_batched_writer::<IcebergBan>(
+        &harness,
+        iceberg::ban::table_definition()?,
+    )
+    .await?;
 
     let awsl = AwsLocal::new().await;
     awsl.create_bucket().await?;
@@ -247,11 +252,12 @@ async fn backfill_filters_invalid_bans(pool: PgPool) -> anyhow::Result<()> {
 
     let opts = test_backfill_options("test-backfill-filter", start_time, end_time);
     let (backfiller, server) =
-        BanBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts)).await?;
+        BanBackfiller::create_batched(pool, awsl.bucket_client(), Some(writer), Some(opts)).await?;
 
     tokio::time::timeout(
         TEST_TIMEOUT,
         task_manager::TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()
@@ -274,9 +280,11 @@ async fn backfill_filters_invalid_bans(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
     let harness = crate::common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer::<IcebergBan>(iceberg::ban::TABLE_NAME)
-        .await?;
+    let (writer, writer_task, _spool_dir) = crate::common::make_batched_writer::<IcebergBan>(
+        &harness,
+        iceberg::ban::table_definition()?,
+    )
+    .await?;
 
     let awsl = AwsLocal::new().await;
     awsl.create_bucket().await?;
@@ -307,11 +315,12 @@ async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
 
     let opts = test_backfill_options("test-backfill-stop", start_time, stop_time);
     let (backfiller, server) =
-        BanBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts)).await?;
+        BanBackfiller::create_batched(pool, awsl.bucket_client(), Some(writer), Some(opts)).await?;
 
     tokio::time::timeout(
         TEST_TIMEOUT,
         task_manager::TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()

--- a/mobile_verifier/tests/integrations/common/mod.rs
+++ b/mobile_verifier/tests/integrations/common/mod.rs
@@ -5,7 +5,9 @@ use file_store::{
 };
 use futures::{stream, StreamExt};
 use helium_crypto::PublicKeyBinary;
-use helium_iceberg::IcebergTestHarness;
+use helium_iceberg::{
+    BatchedWriter, BatchedWriterConfig, BatchedWriterTask, IcebergTestHarness, TableDefinition,
+};
 use helium_proto::services::poc_mobile::{
     mobile_reward_share::Reward as MobileReward, radio_reward_v2, GatewayReward, MobileRewardShare,
     OracleBoostingHexAssignment, OracleBoostingReportV1, PromotionReward, RadioReward,
@@ -19,11 +21,13 @@ use mobile_config::{
     client::{hex_boosting_client::HexBoostingInfoResolver, ClientError},
     sub_dao_epoch_reward_info::EpochRewardInfo,
 };
+use mobile_verifier::backfill::BatchedWriterExt;
 use mobile_verifier::{
     boosting_oracles::AssignedCoverageObjects, GatewayResolution, GatewayResolver, PriceInfo,
 };
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use rust_decimal_macros::dec;
+use serde::Serialize;
 use solana::Token;
 use sqlx::PgPool;
 use std::{
@@ -445,4 +449,23 @@ pub async fn setup_iceberg() -> anyhow::Result<IcebergTestHarness> {
     ])
     .await?;
     Ok(harness)
+}
+
+/// Build a `BatchedWriter` against the harness's catalog with a fresh tempdir
+/// spool. Tests run quickly so the timeout never fires; `max_batch_size = 1`
+/// makes each `queue_all` flush right away so assertions see rows promptly.
+pub async fn make_batched_writer<T>(
+    harness: &IcebergTestHarness,
+    table_def: TableDefinition,
+) -> anyhow::Result<(BatchedWriter<T>, BatchedWriterTask<T>, tempfile::TempDir)>
+where
+    T: Serialize + Send + Sync + 'static,
+{
+    let spool_dir = tempfile::tempdir()?;
+    let config = BatchedWriterConfig::new(spool_dir.path().to_path_buf())
+        .with_max_batch_size(1)
+        .with_batch_timeout(std::time::Duration::from_secs(3600));
+    let (writer, task) =
+        T::batched_writer(harness.iceberg_catalog().clone(), table_def, config).await?;
+    Ok((writer, task, spool_dir))
 }

--- a/mobile_verifier/tests/integrations/speedtest_avgs_iceberg.rs
+++ b/mobile_verifier/tests/integrations/speedtest_avgs_iceberg.rs
@@ -131,8 +131,11 @@ async fn idempotent_write_deduplicates() -> anyhow::Result<()> {
 #[sqlx::test]
 async fn backfill_writes_speedtest_avgs_to_iceberg(pool: PgPool) -> anyhow::Result<()> {
     let harness = crate::common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer::<IcebergSpeedtestAvg>(iceberg::speedtest_avg::TABLE_NAME)
+    let (writer, writer_task, _spool_dir) =
+        crate::common::make_batched_writer::<IcebergSpeedtestAvg>(
+            &harness,
+            iceberg::speedtest_avg::table_definition()?,
+        )
         .await?;
 
     let awsl = AwsLocal::new().await;
@@ -165,13 +168,18 @@ async fn backfill_writes_speedtest_avgs_to_iceberg(pool: PgPool) -> anyhow::Resu
     .await?;
 
     let opts = test_backfill_options("test-avg-backfill", start_time, end_time);
-    let (backfiller, server) =
-        SpeedtestAvgBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts))
-            .await?;
+    let (backfiller, server) = SpeedtestAvgBackfiller::create_batched(
+        pool,
+        awsl.bucket_client(),
+        Some(writer),
+        Some(opts),
+    )
+    .await?;
 
     tokio::time::timeout(
         TEST_TIMEOUT,
         task_manager::TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()
@@ -190,8 +198,11 @@ async fn backfill_writes_speedtest_avgs_to_iceberg(pool: PgPool) -> anyhow::Resu
 #[sqlx::test]
 async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
     let harness = crate::common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer::<IcebergSpeedtestAvg>(iceberg::speedtest_avg::TABLE_NAME)
+    let (writer, writer_task, _spool_dir) =
+        crate::common::make_batched_writer::<IcebergSpeedtestAvg>(
+            &harness,
+            iceberg::speedtest_avg::table_definition()?,
+        )
         .await?;
 
     let awsl = AwsLocal::new().await;
@@ -219,13 +230,18 @@ async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
     }
 
     let opts = test_backfill_options("test-avg-backfill-stop", start_time, stop_time);
-    let (backfiller, server) =
-        SpeedtestAvgBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts))
-            .await?;
+    let (backfiller, server) = SpeedtestAvgBackfiller::create_batched(
+        pool,
+        awsl.bucket_client(),
+        Some(writer),
+        Some(opts),
+    )
+    .await?;
 
     tokio::time::timeout(
         TEST_TIMEOUT,
         task_manager::TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()
@@ -248,8 +264,11 @@ async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn backfill_filters_invalid_speedtest_avgs(pool: PgPool) -> anyhow::Result<()> {
     let harness = crate::common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer::<IcebergSpeedtestAvg>(iceberg::speedtest_avg::TABLE_NAME)
+    let (writer, writer_task, _spool_dir) =
+        crate::common::make_batched_writer::<IcebergSpeedtestAvg>(
+            &harness,
+            iceberg::speedtest_avg::table_definition()?,
+        )
         .await?;
 
     let awsl = AwsLocal::new().await;
@@ -274,13 +293,18 @@ async fn backfill_filters_invalid_speedtest_avgs(pool: PgPool) -> anyhow::Result
     .await?;
 
     let opts = test_backfill_options("test-avg-backfill-filter", start_time, end_time);
-    let (backfiller, server) =
-        SpeedtestAvgBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts))
-            .await?;
+    let (backfiller, server) = SpeedtestAvgBackfiller::create_batched(
+        pool,
+        awsl.bucket_client(),
+        Some(writer),
+        Some(opts),
+    )
+    .await?;
 
     tokio::time::timeout(
         TEST_TIMEOUT,
         task_manager::TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()

--- a/mobile_verifier/tests/integrations/speedtests_iceberg.rs
+++ b/mobile_verifier/tests/integrations/speedtests_iceberg.rs
@@ -139,9 +139,11 @@ async fn idempotent_write_deduplicates() -> anyhow::Result<()> {
 #[sqlx::test]
 async fn backfill_writes_speedtests_to_iceberg(pool: PgPool) -> anyhow::Result<()> {
     let harness = crate::common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer::<IcebergSpeedtest>(iceberg::speedtest::TABLE_NAME)
-        .await?;
+    let (writer, writer_task, _spool_dir) = crate::common::make_batched_writer::<IcebergSpeedtest>(
+        &harness,
+        iceberg::speedtest::table_definition()?,
+    )
+    .await?;
 
     let awsl = AwsLocal::new().await;
     awsl.create_bucket().await?;
@@ -174,11 +176,13 @@ async fn backfill_writes_speedtests_to_iceberg(pool: PgPool) -> anyhow::Result<(
 
     let opts = test_backfill_options("test-backfill", start_time, end_time);
     let (backfiller, server) =
-        SpeedtestBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts)).await?;
+        SpeedtestBackfiller::create_batched(pool, awsl.bucket_client(), Some(writer), Some(opts))
+            .await?;
 
     tokio::time::timeout(
         TEST_TIMEOUT,
         task_manager::TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()
@@ -197,9 +201,11 @@ async fn backfill_writes_speedtests_to_iceberg(pool: PgPool) -> anyhow::Result<(
 #[sqlx::test]
 async fn backfill_filters_invalid_speedtests(pool: PgPool) -> anyhow::Result<()> {
     let harness = crate::common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer::<IcebergSpeedtest>(iceberg::speedtest::TABLE_NAME)
-        .await?;
+    let (writer, writer_task, _spool_dir) = crate::common::make_batched_writer::<IcebergSpeedtest>(
+        &harness,
+        iceberg::speedtest::table_definition()?,
+    )
+    .await?;
 
     let awsl = AwsLocal::new().await;
     awsl.create_bucket().await?;
@@ -228,11 +234,13 @@ async fn backfill_filters_invalid_speedtests(pool: PgPool) -> anyhow::Result<()>
 
     let opts = test_backfill_options("test-backfill-filter", start_time, end_time);
     let (backfiller, server) =
-        SpeedtestBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts)).await?;
+        SpeedtestBackfiller::create_batched(pool, awsl.bucket_client(), Some(writer), Some(opts))
+            .await?;
 
     tokio::time::timeout(
         TEST_TIMEOUT,
         task_manager::TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()
@@ -255,9 +263,11 @@ async fn backfill_filters_invalid_speedtests(pool: PgPool) -> anyhow::Result<()>
 #[sqlx::test]
 async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
     let harness = crate::common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer::<IcebergSpeedtest>(iceberg::speedtest::TABLE_NAME)
-        .await?;
+    let (writer, writer_task, _spool_dir) = crate::common::make_batched_writer::<IcebergSpeedtest>(
+        &harness,
+        iceberg::speedtest::table_definition()?,
+    )
+    .await?;
 
     let awsl = AwsLocal::new().await;
     awsl.create_bucket().await?;
@@ -288,11 +298,13 @@ async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
 
     let opts = test_backfill_options("test-backfill-stop", start_time, stop_time);
     let (backfiller, server) =
-        SpeedtestBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts)).await?;
+        SpeedtestBackfiller::create_batched(pool, awsl.bucket_client(), Some(writer), Some(opts))
+            .await?;
 
     tokio::time::timeout(
         TEST_TIMEOUT,
         task_manager::TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()

--- a/mobile_verifier/tests/integrations/unique_connections_iceberg.rs
+++ b/mobile_verifier/tests/integrations/unique_connections_iceberg.rs
@@ -157,8 +157,11 @@ async fn idempotent_write_deduplicates() -> anyhow::Result<()> {
 #[sqlx::test]
 async fn backfill_writes_unique_connections_to_iceberg(pool: PgPool) -> anyhow::Result<()> {
     let harness = crate::common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer::<IcebergUniqueConnections>(iceberg::unique_connections::TABLE_NAME)
+    let (writer, writer_task, _spool_dir) =
+        crate::common::make_batched_writer::<IcebergUniqueConnections>(
+            &harness,
+            iceberg::unique_connections::table_definition()?,
+        )
         .await?;
 
     let awsl = AwsLocal::new().await;
@@ -191,13 +194,18 @@ async fn backfill_writes_unique_connections_to_iceberg(pool: PgPool) -> anyhow::
     .await?;
 
     let opts = test_backfill_options("test-backfill", start_time, end_time);
-    let (backfiller, server) =
-        UniqueConnectionsBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts))
-            .await?;
+    let (backfiller, server) = UniqueConnectionsBackfiller::create_batched(
+        pool,
+        awsl.bucket_client(),
+        Some(writer),
+        Some(opts),
+    )
+    .await?;
 
     tokio::time::timeout(
         TEST_TIMEOUT,
         task_manager::TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()
@@ -216,8 +224,11 @@ async fn backfill_writes_unique_connections_to_iceberg(pool: PgPool) -> anyhow::
 #[sqlx::test]
 async fn backfill_filters_invalid_unique_connections(pool: PgPool) -> anyhow::Result<()> {
     let harness = crate::common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer::<IcebergUniqueConnections>(iceberg::unique_connections::TABLE_NAME)
+    let (writer, writer_task, _spool_dir) =
+        crate::common::make_batched_writer::<IcebergUniqueConnections>(
+            &harness,
+            iceberg::unique_connections::table_definition()?,
+        )
         .await?;
 
     let awsl = AwsLocal::new().await;
@@ -245,13 +256,18 @@ async fn backfill_filters_invalid_unique_connections(pool: PgPool) -> anyhow::Re
     .await?;
 
     let opts = test_backfill_options("test-backfill-filter", start_time, end_time);
-    let (backfiller, server) =
-        UniqueConnectionsBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts))
-            .await?;
+    let (backfiller, server) = UniqueConnectionsBackfiller::create_batched(
+        pool,
+        awsl.bucket_client(),
+        Some(writer),
+        Some(opts),
+    )
+    .await?;
 
     tokio::time::timeout(
         TEST_TIMEOUT,
         task_manager::TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()
@@ -274,8 +290,11 @@ async fn backfill_filters_invalid_unique_connections(pool: PgPool) -> anyhow::Re
 #[sqlx::test]
 async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
     let harness = crate::common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer::<IcebergUniqueConnections>(iceberg::unique_connections::TABLE_NAME)
+    let (writer, writer_task, _spool_dir) =
+        crate::common::make_batched_writer::<IcebergUniqueConnections>(
+            &harness,
+            iceberg::unique_connections::table_definition()?,
+        )
         .await?;
 
     let awsl = AwsLocal::new().await;
@@ -306,13 +325,18 @@ async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
     }
 
     let opts = test_backfill_options("test-backfill-stop", start_time, stop_time);
-    let (backfiller, server) =
-        UniqueConnectionsBackfiller::create(pool, awsl.bucket_client(), Some(writer), Some(opts))
-            .await?;
+    let (backfiller, server) = UniqueConnectionsBackfiller::create_batched(
+        pool,
+        awsl.bucket_client(),
+        Some(writer),
+        Some(opts),
+    )
+    .await?;
 
     tokio::time::timeout(
         TEST_TIMEOUT,
         task_manager::TaskManager::builder()
+            .add_task(writer_task)
             .add_task(server)
             .add_task(backfiller)
             .build()


### PR DESCRIPTION
Writing a single snapshot per backfilled file causes things to slow down quite dramatically. 
Using the batched writer, we can queue writes, then flush them similar to file-store. With the same guarantees that we won't miss files if things fail because they're being persisted to disk. 

This keeps backfill quite speedy, with intermittent pauses for flushing to iceberg.