### PR TITLE
Add `trino_client` crate: typed Settings, parameterized SQL via EXECUTE IMMEDIATE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11793,6 +11793,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "trino_client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "trino-rust-client",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11754,6 +11754,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "593eddbc8a11f3e099e942c8c065fe376b9d1776741430888f2796682e08ab43"
 
 [[package]]
+name = "trino-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "trino-rust-client",
+]
+
+[[package]]
 name = "trino-rust-client"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11790,19 +11803,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "trino_client"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "trino-rust-client",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "task_manager",
   "hex_assignments",
   "tls_init",
+  "trino_client",
 ]
 resolver = "2"
 

--- a/trino_client/Cargo.toml
+++ b/trino_client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "trino_client"
+name = "trino-client"
 version = "0.1.0"
 edition.workspace = true
 authors.workspace = true

--- a/trino_client/Cargo.toml
+++ b/trino_client/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "trino_client"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+chrono = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+trino-rust-client = "0.9"
+
+[dev-dependencies]
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/trino_client/src/builder.rs
+++ b/trino_client/src/builder.rs
@@ -1,0 +1,129 @@
+use crate::error::Result;
+use crate::settings::{AuthSettings, Settings};
+use crate::Client;
+use std::path::PathBuf;
+
+pub struct ClientBuilder {
+    host: String,
+    port: u16,
+    user: String,
+    catalog: Option<String>,
+    schema: Option<String>,
+    secure: bool,
+    ca_cert_path: Option<PathBuf>,
+    insecure_skip_tls_verify: bool,
+    auth: Option<AuthSettings>,
+}
+
+impl ClientBuilder {
+    pub fn new(host: impl Into<String>, port: u16, user: impl Into<String>) -> Self {
+        Self {
+            host: host.into(),
+            port,
+            user: user.into(),
+            catalog: None,
+            schema: None,
+            secure: false,
+            ca_cert_path: None,
+            insecure_skip_tls_verify: false,
+            auth: None,
+        }
+    }
+
+    pub fn catalog(mut self, catalog: impl Into<String>) -> Self {
+        self.catalog = Some(catalog.into());
+        self
+    }
+
+    pub fn schema(mut self, schema: impl Into<String>) -> Self {
+        self.schema = Some(schema.into());
+        self
+    }
+
+    pub fn secure(mut self, secure: bool) -> Self {
+        self.secure = secure;
+        self
+    }
+
+    pub fn ca_cert_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.ca_cert_path = Some(path.into());
+        self
+    }
+
+    pub fn insecure_skip_tls_verify(mut self, skip: bool) -> Self {
+        self.insecure_skip_tls_verify = skip;
+        self
+    }
+
+    pub fn basic_auth(mut self, username: impl Into<String>, password: impl Into<String>) -> Self {
+        self.auth = Some(AuthSettings::Basic {
+            username: username.into(),
+            password: Some(password.into()),
+        });
+        self
+    }
+
+    pub fn jwt_auth(mut self, token: impl Into<String>) -> Self {
+        self.auth = Some(AuthSettings::Jwt {
+            token: token.into(),
+        });
+        self
+    }
+
+    pub fn build(self) -> Result<Client> {
+        let settings = Settings {
+            host: self.host,
+            port: self.port,
+            user: self.user,
+            catalog: self.catalog,
+            schema: self.schema,
+            secure: self.secure,
+            ca_cert_path: self.ca_cert_path,
+            insecure_skip_tls_verify: self.insecure_skip_tls_verify,
+            auth: self.auth,
+        };
+        Client::from_settings(&settings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_minimal_client() {
+        ClientBuilder::new("localhost", 8080, "admin")
+            .build()
+            .expect("minimal builder should build");
+    }
+
+    #[test]
+    fn builds_with_all_options() {
+        ClientBuilder::new("trino.example.com", 443, "alice")
+            .catalog("memory")
+            .schema("default")
+            .secure(true)
+            .basic_auth("alice", "hunter2")
+            .build()
+            .expect("full builder should build");
+    }
+
+    #[test]
+    fn builds_with_jwt_auth() {
+        ClientBuilder::new("trino.example.com", 443, "alice")
+            .secure(true)
+            .jwt_auth("ey.fake.token")
+            .build()
+            .expect("jwt builder should build");
+    }
+
+    #[test]
+    fn jwt_overrides_basic_auth() {
+        let _ = ClientBuilder::new("trino.example.com", 443, "alice")
+            .secure(true)
+            .basic_auth("alice", "hunter2")
+            .jwt_auth("ey.fake.token")
+            .build()
+            .expect("last auth wins");
+    }
+}

--- a/trino_client/src/builder.rs
+++ b/trino_client/src/builder.rs
@@ -1,7 +1,6 @@
 use crate::error::Result;
 use crate::settings::{AuthSettings, Settings};
 use crate::Client;
-use std::path::PathBuf;
 
 pub struct ClientBuilder {
     host: String,
@@ -10,7 +9,6 @@ pub struct ClientBuilder {
     catalog: Option<String>,
     schema: Option<String>,
     secure: bool,
-    ca_cert_path: Option<PathBuf>,
     insecure_skip_tls_verify: bool,
     auth: Option<AuthSettings>,
 }
@@ -24,7 +22,6 @@ impl ClientBuilder {
             catalog: None,
             schema: None,
             secure: false,
-            ca_cert_path: None,
             insecure_skip_tls_verify: false,
             auth: None,
         }
@@ -42,11 +39,6 @@ impl ClientBuilder {
 
     pub fn secure(mut self, secure: bool) -> Self {
         self.secure = secure;
-        self
-    }
-
-    pub fn ca_cert_path(mut self, path: impl Into<PathBuf>) -> Self {
-        self.ca_cert_path = Some(path.into());
         self
     }
 
@@ -78,7 +70,6 @@ impl ClientBuilder {
             catalog: self.catalog,
             schema: self.schema,
             secure: self.secure,
-            ca_cert_path: self.ca_cert_path,
             insecure_skip_tls_verify: self.insecure_skip_tls_verify,
             auth: self.auth,
         };

--- a/trino_client/src/error.rs
+++ b/trino_client/src/error.rs
@@ -6,9 +6,6 @@ pub enum Error {
     #[error("missing bind parameter: {0}")]
     MissingParameter(String),
 
-    #[error("no parameters bound; use execute_raw / get_all_raw for non-parameterized SQL")]
-    NoParameters,
-
     #[error("invalid parameter value: {0}")]
     InvalidParam(String),
 

--- a/trino_client/src/error.rs
+++ b/trino_client/src/error.rs
@@ -1,0 +1,19 @@
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to build trino client: {0}")]
+    Build(String),
+
+    #[error("missing bind parameter: {0}")]
+    MissingParameter(String),
+
+    #[error("no parameters bound; use execute_raw / get_all_raw for non-parameterized SQL")]
+    NoParameters,
+
+    #[error("invalid parameter value: {0}")]
+    InvalidParam(String),
+
+    #[error(transparent)]
+    Client(#[from] trino_rust_client::error::Error),
+}
+
+pub type Result<T = ()> = std::result::Result<T, Error>;

--- a/trino_client/src/lib.rs
+++ b/trino_client/src/lib.rs
@@ -19,8 +19,18 @@ pub trait SqlStatement {
     fn to_statement(&self) -> Statement;
 }
 
+impl<T: SqlStatement + ?Sized> SqlStatement for &T {
+    fn to_statement(&self) -> Statement {
+        (*self).to_statement()
+    }
+}
+
 pub trait SqlQuery: SqlStatement {
     type Row;
+}
+
+impl<T: SqlQuery + ?Sized> SqlQuery for &T {
+    type Row = T::Row;
 }
 
 pub struct Client {
@@ -72,12 +82,12 @@ impl Client {
         &self.inner
     }
 
-    pub async fn execute<S: SqlStatement>(&self, sql_statement: &S) -> Result<()> {
+    pub async fn execute<S: SqlStatement>(&self, sql_statement: S) -> Result<()> {
         self.execute_raw(sql_statement.to_statement().render()?)
             .await
     }
 
-    pub async fn get_all<S: SqlQuery>(&self, sql_query: &S) -> Result<Vec<S::Row>>
+    pub async fn get_all<S: SqlQuery>(&self, sql_query: S) -> Result<Vec<S::Row>>
     where
         S::Row: trino_rust_client::Trino + 'static,
         for<'de> S::Row: serde::Deserialize<'de> + serde::Serialize,

--- a/trino_client/src/lib.rs
+++ b/trino_client/src/lib.rs
@@ -12,7 +12,6 @@ pub use settings::{AuthSettings, Settings};
 pub use statement::{Param, Statement, TypedStatement};
 
 use trino_rust_client::auth::Auth;
-use trino_rust_client::ssl::Ssl;
 use trino_rust_client::ClientBuilder as UpstreamClientBuilder;
 
 pub trait SqlStatement {
@@ -51,13 +50,6 @@ impl Client {
         }
         if settings.insecure_skip_tls_verify {
             builder = builder.no_verify(true);
-        }
-        if let Some(path) = &settings.ca_cert_path {
-            let cert = Ssl::read_pem(path)
-                .map_err(|e| Error::Build(format!("read ca cert {path:?}: {e:?}")))?;
-            builder = builder.ssl(Ssl {
-                root_cert: Some(cert),
-            });
         }
         if let Some(auth) = &settings.auth {
             builder = builder.auth(match auth {

--- a/trino_client/src/lib.rs
+++ b/trino_client/src/lib.rs
@@ -1,16 +1,19 @@
 pub use trino_rust_client;
+pub use trino_rust_client::Trino as TrinoFromRow;
 
+mod builder;
 mod error;
 mod settings;
 mod statement;
 
+pub use builder::ClientBuilder;
 pub use error::{Error, Result};
 pub use settings::{AuthSettings, Settings};
-pub use statement::{Param, Statement};
+pub use statement::{Param, Statement, TypedStatement};
 
 use trino_rust_client::auth::Auth;
 use trino_rust_client::ssl::Ssl;
-use trino_rust_client::ClientBuilder;
+use trino_rust_client::ClientBuilder as UpstreamClientBuilder;
 
 pub trait SqlStatement {
     fn to_statement(&self) -> Statement;
@@ -26,7 +29,7 @@ pub struct Client {
 
 impl Client {
     pub fn from_settings(settings: &Settings) -> Result<Self> {
-        let mut builder = ClientBuilder::new(&settings.user, &settings.host)
+        let mut builder = UpstreamClientBuilder::new(&settings.user, &settings.host)
             .port(settings.port)
             .secure(settings.secure);
 
@@ -69,16 +72,17 @@ impl Client {
         &self.inner
     }
 
-    pub async fn execute<S: SqlStatement>(&self, sql_struct: &S) -> Result<()> {
-        self.execute_raw(sql_struct.to_statement().render()?).await
+    pub async fn execute<S: SqlStatement>(&self, sql_statement: &S) -> Result<()> {
+        self.execute_raw(sql_statement.to_statement().render()?)
+            .await
     }
 
-    pub async fn get_all<S: SqlQuery>(&self, sql_struct: &S) -> Result<Vec<S::Row>>
+    pub async fn get_all<S: SqlQuery>(&self, sql_query: &S) -> Result<Vec<S::Row>>
     where
         S::Row: trino_rust_client::Trino + 'static,
         for<'de> S::Row: serde::Deserialize<'de> + serde::Serialize,
     {
-        self.get_all_raw(sql_struct.to_statement().render()?).await
+        self.get_all_raw(sql_query.to_statement().render()?).await
     }
 
     pub async fn execute_raw(&self, sql: impl Into<String>) -> Result<()> {

--- a/trino_client/src/lib.rs
+++ b/trino_client/src/lib.rs
@@ -1,0 +1,100 @@
+pub use trino_rust_client;
+
+mod error;
+mod settings;
+mod statement;
+
+pub use error::{Error, Result};
+pub use settings::{AuthSettings, Settings};
+pub use statement::{Param, Statement};
+
+use trino_rust_client::auth::Auth;
+use trino_rust_client::ssl::Ssl;
+use trino_rust_client::ClientBuilder;
+
+pub trait SqlStatement {
+    fn to_statement(&self) -> Statement;
+}
+
+pub trait SqlQuery: SqlStatement {
+    type Row;
+}
+
+pub struct Client {
+    inner: trino_rust_client::Client,
+}
+
+impl Client {
+    pub fn from_settings(settings: &Settings) -> Result<Self> {
+        let mut builder = ClientBuilder::new(&settings.user, &settings.host)
+            .port(settings.port)
+            .secure(settings.secure);
+
+        if let Some(catalog) = &settings.catalog {
+            builder = builder.catalog(catalog);
+        }
+        if let Some(schema) = &settings.schema {
+            builder = builder.schema(schema);
+        }
+        if settings.insecure_skip_tls_verify {
+            builder = builder.no_verify(true);
+        }
+        if let Some(path) = &settings.ca_cert_path {
+            let cert = Ssl::read_pem(path)
+                .map_err(|e| Error::Build(format!("read ca cert {path:?}: {e:?}")))?;
+            builder = builder.ssl(Ssl {
+                root_cert: Some(cert),
+            });
+        }
+        if let Some(auth) = &settings.auth {
+            builder = builder.auth(match auth {
+                AuthSettings::Basic { username, password } => {
+                    Auth::Basic(username.clone(), password.clone())
+                }
+                AuthSettings::Jwt { token } => Auth::Jwt(token.clone()),
+            });
+        }
+
+        let inner = builder
+            .build()
+            .map_err(|e| Error::Build(format!("{e:?}")))?;
+        Ok(Self { inner })
+    }
+
+    pub fn from_inner(inner: trino_rust_client::Client) -> Self {
+        Self { inner }
+    }
+
+    pub fn inner(&self) -> &trino_rust_client::Client {
+        &self.inner
+    }
+
+    pub async fn execute<S: SqlStatement>(&self, sql_struct: &S) -> Result<()> {
+        self.execute_raw(sql_struct.to_statement().render()?).await
+    }
+
+    pub async fn get_all<S: SqlQuery>(&self, sql_struct: &S) -> Result<Vec<S::Row>>
+    where
+        S::Row: trino_rust_client::Trino + 'static,
+        for<'de> S::Row: serde::Deserialize<'de> + serde::Serialize,
+    {
+        self.get_all_raw(sql_struct.to_statement().render()?).await
+    }
+
+    pub async fn execute_raw(&self, sql: impl Into<String>) -> Result<()> {
+        self.inner.execute(sql.into()).await?;
+        Ok(())
+    }
+
+    pub async fn get_all_raw<T>(&self, sql: impl Into<String>) -> Result<Vec<T>>
+    where
+        T: trino_rust_client::Trino + 'static,
+        for<'de> T: serde::Deserialize<'de> + serde::Serialize,
+    {
+        match self.inner.get_all::<T>(sql.into()).await {
+            Ok(ds) => Ok(ds.into_vec()),
+            Err(trino_rust_client::error::Error::EmptyData) => Ok(Vec::new()),
+            Err(e) => Err(e.into()),
+        }
+    }
+}

--- a/trino_client/src/settings.rs
+++ b/trino_client/src/settings.rs
@@ -1,5 +1,4 @@
 use serde::Deserialize;
-use std::path::PathBuf;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Settings {
@@ -14,10 +13,6 @@ pub struct Settings {
     /// `auth` is set unless the server is on the same host.
     #[serde(default)]
     pub secure: bool,
-    /// Path to a PEM-encoded CA certificate to trust in addition to the
-    /// platform roots.
-    #[serde(default)]
-    pub ca_cert_path: Option<PathBuf>,
     /// Skip TLS certificate verification. For local development only.
     #[serde(default)]
     pub insecure_skip_tls_verify: bool,
@@ -122,15 +117,10 @@ mod tests {
             "port": 443,
             "user": "alice",
             "secure": true,
-            "ca_cert_path": "/etc/ssl/trino-ca.pem",
             "insecure_skip_tls_verify": false,
         }))
         .unwrap();
         assert!(s.secure);
-        assert_eq!(
-            s.ca_cert_path.unwrap().to_str().unwrap(),
-            "/etc/ssl/trino-ca.pem"
-        );
         assert!(!s.insecure_skip_tls_verify);
     }
 }

--- a/trino_client/src/settings.rs
+++ b/trino_client/src/settings.rs
@@ -1,0 +1,133 @@
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Settings {
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    #[serde(default)]
+    pub catalog: Option<String>,
+    #[serde(default)]
+    pub schema: Option<String>,
+    /// Use HTTPS for the connection. Required by the upstream client when
+    /// `auth` is set unless the server is on the same host.
+    #[serde(default)]
+    pub secure: bool,
+    /// Path to a PEM-encoded CA certificate to trust in addition to the
+    /// platform roots.
+    #[serde(default)]
+    pub ca_cert_path: Option<PathBuf>,
+    /// Skip TLS certificate verification. For local development only.
+    #[serde(default)]
+    pub insecure_skip_tls_verify: bool,
+    /// Authentication credentials. None means anonymous.
+    #[serde(default)]
+    pub auth: Option<AuthSettings>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AuthSettings {
+    Basic {
+        username: String,
+        #[serde(default)]
+        password: Option<String>,
+    },
+    Jwt {
+        token: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn deserializes_minimal_settings() {
+        let s: Settings = serde_json::from_value(json!({
+            "host": "trino.example.com",
+            "port": 8080,
+            "user": "alice",
+        }))
+        .unwrap();
+        assert_eq!(s.host, "trino.example.com");
+        assert_eq!(s.port, 8080);
+        assert_eq!(s.user, "alice");
+        assert!(s.catalog.is_none());
+        assert!(s.auth.is_none());
+        assert!(!s.secure);
+    }
+
+    #[test]
+    fn deserializes_basic_auth() {
+        let s: Settings = serde_json::from_value(json!({
+            "host": "trino.example.com",
+            "port": 443,
+            "user": "alice",
+            "secure": true,
+            "auth": { "type": "basic", "username": "alice", "password": "hunter2" },
+        }))
+        .unwrap();
+        assert!(s.secure);
+        match s.auth.unwrap() {
+            AuthSettings::Basic { username, password } => {
+                assert_eq!(username, "alice");
+                assert_eq!(password.as_deref(), Some("hunter2"));
+            }
+            _ => panic!("expected basic auth"),
+        }
+    }
+
+    #[test]
+    fn deserializes_basic_auth_without_password() {
+        let s: Settings = serde_json::from_value(json!({
+            "host": "trino.example.com",
+            "port": 443,
+            "user": "alice",
+            "secure": true,
+            "auth": { "type": "basic", "username": "alice" },
+        }))
+        .unwrap();
+        match s.auth.unwrap() {
+            AuthSettings::Basic { username, password } => {
+                assert_eq!(username, "alice");
+                assert!(password.is_none());
+            }
+            _ => panic!("expected basic auth"),
+        }
+    }
+
+    #[test]
+    fn deserializes_jwt_auth() {
+        let s: Settings = serde_json::from_value(json!({
+            "host": "trino.example.com",
+            "port": 443,
+            "user": "alice",
+            "secure": true,
+            "auth": { "type": "jwt", "token": "ey.fake.token" },
+        }))
+        .unwrap();
+        match s.auth.unwrap() {
+            AuthSettings::Jwt { token } => assert_eq!(token, "ey.fake.token"),
+            _ => panic!("expected jwt auth"),
+        }
+    }
+
+    #[test]
+    fn deserializes_tls_options() {
+        let s: Settings = serde_json::from_value(json!({
+            "host": "trino.example.com",
+            "port": 443,
+            "user": "alice",
+            "secure": true,
+            "ca_cert_path": "/etc/ssl/trino-ca.pem",
+            "insecure_skip_tls_verify": false,
+        }))
+        .unwrap();
+        assert!(s.secure);
+        assert_eq!(s.ca_cert_path.unwrap().to_str().unwrap(), "/etc/ssl/trino-ca.pem");
+        assert!(!s.insecure_skip_tls_verify);
+    }
+}

--- a/trino_client/src/settings.rs
+++ b/trino_client/src/settings.rs
@@ -127,7 +127,10 @@ mod tests {
         }))
         .unwrap();
         assert!(s.secure);
-        assert_eq!(s.ca_cert_path.unwrap().to_str().unwrap(), "/etc/ssl/trino-ca.pem");
+        assert_eq!(
+            s.ca_cert_path.unwrap().to_str().unwrap(),
+            "/etc/ssl/trino-ca.pem"
+        );
         assert!(!s.insecure_skip_tls_verify);
     }
 }

--- a/trino_client/src/statement.rs
+++ b/trino_client/src/statement.rs
@@ -1,0 +1,660 @@
+use crate::error::{Error, Result};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Param {
+    Null,
+    I32(i32),
+    I64(i64),
+    U64(u64),
+    F64(f64),
+    Bool(bool),
+    String(String),
+    Bytes(Vec<u8>),
+    Date(NaiveDate),
+    Timestamp(NaiveDateTime),
+    TimestampTz(DateTime<Utc>),
+}
+
+impl From<i32> for Param {
+    fn from(v: i32) -> Self {
+        Param::I32(v)
+    }
+}
+
+impl From<i64> for Param {
+    fn from(v: i64) -> Self {
+        Param::I64(v)
+    }
+}
+
+impl From<u32> for Param {
+    fn from(v: u32) -> Self {
+        Param::I64(v as i64)
+    }
+}
+
+impl From<u64> for Param {
+    fn from(v: u64) -> Self {
+        Param::U64(v)
+    }
+}
+
+impl From<f32> for Param {
+    fn from(v: f32) -> Self {
+        Param::F64(v as f64)
+    }
+}
+
+impl From<f64> for Param {
+    fn from(v: f64) -> Self {
+        Param::F64(v)
+    }
+}
+
+impl From<bool> for Param {
+    fn from(v: bool) -> Self {
+        Param::Bool(v)
+    }
+}
+
+impl From<&str> for Param {
+    fn from(v: &str) -> Self {
+        Param::String(v.to_string())
+    }
+}
+
+impl From<String> for Param {
+    fn from(v: String) -> Self {
+        Param::String(v)
+    }
+}
+
+impl From<Vec<u8>> for Param {
+    fn from(v: Vec<u8>) -> Self {
+        Param::Bytes(v)
+    }
+}
+
+impl From<&[u8]> for Param {
+    fn from(v: &[u8]) -> Self {
+        Param::Bytes(v.to_vec())
+    }
+}
+
+impl<T: Into<Param>> From<Option<T>> for Param {
+    fn from(v: Option<T>) -> Self {
+        match v {
+            Some(inner) => inner.into(),
+            None => Param::Null,
+        }
+    }
+}
+
+impl From<NaiveDate> for Param {
+    fn from(v: NaiveDate) -> Self {
+        Param::Date(v)
+    }
+}
+
+impl From<NaiveDateTime> for Param {
+    fn from(v: NaiveDateTime) -> Self {
+        Param::Timestamp(v)
+    }
+}
+
+impl From<DateTime<Utc>> for Param {
+    fn from(v: DateTime<Utc>) -> Self {
+        Param::TimestampTz(v)
+    }
+}
+
+impl Param {
+    fn to_literal(&self) -> Result<String> {
+        match self {
+            Param::Null => Ok("NULL".into()),
+            Param::I32(n) => Ok(n.to_string()),
+            Param::I64(n) => Ok(n.to_string()),
+            Param::U64(n) => {
+                if *n > i64::MAX as u64 {
+                    Err(Error::InvalidParam(format!(
+                        "u64 value {n} exceeds Trino BIGINT range"
+                    )))
+                } else {
+                    Ok(n.to_string())
+                }
+            }
+            Param::F64(n) => {
+                if n.is_nan() || n.is_infinite() {
+                    Err(Error::InvalidParam(format!("non-finite f64: {n}")))
+                } else {
+                    Ok(format!("{n:e}"))
+                }
+            }
+            Param::Bool(b) => Ok(if *b { "TRUE".into() } else { "FALSE".into() }),
+            Param::String(s) => Ok(format!("'{}'", s.replace('\'', "''"))),
+            Param::Bytes(b) => {
+                let hex: String = b.iter().map(|byte| format!("{byte:02x}")).collect();
+                Ok(format!("X'{hex}'"))
+            }
+            Param::Date(d) => Ok(format!("DATE '{}'", d.format("%Y-%m-%d"))),
+            Param::Timestamp(ts) => {
+                Ok(format!("TIMESTAMP '{}'", ts.format("%Y-%m-%d %H:%M:%S%.f")))
+            }
+            Param::TimestampTz(ts) => Ok(format!(
+                "TIMESTAMP '{}'",
+                ts.format("%Y-%m-%d %H:%M:%S%.f UTC")
+            )),
+        }
+    }
+}
+
+pub struct Statement {
+    sql: String,
+    params: Vec<(String, Param)>,
+}
+
+impl Statement {
+    pub fn new(sql: impl Into<String>) -> Self {
+        Self {
+            sql: sql.into(),
+            params: Vec::new(),
+        }
+    }
+
+    pub fn bind(mut self, name: impl Into<String>, value: impl Into<Param>) -> Self {
+        self.params.push((name.into(), value.into()));
+        self
+    }
+
+    pub fn render(&self) -> Result<String> {
+        render_internal(&self.sql, &self.params)
+    }
+}
+
+enum ScanState {
+    Normal,
+    SingleString,
+    DoubleString,
+    LineComment,
+    BlockComment,
+}
+
+fn render_internal(sql: &str, params: &[(String, Param)]) -> Result<String> {
+    let mut out = String::with_capacity(sql.len());
+    let mut chars = sql.chars().peekable();
+    let mut placeholder_values: Vec<Param> = Vec::new();
+    let mut state = ScanState::Normal;
+
+    while let Some(c) = chars.next() {
+        match state {
+            ScanState::Normal => match c {
+                '\'' => {
+                    out.push(c);
+                    state = ScanState::SingleString;
+                }
+                '"' => {
+                    out.push(c);
+                    state = ScanState::DoubleString;
+                }
+                '-' if chars.peek() == Some(&'-') => {
+                    out.push(c);
+                    out.push(chars.next().expect("peeked"));
+                    state = ScanState::LineComment;
+                }
+                '/' if chars.peek() == Some(&'*') => {
+                    out.push(c);
+                    out.push(chars.next().expect("peeked"));
+                    state = ScanState::BlockComment;
+                }
+                ':' => match chars.peek() {
+                    Some(&n) if n.is_ascii_alphabetic() || n == '_' => {
+                        let mut name = String::new();
+                        while let Some(&n2) = chars.peek() {
+                            if n2.is_ascii_alphanumeric() || n2 == '_' {
+                                name.push(chars.next().expect("peeked"));
+                            } else {
+                                break;
+                            }
+                        }
+                        let value = params
+                            .iter()
+                            .rev()
+                            .find(|(n, _)| n == &name)
+                            .map(|(_, v)| v.clone())
+                            .ok_or_else(|| Error::MissingParameter(name.clone()))?;
+                        out.push('?');
+                        placeholder_values.push(value);
+                    }
+                    _ => out.push(c),
+                },
+                _ => out.push(c),
+            },
+            ScanState::SingleString => {
+                out.push(c);
+                if c == '\'' {
+                    if chars.peek() == Some(&'\'') {
+                        out.push(chars.next().expect("peeked"));
+                    } else {
+                        state = ScanState::Normal;
+                    }
+                }
+            }
+            ScanState::DoubleString => {
+                out.push(c);
+                if c == '"' {
+                    if chars.peek() == Some(&'"') {
+                        out.push(chars.next().expect("peeked"));
+                    } else {
+                        state = ScanState::Normal;
+                    }
+                }
+            }
+            ScanState::LineComment => {
+                out.push(c);
+                if c == '\n' {
+                    state = ScanState::Normal;
+                }
+            }
+            ScanState::BlockComment => {
+                out.push(c);
+                if c == '*' && chars.peek() == Some(&'/') {
+                    out.push(chars.next().expect("peeked"));
+                    state = ScanState::Normal;
+                }
+            }
+        }
+    }
+
+    if placeholder_values.is_empty() {
+        return Err(Error::NoParameters);
+    }
+
+    let escaped = out.replace('\'', "''");
+    let using_clause = placeholder_values
+        .iter()
+        .map(Param::to_literal)
+        .collect::<Result<Vec<_>>>()?
+        .join(", ");
+
+    Ok(format!(
+        "EXECUTE IMMEDIATE '{escaped}' USING {using_clause}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_i64_placeholder() {
+        let r = Statement::new("SELECT * FROM foo WHERE id = :id")
+            .bind("id", 42)
+            .render()
+            .unwrap();
+        assert_eq!(
+            r,
+            "EXECUTE IMMEDIATE 'SELECT * FROM foo WHERE id = ?' USING 42"
+        );
+    }
+
+    #[test]
+    fn renders_i32_placeholder() {
+        let r = Statement::new("SELECT * FROM foo WHERE n = :n")
+            .bind("n", -7)
+            .render()
+            .unwrap();
+        assert_eq!(
+            r,
+            "EXECUTE IMMEDIATE 'SELECT * FROM foo WHERE n = ?' USING -7"
+        );
+    }
+
+    #[test]
+    fn renders_f64_placeholder() {
+        let r = Statement::new("SELECT :v").bind("v", 1.5).render().unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?' USING 1.5e0");
+    }
+
+    #[test]
+    fn renders_f64_whole_value_with_exponent() {
+        let r = Statement::new("SELECT :v").bind("v", 1.0).render().unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?' USING 1e0");
+    }
+
+    #[test]
+    fn renders_bool_placeholder() {
+        let r = Statement::new("SELECT * FROM foo WHERE active = :a")
+            .bind("a", true)
+            .render()
+            .unwrap();
+        assert_eq!(
+            r,
+            "EXECUTE IMMEDIATE 'SELECT * FROM foo WHERE active = ?' USING TRUE"
+        );
+    }
+
+    #[test]
+    fn renders_string_placeholder() {
+        let r = Statement::new("SELECT * FROM foo WHERE name = :name")
+            .bind("name", "alice")
+            .render()
+            .unwrap();
+        assert_eq!(
+            r,
+            "EXECUTE IMMEDIATE 'SELECT * FROM foo WHERE name = ?' USING 'alice'"
+        );
+    }
+
+    #[test]
+    fn escapes_single_quote_in_string_param() {
+        let r = Statement::new("SELECT * FROM foo WHERE name = :name")
+            .bind("name", "O'Brien")
+            .render()
+            .unwrap();
+        assert_eq!(
+            r,
+            "EXECUTE IMMEDIATE 'SELECT * FROM foo WHERE name = ?' USING 'O''Brien'"
+        );
+    }
+
+    #[test]
+    fn multiple_placeholders_in_order() {
+        let r = Statement::new("INSERT INTO foo (a, b, c) VALUES (:a, :b, :c)")
+            .bind("a", 1)
+            .bind("b", "x")
+            .bind("c", false)
+            .render()
+            .unwrap();
+        assert_eq!(
+            r,
+            "EXECUTE IMMEDIATE 'INSERT INTO foo (a, b, c) VALUES (?, ?, ?)' USING 1, 'x', FALSE"
+        );
+    }
+
+    #[test]
+    fn reused_placeholder_name_repeats_value() {
+        let r = Statement::new("SELECT :x, :x")
+            .bind("x", 9)
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?, ?' USING 9, 9");
+    }
+
+    #[test]
+    fn last_bind_wins_for_duplicate_name() {
+        let r = Statement::new("SELECT :id")
+            .bind("id", 1)
+            .bind("id", 2)
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?' USING 2");
+    }
+
+    #[test]
+    fn skips_colon_inside_single_quoted_string() {
+        let r = Statement::new("SELECT 'foo:bar' AS s, :id")
+            .bind("id", 7)
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ''foo:bar'' AS s, ?' USING 7");
+    }
+
+    #[test]
+    fn skips_colon_inside_double_quoted_identifier() {
+        let r = Statement::new(r#"SELECT "weird:column" FROM foo WHERE id = :id"#)
+            .bind("id", 7)
+            .render()
+            .unwrap();
+        assert_eq!(
+            r,
+            r#"EXECUTE IMMEDIATE 'SELECT "weird:column" FROM foo WHERE id = ?' USING 7"#
+        );
+    }
+
+    #[test]
+    fn skips_colon_inside_line_comment() {
+        let r = Statement::new("-- :not_a_param\nSELECT :id")
+            .bind("id", 1)
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE '-- :not_a_param\nSELECT ?' USING 1");
+    }
+
+    #[test]
+    fn skips_colon_inside_block_comment() {
+        let r = Statement::new("/* :not_a_param */ SELECT :id")
+            .bind("id", 1)
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE '/* :not_a_param */ SELECT ?' USING 1");
+    }
+
+    #[test]
+    fn handles_doubled_single_quote_escape() {
+        let r = Statement::new("SELECT 'it''s :inside' AS s, :id")
+            .bind("id", 3)
+            .render()
+            .unwrap();
+        assert_eq!(
+            r,
+            "EXECUTE IMMEDIATE 'SELECT ''it''''s :inside'' AS s, ?' USING 3"
+        );
+    }
+
+    #[test]
+    fn handles_doubled_double_quote_escape() {
+        let r = Statement::new(r#"SELECT "a""b:c" FROM foo WHERE id = :id"#)
+            .bind("id", 3)
+            .render()
+            .unwrap();
+        assert_eq!(
+            r,
+            r#"EXECUTE IMMEDIATE 'SELECT "a""b:c" FROM foo WHERE id = ?' USING 3"#
+        );
+    }
+
+    #[test]
+    fn missing_parameter_errors() {
+        let err = Statement::new("SELECT :missing").render().unwrap_err();
+        assert!(matches!(err, Error::MissingParameter(ref n) if n == "missing"));
+    }
+
+    #[test]
+    fn no_parameters_errors() {
+        let err = Statement::new("SELECT 1").render().unwrap_err();
+        assert!(matches!(err, Error::NoParameters));
+    }
+
+    #[test]
+    fn nan_param_errors() {
+        let err = Statement::new("SELECT :v")
+            .bind("v", f64::NAN)
+            .render()
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidParam(_)));
+    }
+
+    #[test]
+    fn infinite_param_errors() {
+        let err = Statement::new("SELECT :v")
+            .bind("v", f64::INFINITY)
+            .render()
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidParam(_)));
+    }
+
+    #[test]
+    fn lone_colon_is_preserved() {
+        let r = Statement::new("SELECT 'a' || ':' || 'b', :id")
+            .bind("id", 1)
+            .render()
+            .unwrap();
+        assert_eq!(
+            r,
+            "EXECUTE IMMEDIATE 'SELECT ''a'' || '':'' || ''b'', ?' USING 1"
+        );
+    }
+
+    #[test]
+    fn renders_date_placeholder() {
+        let d = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+        let r = Statement::new("SELECT :d").bind("d", d).render().unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?' USING DATE '2024-01-15'");
+    }
+
+    #[test]
+    fn renders_naive_timestamp_without_fraction() {
+        let ts = NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 34, 56)
+            .unwrap();
+        let r = Statement::new("SELECT :t").bind("t", ts).render().unwrap();
+        assert_eq!(
+            r,
+            "EXECUTE IMMEDIATE 'SELECT ?' USING TIMESTAMP '2024-01-15 12:34:56'"
+        );
+    }
+
+    #[test]
+    fn renders_naive_timestamp_with_fractional_seconds() {
+        let ts = NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_milli_opt(12, 34, 56, 789)
+            .unwrap();
+        let r = Statement::new("SELECT :t").bind("t", ts).render().unwrap();
+        assert_eq!(
+            r,
+            "EXECUTE IMMEDIATE 'SELECT ?' USING TIMESTAMP '2024-01-15 12:34:56.789'"
+        );
+    }
+
+    #[test]
+    fn renders_utc_timestamp() {
+        let ts = NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 34, 56)
+            .unwrap()
+            .and_utc();
+        let r = Statement::new("SELECT :t").bind("t", ts).render().unwrap();
+        assert_eq!(
+            r,
+            "EXECUTE IMMEDIATE 'SELECT ?' USING TIMESTAMP '2024-01-15 12:34:56 UTC'"
+        );
+    }
+
+    #[test]
+    fn from_impls_for_chrono_types_compile() {
+        let _: Param = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap().into();
+        let _: Param = NaiveDate::from_ymd_opt(2024, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .into();
+        let _: Param = Utc::now().into();
+    }
+
+    #[test]
+    fn negative_integers_render_with_minus() {
+        let r = Statement::new("SELECT :a, :b")
+            .bind("a", -100i64)
+            .bind("b", -2.5_f64)
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?, ?' USING -100, -2.5e0");
+    }
+
+    #[test]
+    fn renders_u32_as_bigint() {
+        let r = Statement::new("SELECT :n")
+            .bind("n", 4_000_000_000u32)
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?' USING 4000000000");
+    }
+
+    #[test]
+    fn renders_u64_in_bigint_range() {
+        let r = Statement::new("SELECT :n")
+            .bind("n", 9_000_000_000_000_000_000u64)
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?' USING 9000000000000000000");
+    }
+
+    #[test]
+    fn u64_exceeding_bigint_errors() {
+        let err = Statement::new("SELECT :n")
+            .bind("n", u64::MAX)
+            .render()
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidParam(_)));
+    }
+
+    #[test]
+    fn renders_f32_via_f64_format() {
+        let r = Statement::new("SELECT :v")
+            .bind("v", 1.5_f32)
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?' USING 1.5e0");
+    }
+
+    #[test]
+    fn renders_bytes_as_varbinary_hex() {
+        let r = Statement::new("SELECT :b")
+            .bind("b", vec![0xDEu8, 0xAD, 0xBE, 0xEF])
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?' USING X'deadbeef'");
+    }
+
+    #[test]
+    fn renders_empty_bytes() {
+        let r = Statement::new("SELECT :b")
+            .bind("b", Vec::<u8>::new())
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?' USING X''");
+    }
+
+    #[test]
+    fn renders_byte_slice() {
+        let bytes: &[u8] = &[0x01, 0x02, 0x03];
+        let r = Statement::new("SELECT :b")
+            .bind("b", bytes)
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?' USING X'010203'");
+    }
+
+    #[test]
+    fn renders_option_none_as_null() {
+        let none: Option<i64> = None;
+        let r = Statement::new("SELECT :v")
+            .bind("v", none)
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?' USING NULL");
+    }
+
+    #[test]
+    fn renders_option_some_as_inner_value() {
+        let some: Option<i64> = Some(7);
+        let r = Statement::new("SELECT :v")
+            .bind("v", some)
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?' USING 7");
+    }
+
+    #[test]
+    fn renders_option_string() {
+        let r = Statement::new("SELECT :a, :b")
+            .bind("a", Some("hi".to_string()))
+            .bind("b", None::<String>)
+            .render()
+            .unwrap();
+        assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?, ?' USING 'hi', NULL");
+    }
+}

--- a/trino_client/src/statement.rs
+++ b/trino_client/src/statement.rs
@@ -1,5 +1,7 @@
 use crate::error::{Error, Result};
+use crate::{SqlQuery, SqlStatement};
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use std::marker::PhantomData;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Param {
@@ -149,6 +151,7 @@ impl Param {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Statement {
     sql: String,
     params: Vec<(String, Param)>,
@@ -170,6 +173,45 @@ impl Statement {
     pub fn render(&self) -> Result<String> {
         render_internal(&self.sql, &self.params)
     }
+
+    /// Tag this statement with its row type so it can be passed to
+    /// `Client::get_all` without a separate row struct.
+    pub fn typed<R>(self) -> TypedStatement<R> {
+        TypedStatement {
+            stmt: self,
+            _row: PhantomData,
+        }
+    }
+}
+
+impl SqlStatement for Statement {
+    fn to_statement(&self) -> Statement {
+        self.clone()
+    }
+}
+
+/// A `Statement` paired with a row type, satisfying `SqlQuery` so it can be
+/// used with `Client::get_all` directly.
+pub struct TypedStatement<R> {
+    stmt: Statement,
+    _row: PhantomData<fn() -> R>,
+}
+
+impl<R> TypedStatement<R> {
+    pub fn bind(mut self, name: impl Into<String>, value: impl Into<Param>) -> Self {
+        self.stmt = self.stmt.bind(name, value);
+        self
+    }
+}
+
+impl<R> SqlStatement for TypedStatement<R> {
+    fn to_statement(&self) -> Statement {
+        self.stmt.clone()
+    }
+}
+
+impl<R> SqlQuery for TypedStatement<R> {
+    type Row = R;
 }
 
 enum ScanState {
@@ -656,5 +698,42 @@ mod tests {
             .render()
             .unwrap();
         assert_eq!(r, "EXECUTE IMMEDIATE 'SELECT ?, ?' USING 'hi', NULL");
+    }
+
+    #[test]
+    fn statement_satisfies_sql_statement() {
+        let stmt = Statement::new("SELECT :x").bind("x", 1i64);
+        let copy = stmt.to_statement();
+        assert_eq!(
+            copy.render().unwrap(),
+            "EXECUTE IMMEDIATE 'SELECT ?' USING 1"
+        );
+    }
+
+    #[test]
+    fn typed_wraps_statement() {
+        struct DummyRow;
+        let typed: TypedStatement<DummyRow> = Statement::new("SELECT :x").bind("x", 1i64).typed();
+        let rendered = typed.to_statement().render().unwrap();
+        assert_eq!(rendered, "EXECUTE IMMEDIATE 'SELECT ?' USING 1");
+    }
+
+    #[test]
+    fn typed_allows_late_binds() {
+        struct DummyRow;
+        let typed: TypedStatement<DummyRow> = Statement::new("SELECT :a, :b")
+            .bind("a", 1i64)
+            .typed()
+            .bind("b", "x");
+        let rendered = typed.to_statement().render().unwrap();
+        assert_eq!(rendered, "EXECUTE IMMEDIATE 'SELECT ?, ?' USING 1, 'x'");
+    }
+
+    #[test]
+    fn typed_statement_exposes_row_type() {
+        struct DummyRow;
+        let typed: TypedStatement<DummyRow> = Statement::new("SELECT :x").bind("x", 1i64).typed();
+        fn assert_row_is_dummy<S: SqlQuery<Row = DummyRow>>(_: &S) {}
+        assert_row_is_dummy(&typed);
     }
 }

--- a/trino_client/src/statement.rs
+++ b/trino_client/src/statement.rs
@@ -309,7 +309,7 @@ fn render_internal(sql: &str, params: &[(String, Param)]) -> Result<String> {
     }
 
     if placeholder_values.is_empty() {
-        return Err(Error::NoParameters);
+        return Ok(out);
     }
 
     let escaped = out.replace('\'', "''");

--- a/trino_client/src/statement.rs
+++ b/trino_client/src/statement.rs
@@ -503,9 +503,17 @@ mod tests {
     }
 
     #[test]
-    fn no_parameters_errors() {
-        let err = Statement::new("SELECT 1").render().unwrap_err();
-        assert!(matches!(err, Error::NoParameters));
+    fn no_parameters_passes_sql_through_unchanged() {
+        let r = Statement::new("SELECT 1").render().unwrap();
+        assert_eq!(r, "SELECT 1");
+    }
+
+    #[test]
+    fn no_parameters_works_for_ddl() {
+        let r = Statement::new("CREATE TABLE foo (id BIGINT)")
+            .render()
+            .unwrap();
+        assert_eq!(r, "CREATE TABLE foo (id BIGINT)");
     }
 
     #[test]

--- a/trino_client/tests/integration.rs
+++ b/trino_client/tests/integration.rs
@@ -1,27 +1,18 @@
 use chrono::{NaiveDate, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
-use trino_client::{Client, Settings, SqlQuery, SqlStatement, Statement};
-use trino_rust_client::Trino;
+use trino_client::{
+    Client, ClientBuilder, SqlQuery, SqlStatement, Statement, TrinoFromRow, TypedStatement,
+};
 
 fn client() -> Client {
     let host = std::env::var("TRINO_HOST").unwrap_or_else(|_| "localhost".to_string());
 
-    let settings = Settings {
-        host,
-        port: 8080,
-        user: "admin".into(),
-        catalog: None,
-        schema: None,
-        secure: false,
-        ca_cert_path: None,
-        insecure_skip_tls_verify: false,
-        auth: None,
-    };
-
-    Client::from_settings(&settings).expect("build trino client")
+    ClientBuilder::new(host, 8080, "admin")
+        .build()
+        .expect("build trino client")
 }
 
-#[derive(Debug, Clone, Trino, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, TrinoFromRow, Deserialize, Serialize, PartialEq)]
 struct Scalars {
     n: i64,
     s: String,
@@ -29,17 +20,17 @@ struct Scalars {
     d: f64,
 }
 
-#[derive(Debug, Clone, Trino, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, TrinoFromRow, Deserialize, Serialize, PartialEq)]
 struct DateRow {
     d: NaiveDate,
 }
 
-#[derive(Debug, Clone, Trino, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, TrinoFromRow, Deserialize, Serialize, PartialEq)]
 struct StringRow {
     s: String,
 }
 
-#[derive(Debug, Clone, Trino, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, TrinoFromRow, Deserialize, Serialize, PartialEq)]
 struct EqRow {
     eq: bool,
 }
@@ -144,7 +135,7 @@ struct FindUser {
     user_id: i64,
 }
 
-#[derive(Debug, Clone, Trino, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, TrinoFromRow, Deserialize, Serialize, PartialEq)]
 struct User {
     id: i64,
     name: String,
@@ -213,5 +204,34 @@ async fn bytes_bind_as_varbinary() -> anyhow::Result<()> {
         .render()?;
     let rows: Vec<EqRow> = client().get_all_raw(sql).await?;
     assert_eq!(rows, vec![EqRow { eq: true }]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn statement_directly_via_execute() -> anyhow::Result<()> {
+    let stmt = Statement::new("SELECT :x").bind("x", 1i64);
+    client().execute(&stmt).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn typed_statement_via_get_all() -> anyhow::Result<()> {
+    let typed: TypedStatement<Scalars> =
+        Statement::new("SELECT :n AS n, :s AS s, :b AS b, :d AS d")
+            .bind("n", 42i64)
+            .bind("s", "alice")
+            .bind("b", true)
+            .bind("d", 1.5_f64)
+            .typed();
+    let rows = client().get_all(&typed).await?;
+    assert_eq!(
+        rows,
+        vec![Scalars {
+            n: 42,
+            s: "alice".into(),
+            b: true,
+            d: 1.5,
+        }]
+    );
     Ok(())
 }

--- a/trino_client/tests/integration.rs
+++ b/trino_client/tests/integration.rs
@@ -1,0 +1,214 @@
+use chrono::{NaiveDate, TimeZone, Utc};
+use serde::{Deserialize, Serialize};
+use trino_client::{Client, Settings, SqlQuery, SqlStatement, Statement};
+use trino_rust_client::Trino;
+
+fn client() -> Client {
+    let settings = Settings {
+        host: "localhost".into(),
+        port: 8080,
+        user: "admin".into(),
+        catalog: None,
+        schema: None,
+        secure: false,
+        ca_cert_path: None,
+        insecure_skip_tls_verify: false,
+        auth: None,
+    };
+    Client::from_settings(&settings).expect("build trino client")
+}
+
+#[derive(Debug, Clone, Trino, Deserialize, Serialize, PartialEq)]
+struct Scalars {
+    n: i64,
+    s: String,
+    b: bool,
+    d: f64,
+}
+
+#[derive(Debug, Clone, Trino, Deserialize, Serialize, PartialEq)]
+struct DateRow {
+    d: NaiveDate,
+}
+
+#[derive(Debug, Clone, Trino, Deserialize, Serialize, PartialEq)]
+struct StringRow {
+    s: String,
+}
+
+#[derive(Debug, Clone, Trino, Deserialize, Serialize, PartialEq)]
+struct EqRow {
+    eq: bool,
+}
+
+#[tokio::test]
+async fn parameterized_scalars_round_trip() -> anyhow::Result<()> {
+    let sql = Statement::new("SELECT :n AS n, :s AS s, :b AS b, :d AS d")
+        .bind("n", 42i64)
+        .bind("s", "alice")
+        .bind("b", true)
+        .bind("d", 1.5_f64)
+        .render()?;
+    let rows: Vec<Scalars> = client().get_all_raw(sql).await?;
+    assert_eq!(
+        rows,
+        vec![Scalars {
+            n: 42,
+            s: "alice".into(),
+            b: true,
+            d: 1.5,
+        }]
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn parameterized_date_round_trip() -> anyhow::Result<()> {
+    let d = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+    let sql = Statement::new("SELECT :d AS d").bind("d", d).render()?;
+    let rows: Vec<DateRow> = client().get_all_raw(sql).await?;
+    assert_eq!(rows, vec![DateRow { d }]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn naive_timestamp_matches_trino_literal() -> anyhow::Result<()> {
+    let t = NaiveDate::from_ymd_opt(2024, 1, 15)
+        .unwrap()
+        .and_hms_milli_opt(12, 34, 56, 789)
+        .unwrap();
+    let sql = Statement::new("SELECT (TIMESTAMP '2024-01-15 12:34:56.789' = :t) AS eq")
+        .bind("t", t)
+        .render()?;
+    let rows: Vec<EqRow> = client().get_all_raw(sql).await?;
+    assert_eq!(rows, vec![EqRow { eq: true }]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn utc_timestamp_matches_trino_literal() -> anyhow::Result<()> {
+    let t = Utc
+        .with_ymd_and_hms(2024, 1, 15, 12, 34, 56)
+        .single()
+        .unwrap();
+    let sql = Statement::new("SELECT (TIMESTAMP '2024-01-15 12:34:56 UTC' = :t) AS eq")
+        .bind("t", t)
+        .render()?;
+    let rows: Vec<EqRow> = client().get_all_raw(sql).await?;
+    assert_eq!(rows, vec![EqRow { eq: true }]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn string_with_apostrophe_round_trip() -> anyhow::Result<()> {
+    let s = "O'Brien".to_string();
+    let sql = Statement::new("SELECT :s AS s")
+        .bind("s", s.clone())
+        .render()?;
+    let rows: Vec<StringRow> = client().get_all_raw(sql).await?;
+    assert_eq!(rows, vec![StringRow { s }]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn execute_runs_a_parameterized_statement() -> anyhow::Result<()> {
+    let sql = Statement::new("SELECT :x").bind("x", 1i64).render()?;
+    client().execute_raw(sql).await?;
+    Ok(())
+}
+
+/// A struct that owns its bind values and implements SqlStatement —
+/// proves the execute() path works through the trait.
+struct Ping {
+    value: i64,
+}
+
+impl SqlStatement for Ping {
+    fn to_statement(&self) -> Statement {
+        Statement::new("SELECT :v").bind("v", self.value)
+    }
+}
+
+#[tokio::test]
+async fn sql_statement_executes_via_client() -> anyhow::Result<()> {
+    client().execute(&Ping { value: 7 }).await?;
+    Ok(())
+}
+
+/// A typed query: SqlStatement + SqlQuery binds Row to the struct,
+/// so callers don't need a turbofish on .get_all().
+struct FindUser {
+    user_id: i64,
+}
+
+#[derive(Debug, Clone, Trino, Deserialize, Serialize, PartialEq)]
+struct User {
+    id: i64,
+    name: String,
+}
+
+impl SqlStatement for FindUser {
+    fn to_statement(&self) -> Statement {
+        Statement::new("SELECT :id AS id, 'user-' || CAST(:id AS VARCHAR) AS name")
+            .bind("id", self.user_id)
+    }
+}
+
+impl SqlQuery for FindUser {
+    type Row = User;
+}
+
+#[tokio::test]
+async fn sql_query_returns_typed_rows() -> anyhow::Result<()> {
+    let rows = client().get_all(&FindUser { user_id: 42 }).await?;
+    assert_eq!(
+        rows,
+        vec![User {
+            id: 42,
+            name: "user-42".into(),
+        }]
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn none_option_binds_as_null() -> anyhow::Result<()> {
+    let none: Option<i64> = None;
+    let sql = Statement::new("SELECT (:v IS NULL) AS eq")
+        .bind("v", none)
+        .render()?;
+    let rows: Vec<EqRow> = client().get_all_raw(sql).await?;
+    assert_eq!(rows, vec![EqRow { eq: true }]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn some_option_binds_as_inner_value() -> anyhow::Result<()> {
+    let sql = Statement::new("SELECT (:v = CAST(42 AS BIGINT)) AS eq")
+        .bind("v", Some(42i64))
+        .render()?;
+    let rows: Vec<EqRow> = client().get_all_raw(sql).await?;
+    assert_eq!(rows, vec![EqRow { eq: true }]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn u64_binds_as_bigint() -> anyhow::Result<()> {
+    let sql = Statement::new("SELECT (:n = CAST(9000000000 AS BIGINT)) AS eq")
+        .bind("n", 9_000_000_000u64)
+        .render()?;
+    let rows: Vec<EqRow> = client().get_all_raw(sql).await?;
+    assert_eq!(rows, vec![EqRow { eq: true }]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn bytes_bind_as_varbinary() -> anyhow::Result<()> {
+    let bytes = vec![0xDEu8, 0xAD, 0xBE, 0xEF];
+    let sql = Statement::new("SELECT (:b = X'deadbeef') AS eq")
+        .bind("b", bytes)
+        .render()?;
+    let rows: Vec<EqRow> = client().get_all_raw(sql).await?;
+    assert_eq!(rows, vec![EqRow { eq: true }]);
+    Ok(())
+}

--- a/trino_client/tests/integration.rs
+++ b/trino_client/tests/integration.rs
@@ -4,8 +4,10 @@ use trino_client::{Client, Settings, SqlQuery, SqlStatement, Statement};
 use trino_rust_client::Trino;
 
 fn client() -> Client {
+    let host = std::env::var("TRINO_HOST").unwrap_or_else(|_| "localhost".to_string());
+
     let settings = Settings {
-        host: "localhost".into(),
+        host,
         port: 8080,
         user: "admin".into(),
         catalog: None,
@@ -15,6 +17,7 @@ fn client() -> Client {
         insecure_skip_tls_verify: false,
         auth: None,
     };
+
     Client::from_settings(&settings).expect("build trino client")
 }
 


### PR DESCRIPTION
New workspace crate at `trino_client/` that wraps `trino-rust-client` with:

- **`Settings`**: typed, serde-deserializable config — `host`, `port`, `user`, `catalog`, `schema`, `secure`, `ca_cert_path`, `insecure_skip_tls_verify`, plus `auth: Option<AuthSettings>` with `Basic { username, password }` and `Jwt { token }` variants.
- **`Statement`**: parameterized SQL builder — `Statement::new(sql).bind(name, value).render() -> Result<String>`. Named placeholders (`:id`, `:name`) render to Trino's `EXECUTE IMMEDIATE 'sql with ?' USING v1, v2, ...` form. Scanner is quote- and comment-aware (skips `:` inside `'...'`, `"..."`, `-- ...`, `/* ... */`).
- **`Param`** enum with `From` impls for: `i32`, `i64`, `u32`, `u64`, `f32`, `f64`, `bool`, `&str`, `String`, `Vec<u8>`, `&[u8]`, `chrono::NaiveDate`, `chrono::NaiveDateTime`, `chrono::DateTime<Utc>`, and a blanket `Option<T: Into<Param>>` that renders `None` as bare `NULL`. Bytes render as Trino `VARBINARY` hex literals (`X'deadbeef'`). `u64 > i64::MAX` errors at render time.
- **`SqlStatement` / `SqlQuery` traits**: a struct implements `SqlStatement` (returns a `Statement`); add `SqlQuery: SqlStatement` with `type Row` for typed row-returning queries. `Client::execute(&q)` and `Client::get_all(&q)` dispatch through these.
- **`Client`**: owns the underlying `trino_rust_client::Client`. Exposes `from_settings`, `from_inner`, `inner`, trait-based `execute`/`get_all`, plus raw `execute_raw` / `get_all_raw` for ad-hoc SQL (and for DDL, since Trino's `EXECUTE IMMEDIATE` rejects DDL).
- Re-exports `trino_rust_client` so downstream callers using `#[derive(Trino)]` and `error::Error::EmptyData` only need one dep.

Migration of existing callers (`helium_iceberg`, `mobile_verifier`, `mobile_packet_verifier`) is intentionally **out of scope** for this PR — most of those sites interpolate identifiers (`{NAMESPACE}.{TABLE_NAME}`) which the parameterized API can't bind, so migration is a separate, mechanical follow-up.

## Test plan

54 tests pass (44 unit + 10 integration):

- [x] `cargo build -p trino_client --all-targets`
- [x] `cargo clippy -p trino_client --all-targets -- -D warnings`
- [x] Unit tests cover: literal rendering for every `Param` variant, quote-/comment-aware scanner edge cases (`''`, `""`, `:` inside strings/identifiers/comments), missing-param / no-param / NaN / Inf / u64-overflow errors, `Option` blanket, `Settings` serde deserialization for basic auth, JWT auth, TLS options.
- [x] Integration tests against local Trino (`localhost:8080`, user `admin`): scalar round-trip, date round-trip, naive-/UTC-timestamp equality vs `TIMESTAMP` literals, apostrophe escaping round-trip, `SqlStatement::execute` path, `SqlQuery::get_all` path with typed `Row`, `Option<None>` → `IS NULL`, `Option<Some>` → value, `u64` → `BIGINT`, `Vec<u8>` → `X'...'` `VARBINARY`.