### PR TITLE
Remove unused types from heartbeat

### DIFF
--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -1,8 +1,4 @@
-use crate::{
-    heartbeats::{HbType, KeyType, OwnedKeyType},
-    seniority::Seniority,
-    IsAuthorized, Settings,
-};
+use crate::{seniority::Seniority, IsAuthorized, Settings};
 use chrono::{DateTime, Utc};
 use file_store::{
     file_info_poller::FileInfoStream, file_sink::FileSinkClient, file_source,
@@ -18,6 +14,7 @@ use futures::{
     TryStreamExt,
 };
 use h3o::{CellIndex, LatLng};
+use helium_crypto::PublicKeyBinary;
 use helium_proto::services::{
     mobile_config::NetworkKeyRole,
     poc_mobile::{self as proto, CoverageObjectValidity, SignalLevel as SignalLevelProto},
@@ -254,11 +251,9 @@ impl CoverageObject {
         matches!(self.validity, CoverageObjectValidity::Valid)
     }
 
-    pub fn key(&self) -> KeyType<'_> {
+    pub fn key(&self) -> &PublicKeyBinary {
         match self.coverage_object.key_type {
-            file_store_oracles::coverage::KeyType::HotspotKey(ref hotspot_key) => {
-                KeyType::Wifi(hotspot_key)
-            }
+            file_store_oracles::coverage::KeyType::HotspotKey(ref hotspot_key) => hotspot_key,
         }
     }
 
@@ -299,12 +294,10 @@ impl CoverageObject {
     pub async fn save(&self, transaction: &mut Transaction<'_, Postgres>) -> anyhow::Result<()> {
         let insertion_time = Utc::now();
         let key = self.key();
-        let hb_type = key.hb_type();
-        let key = key.to_owned();
 
         sqlx::query(r#"
             INSERT INTO coverage_objects (uuid, radio_type, radio_key, indoor, coverage_claim_time, trust_score, inserted_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            VALUES ($1, 'wifi'::radio_type, $2, $3, $4, $5, $6)
             ON CONFLICT (uuid) DO UPDATE SET
                 radio_type = EXCLUDED.radio_type,
                 radio_key = EXCLUDED.radio_key,
@@ -314,8 +307,7 @@ impl CoverageObject {
                 inserted_at = EXCLUDED.inserted_at
         "#)
         .bind(self.coverage_object.uuid)
-        .bind(hb_type)
-        .bind(&key)
+        .bind(key)
         .bind(self.coverage_object.indoor)
         .bind(self.coverage_object.coverage_claim_time)
         .bind(self.coverage_object.trust_score as i32)
@@ -359,7 +351,7 @@ pub async fn set_invalidated_at(
     exec: &mut Transaction<'_, Postgres>,
     invalidated_at: DateTime<Utc>,
     inserted_at: Option<DateTime<Utc>>,
-    radio_key: KeyType<'_>,
+    radio_key: &PublicKeyBinary,
     uuid: Option<Uuid>,
 ) -> anyhow::Result<()> {
     sqlx::query(
@@ -388,7 +380,7 @@ pub struct HexCoverage {
     #[sqlx(try_from = "i64")]
     pub hex: Cell,
     pub indoor: bool,
-    pub radio_key: OwnedKeyType,
+    pub radio_key: PublicKeyBinary,
     pub signal_level: SignalLevel,
     pub signal_power: i32,
     pub coverage_claim_time: DateTime<Utc>,
@@ -401,14 +393,14 @@ pub struct HexCoverage {
 pub trait CoveredHexStream {
     async fn covered_hex_stream<'a>(
         &'a self,
-        radio_key: KeyType<'a>,
+        radio_key: &'a PublicKeyBinary,
         coverage_obj: &'a Uuid,
         seniority: &'a Seniority,
     ) -> Result<BoxStream<'a, Result<HexCoverage, sqlx::Error>>, sqlx::Error>;
 
     async fn fetch_seniority(
         &self,
-        key: KeyType<'_>,
+        key: &PublicKeyBinary,
         period_end: DateTime<Utc>,
     ) -> Result<Seniority, sqlx::Error>;
 }
@@ -417,7 +409,7 @@ pub trait CoveredHexStream {
 impl CoveredHexStream for Pool<Postgres> {
     async fn covered_hex_stream<'a>(
         &'a self,
-        key: KeyType<'a>,
+        key: &'a PublicKeyBinary,
         coverage_obj: &'a Uuid,
         seniority: &'a Seniority,
     ) -> Result<BoxStream<'a, Result<HexCoverage, sqlx::Error>>, sqlx::Error> {
@@ -453,7 +445,7 @@ impl CoveredHexStream for Pool<Postgres> {
 
     async fn fetch_seniority(
         &self,
-        key: KeyType<'_>,
+        key: &PublicKeyBinary,
         period_end: DateTime<Utc>,
     ) -> Result<Seniority, sqlx::Error> {
         sqlx::query_as(
@@ -516,7 +508,7 @@ pub async fn clear_coverage_objects(
     Ok(())
 }
 
-type CoverageClaimTimeKey = ((String, HbType), Option<Uuid>);
+type CoverageClaimTimeKey = (PublicKeyBinary, Option<Uuid>);
 
 pub struct CoverageClaimTimeCache {
     cache: Arc<Cache<CoverageClaimTimeKey, DateTime<Utc>>>,
@@ -542,11 +534,11 @@ impl CoverageClaimTimeCache {
 
     pub async fn fetch_coverage_claim_time<'a>(
         &self,
-        radio_key: KeyType<'a>,
+        radio_key: &'a PublicKeyBinary,
         coverage_object: &'a Option<Uuid>,
         exec: &mut Transaction<'_, Postgres>,
     ) -> Result<Option<DateTime<Utc>>, sqlx::Error> {
-        let key = (radio_key.to_id(), *coverage_object);
+        let key = (radio_key.clone(), *coverage_object);
         if let Some(coverage_claim_time) = self.cache.get(&key).await {
             Ok(Some(*coverage_claim_time))
         } else {
@@ -598,7 +590,7 @@ impl CoverageObjectCache {
     pub async fn fetch_coverage_object(
         &self,
         uuid: &Uuid,
-        key: KeyType<'_>,
+        key: &PublicKeyBinary,
     ) -> Result<Option<CachedCoverageObject<'_>>, sqlx::Error> {
         let coverage_meta: Option<CoverageObjectMeta> = sqlx::query_as(
 	    "SELECT inserted_at, indoor FROM coverage_objects WHERE uuid = $1 AND radio_key = $2 AND invalidated_at IS NULL LIMIT 1"

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -1,4 +1,4 @@
-use crate::{seniority::Seniority, IsAuthorized, Settings};
+use crate::{cell_type::CellType, seniority::Seniority, IsAuthorized, Settings};
 use chrono::{DateTime, Utc};
 use file_store::{
     file_info_poller::FileInfoStream, file_sink::FileSinkClient, file_source,
@@ -660,5 +660,19 @@ impl CachedCoverageObject<'_> {
             let cov = LatLng::from(*curr_cov);
             curr_max.max(cov.distance_m(latlng))
         })
+    }
+
+    pub fn to_cell_type(&self) -> CellType {
+        match self.meta.indoor {
+            true => CellType::NovaGenericWifiIndoor,
+            false => CellType::NovaGenericWifiOutdoor,
+        }
+    }
+
+    pub fn to_radio_type(&self) -> coverage_point_calculator::RadioType {
+        match self.meta.indoor {
+            true => coverage_point_calculator::RadioType::IndoorWifi,
+            false => coverage_point_calculator::RadioType::OutdoorWifi,
+        }
     }
 }

--- a/mobile_verifier/src/heartbeats/mod.rs
+++ b/mobile_verifier/src/heartbeats/mod.rs
@@ -21,10 +21,7 @@ use mobile_config::gateway::service::info::DeviceType;
 use retainer::Cache;
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use rust_decimal_macros::dec;
-use sqlx::{
-    postgres::{PgArgumentBuffer, PgTypeInfo, PgValueRef},
-    Decode, Encode, Postgres, Transaction, Type,
-};
+use sqlx::{Postgres, Transaction};
 use std::{ops::Range, pin::pin, time};
 use uuid::Uuid;
 
@@ -33,127 +30,8 @@ use self::last_location::{LastLocation, LocationCache};
 /// Minimum number of heartbeats required to give a reward to the hotspot.
 const MINIMUM_HEARTBEAT_COUNT: i64 = 12;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type, Debug)]
-#[sqlx(type_name = "radio_type")]
-#[sqlx(rename_all = "lowercase")]
-pub enum HbType {
-    Wifi,
-}
-
-#[derive(Debug, Copy, Clone)]
-pub enum KeyType<'a> {
-    Wifi(&'a PublicKeyBinary),
-}
-
-impl From<KeyType<'_>> for proto::seniority_update::KeyType {
-    fn from(kt: KeyType<'_>) -> Self {
-        match kt {
-            KeyType::Wifi(key) => proto::seniority_update::KeyType::HotspotKey(key.clone().into()),
-        }
-    }
-}
-
-impl KeyType<'_> {
-    pub fn to_owned(self) -> OwnedKeyType {
-        match self {
-            Self::Wifi(key) => OwnedKeyType::Wifi(key.to_owned()),
-        }
-    }
-
-    pub fn to_id(self) -> (String, HbType) {
-        match self {
-            Self::Wifi(wifi) => (wifi.to_string(), HbType::Wifi),
-        }
-    }
-
-    pub fn hb_type(self) -> HbType {
-        match self {
-            Self::Wifi(_) => HbType::Wifi,
-        }
-    }
-}
-
-impl<'a> From<&'a PublicKeyBinary> for KeyType<'a> {
-    fn from(wifi: &'a PublicKeyBinary) -> Self {
-        Self::Wifi(wifi)
-    }
-}
-
-impl Type<Postgres> for KeyType<'_> {
-    fn type_info() -> PgTypeInfo {
-        PgTypeInfo::with_name("TEXT")
-    }
-}
-
-impl<'a> Encode<'a, Postgres> for KeyType<'a> {
-    fn encode_by_ref(
-        &self,
-        buf: &mut PgArgumentBuffer,
-    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
-        match self {
-            Self::Wifi(wifi) => wifi.encode_by_ref(buf),
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum OwnedKeyType {
-    Wifi(PublicKeyBinary),
-}
-
-impl OwnedKeyType {
-    pub fn to_ref(&self) -> KeyType<'_> {
-        match self {
-            OwnedKeyType::Wifi(pubkey) => KeyType::Wifi(pubkey),
-        }
-    }
-}
-
-impl From<PublicKeyBinary> for OwnedKeyType {
-    fn from(w: PublicKeyBinary) -> Self {
-        Self::Wifi(w)
-    }
-}
-
-impl PartialEq<KeyType<'_>> for OwnedKeyType {
-    fn eq(&self, rhs: &KeyType<'_>) -> bool {
-        match (self, rhs) {
-            (Self::Wifi(lhs), KeyType::Wifi(rhs)) => lhs == *rhs,
-        }
-    }
-}
-
-impl Type<Postgres> for OwnedKeyType {
-    fn type_info() -> PgTypeInfo {
-        PgTypeInfo::with_name("TEXT")
-    }
-}
-
-impl Encode<'_, Postgres> for OwnedKeyType {
-    fn encode_by_ref(
-        &self,
-        buf: &mut PgArgumentBuffer,
-    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
-        match self {
-            Self::Wifi(wifi) => wifi.encode_by_ref(buf),
-        }
-    }
-}
-
-impl<'r> Decode<'r, Postgres> for OwnedKeyType {
-    fn decode(value: PgValueRef<'r>) -> Result<Self, sqlx::error::BoxDynError> {
-        let text = <&str as Decode<Postgres>>::decode(value)?;
-        // Try decoding to a public key binary
-        match text.parse() {
-            Ok(pubkey) => Ok(OwnedKeyType::Wifi(pubkey)),
-            Err(e) => Err(e)?,
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct Heartbeat {
-    pub hb_type: HbType,
     pub hotspot_key: PublicKeyBinary,
     pub operation_mode: bool,
     pub lat: f64,
@@ -170,8 +48,8 @@ impl Heartbeat {
         self.timestamp.duration_trunc(Duration::hours(1))
     }
 
-    pub fn key(&self) -> KeyType<'_> {
-        KeyType::from(&self.hotspot_key)
+    pub fn key(&self) -> &PublicKeyBinary {
+        &self.hotspot_key
     }
 
     pub fn id(&self) -> anyhow::Result<(String, DateTime<Utc>)> {
@@ -195,7 +73,6 @@ impl From<WifiHeartbeatIngestReport> for Heartbeat {
             .location_validation_timestamp
             .filter(|ts| received_timestamp.signed_duration_since(ts) <= Duration::hours(24));
         Self {
-            hb_type: HbType::Wifi,
             coverage_object: value.report.coverage_object(),
             hotspot_key: value.report.pubkey,
             operation_mode: value.report.operation_mode,
@@ -218,8 +95,8 @@ pub struct HeartbeatReward {
 }
 
 impl HeartbeatReward {
-    pub fn key(&self) -> KeyType<'_> {
-        KeyType::Wifi(&self.hotspot_key)
+    pub fn key(&self) -> &PublicKeyBinary {
+        &self.hotspot_key
     }
 
     pub fn id(&self) -> String {
@@ -339,14 +216,10 @@ impl ValidatedHeartbeat {
             ));
         };
 
-        let cell_type = match heartbeat.hb_type {
-            HbType::Wifi => {
-                if coverage_object.meta.indoor {
-                    CellType::NovaGenericWifiIndoor
-                } else {
-                    CellType::NovaGenericWifiOutdoor
-                }
-            }
+        let cell_type = if coverage_object.meta.indoor {
+            CellType::NovaGenericWifiIndoor
+        } else {
+            CellType::NovaGenericWifiOutdoor
         };
 
         if !heartbeat.operation_mode {
@@ -425,21 +298,17 @@ impl ValidatedHeartbeat {
                 Some(coverage_object.meta),
                 proto::HeartbeatValidity::GatewayNotFound,
             )),
-            GatewayResolution::GatewayNotAsserted if heartbeat.hb_type == HbType::Wifi => {
-                Ok(Self::new(
-                    heartbeat,
-                    cell_type,
-                    dec!(0),
-                    None,
-                    None,
-                    None,
-                    Some(coverage_object.meta),
-                    proto::HeartbeatValidity::GatewayNotAsserted,
-                ))
-            }
-            GatewayResolution::AssertedLocation(location, device_type)
-                if heartbeat.hb_type == HbType::Wifi =>
-            {
+            GatewayResolution::GatewayNotAsserted => Ok(Self::new(
+                heartbeat,
+                cell_type,
+                dec!(0),
+                None,
+                None,
+                None,
+                Some(coverage_object.meta),
+                proto::HeartbeatValidity::GatewayNotAsserted,
+            )),
+            GatewayResolution::AssertedLocation(location, device_type) => {
                 let asserted_latlng: LatLng = CellIndex::try_from(location)?.into();
                 let is_valid = match heartbeat.location_validation_timestamp {
                     None => {
@@ -485,9 +354,10 @@ impl ValidatedHeartbeat {
                     use coverage_point_calculator::{
                         asserted_distance_to_trust_multiplier, RadioType,
                     };
-                    let radio_type = match (heartbeat.hb_type, coverage_object.meta.indoor) {
-                        (HbType::Wifi, true) => RadioType::IndoorWifi,
-                        (HbType::Wifi, false) => RadioType::OutdoorWifi,
+                    let radio_type = if coverage_object.meta.indoor {
+                        RadioType::IndoorWifi
+                    } else {
+                        RadioType::OutdoorWifi
                     };
                     asserted_distance_to_trust_multiplier(radio_type, distance_to_asserted as u32)
                 };
@@ -503,16 +373,6 @@ impl ValidatedHeartbeat {
                     proto::HeartbeatValidity::Valid,
                 ))
             }
-            _ => Ok(Self::new(
-                heartbeat,
-                cell_type,
-                dec!(1.0),
-                None,
-                None,
-                None,
-                Some(coverage_object.meta),
-                proto::HeartbeatValidity::Valid,
-            )),
         }
     }
 
@@ -583,13 +443,6 @@ impl ValidatedHeartbeat {
             self.heartbeat.coverage_object,
         )
         .await?;
-        // Save the heartbeat
-        match self.heartbeat.hb_type {
-            HbType::Wifi => self.save_wifi_hb(exec).await,
-        }
-    }
-
-    async fn save_wifi_hb(self, exec: &mut Transaction<'_, Postgres>) -> anyhow::Result<()> {
         let truncated_timestamp = self.truncated_timestamp()?;
         sqlx::query(
             r#"
@@ -734,7 +587,6 @@ mod test {
         ValidatedHeartbeat {
             cell_type: CellType::CellTypeNone,
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: PublicKeyBinary::from(Vec::new()),
                 timestamp,
                 lon: 0.0,

--- a/mobile_verifier/src/heartbeats/mod.rs
+++ b/mobile_verifier/src/heartbeats/mod.rs
@@ -176,8 +176,38 @@ impl ValidatedHeartbeat {
         }
     }
 
+    fn new_invalid(
+        heartbeat: Heartbeat,
+        cell_type: CellType,
+        coverage_meta: CoverageObjectMeta,
+        validity: proto::HeartbeatValidity,
+    ) -> Self {
+        Self {
+            heartbeat,
+            cell_type,
+            location_trust_score_multiplier: dec!(0),
+            distance_to_asserted: None,
+            asserted_location: None,
+            device_type: None,
+            coverage_meta: Some(coverage_meta),
+            validity,
+        }
+    }
+
+    fn new_no_coverage(heartbeat: Heartbeat, validity: proto::HeartbeatValidity) -> Self {
+        Self {
+            heartbeat,
+            cell_type: CellType::CellTypeNone,
+            location_trust_score_multiplier: dec!(0),
+            distance_to_asserted: None,
+            asserted_location: None,
+            device_type: None,
+            coverage_meta: None,
+            validity,
+        }
+    }
+
     /// Validate a heartbeat in the given epoch.
-    #[allow(clippy::too_many_arguments)]
     pub async fn validate(
         mut heartbeat: Heartbeat,
         gateway_info_resolver: &impl GatewayResolver,
@@ -187,89 +217,57 @@ impl ValidatedHeartbeat {
         epoch: &Range<DateTime<Utc>>,
         geofence: &impl GeofenceValidator,
     ) -> anyhow::Result<Self> {
-        let Some(coverage_object) = heartbeat.coverage_object else {
-            return Ok(Self::new(
+        let Some(coverage_object_uuid) = heartbeat.coverage_object else {
+            return Ok(Self::new_no_coverage(
                 heartbeat,
-                CellType::CellTypeNone,
-                dec!(0),
-                None,
-                None,
-                None,
-                None,
                 proto::HeartbeatValidity::BadCoverageObject,
             ));
         };
 
         let Some(coverage_object) = coverage_object_cache
-            .fetch_coverage_object(&coverage_object, heartbeat.key())
+            .fetch_coverage_object(&coverage_object_uuid, heartbeat.key())
             .await?
         else {
-            return Ok(Self::new(
+            return Ok(Self::new_no_coverage(
                 heartbeat,
-                CellType::CellTypeNone,
-                dec!(0),
-                None,
-                None,
-                None,
-                None,
                 proto::HeartbeatValidity::NoSuchCoverageObject,
             ));
         };
 
-        let cell_type = if coverage_object.meta.indoor {
-            CellType::NovaGenericWifiIndoor
-        } else {
-            CellType::NovaGenericWifiOutdoor
-        };
+        let cell_type = coverage_object.to_cell_type();
 
         if !heartbeat.operation_mode {
-            return Ok(Self::new(
+            return Ok(Self::new_invalid(
                 heartbeat,
                 cell_type,
-                dec!(0),
-                None,
-                None,
-                None,
-                Some(coverage_object.meta),
+                coverage_object.meta,
                 proto::HeartbeatValidity::NotOperational,
             ));
         }
 
         if !epoch.contains(&heartbeat.timestamp) {
-            return Ok(Self::new(
+            return Ok(Self::new_invalid(
                 heartbeat,
                 cell_type,
-                dec!(0),
-                None,
-                None,
-                None,
-                Some(coverage_object.meta),
+                coverage_object.meta,
                 proto::HeartbeatValidity::HeartbeatOutsideRange,
             ));
         }
 
         let Ok(mut hb_latlng) = heartbeat.centered_latlng() else {
-            return Ok(Self::new(
+            return Ok(Self::new_invalid(
                 heartbeat,
                 cell_type,
-                dec!(0),
-                None,
-                None,
-                None,
-                Some(coverage_object.meta),
+                coverage_object.meta,
                 proto::HeartbeatValidity::InvalidLatLon,
             ));
         };
 
         if !geofence.in_valid_region(&heartbeat) {
-            return Ok(Self::new(
+            return Ok(Self::new_invalid(
                 heartbeat,
                 cell_type,
-                dec!(0),
-                None,
-                None,
-                None,
-                Some(coverage_object.meta),
+                coverage_object.meta,
                 proto::HeartbeatValidity::UnsupportedLocation,
             ));
         }
@@ -278,34 +276,22 @@ impl ValidatedHeartbeat {
             .resolve_gateway(&heartbeat.hotspot_key, &heartbeat.timestamp)
             .await?
         {
-            GatewayResolution::DataOnly => Ok(Self::new(
+            GatewayResolution::DataOnly => Ok(Self::new_invalid(
                 heartbeat,
                 cell_type,
-                dec!(0),
-                None,
-                None,
-                None,
-                Some(coverage_object.meta),
+                coverage_object.meta,
                 proto::HeartbeatValidity::InvalidDeviceType,
             )),
-            GatewayResolution::GatewayNotFound => Ok(Self::new(
+            GatewayResolution::GatewayNotFound => Ok(Self::new_invalid(
                 heartbeat,
                 cell_type,
-                dec!(0),
-                None,
-                None,
-                None,
-                Some(coverage_object.meta),
+                coverage_object.meta,
                 proto::HeartbeatValidity::GatewayNotFound,
             )),
-            GatewayResolution::GatewayNotAsserted => Ok(Self::new(
+            GatewayResolution::GatewayNotAsserted => Ok(Self::new_invalid(
                 heartbeat,
                 cell_type,
-                dec!(0),
-                None,
-                None,
-                None,
-                Some(coverage_object.meta),
+                coverage_object.meta,
                 proto::HeartbeatValidity::GatewayNotAsserted,
             )),
             GatewayResolution::AssertedLocation(location, device_type) => {
@@ -351,15 +337,10 @@ impl ValidatedHeartbeat {
                     dec!(0)
                 } else {
                     // HIP-119 maximum asserted distance check
-                    use coverage_point_calculator::{
-                        asserted_distance_to_trust_multiplier, RadioType,
-                    };
-                    let radio_type = if coverage_object.meta.indoor {
-                        RadioType::IndoorWifi
-                    } else {
-                        RadioType::OutdoorWifi
-                    };
-                    asserted_distance_to_trust_multiplier(radio_type, distance_to_asserted as u32)
+                    coverage_point_calculator::asserted_distance_to_trust_multiplier(
+                        coverage_object.to_radio_type(),
+                        distance_to_asserted as u32,
+                    )
                 };
 
                 Ok(Self::new(

--- a/mobile_verifier/src/heartbeats/mod.rs
+++ b/mobile_verifier/src/heartbeats/mod.rs
@@ -21,7 +21,7 @@ use mobile_config::gateway::service::info::DeviceType;
 use retainer::Cache;
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use rust_decimal_macros::dec;
-use sqlx::{Postgres, Transaction};
+use sqlx::PgTransaction;
 use std::{ops::Range, pin::pin, time};
 use uuid::Uuid;
 
@@ -415,7 +415,7 @@ impl ValidatedHeartbeat {
         Ok(())
     }
 
-    pub async fn save(self, exec: &mut Transaction<'_, Postgres>) -> anyhow::Result<()> {
+    pub async fn save(self, exec: &mut PgTransaction<'_>) -> anyhow::Result<()> {
         coverage::set_invalidated_at(
             exec,
             self.heartbeat.timestamp,
@@ -456,7 +456,7 @@ pub(crate) async fn process_validated_heartbeats(
     coverage_claim_time_cache: &CoverageClaimTimeCache,
     heartbeat_sink: &FileSinkClient<proto::Heartbeat>,
     seniority_sink: &FileSinkClient<proto::SeniorityUpdate>,
-    transaction: &mut Transaction<'_, Postgres>,
+    transaction: &mut PgTransaction<'_>,
     iceberg_ctx: Option<(&crate::iceberg::HeartbeatWriter, &str)>,
 ) -> anyhow::Result<()> {
     let mut iceberg_records = Vec::new();

--- a/mobile_verifier/src/heartbeats/mod.rs
+++ b/mobile_verifier/src/heartbeats/mod.rs
@@ -450,7 +450,6 @@ impl ValidatedHeartbeat {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn process_validated_heartbeats(
     validated_heartbeats: impl Stream<Item = anyhow::Result<ValidatedHeartbeat>>,
     heartbeat_cache: &Cache<(String, DateTime<Utc>), ()>,

--- a/mobile_verifier/src/heartbeats/wifi.rs
+++ b/mobile_verifier/src/heartbeats/wifi.rs
@@ -13,7 +13,7 @@ use file_store_oracles::{wifi_heartbeat::WifiHeartbeatIngestReport, FileType};
 use futures::stream::StreamExt;
 use helium_proto::services::poc_mobile as proto;
 use retainer::Cache;
-use sqlx::{Pool, Postgres};
+use sqlx::PgPool;
 use std::{
     sync::Arc,
     time::{self, Instant},
@@ -22,7 +22,7 @@ use task_manager::{ManagedTask, TaskManager};
 use tokio::sync::mpsc::Receiver;
 
 pub struct WifiHeartbeatDaemon<GIR, GFV> {
-    pool: sqlx::Pool<sqlx::Postgres>,
+    pool: PgPool,
     gateway_info_resolver: GIR,
     heartbeats: Receiver<FileInfoStream<WifiHeartbeatIngestReport>>,
     max_distance_to_coverage: u32,
@@ -39,7 +39,7 @@ where
 {
     #[allow(clippy::too_many_arguments)]
     pub async fn create_managed_task(
-        pool: Pool<Postgres>,
+        pool: PgPool,
         settings: &Settings,
         bucket_client: BucketClient,
         gateway_resolver: GIR,

--- a/mobile_verifier/src/iceberg/heartbeat.rs
+++ b/mobile_verifier/src/iceberg/heartbeat.rs
@@ -160,10 +160,7 @@ fn device_type_string(device_type: DeviceType) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        cell_type::CellType,
-        heartbeats::{HbType, Heartbeat},
-    };
+    use crate::{cell_type::CellType, heartbeats::Heartbeat};
     use chrono::Utc;
     use helium_crypto::PublicKeyBinary;
     use helium_proto::services::poc_mobile::{HeartbeatValidity, LocationSource};
@@ -180,7 +177,6 @@ mod tests {
         let now = Utc::now();
         ValidatedHeartbeat {
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: PublicKeyBinary::from(vec![1, 2, 3]),
                 operation_mode: true,
                 lat: 37.7749,

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -551,7 +551,7 @@ mod test {
     use crate::{
         coverage::{CoveredHexStream, HexCoverage},
         data_session::{self, HotspotDataSession, HotspotReward},
-        heartbeats::{HeartbeatReward, KeyType, OwnedKeyType},
+        heartbeats::HeartbeatReward,
         speedtests::Speedtest,
         speedtests_average::SpeedtestAverage,
     };
@@ -831,22 +831,22 @@ mod test {
     }
 
     #[async_trait::async_trait]
-    impl CoveredHexStream for HashMap<(OwnedKeyType, Uuid), Vec<HexCoverage>> {
+    impl CoveredHexStream for HashMap<(PublicKeyBinary, Uuid), Vec<HexCoverage>> {
         async fn covered_hex_stream<'a>(
             &'a self,
-            key: KeyType<'a>,
+            key: &'a PublicKeyBinary,
             coverage_obj: &'a Uuid,
             _seniority: &'a Seniority,
         ) -> Result<BoxStream<'a, Result<HexCoverage, sqlx::Error>>, sqlx::Error> {
             Ok(
-                stream::iter(self.get(&(key.to_owned(), *coverage_obj)).unwrap().clone())
+                stream::iter(self.get(&(key.clone(), *coverage_obj)).unwrap().clone())
                     .map(Ok)
                     .boxed(),
             )
         }
         async fn fetch_seniority(
             &self,
-            _key: KeyType<'_>,
+            _key: &PublicKeyBinary,
             _period_end: DateTime<Utc>,
         ) -> Result<Seniority, sqlx::Error> {
             Ok(Seniority {
@@ -859,9 +859,8 @@ mod test {
         }
     }
 
-    fn simple_hex_coverage<'a>(key: impl Into<KeyType<'a>>, hex: u64) -> Vec<HexCoverage> {
-        let key = key.into();
-        let radio_key = key.to_owned();
+    fn simple_hex_coverage(key: &PublicKeyBinary, hex: u64) -> Vec<HexCoverage> {
+        let radio_key = key.clone();
         let hex = hex.try_into().expect("valid h3 cell");
 
         vec![HexCoverage {
@@ -877,9 +876,8 @@ mod test {
         }]
     }
 
-    fn bad_hex_coverage<'a>(key: impl Into<KeyType<'a>>, hex: u64) -> Vec<HexCoverage> {
-        let key = key.into();
-        let radio_key = key.to_owned();
+    fn bad_hex_coverage(key: &PublicKeyBinary, hex: u64) -> Vec<HexCoverage> {
+        let radio_key = key.clone();
         let hex = hex.try_into().expect("valid h3 cell");
 
         vec![HexCoverage {
@@ -922,7 +920,7 @@ mod test {
 
         let mut hex_coverage = HashMap::new();
         hex_coverage.insert(
-            (OwnedKeyType::Wifi(gw1.clone()), cov_obj_1),
+            (gw1.clone(), cov_obj_1),
             simple_hex_coverage(&gw1, 0x8a1fb46622dffff),
         );
 
@@ -1068,19 +1066,19 @@ mod test {
         // Setup hex coverages
         let mut hex_coverage = HashMap::new();
         hex_coverage.insert(
-            (OwnedKeyType::Wifi(gw10.clone()), cov_obj_10),
+            (gw10.clone(), cov_obj_10),
             simple_hex_coverage(&gw10, 0x8a1fb46622dffff),
         );
         hex_coverage.insert(
-            (OwnedKeyType::from(gw20.clone()), cov_obj_20),
+            (gw20.clone(), cov_obj_20),
             simple_hex_coverage(&gw20, 0x8a1fb46632dffff),
         );
         hex_coverage.insert(
-            (OwnedKeyType::from(gw21.clone()), cov_obj_21),
+            (gw21.clone(), cov_obj_21),
             simple_hex_coverage(&gw21, 0x8a1fb46642dffff),
         );
         hex_coverage.insert(
-            (OwnedKeyType::from(gw30.clone()), cov_obj_30),
+            (gw30.clone(), cov_obj_30),
             simple_hex_coverage(&gw30, 0x8a1fb46652dffff),
         );
 
@@ -1256,13 +1254,14 @@ mod test {
         averages.insert(gw2.clone(), gw2_average);
 
         let speedtest_avgs = SpeedtestAverages { averages };
-        let mut hex_coverage: HashMap<(OwnedKeyType, Uuid), Vec<HexCoverage>> = Default::default();
+        let mut hex_coverage: HashMap<(PublicKeyBinary, Uuid), Vec<HexCoverage>> =
+            Default::default();
         hex_coverage.insert(
-            (OwnedKeyType::from(gw1.clone()), g1_cov_obj),
+            (gw1.clone(), g1_cov_obj),
             bad_hex_coverage(&gw1, 0x8a1fb46622dffff),
         );
         hex_coverage.insert(
-            (OwnedKeyType::from(gw2.clone()), g2_cov_obj),
+            (gw2.clone(), g2_cov_obj),
             bad_hex_coverage(&gw2, 0x8a1fb46642dffff),
         );
 

--- a/mobile_verifier/src/rewarder/db.rs
+++ b/mobile_verifier/src/rewarder/db.rs
@@ -146,7 +146,6 @@ mod tests {
 
         let wifi_heartbeat = heartbeats::ValidatedHeartbeat {
             heartbeat: heartbeats::Heartbeat {
-                hb_type: heartbeats::HbType::Wifi,
                 hotspot_key: wifi_pubkey_bin.clone(),
                 operation_mode: true,
                 lat: 0.0,

--- a/mobile_verifier/src/seniority.rs
+++ b/mobile_verifier/src/seniority.rs
@@ -1,11 +1,12 @@
 use chrono::{DateTime, Duration, Utc};
 use file_store::file_sink::FileSinkClient;
+use helium_crypto::PublicKeyBinary;
 use sqlx::{Postgres, Transaction};
 use uuid::Uuid;
 
 use helium_proto::services::poc_mobile as proto;
 
-use crate::heartbeats::{KeyType, ValidatedHeartbeat};
+use crate::heartbeats::ValidatedHeartbeat;
 
 #[derive(Clone, Debug, PartialEq, sqlx::FromRow)]
 pub struct Seniority {
@@ -18,7 +19,7 @@ pub struct Seniority {
 
 impl Seniority {
     pub async fn fetch_latest(
-        key: KeyType<'_>,
+        key: &PublicKeyBinary,
         exec: &mut Transaction<'_, Postgres>,
     ) -> Result<Option<Self>, sqlx::Error> {
         sqlx::query_as(
@@ -32,7 +33,7 @@ impl Seniority {
 
 #[derive(Debug)]
 pub struct SeniorityUpdate<'a> {
-    key: KeyType<'a>,
+    key: &'a PublicKeyBinary,
     heartbeat_ts: DateTime<Utc>,
     uuid: Uuid,
     pub action: SeniorityUpdateAction,
@@ -52,7 +53,7 @@ pub enum SeniorityUpdateAction {
 
 impl<'a> SeniorityUpdate<'a> {
     pub fn new(
-        key: KeyType<'a>,
+        key: &'a PublicKeyBinary,
         heartbeat_ts: DateTime<Utc>,
         uuid: Uuid,
         action: SeniorityUpdateAction,
@@ -149,7 +150,9 @@ impl SeniorityUpdate<'_> {
             seniorities
                 .write(
                     proto::SeniorityUpdate {
-                        key_type: Some(self.key.into()),
+                        key_type: Some(proto::seniority_update::KeyType::HotspotKey(
+                            self.key.clone().into(),
+                        )),
                         new_seniority_timestamp: new_seniority.timestamp() as u64,
                         reason: update_reason as i32,
                         new_seniority_timestamp_ms: new_seniority.timestamp_millis() as u64,
@@ -173,7 +176,7 @@ impl SeniorityUpdate<'_> {
                     INSERT INTO seniority
                       (radio_key, last_heartbeat, uuid, seniority_ts, inserted_at, update_reason, radio_type)
                     VALUES
-                      ($1, $2, $3, $4, $5, $6, $7)
+                      ($1, $2, $3, $4, $5, $6, 'wifi'::radio_type)
                     ON CONFLICT (radio_key, radio_type, seniority_ts) DO UPDATE SET
                       uuid = EXCLUDED.uuid,
                       last_heartbeat = EXCLUDED.last_heartbeat,
@@ -186,7 +189,6 @@ impl SeniorityUpdate<'_> {
                 .bind(new_seniority)
                 .bind(Utc::now())
                 .bind(update_reason as i32)
-                .bind(self.key.hb_type())
                 .execute(&mut **exec)
                 .await?;
             }
@@ -232,7 +234,6 @@ mod tests {
         fn generate() -> anyhow::Result<Self> {
             Ok(Self {
                 heartbeat: Heartbeat {
-                    hb_type: crate::heartbeats::HbType::Wifi,
                     hotspot_key: PublicKeyBinary::from_str("1trSuseaaeZSW8pqSsYKFkFYTfFVvy8DbPCcne6fYYfry6XqzdN1PwAsqinbGKW2ux9554Dw4ciw1uDTdKjBZfjYeuzCEpd95kmZMPGiHaT5ZwasdPgSzXCSYzqmGeQ97riiqEik9xKKhxU52tjCgLd7HNfpLGT9ceY71FCcKBM3fooUZCSiNNibsVvorBWdWjvetgsHLwjTGuwYMGQ2BpmA15r9t3EGNnrfKMv6E1VmoBcuyPYgi7bBLZYpW16Yua3aHd78Jz8QqBVz51S5xRTwDBmgK41e9tSVSqMcQbcZkXi5W7Jru8QEiUTHWyghHgSYpsvCfcQkVBKkP7fHpM4Jh1YTxY2MEvLaoTzxFLRtrM")?,
                     operation_mode: true,
                     lat: 0.0,

--- a/mobile_verifier/tests/integrations/coverage.rs
+++ b/mobile_verifier/tests/integrations/coverage.rs
@@ -4,7 +4,6 @@ use futures::TryStreamExt;
 use helium_crypto::PublicKeyBinary;
 use mobile_verifier::{
     coverage::{CoveredHexStream, HexCoverage},
-    heartbeats::KeyType,
     seniority::Seniority,
 };
 use sqlx::PgPool;
@@ -19,7 +18,7 @@ async fn test_covered_hex_stream(pool: PgPool) {
         .expect("failed gw1 parse");
 
     // WIFI should work
-    let wifi_key = KeyType::Wifi(&wifi_pub_key);
+    let wifi_key = &wifi_pub_key;
     let seniority = Seniority::fetch_latest(wifi_key, &mut txn)
         .await
         .unwrap()

--- a/mobile_verifier/tests/integrations/heartbeats.rs
+++ b/mobile_verifier/tests/integrations/heartbeats.rs
@@ -4,7 +4,7 @@ use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_mobile::{HeartbeatValidity, LocationSource};
 use mobile_verifier::{
     cell_type::CellType,
-    heartbeats::{HbType, Heartbeat, HeartbeatReward, ValidatedHeartbeat},
+    heartbeats::{Heartbeat, HeartbeatReward, ValidatedHeartbeat},
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -16,7 +16,6 @@ async fn test_save_wifi_heartbeat(pool: PgPool) -> anyhow::Result<()> {
     let coverage_object = Uuid::new_v4();
     let heartbeat = ValidatedHeartbeat {
         heartbeat: Heartbeat {
-            hb_type: HbType::Wifi,
             hotspot_key: "11eX55faMbqZB7jzN4p67m6w7ScPMH6ubnvCjCPLh72J49PaJEL"
                 .parse()
                 .unwrap(),

--- a/mobile_verifier/tests/integrations/heartbeats_iceberg.rs
+++ b/mobile_verifier/tests/integrations/heartbeats_iceberg.rs
@@ -9,7 +9,7 @@ use mobile_config::gateway::service::info::DeviceType;
 use mobile_verifier::{
     backfill::BackfillOptions,
     cell_type::CellType,
-    heartbeats::{backfill::HeartbeatBackfiller, HbType, Heartbeat, ValidatedHeartbeat},
+    heartbeats::{backfill::HeartbeatBackfiller, Heartbeat, ValidatedHeartbeat},
     iceberg::{self, heartbeat::IcebergHeartbeat},
 };
 use rust_decimal_macros::dec;
@@ -71,7 +71,6 @@ fn make_validated_heartbeat(index: u8) -> ValidatedHeartbeat {
 
     ValidatedHeartbeat {
         heartbeat: Heartbeat {
-            hb_type: HbType::Wifi,
             hotspot_key: PublicKeyBinary::from(vec![index, index, index]),
             operation_mode: true,
             lat: 37.0 + f64::from(index),
@@ -124,7 +123,6 @@ async fn write_heartbeat_with_no_optional_fields() -> anyhow::Result<()> {
     let now = truncated_now();
     let vhb = ValidatedHeartbeat {
         heartbeat: Heartbeat {
-            hb_type: HbType::Wifi,
             hotspot_key: PublicKeyBinary::from(vec![10, 20, 30]),
             operation_mode: true,
             lat: 40.0,
@@ -201,7 +199,6 @@ async fn write_heartbeats_all_device_types() -> anyhow::Result<()> {
         .map(|(i, (dt, _))| {
             let vhb = ValidatedHeartbeat {
                 heartbeat: Heartbeat {
-                    hb_type: HbType::Wifi,
                     hotspot_key: PublicKeyBinary::from(vec![i as u8 + 50]),
                     operation_mode: true,
                     lat: 37.0,

--- a/mobile_verifier/tests/integrations/hex_boosting.rs
+++ b/mobile_verifier/tests/integrations/hex_boosting.rs
@@ -17,7 +17,7 @@ use mobile_config::{boosted_hex_info::BoostedHexInfo, sub_dao_epoch_reward_info:
 use mobile_verifier::{
     cell_type::CellType,
     coverage::CoverageObject,
-    heartbeats::{HbType, Heartbeat, ValidatedHeartbeat},
+    heartbeats::{Heartbeat, ValidatedHeartbeat},
     reward_shares, rewarder, speedtests,
     unique_connections::{self, MINIMUM_UNIQUE_CONNECTIONS},
 };
@@ -1080,7 +1080,6 @@ async fn seed_heartbeats_v2(
         );
         let wifi_heartbeat1 = ValidatedHeartbeat {
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: hotspot_key1,
                 operation_mode: true,
                 lat: 0.0,
@@ -1109,7 +1108,6 @@ async fn seed_heartbeats_v2(
         );
         let wifi_heartbeat2 = ValidatedHeartbeat {
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: hotspot_key2,
                 operation_mode: true,
                 lat: 0.0,
@@ -1138,7 +1136,6 @@ async fn seed_heartbeats_v2(
         );
         let wifi_heartbeat3 = ValidatedHeartbeat {
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: hotspot_key3,
                 operation_mode: true,
                 lat: 0.0,
@@ -1195,7 +1192,6 @@ async fn seed_heartbeats_with_location_trust(
         );
         let wifi_heartbeat1 = ValidatedHeartbeat {
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: hotspot_key1,
                 operation_mode: true,
                 lat: 0.0,
@@ -1224,7 +1220,6 @@ async fn seed_heartbeats_with_location_trust(
         );
         let wifi_heartbeat2 = ValidatedHeartbeat {
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: hotspot_key2,
                 operation_mode: true,
                 lat: 0.0,
@@ -1253,7 +1248,6 @@ async fn seed_heartbeats_with_location_trust(
         );
         let wifi_heartbeat3 = ValidatedHeartbeat {
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: hotspot_key3,
 
                 operation_mode: true,
@@ -1304,7 +1298,6 @@ async fn seed_heartbeats_v4(
         );
         let wifi_heartbeat1 = ValidatedHeartbeat {
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: hotspot_key1,
 
                 operation_mode: true,
@@ -1334,7 +1327,6 @@ async fn seed_heartbeats_v4(
         );
         let wifi_heartbeat2 = ValidatedHeartbeat {
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: hotspot_key2,
 
                 operation_mode: true,
@@ -1364,7 +1356,6 @@ async fn seed_heartbeats_v4(
         );
         let wifi_heartbeat3 = ValidatedHeartbeat {
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: hotspot_key4,
 
                 operation_mode: true,
@@ -1544,7 +1535,7 @@ async fn save_seniority_object(
         INSERT INTO seniority
           (radio_key, last_heartbeat, uuid, seniority_ts, inserted_at, update_reason, radio_type)
         VALUES
-          ($1, $2, $3, $4, $5, $6, $7)
+          ($1, $2, $3, $4, $5, $6, 'wifi'::radio_type)
         "#,
     )
     .bind(hb.heartbeat.key())
@@ -1553,7 +1544,6 @@ async fn save_seniority_object(
     .bind(ts)
     .bind(ts)
     .bind(SeniorityUpdateReason::NewCoverageClaimTime as i32)
-    .bind(hb.heartbeat.hb_type)
     .execute(&mut **exec)
     .await?;
     Ok(())

--- a/mobile_verifier/tests/integrations/last_location.rs
+++ b/mobile_verifier/tests/integrations/last_location.rs
@@ -8,7 +8,7 @@ use helium_proto::services::poc_mobile::{self as proto, LocationSource};
 use mobile_verifier::{
     coverage::{CoverageObject, CoverageObjectCache},
     geofence::GeofenceValidator,
-    heartbeats::{last_location::LocationCache, HbType, Heartbeat, ValidatedHeartbeat},
+    heartbeats::{last_location::LocationCache, Heartbeat, ValidatedHeartbeat},
 };
 use rust_decimal_macros::dec;
 use sqlx::{PgPool, Postgres, Transaction};
@@ -267,7 +267,6 @@ impl HeartbeatBuilder {
         });
 
         Heartbeat {
-            hb_type: HbType::Wifi,
             hotspot_key: self.hotspot,
             operation_mode: true,
             lat,

--- a/mobile_verifier/tests/integrations/modeled_coverage.rs
+++ b/mobile_verifier/tests/integrations/modeled_coverage.rs
@@ -21,9 +21,7 @@ use mobile_verifier::{
     banning::BannedRadios,
     coverage::{CoverageClaimTimeCache, CoverageObject, CoverageObjectCache},
     geofence::GeofenceValidator,
-    heartbeats::{
-        last_location::LocationCache, Heartbeat, HeartbeatReward, KeyType, ValidatedHeartbeat,
-    },
+    heartbeats::{last_location::LocationCache, Heartbeat, HeartbeatReward, ValidatedHeartbeat},
     reward_shares::CoverageShares,
     rewarder::boosted_hex_eligibility::BoostedHexEligibility,
     seniority::{Seniority, SeniorityUpdate},
@@ -60,7 +58,7 @@ async fn test_save_wifi_coverage_object(pool: PgPool) -> anyhow::Result<()> {
     let key: PublicKeyBinary = "11eX55faMbqZB7jzN4p67m6w7ScPMH6ubnvCjCPLh72J49PaJEL"
         .parse()
         .unwrap();
-    let key = KeyType::from(&key);
+    let key = &key;
 
     assert!(cache.fetch_coverage_object(&uuid, key).await?.is_none());
 
@@ -127,7 +125,7 @@ async fn test_coverage_object_save_updates(pool: PgPool) -> anyhow::Result<()> {
     let bkey: PublicKeyBinary = "11eX55faMbqZB7jzN4p67m6w7ScPMH6ubnvCjCPLh72J49PaJEL"
         .parse()
         .unwrap();
-    let key = KeyType::from(&bkey);
+    let key = &bkey;
 
     assert!(cache.fetch_coverage_object(&uuid, key).await?.is_none());
 

--- a/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
+++ b/mobile_verifier/tests/integrations/rewarder_poc_dc.rs
@@ -16,7 +16,7 @@ use mobile_verifier::{
     cell_type::CellType,
     coverage::CoverageObject,
     data_session,
-    heartbeats::{HbType, Heartbeat, ValidatedHeartbeat},
+    heartbeats::{Heartbeat, ValidatedHeartbeat},
     reward_shares::{self, DataTransferAndPocAllocatedRewardBuckets},
     rewarder, speedtests, unique_connections,
 };
@@ -291,7 +291,6 @@ async fn seed_heartbeats(
         );
         let wifi_heartbeat_1 = ValidatedHeartbeat {
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: hotspot_key1,
                 operation_mode: true,
                 lat: 0.0,
@@ -320,7 +319,6 @@ async fn seed_heartbeats(
         );
         let wifi_heartbeat_2 = ValidatedHeartbeat {
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: hotspot_key2,
                 operation_mode: true,
                 lat: 0.0,
@@ -349,7 +347,6 @@ async fn seed_heartbeats(
         );
         let wifi_heartbeat_3 = ValidatedHeartbeat {
             heartbeat: Heartbeat {
-                hb_type: HbType::Wifi,
                 hotspot_key: hotspot_key3,
                 operation_mode: true,
                 lat: 0.0,
@@ -553,7 +550,7 @@ async fn save_seniority_object(
         INSERT INTO seniority
           (radio_key, last_heartbeat, uuid, seniority_ts, inserted_at, update_reason, radio_type)
         VALUES
-          ($1, $2, $3, $4, $5, $6, $7)
+          ($1, $2, $3, $4, $5, $6, 'wifi'::radio_type)
         "#,
     )
     .bind(hb.heartbeat.key())
@@ -562,7 +559,6 @@ async fn save_seniority_object(
     .bind(ts)
     .bind(ts)
     .bind(proto::SeniorityUpdateReason::NewCoverageClaimTime as i32)
-    .bind(hb.heartbeat.hb_type)
     .execute(&mut **exec)
     .await?;
     Ok(())

--- a/mobile_verifier/tests/integrations/seniority.rs
+++ b/mobile_verifier/tests/integrations/seniority.rs
@@ -3,7 +3,7 @@ use helium_proto::services::poc_mobile::{
     HeartbeatValidity, LocationSource, SeniorityUpdateReason,
 };
 use mobile_verifier::cell_type::CellType;
-use mobile_verifier::heartbeats::{HbType, Heartbeat, ValidatedHeartbeat};
+use mobile_verifier::heartbeats::{Heartbeat, ValidatedHeartbeat};
 use mobile_verifier::seniority::{Seniority, SeniorityUpdate, SeniorityUpdateAction};
 use rust_decimal_macros::dec;
 use sqlx::PgPool;
@@ -14,7 +14,6 @@ async fn test_seniority_updates(pool: PgPool) -> anyhow::Result<()> {
     let coverage_object = Uuid::new_v4();
     let mut heartbeat = ValidatedHeartbeat {
         heartbeat: Heartbeat {
-            hb_type: HbType::Wifi,
             hotspot_key: "11eX55faMbqZB7jzN4p67m6w7ScPMH6ubnvCjCPLh72J49PaJEL"
                 .parse()
                 .unwrap(),


### PR DESCRIPTION
Wifi is the only KeyType we use anymore, we can remove the 3 layers of wrappers for dealing with PubKeys.