### PR TITLE
Heartbeat backfill

### DIFF
--- a/file_store_oracles/src/mobile/mod.rs
+++ b/file_store_oracles/src/mobile/mod.rs
@@ -7,4 +7,5 @@ pub mod mobile_session;
 pub mod mobile_subscriber;
 pub mod mobile_transfer;
 pub mod speedtest;
+pub mod validated_heartbeat;
 pub mod wifi_heartbeat;

--- a/file_store_oracles/src/mobile/validated_heartbeat.rs
+++ b/file_store_oracles/src/mobile/validated_heartbeat.rs
@@ -1,0 +1,139 @@
+use chrono::{DateTime, Utc};
+use file_store::traits::{MsgDecode, TimestampDecode, TimestampDecodeError, TimestampDecodeResult};
+use helium_crypto::PublicKeyBinary;
+use helium_proto::services::poc_mobile::{
+    CellType, Heartbeat as HeartbeatProto, HeartbeatValidity, LocationSource,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{prost_enum, traits::MsgTimestamp};
+
+#[derive(thiserror::Error, Debug)]
+pub enum ValidatedHeartbeatError {
+    #[error("invalid timestamp: {0}")]
+    Timestamp(#[from] TimestampDecodeError),
+
+    #[error("unsupported cell type: {0}")]
+    CellType(prost::UnknownEnumValue),
+
+    #[error("unsupported validity: {0}")]
+    Validity(prost::UnknownEnumValue),
+
+    #[error("unsupported location source: {0}")]
+    LocationSource(prost::UnknownEnumValue),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ValidatedHeartbeat {
+    pub pubkey: PublicKeyBinary,
+    pub cbsd_id: String,
+    pub cell_type: CellType,
+    pub validity: HeartbeatValidity,
+    pub received_timestamp: DateTime<Utc>,
+    pub lat: f64,
+    pub lon: f64,
+    pub coverage_object: Vec<u8>,
+    pub location_validation_timestamp: Option<DateTime<Utc>>,
+    pub distance_to_asserted: u64,
+    pub location_trust_score_multiplier_milli: u32,
+    pub location_source: LocationSource,
+}
+
+impl ValidatedHeartbeat {
+    pub fn coverage_object(&self) -> Option<Uuid> {
+        Uuid::from_slice(&self.coverage_object).ok()
+    }
+}
+
+impl MsgDecode for ValidatedHeartbeat {
+    type Msg = HeartbeatProto;
+}
+
+impl MsgTimestamp<TimestampDecodeResult> for HeartbeatProto {
+    fn timestamp(&self) -> TimestampDecodeResult {
+        self.timestamp.to_timestamp()
+    }
+}
+
+impl TryFrom<HeartbeatProto> for ValidatedHeartbeat {
+    type Error = ValidatedHeartbeatError;
+
+    fn try_from(v: HeartbeatProto) -> Result<Self, Self::Error> {
+        let location_validation_timestamp = if v.location_validation_timestamp == 0 {
+            None
+        } else {
+            v.location_validation_timestamp.to_timestamp().ok()
+        };
+
+        Ok(Self {
+            pubkey: v.pub_key.into(),
+            cbsd_id: v.cbsd_id,
+            cell_type: prost_enum(v.cell_type, ValidatedHeartbeatError::CellType)?,
+            validity: prost_enum(v.validity, ValidatedHeartbeatError::Validity)?,
+            received_timestamp: v.timestamp.to_timestamp()?,
+            lat: v.lat,
+            lon: v.lon,
+            coverage_object: v.coverage_object,
+            location_validation_timestamp,
+            distance_to_asserted: v.distance_to_asserted,
+            location_trust_score_multiplier_milli: v.location_trust_score_multiplier,
+            location_source: prost_enum(v.location_source, ValidatedHeartbeatError::LocationSource)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    #[test]
+    fn decode_validated_heartbeat_proto() {
+        let pub_key = vec![1u8, 2, 3, 4];
+        let now = Utc::now().timestamp() as u64;
+        let proto = HeartbeatProto {
+            pub_key: pub_key.clone(),
+            timestamp: now,
+            cell_type: CellType::NovaGenericWifiIndoor as i32,
+            validity: HeartbeatValidity::Valid as i32,
+            lat: 37.7749,
+            lon: -122.4194,
+            coverage_object: Uuid::new_v4().as_bytes().to_vec(),
+            location_validation_timestamp: now,
+            distance_to_asserted: 42,
+            location_trust_score_multiplier: 750,
+            location_source: LocationSource::Skyhook as i32,
+            ..Default::default()
+        };
+
+        let buf = proto.encode_to_vec();
+        let decoded = ValidatedHeartbeat::decode(buf.as_slice()).unwrap();
+
+        assert_eq!(decoded.pubkey, PublicKeyBinary::from(pub_key));
+        assert_eq!(decoded.validity, HeartbeatValidity::Valid);
+        assert_eq!(decoded.distance_to_asserted, 42);
+        assert_eq!(decoded.location_trust_score_multiplier_milli, 750);
+        assert!(decoded.location_validation_timestamp.is_some());
+        assert!(decoded.coverage_object().is_some());
+    }
+
+    #[test]
+    fn zero_location_validation_timestamp_decodes_to_none() {
+        let proto = HeartbeatProto {
+            pub_key: vec![1],
+            timestamp: Utc::now().timestamp() as u64,
+            cell_type: CellType::NovaGenericWifiIndoor as i32,
+            validity: HeartbeatValidity::Valid as i32,
+            location_trust_score_multiplier: 1000,
+            location_source: LocationSource::Gps as i32,
+            ..Default::default()
+        };
+
+        let buf = proto.encode_to_vec();
+        let decoded = ValidatedHeartbeat::decode(buf.as_slice()).unwrap();
+
+        assert!(decoded.location_validation_timestamp.is_none());
+        assert_eq!(decoded.distance_to_asserted, 0);
+    }
+}

--- a/file_store_oracles/src/mobile/validated_heartbeat.rs
+++ b/file_store_oracles/src/mobile/validated_heartbeat.rs
@@ -4,6 +4,7 @@ use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_mobile::{
     CellType, Heartbeat as HeartbeatProto, HeartbeatValidity, LocationSource,
 };
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -36,7 +37,10 @@ pub struct ValidatedHeartbeat {
     pub coverage_object: Vec<u8>,
     pub location_validation_timestamp: Option<DateTime<Utc>>,
     pub distance_to_asserted: u64,
-    pub location_trust_score_multiplier_milli: u32,
+    /// 0.0..=1.0 score. On the wire this is encoded as a `u32` scaled by
+    /// 1000 (see `helium_proto::services::poc_mobile::Heartbeat`); we
+    /// unscale on decode so callers don't have to remember the encoding.
+    pub location_trust_score_multiplier: Decimal,
     pub location_source: LocationSource,
 }
 
@@ -66,6 +70,11 @@ impl TryFrom<HeartbeatProto> for ValidatedHeartbeat {
             v.location_validation_timestamp.to_timestamp().ok()
         };
 
+        // Wire encoding is `score * 1000` packed in a `u32`. `Decimal::new`
+        // with scale=3 reverses that without going through f64.
+        let location_trust_score_multiplier =
+            Decimal::new(v.location_trust_score_multiplier as i64, 3);
+
         Ok(Self {
             pubkey: v.pub_key.into(),
             cbsd_id: v.cbsd_id,
@@ -77,8 +86,11 @@ impl TryFrom<HeartbeatProto> for ValidatedHeartbeat {
             coverage_object: v.coverage_object,
             location_validation_timestamp,
             distance_to_asserted: v.distance_to_asserted,
-            location_trust_score_multiplier_milli: v.location_trust_score_multiplier,
-            location_source: prost_enum(v.location_source, ValidatedHeartbeatError::LocationSource)?,
+            location_trust_score_multiplier,
+            location_source: prost_enum(
+                v.location_source,
+                ValidatedHeartbeatError::LocationSource,
+            )?,
         })
     }
 }
@@ -113,7 +125,11 @@ mod tests {
         assert_eq!(decoded.pubkey, PublicKeyBinary::from(pub_key));
         assert_eq!(decoded.validity, HeartbeatValidity::Valid);
         assert_eq!(decoded.distance_to_asserted, 42);
-        assert_eq!(decoded.location_trust_score_multiplier_milli, 750);
+        // Wire value 750 (u32, scaled by 1000) decodes to Decimal 0.750.
+        assert_eq!(
+            decoded.location_trust_score_multiplier,
+            Decimal::new(750, 3)
+        );
         assert!(decoded.location_validation_timestamp.is_some());
         assert!(decoded.coverage_object().is_some());
     }

--- a/helium_iceberg/src/batched_writer/mod.rs
+++ b/helium_iceberg/src/batched_writer/mod.rs
@@ -65,8 +65,22 @@ impl BatchedWriterConfig {
         self
     }
 
+    pub fn with_max_batch_size_opt(mut self, n: Option<usize>) -> Self {
+        if let Some(n) = n {
+            self.max_batch_size = n;
+        }
+        self
+    }
+
     pub fn with_batch_timeout(mut self, d: Duration) -> Self {
         self.batch_timeout = d;
+        self
+    }
+
+    pub fn with_batch_timeout_opt(mut self, d: Option<Duration>) -> Self {
+        if let Some(d) = d {
+            self.batch_timeout = d;
+        }
         self
     }
 

--- a/mobile_verifier/src/cli/backfill_ban.rs
+++ b/mobile_verifier/src/cli/backfill_ban.rs
@@ -7,6 +7,7 @@ use crate::{
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use helium_iceberg::BatchedWriterConfig;
+use std::time::Duration;
 use task_manager::TaskManager;
 
 #[derive(Debug, clap::Args)]
@@ -25,6 +26,15 @@ pub struct Cmd {
     /// Format: RFC 3339 (e.g., 2025-02-25T00:00:00Z)
     #[clap(long)]
     stop_after: DateTime<Utc>,
+
+    /// Batch size for processing files.
+    #[clap(long)]
+    batch_size: Option<usize>,
+
+    /// Max time the batched writer waits before flushing a partial batch.
+    /// Accepts human-readable durations like "5m", "30s", "1h".
+    #[clap(long, value_parser = humantime::parse_duration)]
+    batch_timeout: Option<Duration>,
 }
 
 impl Cmd {
@@ -43,7 +53,9 @@ impl Cmd {
         let (writer, writer_task) = IcebergBan::batched_writer(
             iceberg_settings.connect().await?,
             iceberg::ban::table_definition()?,
-            BatchedWriterConfig::new(settings.cache.join("iceberg-spool/ban-backfill")),
+            BatchedWriterConfig::new(settings.cache.join("iceberg-spool/ban-backfill"))
+                .with_max_batch_size_opt(self.batch_size)
+                .with_batch_timeout_opt(self.batch_timeout),
         )
         .await?;
 

--- a/mobile_verifier/src/cli/backfill_heartbeat.rs
+++ b/mobile_verifier/src/cli/backfill_heartbeat.rs
@@ -1,0 +1,83 @@
+use crate::{
+    backfill::BatchedWriterExt,
+    heartbeats::backfill::HeartbeatBackfiller,
+    iceberg::{self, IcebergHeartbeat},
+    Settings,
+};
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use helium_iceberg::BatchedWriterConfig;
+use task_manager::TaskManager;
+
+#[derive(Debug, clap::Args)]
+pub struct Cmd {
+    /// Process name for tracking heartbeat backfill (avoids conflict with daemon)
+    #[clap(long, default_value = "heartbeat-backfill")]
+    process_name: String,
+
+    /// Start processing files after this timestamp.
+    /// Format: RFC 3339 (e.g., 2024-01-01T00:00:00Z)
+    #[clap(long)]
+    start_after: DateTime<Utc>,
+
+    /// Stop processing files when their timestamp is > this value.
+    /// Use this to avoid reprocessing files that the daemon has already handled.
+    /// Format: RFC 3339 (e.g., 2025-02-25T00:00:00Z)
+    #[clap(long)]
+    stop_after: DateTime<Utc>,
+}
+
+impl Cmd {
+    pub async fn run(self, settings: &Settings) -> Result<()> {
+        let pool = settings
+            .database
+            .connect("mobile-verifier-heartbeat-backfill")
+            .await?;
+        sqlx::migrate!().run(&pool).await?;
+
+        let iceberg_settings = settings
+            .iceberg_settings
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("iceberg_settings required for heartbeat backfill"))?;
+
+        let (writer, writer_task) = IcebergHeartbeat::batched_writer(
+            iceberg_settings.connect().await?,
+            iceberg::heartbeat::table_definition()?,
+            BatchedWriterConfig::new(settings.cache.join("iceberg-spool/heartbeat-backfill"))
+                .with_max_batch_size(20_000_000),
+        )
+        .await?;
+
+        tracing::info!(
+            process_name = %self.process_name,
+            start_after = %self.start_after,
+            stop_after = %self.stop_after,
+            "starting heartbeat backfill"
+        );
+
+        let opts = crate::backfill::BackfillOptions {
+            process_name: self.process_name,
+            start_after: self.start_after,
+            stop_after: self.stop_after,
+            poll_duration: None,
+            idle_timeout: None,
+        };
+
+        let (backfiller, server) = HeartbeatBackfiller::create_batched(
+            pool,
+            settings.buckets.output.connect().await,
+            Some(writer),
+            Some(opts),
+        )
+        .await?;
+
+        TaskManager::builder()
+            .add_task(writer_task)
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start()
+            .await?;
+        Ok(())
+    }
+}

--- a/mobile_verifier/src/cli/backfill_heartbeat.rs
+++ b/mobile_verifier/src/cli/backfill_heartbeat.rs
@@ -7,6 +7,7 @@ use crate::{
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use helium_iceberg::BatchedWriterConfig;
+use std::time::Duration;
 use task_manager::TaskManager;
 
 #[derive(Debug, clap::Args)]
@@ -25,6 +26,15 @@ pub struct Cmd {
     /// Format: RFC 3339 (e.g., 2025-02-25T00:00:00Z)
     #[clap(long)]
     stop_after: DateTime<Utc>,
+
+    /// Batch size for processing files.
+    #[clap(long)]
+    batch_size: Option<usize>,
+
+    /// Max time the batched writer waits before flushing a partial batch.
+    /// Accepts human-readable durations like "5m", "30s", "1h".
+    #[clap(long, value_parser = humantime::parse_duration)]
+    batch_timeout: Option<Duration>,
 }
 
 impl Cmd {
@@ -44,7 +54,8 @@ impl Cmd {
             iceberg_settings.connect().await?,
             iceberg::heartbeat::table_definition()?,
             BatchedWriterConfig::new(settings.cache.join("iceberg-spool/heartbeat-backfill"))
-                .with_max_batch_size(20_000_000),
+                .with_max_batch_size_opt(self.batch_size)
+                .with_batch_timeout_opt(self.batch_timeout),
         )
         .await?;
 

--- a/mobile_verifier/src/cli/backfill_speedtest.rs
+++ b/mobile_verifier/src/cli/backfill_speedtest.rs
@@ -7,6 +7,7 @@ use crate::{
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use helium_iceberg::BatchedWriterConfig;
+use std::time::Duration;
 use task_manager::TaskManager;
 
 #[derive(Debug, clap::Args)]
@@ -25,6 +26,15 @@ pub struct Cmd {
     /// Format: RFC 3339 (e.g., 2025-02-25T00:00:00Z)
     #[clap(long)]
     stop_after: DateTime<Utc>,
+
+    /// Batch size for processing files.
+    #[clap(long)]
+    batch_size: Option<usize>,
+
+    /// Max time the batched writer waits before flushing a partial batch.
+    /// Accepts human-readable durations like "5m", "30s", "1h".
+    #[clap(long, value_parser = humantime::parse_duration)]
+    batch_timeout: Option<Duration>,
 }
 
 impl Cmd {
@@ -43,7 +53,9 @@ impl Cmd {
         let (writer, writer_task) = IcebergSpeedtest::batched_writer(
             iceberg_settings.connect().await?,
             iceberg::speedtest::table_definition()?,
-            BatchedWriterConfig::new(settings.cache.join("iceberg-spool/speedtest-backfill")),
+            BatchedWriterConfig::new(settings.cache.join("iceberg-spool/speedtest-backfill"))
+                .with_max_batch_size_opt(self.batch_size)
+                .with_batch_timeout_opt(self.batch_timeout),
         )
         .await?;
 

--- a/mobile_verifier/src/cli/backfill_speedtest_avg.rs
+++ b/mobile_verifier/src/cli/backfill_speedtest_avg.rs
@@ -7,6 +7,7 @@ use crate::{
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use helium_iceberg::BatchedWriterConfig;
+use std::time::Duration;
 use task_manager::TaskManager;
 
 #[derive(Debug, clap::Args)]
@@ -25,6 +26,15 @@ pub struct Cmd {
     /// Format: RFC 3339 (e.g., 2025-02-25T00:00:00Z)
     #[clap(long)]
     stop_after: DateTime<Utc>,
+
+    /// Batch size for processing files.
+    #[clap(long)]
+    batch_size: Option<usize>,
+
+    /// Max time the batched writer waits before flushing a partial batch.
+    /// Accepts human-readable durations like "5m", "30s", "1h".
+    #[clap(long, value_parser = humantime::parse_duration)]
+    batch_timeout: Option<Duration>,
 }
 
 impl Cmd {
@@ -42,7 +52,9 @@ impl Cmd {
         let (writer, writer_task) = IcebergSpeedtestAvg::batched_writer(
             iceberg_settings.connect().await?,
             iceberg::speedtest_avg::table_definition()?,
-            BatchedWriterConfig::new(settings.cache.join("iceberg-spool/speedtest-avg-backfill")),
+            BatchedWriterConfig::new(settings.cache.join("iceberg-spool/speedtest-avg-backfill"))
+                .with_max_batch_size_opt(self.batch_size)
+                .with_batch_timeout_opt(self.batch_timeout),
         )
         .await?;
 

--- a/mobile_verifier/src/cli/mod.rs
+++ b/mobile_verifier/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod backfill_ban;
+pub mod backfill_heartbeat;
 pub mod backfill_speedtest;
 pub mod backfill_speedtest_avg;
 pub mod reward_from_db;

--- a/mobile_verifier/src/heartbeats/backfill.rs
+++ b/mobile_verifier/src/heartbeats/backfill.rs
@@ -1,0 +1,59 @@
+use file_store_oracles::{validated_heartbeat::ValidatedHeartbeat, FileType};
+use helium_proto::services::poc_mobile::HeartbeatValidity;
+
+use crate::{
+    backfill::{Backfiller, IcebergBackfill},
+    iceberg::IcebergHeartbeat,
+};
+
+pub struct HeartbeatConverter;
+
+impl IcebergBackfill for HeartbeatConverter {
+    type FileRecord = ValidatedHeartbeat;
+    type IcebergRow = IcebergHeartbeat;
+    const FILE_TYPE: FileType = FileType::ValidatedHeartbeat;
+
+    fn convert(record: ValidatedHeartbeat) -> Option<IcebergHeartbeat> {
+        (record.validity == HeartbeatValidity::Valid).then(|| record.into())
+    }
+}
+
+pub type HeartbeatBackfiller = Backfiller<HeartbeatConverter>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use helium_crypto::PublicKeyBinary;
+    use helium_proto::services::poc_mobile::{CellType, LocationSource};
+    use uuid::Uuid;
+
+    fn make_record(validity: HeartbeatValidity) -> ValidatedHeartbeat {
+        ValidatedHeartbeat {
+            pubkey: PublicKeyBinary::from(vec![1, 2, 3]),
+            cbsd_id: String::new(),
+            cell_type: CellType::NovaGenericWifiIndoor,
+            validity,
+            received_timestamp: Utc::now(),
+            lat: 37.7749,
+            lon: -122.4194,
+            coverage_object: Uuid::new_v4().as_bytes().to_vec(),
+            location_validation_timestamp: Some(Utc::now()),
+            distance_to_asserted: 250,
+            location_trust_score_multiplier_milli: 750,
+            location_source: LocationSource::Skyhook,
+        }
+    }
+
+    #[test]
+    fn invalid_heartbeats_are_filtered() {
+        let invalid = make_record(HeartbeatValidity::HeartbeatOutsideRange);
+        assert!(HeartbeatConverter::convert(invalid).is_none());
+    }
+
+    #[test]
+    fn valid_heartbeats_pass_through() {
+        let record = make_record(HeartbeatValidity::Valid);
+        assert!(HeartbeatConverter::convert(record).is_some());
+    }
+}

--- a/mobile_verifier/src/heartbeats/backfill.rs
+++ b/mobile_verifier/src/heartbeats/backfill.rs
@@ -40,7 +40,7 @@ mod tests {
             coverage_object: Uuid::new_v4().as_bytes().to_vec(),
             location_validation_timestamp: Some(Utc::now()),
             distance_to_asserted: 250,
-            location_trust_score_multiplier_milli: 750,
+            location_trust_score_multiplier: rust_decimal::Decimal::new(750, 3),
             location_source: LocationSource::Skyhook,
         }
     }

--- a/mobile_verifier/src/heartbeats/mod.rs
+++ b/mobile_verifier/src/heartbeats/mod.rs
@@ -1,3 +1,4 @@
+pub mod backfill;
 pub mod last_location;
 pub mod wifi;
 

--- a/mobile_verifier/src/iceberg/heartbeat.rs
+++ b/mobile_verifier/src/iceberg/heartbeat.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, FixedOffset};
 use helium_iceberg::{FieldDefinition, PartitionDefinition, SortFieldDefinition, TableDefinition};
+use helium_proto::services::poc_mobile::CellType as ProtoCellType;
 use rust_decimal::prelude::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use trino_rust_client::Trino;
@@ -94,6 +95,54 @@ impl From<&ValidatedHeartbeat> for IcebergHeartbeat {
                 .unwrap_or_default(),
             location_source: value.heartbeat.location_source.as_str_name().to_string(),
         }
+    }
+}
+
+/// Build an `IcebergHeartbeat` directly from the on-wire validated-heartbeat
+/// proto used for backfill. The wire format drops `heartbeat_timestamp` and
+/// `asserted_location`, so those collapse to `received_timestamp` / `None`.
+/// `device_type` is recovered from `cell_type` — the wire enum has no
+/// `WifiDataOnly` variant, but data-only hotspots don't heartbeat so the
+/// mapping is lossless for this stream.
+impl From<file_store_oracles::validated_heartbeat::ValidatedHeartbeat> for IcebergHeartbeat {
+    fn from(value: file_store_oracles::validated_heartbeat::ValidatedHeartbeat) -> Self {
+        let received_timestamp = value.received_timestamp.into();
+        let coverage_object = uuid::Uuid::from_slice(&value.coverage_object)
+            .map(|u| u.to_string())
+            .unwrap_or_default();
+        let device_type =
+            cell_type_to_device_type(value.cell_type).map(|dt| device_type_string(dt).to_string());
+        Self {
+            hotspot_pubkey: value.pubkey.to_string(),
+            received_timestamp,
+            heartbeat_timestamp: received_timestamp,
+            device_type,
+            lat: value.lat,
+            lon: value.lon,
+            coverage_object,
+            location_validation_timestamp: value.location_validation_timestamp.map(Into::into),
+            distance_to_asserted: Some(value.distance_to_asserted as i64),
+            asserted_location: None,
+            location_trust_score_multiplier: value.location_trust_score_multiplier_milli as f64
+                / 1000.0,
+            location_source: value.location_source.as_str_name().to_string(),
+        }
+    }
+}
+
+/// Recover the hotspot's `DeviceType` from the wire `cell_type` field for
+/// backfill rows. `WifiDataOnly` is unreachable here — the wire enum doesn't
+/// carry it and those hotspots don't emit heartbeats anyway.
+fn cell_type_to_device_type(cell_type: ProtoCellType) -> Option<DeviceType> {
+    match cell_type {
+        ProtoCellType::Nova436h
+        | ProtoCellType::Nova430i
+        | ProtoCellType::Neutrino430
+        | ProtoCellType::SercommIndoor
+        | ProtoCellType::SercommOutdoor => Some(DeviceType::Cbrs),
+        ProtoCellType::NovaGenericWifiIndoor => Some(DeviceType::WifiIndoor),
+        ProtoCellType::NovaGenericWifiOutdoor => Some(DeviceType::WifiOutdoor),
+        ProtoCellType::None => None,
     }
 }
 
@@ -217,6 +266,117 @@ mod tests {
             iceberg.asserted_location,
             Some("8a1fb466d2dffff".to_string())
         );
+    }
+
+    #[test]
+    fn from_wire_validated_heartbeat_collapses_lost_fields() {
+        use file_store_oracles::validated_heartbeat::ValidatedHeartbeat as WireHeartbeat;
+        use helium_proto::services::poc_mobile::{
+            CellType as ProtoCellType, HeartbeatValidity, LocationSource,
+        };
+
+        let received = Utc::now();
+        let coverage_uuid = Uuid::new_v4();
+        let validation_ts = received - chrono::Duration::minutes(5);
+
+        let wire = WireHeartbeat {
+            pubkey: PublicKeyBinary::from(vec![9, 9, 9]),
+            cbsd_id: String::new(),
+            cell_type: ProtoCellType::NovaGenericWifiIndoor,
+            validity: HeartbeatValidity::Valid,
+            received_timestamp: received,
+            lat: 1.5,
+            lon: -2.5,
+            coverage_object: coverage_uuid.as_bytes().to_vec(),
+            location_validation_timestamp: Some(validation_ts),
+            distance_to_asserted: 123,
+            location_trust_score_multiplier_milli: 500,
+            location_source: LocationSource::Gps,
+        };
+
+        let row: IcebergHeartbeat = wire.into();
+
+        // Fields preserved from the wire.
+        assert_eq!(
+            row.hotspot_pubkey,
+            PublicKeyBinary::from(vec![9, 9, 9]).to_string()
+        );
+        assert_eq!(row.lat, 1.5);
+        assert_eq!(row.lon, -2.5);
+        assert_eq!(row.coverage_object, coverage_uuid.to_string());
+        assert_eq!(row.distance_to_asserted, Some(123));
+        assert!((row.location_trust_score_multiplier - 0.5).abs() < f64::EPSILON);
+        assert_eq!(row.location_source, "gps");
+        assert!(row.location_validation_timestamp.is_some());
+        // `device_type` is recovered from the wire `cell_type`.
+        assert_eq!(row.device_type, Some("wifi_indoor".to_string()));
+
+        // Fields lost on the wire collapse to received_timestamp / None.
+        assert_eq!(row.heartbeat_timestamp, row.received_timestamp);
+        assert!(row.asserted_location.is_none());
+    }
+
+    #[test]
+    fn from_wire_validated_heartbeat_empty_coverage_yields_empty_string() {
+        use file_store_oracles::validated_heartbeat::ValidatedHeartbeat as WireHeartbeat;
+        use helium_proto::services::poc_mobile::{
+            CellType as ProtoCellType, HeartbeatValidity, LocationSource,
+        };
+
+        let wire = WireHeartbeat {
+            pubkey: PublicKeyBinary::from(vec![1]),
+            cbsd_id: String::new(),
+            cell_type: ProtoCellType::NovaGenericWifiIndoor,
+            validity: HeartbeatValidity::Valid,
+            received_timestamp: Utc::now(),
+            lat: 0.0,
+            lon: 0.0,
+            coverage_object: vec![],
+            location_validation_timestamp: None,
+            distance_to_asserted: 0,
+            location_trust_score_multiplier_milli: 1000,
+            location_source: LocationSource::Unknown,
+        };
+
+        let row: IcebergHeartbeat = wire.into();
+        assert_eq!(row.coverage_object, "");
+        assert!(row.location_validation_timestamp.is_none());
+        assert_eq!(row.distance_to_asserted, Some(0));
+        assert!((row.location_trust_score_multiplier - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn cell_type_to_device_type_covers_wire_variants() {
+        use helium_proto::services::poc_mobile::CellType as Proto;
+        assert_eq!(
+            cell_type_to_device_type(Proto::Nova436h),
+            Some(DeviceType::Cbrs)
+        );
+        assert_eq!(
+            cell_type_to_device_type(Proto::Nova430i),
+            Some(DeviceType::Cbrs)
+        );
+        assert_eq!(
+            cell_type_to_device_type(Proto::Neutrino430),
+            Some(DeviceType::Cbrs)
+        );
+        assert_eq!(
+            cell_type_to_device_type(Proto::SercommIndoor),
+            Some(DeviceType::Cbrs)
+        );
+        assert_eq!(
+            cell_type_to_device_type(Proto::SercommOutdoor),
+            Some(DeviceType::Cbrs)
+        );
+        assert_eq!(
+            cell_type_to_device_type(Proto::NovaGenericWifiIndoor),
+            Some(DeviceType::WifiIndoor)
+        );
+        assert_eq!(
+            cell_type_to_device_type(Proto::NovaGenericWifiOutdoor),
+            Some(DeviceType::WifiOutdoor)
+        );
+        assert_eq!(cell_type_to_device_type(Proto::None), None);
     }
 
     #[test]

--- a/mobile_verifier/src/iceberg/heartbeat.rs
+++ b/mobile_verifier/src/iceberg/heartbeat.rs
@@ -123,8 +123,10 @@ impl From<file_store_oracles::validated_heartbeat::ValidatedHeartbeat> for Icebe
             location_validation_timestamp: value.location_validation_timestamp.map(Into::into),
             distance_to_asserted: Some(value.distance_to_asserted as i64),
             asserted_location: None,
-            location_trust_score_multiplier: value.location_trust_score_multiplier_milli as f64
-                / 1000.0,
+            location_trust_score_multiplier: value
+                .location_trust_score_multiplier
+                .to_f64()
+                .unwrap_or_default(),
             location_source: value.location_source.as_str_name().to_string(),
         }
     }
@@ -290,7 +292,7 @@ mod tests {
             coverage_object: coverage_uuid.as_bytes().to_vec(),
             location_validation_timestamp: Some(validation_ts),
             distance_to_asserted: 123,
-            location_trust_score_multiplier_milli: 500,
+            location_trust_score_multiplier: rust_decimal::Decimal::new(500, 3),
             location_source: LocationSource::Gps,
         };
 
@@ -334,7 +336,7 @@ mod tests {
             coverage_object: vec![],
             location_validation_timestamp: None,
             distance_to_asserted: 0,
-            location_trust_score_multiplier_milli: 1000,
+            location_trust_score_multiplier: rust_decimal::Decimal::new(1000, 3),
             location_source: LocationSource::Unknown,
         };
 

--- a/mobile_verifier/src/main.rs
+++ b/mobile_verifier/src/main.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use clap::Parser;
 use mobile_verifier::{
     cli::{
-        backfill_ban, backfill_speedtest, backfill_speedtest_avg, reward_from_db, server,
-        verify_disktree,
+        backfill_ban, backfill_heartbeat, backfill_speedtest, backfill_speedtest_avg,
+        reward_from_db, server, verify_disktree,
     },
     Settings,
 };
@@ -47,6 +47,8 @@ pub enum Cmd {
     BackfillSpeedtestAvg(backfill_speedtest_avg::Cmd),
     /// Backfill historical VerifiedMobileBanReport files to the poc.bans iceberg table.
     BackfillBan(backfill_ban::Cmd),
+    /// Backfill historical validated Heartbeat files to the poc.heartbeats iceberg table.
+    BackfillHeartbeat(backfill_heartbeat::Cmd),
 }
 
 impl Cmd {
@@ -58,6 +60,7 @@ impl Cmd {
             Self::BackfillSpeedtest(cmd) => cmd.run(&settings).await,
             Self::BackfillSpeedtestAvg(cmd) => cmd.run(&settings).await,
             Self::BackfillBan(cmd) => cmd.run(&settings).await,
+            Self::BackfillHeartbeat(cmd) => cmd.run(&settings).await,
         }
     }
 }

--- a/mobile_verifier/tests/integrations/heartbeats_iceberg.rs
+++ b/mobile_verifier/tests/integrations/heartbeats_iceberg.rs
@@ -1,14 +1,59 @@
-use chrono::{DateTime, SubsecRound, Utc};
+use chrono::{DateTime, Duration, SubsecRound, Utc};
+use file_store::aws_local::AwsLocal;
+use file_store_oracles::FileType;
 use helium_crypto::PublicKeyBinary;
-use helium_proto::services::poc_mobile::{HeartbeatValidity, LocationSource};
+use helium_proto::services::poc_mobile::{
+    CellType as ProtoCellType, Heartbeat as HeartbeatProto, HeartbeatValidity, LocationSource,
+};
 use mobile_config::gateway::service::info::DeviceType;
 use mobile_verifier::{
+    backfill::BackfillOptions,
     cell_type::CellType,
-    heartbeats::{HbType, Heartbeat, ValidatedHeartbeat},
+    heartbeats::{backfill::HeartbeatBackfiller, HbType, Heartbeat, ValidatedHeartbeat},
     iceberg::{self, heartbeat::IcebergHeartbeat},
 };
 use rust_decimal_macros::dec;
+use sqlx::PgPool;
 use uuid::Uuid;
+
+const TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+fn test_backfill_options(
+    process_name: &str,
+    start_after: DateTime<Utc>,
+    stop_after: DateTime<Utc>,
+) -> BackfillOptions {
+    BackfillOptions {
+        process_name: process_name.to_string(),
+        start_after,
+        stop_after,
+        poll_duration: Some(std::time::Duration::from_millis(100)),
+        idle_timeout: Some(std::time::Duration::from_millis(500)),
+    }
+}
+
+fn make_validated_heartbeat_proto(
+    timestamp: DateTime<Utc>,
+    validity: HeartbeatValidity,
+) -> HeartbeatProto {
+    let pubkey: PublicKeyBinary = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6"
+        .parse()
+        .unwrap();
+    HeartbeatProto {
+        pub_key: pubkey.as_ref().to_vec(),
+        timestamp: timestamp.timestamp() as u64,
+        cell_type: ProtoCellType::NovaGenericWifiIndoor as i32,
+        validity: validity as i32,
+        lat: 37.7749,
+        lon: -122.4194,
+        coverage_object: Uuid::new_v4().as_bytes().to_vec(),
+        location_validation_timestamp: timestamp.timestamp() as u64,
+        distance_to_asserted: 250,
+        location_trust_score_multiplier: 750,
+        location_source: LocationSource::Skyhook as i32,
+        ..Default::default()
+    }
+}
 
 fn truncated_now() -> DateTime<Utc> {
     Utc::now().trunc_subsecs(3)
@@ -244,5 +289,125 @@ async fn empty_write_produces_no_rows() -> anyhow::Result<()> {
 
     assert_eq!(all.len(), 0);
 
+    Ok(())
+}
+
+// ── Backfill tests (DB needed for file-tracking state) ────────────────────────
+
+#[sqlx::test]
+async fn backfill_writes_validated_heartbeats_to_iceberg(pool: PgPool) -> anyhow::Result<()> {
+    let harness = crate::common::setup_iceberg().await?;
+    let (writer, writer_task, _spool_dir) = crate::common::make_batched_writer::<IcebergHeartbeat>(
+        &harness,
+        iceberg::heartbeat::table_definition()?,
+    )
+    .await?;
+
+    let awsl = AwsLocal::new().await;
+    awsl.create_bucket().await?;
+
+    let base_time = Utc::now() - Duration::hours(1);
+    let start_time = base_time - Duration::minutes(1);
+    let file1_time = base_time;
+    let file2_time = base_time + Duration::minutes(5);
+    let end_time = base_time + Duration::days(42);
+
+    awsl.put_protos_at_time(
+        FileType::ValidatedHeartbeat.to_string(),
+        vec![make_validated_heartbeat_proto(
+            file1_time,
+            HeartbeatValidity::Valid,
+        )],
+        file1_time,
+    )
+    .await?;
+
+    awsl.put_protos_at_time(
+        FileType::ValidatedHeartbeat.to_string(),
+        vec![make_validated_heartbeat_proto(
+            file2_time,
+            HeartbeatValidity::Valid,
+        )],
+        file2_time,
+    )
+    .await?;
+
+    let opts = test_backfill_options("test-heartbeat-backfill", start_time, end_time);
+    let (backfiller, server) =
+        HeartbeatBackfiller::create_batched(pool, awsl.bucket_client(), Some(writer), Some(opts))
+            .await?;
+
+    tokio::time::timeout(
+        TEST_TIMEOUT,
+        task_manager::TaskManager::builder()
+            .add_task(writer_task)
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start(),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("backfill timed out after {:?}", TEST_TIMEOUT))??;
+
+    let rows = iceberg::heartbeat::get_all(harness.trino()).await?;
+    assert_eq!(rows.len(), 2, "expected 2 heartbeats in iceberg");
+
+    awsl.cleanup().await?;
+    Ok(())
+}
+
+#[sqlx::test]
+async fn backfill_filters_invalid_heartbeats(pool: PgPool) -> anyhow::Result<()> {
+    let harness = crate::common::setup_iceberg().await?;
+    let (writer, writer_task, _spool_dir) = crate::common::make_batched_writer::<IcebergHeartbeat>(
+        &harness,
+        iceberg::heartbeat::table_definition()?,
+    )
+    .await?;
+
+    let awsl = AwsLocal::new().await;
+    awsl.create_bucket().await?;
+
+    let base_time = Utc::now() - Duration::hours(1);
+    let start_time = base_time - Duration::minutes(1);
+    let file_time = base_time;
+    let end_time = base_time + Duration::days(42);
+
+    awsl.put_protos_at_time(
+        FileType::ValidatedHeartbeat.to_string(),
+        vec![
+            make_validated_heartbeat_proto(file_time, HeartbeatValidity::Valid),
+            make_validated_heartbeat_proto(file_time, HeartbeatValidity::HeartbeatOutsideRange),
+            make_validated_heartbeat_proto(file_time, HeartbeatValidity::GatewayNotFound),
+        ],
+        file_time,
+    )
+    .await?;
+
+    let opts = test_backfill_options("test-heartbeat-backfill-filter", start_time, end_time);
+    let (backfiller, server) =
+        HeartbeatBackfiller::create_batched(pool, awsl.bucket_client(), Some(writer), Some(opts))
+            .await?;
+
+    tokio::time::timeout(
+        TEST_TIMEOUT,
+        task_manager::TaskManager::builder()
+            .add_task(writer_task)
+            .add_task(server)
+            .add_task(backfiller)
+            .build()
+            .start(),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("backfill timed out after {:?}", TEST_TIMEOUT))??;
+
+    let rows = iceberg::heartbeat::get_all(harness.trino()).await?;
+    assert_eq!(
+        rows.len(),
+        1,
+        "only valid heartbeats should be written to iceberg"
+    );
+
+    awsl.cleanup().await?;
     Ok(())
 }


### PR DESCRIPTION
Backfill CLI command for heartbeats

- heartbeat timestamp is the received_timestamp from ingest
- we don't have historical asserted locations

Many of the early heartbeat files contain ~500k valid heartbeats.

Locally, I've been running with a `--batch-size 20,000,000` as to not create a snapshot per file.
This gives us an arrow file of `~2.5Gb` before upload. The parquet files in iceberg are `~32Mb`.

Because of the size of heartbeat files, and the constraints we've been running the backfill jobs with, I would suggest also providing `--batch-timeout 30min` so we don't roll the default `1min` and create a load of snapshots while waiting on parsing.

(`--batch-size` and `--batch-timeout` were also added as args for bans, speedtests, and speedtest-avgs.)