### PR TITLE
mobile-packet-verifier backfill breakout and batching

### DIFF
--- a/mobile_packet_verifier/src/backfill.rs
+++ b/mobile_packet_verifier/src/backfill.rs
@@ -39,14 +39,14 @@ use file_store_oracles::{
 use futures::StreamExt;
 use helium_proto::services::poc_mobile::verified_data_transfer_ingest_report_v1::ReportStatus;
 use sqlx::{PgPool, Pool, Postgres};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use task_manager::{ManagedTask, TaskManager};
 use tokio::sync::mpsc::Receiver;
 
 use crate::settings::Settings;
 
 #[derive(Debug, clap::Args)]
-pub struct Cmd {
+pub struct BackfillSessionsCmd {
     /// Process name for tracking sessions backfill (avoids conflict with daemon)
     #[clap(long, default_value = "backfill")]
     process_name: String,
@@ -63,7 +63,25 @@ pub struct Cmd {
     stop_after: DateTime<Utc>,
 }
 
-impl Cmd {
+#[derive(Debug, clap::Args)]
+pub struct BackfillBurnedCmd {
+    /// Process name for tracking sessions backfill (avoids conflict with daemon)
+    #[clap(long, default_value = "backfill")]
+    process_name: String,
+
+    /// Start processing files after this timestamp.
+    /// Format: RFC 3339 (e.g., 2024-01-01T00:00:00Z)
+    #[clap(long)]
+    start_after: DateTime<Utc>,
+
+    /// Stop processing files when their timestamp is > this value.
+    /// Use this to avoid reprocessing files that the daemon has already handled.
+    /// Format: RFC 3339 (e.g., 2025-02-25T00:00:00Z)
+    #[clap(long)]
+    stop_after: DateTime<Utc>,
+}
+
+impl BackfillSessionsCmd {
     pub async fn run(self, settings: &Settings) -> Result<()> {
         let iceberg_settings = settings
             .iceberg_settings
@@ -76,7 +94,7 @@ impl Cmd {
             .await?;
         sqlx::migrate!().run(&pool).await?;
 
-        let (session_writer, burned_session_writer) =
+        let (session_writer, _burned_session_writer) =
             iceberg::get_writers(iceberg_settings).await?;
 
         tracing::info!(
@@ -96,6 +114,40 @@ impl Cmd {
         )
         .await?;
 
+        TaskManager::builder()
+            .add_task(data_sessions_task)
+            .build()
+            .start()
+            .await?;
+        Ok(())
+    }
+}
+
+impl BackfillBurnedCmd {
+    pub async fn run(self, settings: &Settings) -> Result<()> {
+        let iceberg_settings = settings
+            .iceberg_settings
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("iceberg_settings required for backfill"))?;
+
+        let pool = settings
+            .database
+            .connect("mobile-packet-verifier-backfill")
+            .await?;
+        sqlx::migrate!().run(&pool).await?;
+
+        let (_session_writer, burned_session_writer) =
+            iceberg::get_writers(iceberg_settings).await?;
+
+        tracing::info!(
+            process_name = %self.process_name,
+            start_after = %self.start_after,
+            stop_after = %self.stop_after,
+            "starting all backfills"
+        );
+
+        let options = BackfillOptions::new(&self.process_name, self.start_after, self.stop_after);
+
         let burned_sessions_task = BurnedSessionsBackfiller::create_managed_task(
             pool,
             settings.output_bucket.connect().await,
@@ -105,7 +157,6 @@ impl Cmd {
         .await?;
 
         TaskManager::builder()
-            .add_task(data_sessions_task)
             .add_task(burned_sessions_task)
             .build()
             .start()
@@ -275,6 +326,8 @@ impl DataSessionsBackfiller {
             return Ok(());
         };
 
+        let start = Instant::now();
+
         let file_info = file.file_info.clone();
         let age = format_file_age(&file_info);
         tracing::debug!(
@@ -287,31 +340,35 @@ impl DataSessionsBackfiller {
         let mut txn = self.pool.begin().await?;
         let write_id = file.file_info.key.clone();
 
-        let reports = file.into_stream(&mut txn).await?;
+        let all: Vec<_> = file.into_stream(&mut txn).await?.collect().await;
+        let total = all.len();
+        let collect_time = start.elapsed();
 
-        let all_reports: Vec<_> = reports.collect().await;
-        let total = all_reports.len();
-
-        let iceberg_sessions: Vec<_> = all_reports
+        let start = Instant::now();
+        let rows: Vec<_> = all
             .into_iter()
             .filter(|verified_report| verified_report.status == ReportStatus::Valid)
             .map(|verified_report| IcebergDataTransferSession::from(verified_report.report))
             .collect();
+        let written = rows.len();
+        let transform_time = start.elapsed();
 
-        let valid_count = iceberg_sessions.len();
-        let filtered_count = total - valid_count;
-
+        let start = Instant::now();
         writer
-            .write_idempotent(&write_id, iceberg_sessions)
+            .write_idempotent(&write_id, rows)
             .await
             .context("writing sessions to iceberg")?;
 
         txn.commit().await.context("committing db transaction")?;
+        let write_time = start.elapsed();
 
         tracing::info!(
             file = %file_info,
-            valid_count,
-            filtered_count,
+            written,
+            skipped = total - written,
+            age = %age,
+            ?collect_time, ?transform_time, ?write_time,
+            total_time = ?(collect_time + transform_time + write_time),
             "backfilled verified sessions file"
         );
         Ok(())

--- a/mobile_packet_verifier/src/backfill.rs
+++ b/mobile_packet_verifier/src/backfill.rs
@@ -1,8 +1,23 @@
-use crate::iceberg::{
-    self, burned_session::IcebergBurnedDataTransferSession, session::IcebergDataTransferSession,
-    BurnedDataTransferWriter, DataTransferWriter,
-};
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use file_store::{file_info_poller::FileInfoStream, file_source, BucketClient, FileInfo};
+use file_store_oracles::{
+    mobile_session::VerifiedDataTransferIngestReport, mobile_transfer::ValidDataTransferSession,
+    FileType,
+};
+use futures::StreamExt;
+use helium_iceberg::BatchedWriter;
+use helium_proto::services::poc_mobile::verified_data_transfer_ingest_report_v1::ReportStatus;
+use sqlx::{PgPool, Pool, Postgres};
+use std::time::{Duration, Instant};
+use task_manager::{ManagedTask, TaskManager};
+use tokio::sync::mpsc::Receiver;
+
+use crate::{iceberg, settings::Settings};
+
+type BatchedDataTransferWriter = BatchedWriter<iceberg::session::IcebergDataTransferSession>;
+type BatchedBurnedDataTranfserWriter =
+    BatchedWriter<iceberg::burned_session::IcebergBurnedDataTransferSession>;
 
 /// A server task returned by [`DataSessionsBackfiller::create`] and
 /// [`BurnedSessionsBackfiller::create`].
@@ -30,20 +45,6 @@ impl ManagedTask for BackfillPollerServer {
         }
     }
 }
-use chrono::{DateTime, Utc};
-use file_store::{file_info_poller::FileInfoStream, file_source, BucketClient, FileInfo};
-use file_store_oracles::{
-    mobile_session::VerifiedDataTransferIngestReport, mobile_transfer::ValidDataTransferSession,
-    FileType,
-};
-use futures::StreamExt;
-use helium_proto::services::poc_mobile::verified_data_transfer_ingest_report_v1::ReportStatus;
-use sqlx::{PgPool, Pool, Postgres};
-use std::time::{Duration, Instant};
-use task_manager::{ManagedTask, TaskManager};
-use tokio::sync::mpsc::Receiver;
-
-use crate::settings::Settings;
 
 #[derive(Debug, clap::Args)]
 pub struct BackfillSessionsCmd {
@@ -61,6 +62,10 @@ pub struct BackfillSessionsCmd {
     /// Format: RFC 3339 (e.g., 2025-02-25T00:00:00Z)
     #[clap(long)]
     stop_after: DateTime<Utc>,
+
+    /// Number of sessions to process in each batch.
+    #[clap(long, default_value = "1000000")]
+    batch_size: usize,
 }
 
 #[derive(Debug, clap::Args)]
@@ -79,6 +84,10 @@ pub struct BackfillBurnedCmd {
     /// Format: RFC 3339 (e.g., 2025-02-25T00:00:00Z)
     #[clap(long)]
     stop_after: DateTime<Utc>,
+
+    /// Number of sessions to process in each batch.
+    #[clap(long, default_value = "1000000")]
+    batch_size: usize,
 }
 
 impl BackfillSessionsCmd {
@@ -94,13 +103,27 @@ impl BackfillSessionsCmd {
             .await?;
         sqlx::migrate!().run(&pool).await?;
 
-        let (session_writer, _burned_session_writer) =
-            iceberg::get_writers(iceberg_settings).await?;
+        let catalog = iceberg_settings.connect().await?;
+        let table_def = iceberg::session::table_definition()?;
+        catalog
+            .create_namespace_if_not_exists(table_def.namespace())
+            .await?;
+        let table = catalog.create_table_if_not_exists(table_def).await?;
+
+        let (writer, writer_task) = helium_iceberg::BatchedWriter::new(
+            table,
+            helium_iceberg::BatchedWriterConfig::new(
+                settings.cache.join("iceberg-spool/data-sessions"),
+            )
+            .with_max_batch_size(self.batch_size)
+            .with_batch_timeout(Duration::from_mins(5)),
+        );
 
         tracing::info!(
             process_name = %self.process_name,
             start_after = %self.start_after,
             stop_after = %self.stop_after,
+            batch_size = self.batch_size,
             "starting all backfills"
         );
 
@@ -109,12 +132,13 @@ impl BackfillSessionsCmd {
         let data_sessions_task = DataSessionsBackfiller::create_managed_task(
             pool.clone(),
             settings.output_bucket.connect().await,
-            Some(session_writer),
+            Some(writer),
             options.clone(),
         )
         .await?;
 
         TaskManager::builder()
+            .add_task(writer_task)
             .add_task(data_sessions_task)
             .build()
             .start()
@@ -136,13 +160,27 @@ impl BackfillBurnedCmd {
             .await?;
         sqlx::migrate!().run(&pool).await?;
 
-        let (_session_writer, burned_session_writer) =
-            iceberg::get_writers(iceberg_settings).await?;
+        let catalog = iceberg_settings.connect().await?;
+        let table_def = iceberg::burned_session::table_definition()?;
+        catalog
+            .create_namespace_if_not_exists(table_def.namespace())
+            .await?;
+        let table = catalog.create_table_if_not_exists(table_def).await?;
+
+        let (writer, writer_task) = helium_iceberg::BatchedWriter::new(
+            table,
+            helium_iceberg::BatchedWriterConfig::new(
+                settings.cache.join("iceberg-spool/burned-sessions"),
+            )
+            .with_max_batch_size(self.batch_size)
+            .with_batch_timeout(Duration::from_mins(5)),
+        );
 
         tracing::info!(
             process_name = %self.process_name,
             start_after = %self.start_after,
             stop_after = %self.stop_after,
+            batch_size = self.batch_size,
             "starting all backfills"
         );
 
@@ -151,12 +189,13 @@ impl BackfillBurnedCmd {
         let burned_sessions_task = BurnedSessionsBackfiller::create_managed_task(
             pool,
             settings.output_bucket.connect().await,
-            Some(burned_session_writer),
+            Some(writer),
             options,
         )
         .await?;
 
         TaskManager::builder()
+            .add_task(writer_task)
             .add_task(burned_sessions_task)
             .build()
             .start()
@@ -204,7 +243,7 @@ impl BackfillOptions {
 pub struct DataSessionsBackfiller {
     pool: Pool<Postgres>,
     reports: Receiver<FileInfoStream<VerifiedDataTransferIngestReport>>,
-    writer: Option<DataTransferWriter>,
+    writer: Option<BatchedDataTransferWriter>,
     done: bool,
 }
 
@@ -212,7 +251,7 @@ impl DataSessionsBackfiller {
     pub fn new(
         pool: Pool<Postgres>,
         reports: Receiver<FileInfoStream<VerifiedDataTransferIngestReport>>,
-        writer: Option<DataTransferWriter>,
+        writer: Option<BatchedDataTransferWriter>,
     ) -> Self {
         let done = writer.is_none();
         Self {
@@ -234,7 +273,7 @@ impl DataSessionsBackfiller {
     pub async fn create(
         pool: PgPool,
         bucket_client: BucketClient,
-        writer: Option<DataTransferWriter>,
+        writer: Option<BatchedDataTransferWriter>,
         options: Option<BackfillOptions>,
     ) -> anyhow::Result<(Self, BackfillPollerServer)> {
         let (Some(writer), Some(options)) = (writer, options) else {
@@ -264,7 +303,7 @@ impl DataSessionsBackfiller {
     pub async fn create_managed_task(
         pool: PgPool,
         bucket_client: BucketClient,
-        writer: Option<DataTransferWriter>,
+        writer: Option<BatchedDataTransferWriter>,
         options: BackfillOptions,
     ) -> anyhow::Result<TaskManager> {
         let (backfiller, server) = Self::create(pool, bucket_client, writer, Some(options)).await?;
@@ -338,37 +377,32 @@ impl DataSessionsBackfiller {
         );
 
         let mut txn = self.pool.begin().await?;
-        let write_id = file.file_info.key.clone();
 
         let all: Vec<_> = file.into_stream(&mut txn).await?.collect().await;
         let total = all.len();
-        let collect_time = start.elapsed();
 
-        let start = Instant::now();
         let rows: Vec<_> = all
             .into_iter()
             .filter(|verified_report| verified_report.status == ReportStatus::Valid)
-            .map(|verified_report| IcebergDataTransferSession::from(verified_report.report))
+            .map(|verified_report| {
+                iceberg::IcebergDataTransferSession::from(verified_report.report)
+            })
             .collect();
         let written = rows.len();
-        let transform_time = start.elapsed();
 
-        let start = Instant::now();
         writer
-            .write_idempotent(&write_id, rows)
+            .queue_all(rows)
             .await
-            .context("writing sessions to iceberg")?;
+            .context("queueing data sessions backfill")?;
 
         txn.commit().await.context("committing db transaction")?;
-        let write_time = start.elapsed();
 
         tracing::info!(
             file = %file_info,
             written,
             skipped = total - written,
             age = %age,
-            ?collect_time, ?transform_time, ?write_time,
-            total_time = ?(collect_time + transform_time + write_time),
+            duration = ?start.elapsed(),
             "backfilled verified sessions file"
         );
         Ok(())
@@ -384,7 +418,7 @@ impl ManagedTask for DataSessionsBackfiller {
 pub struct BurnedSessionsBackfiller {
     pool: Pool<Postgres>,
     reports: Receiver<FileInfoStream<ValidDataTransferSession>>,
-    writer: Option<BurnedDataTransferWriter>,
+    writer: Option<BatchedBurnedDataTranfserWriter>,
     done: bool,
 }
 
@@ -392,7 +426,7 @@ impl BurnedSessionsBackfiller {
     pub async fn create(
         pool: PgPool,
         bucket_client: BucketClient,
-        writer: Option<BurnedDataTransferWriter>,
+        writer: Option<BatchedBurnedDataTranfserWriter>,
         options: Option<BackfillOptions>,
     ) -> anyhow::Result<(Self, BackfillPollerServer)> {
         let (Some(writer), Some(options)) = (writer, options) else {
@@ -425,7 +459,7 @@ impl BurnedSessionsBackfiller {
     pub async fn create_managed_task(
         pool: PgPool,
         bucket_client: BucketClient,
-        writer: Option<BurnedDataTransferWriter>,
+        writer: Option<BatchedBurnedDataTranfserWriter>,
         options: BackfillOptions,
     ) -> anyhow::Result<TaskManager> {
         let (burned_backfiller, server) =
@@ -440,7 +474,7 @@ impl BurnedSessionsBackfiller {
     pub fn new(
         pool: Pool<Postgres>,
         reports: Receiver<FileInfoStream<ValidDataTransferSession>>,
-        writer: Option<BurnedDataTransferWriter>,
+        writer: Option<BatchedBurnedDataTranfserWriter>,
     ) -> Self {
         let done = writer.is_none();
         Self {
@@ -507,6 +541,8 @@ impl BurnedSessionsBackfiller {
             return Ok(());
         };
 
+        let start = Instant::now();
+
         let file_info = file.file_info.clone();
         let age = format_file_age(&file_info);
         tracing::info!(
@@ -517,24 +553,31 @@ impl BurnedSessionsBackfiller {
         );
 
         let mut txn = self.pool.begin().await?;
-        let write_id = file.file_info.key.clone();
 
-        let reports = file.into_stream(&mut txn).await?;
+        let all: Vec<_> = file.into_stream(&mut txn).await?.collect().await;
 
-        let iceberg_sessions = reports
-            .map(|session| IcebergBurnedDataTransferSession::from_session(session, &file_info))
-            .collect::<Vec<_>>()
-            .await;
+        let rows: Vec<_> = all
+            .into_iter()
+            .map(|session| {
+                iceberg::IcebergBurnedDataTransferSession::from_session(session, &file_info)
+            })
+            .collect();
+        let written = rows.len();
 
-        let count = iceberg_sessions.len();
         writer
-            .write_idempotent(&write_id, iceberg_sessions)
+            .queue_all(rows)
             .await
             .context("writing burned sessions to iceberg")?;
 
         txn.commit().await.context("committing db transaction")?;
 
-        tracing::info!(file = %file_info, count, "backfilled burned sessions file");
+        tracing::info!(
+            file = %file_info,
+            written,
+            age = %age,
+            duration = ?start.elapsed(),
+            "backfilled burned sessions file"
+        );
         Ok(())
     }
 }

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -60,7 +60,6 @@ pub struct Daemon<S, MCR> {
 }
 
 impl<S, MCR> Daemon<S, MCR> {
-    #[expect(clippy::too_many_arguments)]
     pub fn new(
         pool: Pool<Postgres>,
         burn_period: Duration,

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -1,6 +1,5 @@
 use crate::{
     accumulate::{accumulate_sessions, AccumulatedSessions},
-    backfill::{BackfillOptions, BurnedSessionsBackfiller, DataSessionsBackfiller},
     banning::{self, BannedRadios},
     burner::Burner,
     event_ids::EventIdPurger,
@@ -58,9 +57,6 @@ pub struct Daemon<S, MCR> {
     mobile_config_resolver: MCR,
     ingest_reports: IngestReports,
     event_tx: tokio::sync::broadcast::Sender<DaemonEvent>,
-    // backfill temp
-    session_backfill: DataSessionsBackfiller,
-    burned_backfill: BurnedSessionsBackfiller,
 }
 
 impl<S, MCR> Daemon<S, MCR> {
@@ -73,9 +69,6 @@ impl<S, MCR> Daemon<S, MCR> {
         ingest_reports: IngestReports,
         burner: Burner<S>,
         mobile_config_resolver: MCR,
-        // backfill temp
-        session_backfill: DataSessionsBackfiller,
-        burned_backfill: BurnedSessionsBackfiller,
     ) -> Self {
         let (event_tx, _event_rx) = tokio::sync::broadcast::channel(100);
         Self {
@@ -86,8 +79,6 @@ impl<S, MCR> Daemon<S, MCR> {
             initial_burn_delay,
             mobile_config_resolver,
             ingest_reports,
-            session_backfill,
-            burned_backfill,
             event_tx,
         }
     }
@@ -134,18 +125,6 @@ where
                 file = self.ingest_reports.recv() => {
                     self.ingest_reports.handle(file, &self.mobile_config_resolver).await?;
                     let _ = self.event_tx.send(DaemonEvent::ReportHandle);
-                }
-                // Backfill runs at lowest priority — only fires when burn and
-                // ingest have nothing ready. When iceberg is not configured,
-                // the backfillers set done=true on construction and recv()
-                // returns pending() immediately, so these arms never fire.
-                file = self.session_backfill.recv() => {
-                    self.session_backfill.handle(file).await?;
-                    let _ = self.event_tx.send(DaemonEvent::BackfillDataSession);
-                }
-                file = self.burned_backfill.recv() => {
-                    self.burned_backfill.handle(file).await?;
-                    let _ = self.event_tx.send(DaemonEvent::BackfillBurnedSession);
                 }
             }
         }
@@ -354,34 +333,6 @@ impl Cmd {
             session_writer.clone(),
         );
 
-        // Backfill covers [backfill.start_after, backfill.stop_after):
-        //   - backfill.stop_after is the Iceberg deployment date (set at deploy time)
-        //   - everything before stop_after is historical data written by the backfiller
-        //   - everything from stop_after onwards is written to Iceberg in real-time
-        // This boundary is deterministic and configured at deploy time — no overlap.
-        //
-        // When settings.backfill is None (or iceberg_settings is None so writers are None),
-        // create() returns a no-op backfiller with no poller.
-        let backfill_opts = settings
-            .backfill
-            .as_ref()
-            .map(|b| BackfillOptions::new("backfill", b.start_after, b.stop_after));
-
-        let (data_session_backfill, backfill_reports_server) = DataSessionsBackfiller::create(
-            pool.clone(),
-            settings.output_bucket.connect().await,
-            session_writer,
-            backfill_opts.clone(),
-        )
-        .await?;
-        let (burned_session_backfill, burned_reports_server) = BurnedSessionsBackfiller::create(
-            pool.clone(),
-            settings.output_bucket.connect().await,
-            burned_session_writer.clone(),
-            backfill_opts,
-        )
-        .await?;
-
         let daemon = Daemon::new(
             pool.clone(),
             settings.burn_period,
@@ -390,8 +341,6 @@ impl Cmd {
             ingest_reports,
             burner,
             resolver,
-            data_session_backfill,
-            burned_session_backfill,
         );
 
         let event_id_purger = EventIdPurger::from_settings(pool.clone(), settings);
@@ -405,8 +354,6 @@ impl Cmd {
             .add_task(banning)
             .add_task(event_id_purger)
             .add_task(daemon)
-            .add_task(backfill_reports_server)
-            .add_task(burned_reports_server)
             .build()
             .start()
             .await?;

--- a/mobile_packet_verifier/src/main.rs
+++ b/mobile_packet_verifier/src/main.rs
@@ -29,14 +29,16 @@ impl Cli {
 #[derive(clap::Subcommand)]
 pub enum Cmd {
     Server(daemon::Cmd),
-    Backfill(backfill::Cmd),
+    BackfillSessions(backfill::BackfillSessionsCmd),
+    BackfillBurned(backfill::BackfillBurnedCmd),
 }
 
 impl Cmd {
     async fn run(self, settings: Settings) -> Result<()> {
         match self {
             Self::Server(cmd) => cmd.run(&settings).await,
-            Self::Backfill(cmd) => cmd.run(&settings).await,
+            Self::BackfillSessions(cmd) => cmd.run(&settings).await,
+            Self::BackfillBurned(cmd) => cmd.run(&settings).await,
         }
     }
 }

--- a/mobile_packet_verifier/tests/integrations/backfill.rs
+++ b/mobile_packet_verifier/tests/integrations/backfill.rs
@@ -21,6 +21,7 @@ use mobile_packet_verifier::{
 };
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
+use task_manager::TaskManager;
 use trino_rust_client::Trino;
 
 use crate::common;
@@ -68,9 +69,8 @@ fn make_verified_report(
 #[sqlx::test]
 async fn backfill_writes_sessions_to_iceberg(pool: PgPool) -> anyhow::Result<()> {
     let harness = common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer(iceberg::session::TABLE_NAME)
-        .await?;
+    let (writer, writer_task, _spool_dir) =
+        common::make_batched_writer(&harness, iceberg::session::table_definition()?).await?;
 
     let awsl = AwsLocal::new().await;
     awsl.create_bucket().await?;
@@ -107,16 +107,22 @@ async fn backfill_writes_sessions_to_iceberg(pool: PgPool) -> anyhow::Result<()>
     // Run backfill - poller will exit via idle_timeout after processing all files
     let options = common::test_backfill_options("test-backfill", start_time, end_time);
 
+    let (backfiller, server) = DataSessionsBackfiller::create(
+        pool.clone(),
+        awsl.bucket_client(),
+        Some(writer),
+        Some(options),
+    )
+    .await?;
+
     tokio::time::timeout(
         TEST_TIMEOUT,
-        DataSessionsBackfiller::create_managed_task(
-            pool.clone(),
-            awsl.bucket_client(),
-            Some(writer),
-            options,
-        )
-        .await?
-        .start(),
+        TaskManager::builder()
+            .add_task(writer_task)
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start(),
     )
     .await
     .map_err(|_| anyhow::anyhow!("backfill timed out after {:?}", TEST_TIMEOUT))??;
@@ -132,9 +138,8 @@ async fn backfill_writes_sessions_to_iceberg(pool: PgPool) -> anyhow::Result<()>
 #[sqlx::test]
 async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
     let harness = common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer(iceberg::session::TABLE_NAME)
-        .await?;
+    let (writer, writer_task, _spool_dir) =
+        common::make_batched_writer(&harness, iceberg::session::table_definition()?).await?;
 
     let awsl = AwsLocal::new().await;
     awsl.create_bucket().await?;
@@ -184,16 +189,22 @@ async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
     // Run backfill with stop_after = file3_time (should process only first 2 files)
     // Poller exits via stop_after before reaching file3, then idle_timeout triggers exit
     let options = common::test_backfill_options("test-backfill-stop", start_time, stop_time);
+    let (backfiller, server) = DataSessionsBackfiller::create(
+        pool.clone(),
+        awsl.bucket_client(),
+        Some(writer),
+        Some(options),
+    )
+    .await?;
+
     tokio::time::timeout(
         TEST_TIMEOUT,
-        DataSessionsBackfiller::create_managed_task(
-            pool.clone(),
-            awsl.bucket_client(),
-            Some(writer),
-            options,
-        )
-        .await?
-        .start(),
+        TaskManager::builder()
+            .add_task(writer_task)
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start(),
     )
     .await
     .map_err(|_| anyhow::anyhow!("backfill timed out after {:?}", TEST_TIMEOUT))??;
@@ -213,9 +224,6 @@ async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test]
 async fn backfill_resumes_after_interruption(pool: PgPool) -> anyhow::Result<()> {
     let harness = common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer(iceberg::session::TABLE_NAME)
-        .await?;
 
     let awsl = AwsLocal::new().await;
     awsl.create_bucket().await?;
@@ -267,16 +275,23 @@ async fn backfill_resumes_after_interruption(pool: PgPool) -> anyhow::Result<()>
 
     // First run: process only first 2 files (stop before file3_time)
     let options = common::test_backfill_options(process_name, start_time, stop_time);
+    let (writer, writer_task, _spool_dir) =
+        common::make_batched_writer(&harness, iceberg::session::table_definition()?).await?;
+    let (backfiller, server) = DataSessionsBackfiller::create(
+        pool.clone(),
+        awsl.bucket_client(),
+        Some(writer),
+        Some(options),
+    )
+    .await?;
     tokio::time::timeout(
         TEST_TIMEOUT,
-        DataSessionsBackfiller::create_managed_task(
-            pool.clone(),
-            awsl.bucket_client(),
-            Some(writer.clone()),
-            options,
-        )
-        .await?
-        .start(),
+        TaskManager::builder()
+            .add_task(writer_task)
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start(),
     )
     .await
     .map_err(|_| anyhow::anyhow!("backfill timed out after {:?}", TEST_TIMEOUT))??;
@@ -292,16 +307,23 @@ async fn backfill_resumes_after_interruption(pool: PgPool) -> anyhow::Result<()>
     // The FileInfoPoller should skip already-processed files
     // Poller exits via idle_timeout after processing file3
     let options = common::test_backfill_options(process_name, start_time, end_time);
+    let (writer, writer_task, _spool_dir) =
+        common::make_batched_writer(&harness, iceberg::session::table_definition()?).await?;
+    let (backfiller, server) = DataSessionsBackfiller::create(
+        pool.clone(),
+        awsl.bucket_client(),
+        Some(writer),
+        Some(options),
+    )
+    .await?;
     tokio::time::timeout(
         TEST_TIMEOUT,
-        DataSessionsBackfiller::create_managed_task(
-            pool.clone(),
-            awsl.bucket_client(),
-            Some(writer),
-            options,
-        )
-        .await?
-        .start(),
+        TaskManager::builder()
+            .add_task(writer_task)
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start(),
     )
     .await
     .map_err(|_| anyhow::anyhow!("backfill timed out after {:?}", TEST_TIMEOUT))??;
@@ -321,9 +343,8 @@ async fn backfill_resumes_after_interruption(pool: PgPool) -> anyhow::Result<()>
 #[sqlx::test]
 async fn backfill_filters_invalid_sessions(pool: PgPool) -> anyhow::Result<()> {
     let harness = common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer(iceberg::session::TABLE_NAME)
-        .await?;
+    let (writer, writer_task, _spool_dir) =
+        common::make_batched_writer(&harness, iceberg::session::table_definition()?).await?;
 
     let awsl = AwsLocal::new().await;
     awsl.create_bucket().await?;
@@ -353,16 +374,22 @@ async fn backfill_filters_invalid_sessions(pool: PgPool) -> anyhow::Result<()> {
 
     let options = common::test_backfill_options("test-backfill-filter", start_time, end_time);
 
+    let (backfiller, server) = DataSessionsBackfiller::create(
+        pool.clone(),
+        awsl.bucket_client(),
+        Some(writer),
+        Some(options),
+    )
+    .await?;
+
     tokio::time::timeout(
         TEST_TIMEOUT,
-        DataSessionsBackfiller::create_managed_task(
-            pool.clone(),
-            awsl.bucket_client(),
-            Some(writer),
-            options,
-        )
-        .await?
-        .start(),
+        TaskManager::builder()
+            .add_task(writer_task)
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start(),
     )
     .await
     .map_err(|_| anyhow::anyhow!("backfill timed out after {:?}", TEST_TIMEOUT))??;
@@ -397,9 +424,8 @@ fn make_valid_data_transfer_session(
 #[sqlx::test]
 async fn burned_backfill_writes_sessions_to_iceberg(pool: PgPool) -> anyhow::Result<()> {
     let harness = common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer(iceberg::burned_session::TABLE_NAME)
-        .await?;
+    let (writer, writer_task, _spool_dir) =
+        common::make_batched_writer(&harness, iceberg::burned_session::table_definition()?).await?;
 
     let awsl = AwsLocal::new().await;
     awsl.create_bucket().await?;
@@ -424,16 +450,22 @@ async fn burned_backfill_writes_sessions_to_iceberg(pool: PgPool) -> anyhow::Res
 
     let options = common::test_backfill_options("test-burned-backfill", start_time, end_time);
 
+    let (backfiller, server) = BurnedSessionsBackfiller::create(
+        pool.clone(),
+        awsl.bucket_client(),
+        Some(writer),
+        Some(options),
+    )
+    .await?;
+
     tokio::time::timeout(
         TEST_TIMEOUT,
-        BurnedSessionsBackfiller::create_managed_task(
-            pool.clone(),
-            awsl.bucket_client(),
-            Some(writer),
-            options,
-        )
-        .await?
-        .start(),
+        TaskManager::builder()
+            .add_task(writer_task)
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start(),
     )
     .await
     .map_err(|_| anyhow::anyhow!("backfill timed out after {:?}", TEST_TIMEOUT))??;
@@ -450,9 +482,8 @@ async fn burned_backfill_uses_file_timestamp_when_burn_timestamp_is_epoch(
     pool: PgPool,
 ) -> anyhow::Result<()> {
     let harness = common::setup_iceberg().await?;
-    let writer = harness
-        .get_table_writer(iceberg::burned_session::TABLE_NAME)
-        .await?;
+    let (writer, writer_task, _spool_dir) =
+        common::make_batched_writer(&harness, iceberg::burned_session::table_definition()?).await?;
 
     let awsl = AwsLocal::new().await;
     awsl.create_bucket().await?;
@@ -478,17 +509,23 @@ async fn burned_backfill_uses_file_timestamp_when_burn_timestamp_is_epoch(
 
     let options = common::test_backfill_options("test-burned-backfill-epoch", start_time, end_time);
 
+    let (backfiller, server) = BurnedSessionsBackfiller::create(
+        pool.clone(),
+        awsl.bucket_client(),
+        Some(writer),
+        Some(options),
+    )
+    .await
+    .context("burned backfiller")?;
+
     tokio::time::timeout(
         TEST_TIMEOUT,
-        BurnedSessionsBackfiller::create_managed_task(
-            pool.clone(),
-            awsl.bucket_client(),
-            Some(writer),
-            options,
-        )
-        .await
-        .context("burned backfiller")?
-        .start(),
+        TaskManager::builder()
+            .add_task(writer_task)
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start(),
     )
     .await
     .map_err(|_| anyhow::anyhow!("backfill timed out after {:?}", TEST_TIMEOUT))??;

--- a/mobile_packet_verifier/tests/integrations/common/mod.rs
+++ b/mobile_packet_verifier/tests/integrations/common/mod.rs
@@ -1,7 +1,10 @@
 use chrono::{DateTime, Utc};
 use helium_crypto::PublicKeyBinary;
-use helium_iceberg::IcebergTestHarness;
+use helium_iceberg::{
+    BatchedWriter, BatchedWriterConfig, BatchedWriterTask, IcebergTestHarness, TableDefinition,
+};
 use mobile_packet_verifier::{backfill::BackfillOptions, iceberg, MobileConfigResolverExt};
+use serde::Serialize;
 
 pub async fn setup_iceberg() -> anyhow::Result<IcebergTestHarness> {
     let harness = IcebergTestHarness::new_with_tables([
@@ -11,6 +14,27 @@ pub async fn setup_iceberg() -> anyhow::Result<IcebergTestHarness> {
     .await?;
 
     Ok(harness)
+}
+
+/// Build a `BatchedWriter` against the harness's catalog with a fresh tempdir
+/// spool. `max_batch_size = 1` makes each `queue_all` flush right away so test
+/// assertions see rows promptly; long timeout so the timer never fires before
+/// shutdown drains the spool.
+pub async fn make_batched_writer<T>(
+    harness: &IcebergTestHarness,
+    table_def: TableDefinition,
+) -> anyhow::Result<(BatchedWriter<T>, BatchedWriterTask<T>, tempfile::TempDir)>
+where
+    T: Serialize + Send + Sync + 'static,
+{
+    let spool_dir = tempfile::tempdir()?;
+    let config = BatchedWriterConfig::new(spool_dir.path().to_path_buf())
+        .with_max_batch_size(1)
+        .with_batch_timeout(std::time::Duration::from_secs(3600));
+    let catalog = harness.iceberg_catalog().clone();
+    let table = catalog.create_table_if_not_exists(table_def).await?;
+    let (writer, task) = BatchedWriter::new(table, config);
+    Ok((writer, task, spool_dir))
 }
 
 enum ValidKeys {

--- a/mobile_packet_verifier/tests/integrations/daemon.rs
+++ b/mobile_packet_verifier/tests/integrations/daemon.rs
@@ -12,13 +12,11 @@ use helium_crypto::PublicKeyBinary;
 use helium_proto::services::{
     packet_verifier::ValidDataTransferSession,
     poc_mobile::{
-        verified_data_transfer_ingest_report_v1::ReportStatus, CarrierIdV2,
-        DataTransferRadioAccessTechnology, DataTransferSessionIngestReportV1,
+        CarrierIdV2, DataTransferRadioAccessTechnology, DataTransferSessionIngestReportV1,
         VerifiedDataTransferIngestReportV1,
     },
 };
 use mobile_packet_verifier::{
-    backfill::{BurnedSessionsBackfiller, DataSessionsBackfiller},
     burner::Burner,
     daemon::{Daemon, IngestReports},
     iceberg,
@@ -60,17 +58,6 @@ fn make_ingest_report(
         },
     }
     .into()
-}
-
-fn make_verified_report(
-    timestamp: chrono::DateTime<Utc>,
-    event_id: &str,
-) -> VerifiedDataTransferIngestReportV1 {
-    VerifiedDataTransferIngestReportV1 {
-        report: Some(make_ingest_report(timestamp, event_id)),
-        status: ReportStatus::Valid as i32,
-        timestamp: timestamp.timestamp_millis() as u64,
-    }
 }
 
 fn mk_data_transfer_session(
@@ -185,11 +172,6 @@ async fn daemon_processes_ingest_reports(pool: PgPool) -> anyhow::Result<()> {
         .create()
         .await?;
 
-    // Backfillers with None writer: done=true on construction, recv() returns
-    // pending() immediately, so the select! arms never fire.
-    let (_, session_rx) = tokio::sync::mpsc::channel(10);
-    let (_, burned_rx) = tokio::sync::mpsc::channel(10);
-
     let ingest_reports = IngestReports::new(
         pool.clone(),
         reports,
@@ -205,8 +187,6 @@ async fn daemon_processes_ingest_reports(pool: PgPool) -> anyhow::Result<()> {
         ingest_reports,
         noop_burner(),
         common::TestMobileConfig::all_valid(),
-        DataSessionsBackfiller::new(pool.clone(), session_rx, None),
-        BurnedSessionsBackfiller::new(pool.clone(), burned_rx, None),
     );
 
     let (trigger, listener) = triggered::trigger();
@@ -248,157 +228,6 @@ async fn daemon_processes_ingest_reports(pool: PgPool) -> anyhow::Result<()> {
     );
 
     awsl.cleanup().await?;
-    Ok(())
-}
-
-/// Verify that when Iceberg is configured, the daemon's backfill arms process
-/// verified session files and write them to Iceberg during idle time.
-/// No ingest reports are present; the test exits when the Iceberg row appears.
-#[sqlx::test]
-async fn daemon_with_iceberg_processes_backfill(pool: PgPool) -> anyhow::Result<()> {
-    let harness = common::setup_iceberg().await?;
-    let session_writer = harness
-        .get_table_writer(iceberg::session::TABLE_NAME)
-        .await?;
-
-    let awsl = AwsLocal::new().await;
-    awsl.create_bucket().await?;
-
-    let base_time = Utc::now() - Duration::hours(1);
-    let start_time = base_time - Duration::minutes(1);
-    let end_time = base_time + Duration::days(42);
-    let file_time = base_time;
-
-    // Put a verified session file that the session backfiller will pick up.
-    awsl.put_protos_at_time(
-        FileType::VerifiedDataTransferSession.to_string(),
-        vec![make_verified_report(file_time, "backfill-event-1")],
-        file_time,
-    )
-    .await?;
-
-    // Session backfiller with a real writer.
-    let backfill_opts = common::test_backfill_options("daemon-backfill", start_time, end_time);
-    let (session_backfill, session_backfill_server) = DataSessionsBackfiller::create(
-        pool.clone(),
-        awsl.bucket_client(),
-        Some(session_writer),
-        Some(backfill_opts),
-    )
-    .await?;
-
-    // Burned backfiller with no writer (no burned session files in this test).
-    let (_, burned_rx) = tokio::sync::mpsc::channel(10);
-    let burned_backfill = BurnedSessionsBackfiller::new(pool.clone(), burned_rx, None);
-
-    // Reports channel kept open so the daemon's ingest arm just blocks.
-    let (_reports_tx, reports_rx) = tokio::sync::mpsc::channel(10);
-
-    let (verified_tx, _verified_rx) = tokio::sync::mpsc::channel(100);
-    let ingest_reports = IngestReports::new(
-        pool.clone(),
-        reports_rx,
-        FileSinkClient::new(verified_tx, "test"),
-        None,
-    );
-
-    let daemon = Daemon::new(
-        pool.clone(),
-        NO_BURN,
-        NO_BURN,
-        NO_BURN,
-        ingest_reports,
-        noop_burner(),
-        common::TestMobileConfig::all_valid(),
-        session_backfill,
-        burned_backfill,
-    );
-
-    // Shutdown: poll Iceberg until the backfilled row appears, then trigger.
-    // When the Iceberg write is committed the backfiller has finished its work.
-    let (trigger, listener) = triggered::trigger();
-
-    let trino_client = harness.owned_trino().await?;
-    let job = TaskManager::builder()
-        .add_task(session_backfill_server)
-        .add_task(daemon)
-        .add_task(|_| async {
-            trigger
-                .when_iceberg_sessions_exist(trino_client)
-                .await
-                .expect("iceberg sessions exist");
-            Ok(())
-        })
-        .build();
-
-    // Spawn the TaskManager separately so we can borrow `harness` in this task.
-    tokio::time::timeout(TEST_TIMEOUT, Box::new(job).start_task(listener))
-        .await
-        .map_err(|err| anyhow::anyhow!("deamon failed {:?}", err))??;
-
-    let rows = iceberg::session::get_all(harness.trino()).await?;
-    assert_eq!(rows.len(), 1, "expected 1 backfilled session in iceberg");
-
-    awsl.cleanup().await?;
-    Ok(())
-}
-
-/// Verify that when Iceberg is not configured, the daemon starts and runs without
-/// panicking. Backfillers are disabled (done=true on construction). Shutdown is
-/// driven by an explicit trigger after a brief delay — this test only checks that
-/// the daemon wires up and starts cleanly, not that any processing occurs.
-#[sqlx::test]
-async fn daemon_without_iceberg_skips_backfill(pool: PgPool) -> anyhow::Result<()> {
-    pending_burns::initialize(&pool).await?;
-
-    // Manual reports channel — keep the sender alive so the daemon's ingest arm
-    // just blocks rather than bailing with "sender dropped".
-    // No S3 is needed since no files are processed in this test.
-    let (_reports_tx, reports_rx) = tokio::sync::mpsc::channel(10);
-
-    // No-op backfillers (no Iceberg writer → done=true, recv() returns pending())
-    let (_, session_rx) = tokio::sync::mpsc::channel(10);
-    let (_, burned_rx) = tokio::sync::mpsc::channel(10);
-
-    let (verified_tx, _verified_rx) = tokio::sync::mpsc::channel(100);
-    let ingest_reports = IngestReports::new(
-        pool.clone(),
-        reports_rx,
-        FileSinkClient::new(verified_tx, "test"),
-        None,
-    );
-
-    let daemon = Daemon::new(
-        pool.clone(),
-        NO_BURN,
-        NO_BURN,
-        NO_BURN,
-        ingest_reports,
-        noop_burner(),
-        common::TestMobileConfig::all_valid(),
-        DataSessionsBackfiller::new(pool.clone(), session_rx, None),
-        BurnedSessionsBackfiller::new(pool.clone(), burned_rx, None),
-    );
-
-    let (trigger, listener) = triggered::trigger();
-    let job = TaskManager::builder()
-        .add_task(daemon)
-        .add_task(|_| async {
-            // Trigger shutdown after a short delay — enough to confirm the
-            // daemon starts without panicking and idles cleanly.
-            trigger.after_sleep(300).await;
-            Ok(())
-        })
-        .build();
-
-    tokio::time::timeout(TEST_TIMEOUT, Box::new(job).start_task(listener))
-        .await
-        .map_err(|err| anyhow::anyhow!("daemon failed {err:?}"))??;
-
-    // No files were processed; pending burns table should be empty.
-    let burns = pending_burns::get_all(&pool).await?;
-    assert!(burns.is_empty(), "expected no pending burns");
-
     Ok(())
 }
 
@@ -463,10 +292,6 @@ async fn daemon_burns_sessions(pool: PgPool) -> anyhow::Result<()> {
         Some(burned_writer),
     );
 
-    // No-op backfillers
-    let (_, session_rx) = tokio::sync::mpsc::channel(10);
-    let (_, burned_rx) = tokio::sync::mpsc::channel(10);
-
     // Keep reports channel sender alive so the daemon's ingest arm just blocks.
     let (_reports_tx, reports_rx) = tokio::sync::mpsc::channel(1);
 
@@ -487,8 +312,6 @@ async fn daemon_burns_sessions(pool: PgPool) -> anyhow::Result<()> {
         ingest_reports,
         burner,
         common::TestMobileConfig::all_valid(),
-        DataSessionsBackfiller::new(pool.clone(), session_rx, None),
-        BurnedSessionsBackfiller::new(pool.clone(), burned_rx, None),
     );
 
     // On BurnSuccess, manually commit the Automatic FileSink so the rolled file
@@ -631,10 +454,6 @@ async fn daemon_full_flow(pool: PgPool) -> anyhow::Result<()> {
         .create()
         .await?;
 
-    // No-op backfillers — this test exercises only the real-time ingest + burn path.
-    let (_, session_rx) = tokio::sync::mpsc::channel(10);
-    let (_, burned_rx) = tokio::sync::mpsc::channel(10);
-
     let ingest_reports = IngestReports::new(
         pool.clone(),
         reports,
@@ -652,8 +471,6 @@ async fn daemon_full_flow(pool: PgPool) -> anyhow::Result<()> {
         ingest_reports,
         burner,
         common::TestMobileConfig::all_valid(),
-        DataSessionsBackfiller::new(pool.clone(), session_rx, None),
-        BurnedSessionsBackfiller::new(pool.clone(), burned_rx, None),
     );
 
     // On BurnSuccess, manually commit the Automatic FileSink so the rolled file
@@ -745,169 +562,6 @@ async fn daemon_full_flow(pool: PgPool) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Verify that the backfill `stop_after` boundary is respected when the daemon
-/// runs with embedded backfillers alongside a real-time ingest path.
-///
-/// **Scenario**:
-/// - A "historical" VerifiedDataTransferSession file exists at `T_historical`
-///   (one hour before the boundary).
-/// - A "new" VerifiedDataTransferSession file exists at `T_new` (30 minutes
-///   after the boundary).
-/// - Backfill is configured with `stop_after = boundary`.
-/// - An ingest report is also present and processed by the real-time path,
-///   writing its own Iceberg session record.
-///
-/// **Expected**:
-/// - Iceberg has exactly 2 session records:
-///   1. The historical session (written by the backfiller).
-///   2. The fresh ingest session (written by the real-time daemon path).
-/// - The new VerifiedDataTransferSession file (T_new) is **not** processed by
-///   the backfiller because it lies beyond `stop_after`.
-#[sqlx::test]
-async fn daemon_backfill_boundary(pool: PgPool) -> anyhow::Result<()> {
-    pending_burns::initialize(&pool).await?;
-
-    let harness = common::setup_iceberg().await?;
-    let session_writer = harness
-        .get_table_writer(iceberg::session::TABLE_NAME)
-        .await?;
-
-    let awsl = AwsLocal::new().await;
-    awsl.create_bucket().await?;
-
-    // Times
-    let boundary = Utc::now() - Duration::hours(1); // "Iceberg deployment date"
-    let historical_time = boundary - Duration::hours(1); // before boundary → backfiller processes
-    let new_verified_time = boundary + Duration::minutes(30); // after boundary → backfiller skips
-    let ingest_time = Utc::now() - Duration::minutes(5); // fresh ingest → real-time path
-    let ingest_start = ingest_time - Duration::minutes(1);
-
-    // Historical VerifiedDataTransferSession file (before boundary)
-    awsl.put_protos_at_time(
-        FileType::VerifiedDataTransferSession.to_string(),
-        vec![make_verified_report(historical_time, "historical-event")],
-        historical_time,
-    )
-    .await?;
-
-    // New VerifiedDataTransferSession file (after boundary) — backfiller must skip this
-    awsl.put_protos_at_time(
-        FileType::VerifiedDataTransferSession.to_string(),
-        vec![make_verified_report(
-            new_verified_time,
-            "new-verified-event",
-        )],
-        new_verified_time,
-    )
-    .await?;
-
-    // Fresh ingest report — processed by the daemon's real-time path
-    awsl.put_protos_at_time(
-        FileType::DataTransferSessionIngestReport.to_string(),
-        vec![make_ingest_report(ingest_time, "ingest-event")],
-        ingest_time,
-    )
-    .await?;
-
-    // Backfill: start before historical_time, stop at boundary
-    let backfill_start = historical_time - Duration::minutes(1);
-    let backfill_opts = common::test_backfill_options("boundary-test", backfill_start, boundary);
-    let (session_backfill, session_backfill_server) = DataSessionsBackfiller::create(
-        pool.clone(),
-        awsl.bucket_client(),
-        Some(session_writer),
-        Some(backfill_opts),
-    )
-    .await?;
-
-    let (_, burned_rx) = tokio::sync::mpsc::channel(10);
-    let burned_backfill = BurnedSessionsBackfiller::new(pool.clone(), burned_rx, None);
-
-    // Real-time reports poller for the fresh ingest file.
-    let (reports, reports_server) = file_source::continuous_source()
-        .state(pool.clone())
-        .bucket_client(awsl.bucket_client())
-        .prefix(FileType::DataTransferSessionIngestReport.to_string())
-        .lookback_start_after(ingest_start)
-        .poll_duration_opt(Some(std::time::Duration::from_millis(100)))
-        .create()
-        .await?;
-
-    // No-op file sinks for verified sessions output (not asserting S3 in this test).
-    let (verified_tx, _verified_rx) = tokio::sync::mpsc::channel(100);
-    // No real-time Iceberg writer: the ingest path produces a pending_burn which
-    // serves as its "done" signal; session rows come from the backfiller only.
-    let ingest_reports = IngestReports::new(
-        pool.clone(),
-        reports,
-        FileSinkClient::new(verified_tx, "test"),
-        None,
-    );
-
-    let daemon = Daemon::new(
-        pool.clone(),
-        NO_BURN,
-        NO_BURN,
-        NO_BURN,
-        ingest_reports,
-        noop_burner(),
-        common::TestMobileConfig::all_valid(),
-        session_backfill,
-        burned_backfill,
-    );
-
-    let (trigger, listener) = triggered::trigger();
-
-    let job = TaskManager::builder()
-        .add_task(session_backfill_server)
-        .add_task(reports_server)
-        .add_task(daemon)
-        .build();
-
-    let job_handle = tokio::spawn(Box::new(job).start_task(listener));
-
-    // Shutdown: wait for:
-    //   - the historical backfill row in Iceberg, AND
-    //   - the pending burn from the fresh ingest (signals real-time path completed)
-    let pool_watch = pool.clone();
-    tokio::time::timeout(TEST_TIMEOUT, async {
-        loop {
-            let iceberg_rows = iceberg::session::get_all(harness.trino()).await?;
-            let burns = pending_burns::get_all(&pool_watch).await?;
-            // 1 backfilled row + ingest produced a pending burn
-            if !iceberg_rows.is_empty() && !burns.is_empty() {
-                trigger.trigger();
-                return anyhow::Ok(());
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        }
-    })
-    .await
-    .map_err(|_| anyhow::anyhow!("boundary test timed out after {:?}", TEST_TIMEOUT))??;
-
-    job_handle
-        .await
-        .map_err(|e| anyhow::anyhow!("job panicked: {e}"))??;
-
-    // The backfiller should have written exactly 1 row: the historical session.
-    // The "new" VerifiedDataTransferSession file (T_new) must NOT appear because
-    // it lies beyond stop_after.
-    let rows = iceberg::session::get_all(harness.trino()).await?;
-    assert_eq!(
-        rows.len(),
-        1,
-        "backfiller must write only the historical session; \
-         new-verified-event (past stop_after) must be excluded"
-    );
-
-    // The fresh ingest produced a pending burn (real-time path ran correctly).
-    let burns = pending_burns::get_all(&pool).await?;
-    assert_eq!(burns.len(), 1, "ingest should have produced 1 pending burn");
-
-    awsl.cleanup().await?;
-    Ok(())
-}
-
 async fn verified_data_transfer_files(
     bucket_client: &BucketClient,
 ) -> anyhow::Result<Vec<FileInfo>> {
@@ -947,41 +601,18 @@ async fn commit_valid_session_sink_on_burn(
 mod trigger {
     use file_store::file_upload::FileUpload;
     use mobile_packet_verifier::daemon::DaemonEvent;
-    use mobile_packet_verifier::iceberg;
-    use std::time::Duration;
     use tokio::sync::broadcast::Receiver;
-    use tokio::time::sleep;
 
     pub trait TriggerExt {
-        async fn when_iceberg_sessions_exist(
-            self,
-            trino: trino_rust_client::Client,
-        ) -> anyhow::Result<()>;
         async fn when_uploads_completed_at_least(
             self,
             n_uploads: u64,
             events: Receiver<DaemonEvent>,
             file_upload_watcher: FileUpload,
         ) -> anyhow::Result<()>;
-
-        async fn after_sleep(self, ms: u64);
     }
 
     impl TriggerExt for triggered::Trigger {
-        async fn when_iceberg_sessions_exist(
-            self,
-            trino: trino_rust_client::Client,
-        ) -> anyhow::Result<()> {
-            loop {
-                let rows = iceberg::session::get_all(&trino).await.unwrap_or_default();
-                if !rows.is_empty() {
-                    self.trigger();
-                    return Ok(());
-                }
-                sleep(Duration::from_millis(100)).await;
-            }
-        }
-
         async fn when_uploads_completed_at_least(
             self,
             n_uploads: u64,
@@ -998,11 +629,6 @@ mod trigger {
                 }
             }
             anyhow::bail!("no report handle event received");
-        }
-
-        async fn after_sleep(self, ms: u64) {
-            sleep(Duration::from_millis(ms)).await;
-            self.trigger();
         }
     }
 }


### PR DESCRIPTION
Data Transfer Sessions and Burned Data Transfer Sessions backfill jobs have been removed from Daemon and broken out into individual processes.

- `backfill-sessions`
- `backfill-burned`

Default for batches is 1,000,000 records, which gives about 500Mb arrow files before uploading.
Batch size is overridable with the `--batch-size` cli argument.

We need a persistent volume for the BatchedWriter to store it's state.
And postgres for tracking progress of files.

Backfill process name has been kept the same, it should be able to pick up from previous backfill runs if pointing at the same database instance.

Sample command
```sh
mobile-packet-verifier \
    -c settings.toml \
    backfill-burned \
    --start-after 2020-04-01T00:00:00Z \
    --stop-after 2026-04-02T00:00:00Z \
    [--batch-size 100000]
```