### PR TITLE
Add env variable to control aws identity cache timeout

### DIFF
--- a/file_store/src/lib.rs
+++ b/file_store/src/lib.rs
@@ -24,7 +24,7 @@ pub use rolling_file_sink::{RollingFileSink, RollingFileSinkError, RollingFileWr
 pub use settings::{BucketSettings, Settings};
 
 // Client functions
-use aws_config::BehaviorVersion;
+use aws_config::{identity::IdentityCache, BehaviorVersion};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_smithy_types_convert::stream::PaginationStreamExt;
 use bytes::BytesMut;
@@ -34,8 +34,19 @@ use futures::{
     stream::{self, BoxStream},
     FutureExt, StreamExt, TryFutureExt, TryStreamExt,
 };
-use std::{collections::HashMap, future::Future, path::Path, sync::OnceLock};
+use std::{collections::HashMap, future::Future, path::Path, sync::OnceLock, time::Duration};
 use tokio::sync::Mutex;
+
+const IDENTITY_LOAD_TIMEOUT_ENV: &str = "FILE_STORE_IDENTITY_LOAD_TIMEOUT_SECS";
+const DEFAULT_IDENTITY_LOAD_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn identity_load_timeout() -> Duration {
+    std::env::var(IDENTITY_LOAD_TIMEOUT_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_IDENTITY_LOAD_TIMEOUT)
+}
 
 pub type Client = aws_sdk_s3::Client;
 pub type Stream<T> = BoxStream<'static, Result<T>>;
@@ -94,7 +105,14 @@ pub async fn new_client(
         return client.clone();
     }
 
-    let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .identity_cache(
+            IdentityCache::lazy()
+                .load_timeout(identity_load_timeout())
+                .build(),
+        )
+        .load()
+        .await;
 
     let mut s3_config = aws_sdk_s3::config::Builder::from(&config);
 


### PR DESCRIPTION
## Summary

- Set a 30 s `load_timeout` on the AWS SDK identity cache in `file_store::new_client`, replacing the SDK default of 5 s. Allow override via the `FILE_STORE_IDENTITY_LOAD_TIMEOUT_SECS` env var.
- Fixes sporadic `mobile-packet-verifier backfill-session` failures of the form `aws error: get_object (...) → dispatch failure → identity resolver timed out after 5s`.

## Why

The S3 client is cached, but credentials inside it are loaded lazily by `IdentityCache::lazy()` and re-fetched when they expire (~hourly on EC2/ECS via IMDS). The SDK's default 5 s identity-load timeout is too tight: when IMDS / STS briefly stalls, the next in-flight `get_object` is failed.

The backfill CLI hits this far more than the daemon because it issues `get_object` back-to-back at high rate over long runs, virtually guaranteeing a refresh will land on an active request.

This restores the behavior of the previous `load_timeout(30s)` setting (commit `19b20186`) that was removed in commit `73d5511d` during an AWS SDK upgrade — that commit's message explicitly anticipated re-adding it "if we're still getting timeout failures." We are.

## Changes

- `file_store/src/lib.rs`
  - Add `IdentityCache` import and `Duration` to existing imports.
  - Add `FILE_STORE_IDENTITY_LOAD_TIMEOUT_SECS` env constant + `identity_load_timeout()` helper (default 30 s, falls back to default on parse failure).
  - In `new_client`, chain `.identity_cache(IdentityCache::lazy().load_timeout(...).build())` onto `aws_config::defaults(...)`.

Single call site, so every `file_store` consumer (price tracker, all verifiers, backfill CLIs, tests) inherits the longer timeout — no per-config plumbing.
