### PR TITLE
task man task types

### DIFF
--- a/mobile_config/src/cli/server.rs
+++ b/mobile_config/src/cli/server.rs
@@ -81,11 +81,11 @@ impl Server {
 
         TaskManager::builder()
             .add_task(grpc_server)
-            .add_task(Tracker::new(
+            .add_task(task_manager::periodic(Tracker::new(
                 pool.clone(),
                 metadata_pool.clone(),
                 settings.gateway_tracker_interval,
-            ))
+            )))
             .build()
             .start()
             .await?;

--- a/mobile_config/src/gateway/tracker.rs
+++ b/mobile_config/src/gateway/tracker.rs
@@ -6,7 +6,7 @@ use std::{
     collections::HashMap,
     time::{Duration, Instant},
 };
-use task_manager::ManagedTask;
+use task_manager::Periodic;
 
 const EXECUTE_DURATION_METRIC: &str =
     concat!(env!("CARGO_PKG_NAME"), "-", "tracker-execute-duration");
@@ -17,9 +17,18 @@ pub struct Tracker {
     interval: Duration,
 }
 
-impl ManagedTask for Tracker {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        task_manager::spawn(self.run(shutdown))
+impl Periodic for Tracker {
+    type Error = anyhow::Error;
+
+    fn interval(&self) -> Duration {
+        self.interval
+    }
+
+    async fn tick(&mut self) -> anyhow::Result<()> {
+        if let Err(err) = execute(&self.pool, &self.metadata).await {
+            tracing::error!(?err, "error in tracking changes to mobile radios");
+        }
+        Ok(())
     }
 }
 
@@ -30,27 +39,6 @@ impl Tracker {
             metadata,
             interval,
         }
-    }
-
-    async fn run(self, mut shutdown: triggered::Listener) -> anyhow::Result<()> {
-        tracing::info!("starting with interval: {:?}", self.interval);
-        let mut interval = tokio::time::interval(self.interval);
-
-        loop {
-            tokio::select! {
-                biased;
-                _ = &mut shutdown => break,
-                _ = interval.tick() => {
-                    if let Err(err) = execute(&self.pool, &self.metadata).await {
-                        tracing::error!(?err, "error in tracking changes to mobile radios");
-                    }
-                }
-            }
-        }
-
-        tracing::info!("stopping");
-
-        Ok(())
     }
 }
 

--- a/mobile_packet_verifier/src/backfill.rs
+++ b/mobile_packet_verifier/src/backfill.rs
@@ -9,8 +9,9 @@ use futures::StreamExt;
 use helium_iceberg::BatchedWriter;
 use helium_proto::services::poc_mobile::verified_data_transfer_ingest_report_v1::ReportStatus;
 use sqlx::{PgPool, Pool, Postgres};
+use std::ops::ControlFlow;
 use std::time::{Duration, Instant};
-use task_manager::{ManagedTask, TaskManager};
+use task_manager::{ChannelConsumer, ManagedTask, TaskManager};
 use tokio::sync::mpsc::Receiver;
 
 use crate::{iceberg, settings::Settings};
@@ -262,14 +263,6 @@ impl DataSessionsBackfiller {
         }
     }
 
-    pub async fn recv(&mut self) -> Option<FileInfoStream<VerifiedDataTransferIngestReport>> {
-        if self.done {
-            std::future::pending().await
-        } else {
-            self.reports.recv().await
-        }
-    }
-
     pub async fn create(
         pool: PgPool,
         bucket_client: BucketClient,
@@ -310,51 +303,8 @@ impl DataSessionsBackfiller {
 
         Ok(TaskManager::builder()
             .add_task(server)
-            .add_task(backfiller)
+            .add_task(task_manager::channel_consumer(backfiller))
             .build())
-    }
-
-    async fn run(mut self, mut shutdown: triggered::Listener) -> Result<()> {
-        tracing::info!("sessions backfiller starting");
-        loop {
-            if self.done {
-                tracing::info!("sessions backfiller complete");
-                return Ok(());
-            }
-            tokio::select! {
-                biased;
-                _ = &mut shutdown => {
-                    tracing::info!("sessions backfiller shutting down");
-                    return Ok(());
-                }
-                file = self.recv() => {
-                    self.handle(file).await?;
-                }
-            }
-        }
-    }
-
-    pub async fn handle(
-        &mut self,
-        file: Option<FileInfoStream<VerifiedDataTransferIngestReport>>,
-    ) -> anyhow::Result<()> {
-        let Some(file_info_stream) = file else {
-            // Channel closed - poller reached stop_after or finished
-            tracing::info!("session backfiller completed");
-            self.done = true;
-            return Ok(());
-        };
-        let age = format_file_age(&file_info_stream.file_info);
-        tracing::info!(
-            file = %file_info_stream.file_info,
-            timestamp = %file_info_stream.file_info.timestamp,
-            age = %age,
-            "received file"
-        );
-
-        self.handle_file(file_info_stream).await?;
-
-        Ok(())
     }
 
     async fn handle_file(
@@ -409,9 +359,39 @@ impl DataSessionsBackfiller {
     }
 }
 
-impl ManagedTask for DataSessionsBackfiller {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        task_manager::spawn(self.run(shutdown))
+impl ChannelConsumer for DataSessionsBackfiller {
+    type Item = FileInfoStream<VerifiedDataTransferIngestReport>;
+    type Error = anyhow::Error;
+
+    async fn recv(&mut self) -> Option<Self::Item> {
+        self.reports.recv().await
+    }
+
+    async fn on_start(&mut self) -> anyhow::Result<ControlFlow<()>> {
+        tracing::info!("sessions backfiller starting");
+        if self.done {
+            tracing::info!("sessions backfiller complete");
+            Ok(ControlFlow::Break(()))
+        } else {
+            Ok(ControlFlow::Continue(()))
+        }
+    }
+
+    async fn handle(&mut self, file_info_stream: Self::Item) -> anyhow::Result<()> {
+        let age = format_file_age(&file_info_stream.file_info);
+        tracing::info!(
+            file = %file_info_stream.file_info,
+            timestamp = %file_info_stream.file_info.timestamp,
+            age = %age,
+            "received file"
+        );
+        self.handle_file(file_info_stream).await
+    }
+
+    async fn on_receiver_closed(&mut self) -> anyhow::Result<ControlFlow<()>> {
+        tracing::info!("session backfiller completed");
+        self.done = true;
+        Ok(ControlFlow::Break(()))
     }
 }
 
@@ -467,7 +447,7 @@ impl BurnedSessionsBackfiller {
 
         Ok(TaskManager::builder()
             .add_task(server)
-            .add_task(burned_backfiller)
+            .add_task(task_manager::channel_consumer(burned_backfiller))
             .build())
     }
 
@@ -483,57 +463,6 @@ impl BurnedSessionsBackfiller {
             writer,
             done,
         }
-    }
-
-    async fn run(mut self, mut shutdown: triggered::Listener) -> Result<()> {
-        tracing::info!("burned backfiller starting");
-        loop {
-            if self.done {
-                tracing::info!("burned backfiller complete");
-                return Ok(());
-            }
-            tokio::select! {
-                biased;
-                _ = &mut shutdown => {
-                    tracing::info!("burned backfiller shutting down");
-                    return Ok(());
-                }
-                file = self.recv() => {
-                    self.handle(file).await?;
-                }
-            }
-        }
-    }
-
-    pub async fn recv(&mut self) -> Option<FileInfoStream<ValidDataTransferSession>> {
-        if self.done {
-            std::future::pending().await
-        } else {
-            self.reports.recv().await
-        }
-    }
-
-    pub async fn handle(
-        &mut self,
-        file: Option<FileInfoStream<ValidDataTransferSession>>,
-    ) -> anyhow::Result<()> {
-        let Some(file_info_stream) = file else {
-            // Channel closed - poller reached stop_after or finished
-            tracing::info!("burned backfiller completed");
-            self.done = true;
-            return Ok(());
-        };
-        let age = format_file_age(&file_info_stream.file_info);
-        tracing::info!(
-            file = %file_info_stream.file_info,
-            timestamp = %file_info_stream.file_info.timestamp,
-            age = %age,
-            "received file"
-        );
-
-        self.handle_file(file_info_stream).await?;
-
-        Ok(())
     }
 
     async fn handle_file(&self, file: FileInfoStream<ValidDataTransferSession>) -> Result<()> {
@@ -582,9 +511,39 @@ impl BurnedSessionsBackfiller {
     }
 }
 
-impl ManagedTask for BurnedSessionsBackfiller {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        task_manager::spawn(self.run(shutdown))
+impl ChannelConsumer for BurnedSessionsBackfiller {
+    type Item = FileInfoStream<ValidDataTransferSession>;
+    type Error = anyhow::Error;
+
+    async fn recv(&mut self) -> Option<Self::Item> {
+        self.reports.recv().await
+    }
+
+    async fn on_start(&mut self) -> anyhow::Result<ControlFlow<()>> {
+        tracing::info!("burned backfiller starting");
+        if self.done {
+            tracing::info!("burned backfiller complete");
+            Ok(ControlFlow::Break(()))
+        } else {
+            Ok(ControlFlow::Continue(()))
+        }
+    }
+
+    async fn handle(&mut self, file_info_stream: Self::Item) -> anyhow::Result<()> {
+        let age = format_file_age(&file_info_stream.file_info);
+        tracing::info!(
+            file = %file_info_stream.file_info,
+            timestamp = %file_info_stream.file_info.timestamp,
+            age = %age,
+            "received file"
+        );
+        self.handle_file(file_info_stream).await
+    }
+
+    async fn on_receiver_closed(&mut self) -> anyhow::Result<ControlFlow<()>> {
+        tracing::info!("burned backfiller completed");
+        self.done = true;
+        Ok(ControlFlow::Break(()))
     }
 }
 

--- a/mobile_packet_verifier/src/banning/ingestor.rs
+++ b/mobile_packet_verifier/src/banning/ingestor.rs
@@ -1,8 +1,10 @@
+use std::ops::ControlFlow;
+
 use file_store::file_info_poller::FileInfoStream;
 use file_store_oracles::mobile_ban::VerifiedBanReport;
 use futures::StreamExt;
 use sqlx::{PgConnection, PgPool};
-use task_manager::ManagedTask;
+use task_manager::ChannelConsumer;
 use tokio::sync::mpsc::Receiver;
 
 use super::db;
@@ -12,36 +14,28 @@ pub struct BanIngestor {
     report_rx: Receiver<FileInfoStream<VerifiedBanReport>>,
 }
 
-impl ManagedTask for BanIngestor {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        task_manager::spawn(self.run(shutdown))
+impl ChannelConsumer for BanIngestor {
+    type Item = FileInfoStream<VerifiedBanReport>;
+    type Error = anyhow::Error;
+
+    async fn recv(&mut self) -> Option<Self::Item> {
+        self.report_rx.recv().await
+    }
+
+    async fn handle(&mut self, file_info_stream: Self::Item) -> anyhow::Result<()> {
+        self.handle_ban_report_file(file_info_stream).await
+    }
+
+    async fn on_receiver_closed(&mut self) -> anyhow::Result<ControlFlow<()>> {
+        Err(anyhow::anyhow!(
+            "hotspot ban FileInfoPoller sender was dropped unexpectedly"
+        ))
     }
 }
 
 impl BanIngestor {
     pub fn new(pool: PgPool, report_rx: Receiver<FileInfoStream<VerifiedBanReport>>) -> Self {
         Self { pool, report_rx }
-    }
-
-    async fn run(mut self, mut shutdown: triggered::Listener) -> anyhow::Result<()> {
-        tracing::info!("starting ban ingestor");
-
-        loop {
-            tokio::select! {
-                biased;
-                _ = &mut shutdown => break,
-                file = self.report_rx.recv() => {
-                    let Some(file_info_stream) = file else {
-                        anyhow::bail!("hotspot ban FileInfoPoller sender was dropped unexpectedly");
-                    };
-                    self.handle_ban_report_file(file_info_stream).await?;
-                }
-
-            }
-        }
-
-        tracing::info!("stopping ban ingestor");
-        Ok(())
     }
 
     async fn handle_ban_report_file(

--- a/mobile_packet_verifier/src/banning/mod.rs
+++ b/mobile_packet_verifier/src/banning/mod.rs
@@ -55,8 +55,8 @@ pub async fn create_managed_task(
 
     Ok(TaskManager::builder()
         .add_task(ban_report_server)
-        .add_task(ingestor)
-        .add_task(purger)
+        .add_task(task_manager::channel_consumer(ingestor))
+        .add_task(task_manager::periodic(purger))
         .build())
 }
 

--- a/mobile_packet_verifier/src/banning/purger.rs
+++ b/mobile_packet_verifier/src/banning/purger.rs
@@ -2,39 +2,28 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
-use task_manager::ManagedTask;
+use task_manager::Periodic;
 
 pub struct BanPurger {
     pool: PgPool,
     interval: Duration,
 }
 
-impl ManagedTask for BanPurger {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        task_manager::spawn(self.run(shutdown))
+impl Periodic for BanPurger {
+    type Error = anyhow::Error;
+
+    fn interval(&self) -> Duration {
+        self.interval
+    }
+
+    async fn tick(&mut self) -> anyhow::Result<()> {
+        self.purge(Utc::now()).await
     }
 }
 
 impl BanPurger {
     pub fn new(pool: PgPool, interval: Duration) -> Self {
         Self { pool, interval }
-    }
-
-    async fn run(mut self, mut shutdown: triggered::Listener) -> anyhow::Result<()> {
-        tracing::info!("ban purger starting");
-        let mut timer = tokio::time::interval(self.interval);
-
-        loop {
-            tokio::select! {
-                biased;
-                _ = &mut shutdown => break,
-                _ = timer.tick() => self.purge(Utc::now()).await?
-            }
-        }
-
-        tracing::info!("ban purger stopping");
-
-        Ok(())
     }
 
     async fn purge(&mut self, timestamp: DateTime<Utc>) -> anyhow::Result<()> {

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -351,7 +351,7 @@ impl Cmd {
             .add_task(verified_sessions_server)
             .add_task(reports_server)
             .add_task(banning)
-            .add_task(event_id_purger)
+            .add_task(task_manager::periodic(event_id_purger))
             .add_task(daemon)
             .build()
             .start()

--- a/mobile_packet_verifier/src/event_ids.rs
+++ b/mobile_packet_verifier/src/event_ids.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use sqlx::{Pool, Postgres, Transaction};
 use std::time::Duration;
-use task_manager::ManagedTask;
+use task_manager::Periodic;
 
 use crate::settings::Settings;
 
@@ -25,9 +25,15 @@ pub struct EventIdPurger {
     max_age: Duration,
 }
 
-impl ManagedTask for EventIdPurger {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        task_manager::spawn(self.run(shutdown))
+impl Periodic for EventIdPurger {
+    type Error = anyhow::Error;
+
+    fn interval(&self) -> Duration {
+        self.interval
+    }
+
+    async fn tick(&mut self) -> anyhow::Result<()> {
+        purge(&self.conn, self.max_age).await
     }
 }
 
@@ -37,21 +43,6 @@ impl EventIdPurger {
             conn,
             interval: settings.purger_interval,
             max_age: settings.purger_max_age,
-        }
-    }
-
-    pub async fn run(self, mut shutdown: triggered::Listener) -> anyhow::Result<()> {
-        let mut timer = tokio::time::interval(self.interval);
-
-        loop {
-            tokio::select! {
-                _ = &mut shutdown => {
-                    return Ok(())
-                }
-                _ = timer.tick() => {
-                    purge(&self.conn, self.max_age).await?;
-                }
-            }
         }
     }
 }

--- a/mobile_packet_verifier/tests/integrations/backfill.rs
+++ b/mobile_packet_verifier/tests/integrations/backfill.rs
@@ -120,7 +120,7 @@ async fn backfill_writes_sessions_to_iceberg(pool: PgPool) -> anyhow::Result<()>
         TaskManager::builder()
             .add_task(writer_task)
             .add_task(server)
-            .add_task(backfiller)
+            .add_task(task_manager::channel_consumer(backfiller))
             .build()
             .start(),
     )
@@ -202,7 +202,7 @@ async fn backfill_stops_at_timestamp(pool: PgPool) -> anyhow::Result<()> {
         TaskManager::builder()
             .add_task(writer_task)
             .add_task(server)
-            .add_task(backfiller)
+            .add_task(task_manager::channel_consumer(backfiller))
             .build()
             .start(),
     )
@@ -289,7 +289,7 @@ async fn backfill_resumes_after_interruption(pool: PgPool) -> anyhow::Result<()>
         TaskManager::builder()
             .add_task(writer_task)
             .add_task(server)
-            .add_task(backfiller)
+            .add_task(task_manager::channel_consumer(backfiller))
             .build()
             .start(),
     )
@@ -321,7 +321,7 @@ async fn backfill_resumes_after_interruption(pool: PgPool) -> anyhow::Result<()>
         TaskManager::builder()
             .add_task(writer_task)
             .add_task(server)
-            .add_task(backfiller)
+            .add_task(task_manager::channel_consumer(backfiller))
             .build()
             .start(),
     )
@@ -387,7 +387,7 @@ async fn backfill_filters_invalid_sessions(pool: PgPool) -> anyhow::Result<()> {
         TaskManager::builder()
             .add_task(writer_task)
             .add_task(server)
-            .add_task(backfiller)
+            .add_task(task_manager::channel_consumer(backfiller))
             .build()
             .start(),
     )
@@ -463,7 +463,7 @@ async fn burned_backfill_writes_sessions_to_iceberg(pool: PgPool) -> anyhow::Res
         TaskManager::builder()
             .add_task(writer_task)
             .add_task(server)
-            .add_task(backfiller)
+            .add_task(task_manager::channel_consumer(backfiller))
             .build()
             .start(),
     )
@@ -523,7 +523,7 @@ async fn burned_backfill_uses_file_timestamp_when_burn_timestamp_is_epoch(
         TaskManager::builder()
             .add_task(writer_task)
             .add_task(server)
-            .add_task(backfiller)
+            .add_task(task_manager::channel_consumer(backfiller))
             .build()
             .start(),
     )

--- a/mobile_verifier/src/banning/ingestor.rs
+++ b/mobile_verifier/src/banning/ingestor.rs
@@ -1,3 +1,5 @@
+use std::ops::ControlFlow;
+
 use chrono::Utc;
 use file_store::BucketClient;
 use file_store::{
@@ -16,7 +18,7 @@ use futures::StreamExt;
 use helium_proto::services::mobile_config::NetworkKeyRole;
 use mobile_config::client::{authorization_client::AuthorizationVerifier, AuthorizationClient};
 use sqlx::{PgConnection, PgPool};
-use task_manager::{ManagedTask, TaskManager};
+use task_manager::{ChannelConsumer, ManagedTask, TaskManager};
 use tokio::sync::mpsc::Receiver;
 
 use crate::{
@@ -53,9 +55,22 @@ pub struct BanIngestor {
     iceberg_writer: Option<iceberg::BanWriter>,
 }
 
-impl ManagedTask for BanIngestor {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        task_manager::spawn(self.run(shutdown))
+impl ChannelConsumer for BanIngestor {
+    type Item = FileInfoStream<BanReport>;
+    type Error = anyhow::Error;
+
+    async fn recv(&mut self) -> Option<Self::Item> {
+        self.report_rx.recv().await
+    }
+
+    async fn handle(&mut self, file_info_stream: Self::Item) -> anyhow::Result<()> {
+        self.process_file(file_info_stream).await
+    }
+
+    async fn on_receiver_closed(&mut self) -> anyhow::Result<ControlFlow<()>> {
+        Err(anyhow::anyhow!(
+            "hotspot ban FileInfoPoller sender was dropped unexpectedly"
+        ))
     }
 }
 
@@ -96,7 +111,7 @@ impl BanIngestor {
         Ok(TaskManager::builder()
             .add_task(verified_sink_server)
             .add_task(ingest_server)
-            .add_task(ingestor)
+            .add_task(task_manager::channel_consumer(ingestor))
             .build())
     }
 
@@ -114,27 +129,6 @@ impl BanIngestor {
             verified_sink,
             iceberg_writer,
         }
-    }
-
-    async fn run(mut self, mut shutdown: triggered::Listener) -> anyhow::Result<()> {
-        tracing::info!("starting ban ingestor");
-
-        loop {
-            tokio::select! {
-                biased;
-                _ = &mut shutdown => break,
-                msg = self.report_rx.recv() => {
-                    let Some(file_info_stream) = msg else {
-                        anyhow::bail!("hotspot ban FileInfoPoller sender was dropped unexpectedly");
-                    };
-                    self.process_file(file_info_stream).await?;
-                }
-            }
-        }
-
-        tracing::info!("stopping ban ingestor");
-
-        Ok(())
     }
 
     async fn process_file(

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -30,7 +30,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use task_manager::{ManagedTask, TaskManager};
+use task_manager::{ChannelConsumer, ManagedTask, TaskManager};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use uuid::Uuid;
 
@@ -112,7 +112,7 @@ impl CoverageDaemon {
         Ok(TaskManager::builder()
             .add_task(valid_coverage_objs_server)
             .add_task(coverage_objs_server)
-            .add_task(coverage_daemon)
+            .add_task(task_manager::channel_consumer(coverage_daemon))
             .build())
     }
 
@@ -130,25 +130,6 @@ impl CoverageDaemon {
             coverage_obj_sink,
             new_coverage_object_notifier,
         }
-    }
-
-    pub async fn run(mut self, shutdown: triggered::Listener) -> anyhow::Result<()> {
-        loop {
-            tokio::select! {
-                _ = shutdown.clone() => {
-                    tracing::info!("CoverageDaemon shutting down");
-                    break;
-                }
-                Some(file) = self.coverage_objs.recv() => {
-                    let start = Instant::now();
-                    self.process_file(file).await?;
-                    metrics::histogram!("coverage_object_processing_time")
-                        .record(start.elapsed());
-                }
-            }
-        }
-
-        Ok(())
     }
 
     async fn process_file(
@@ -182,9 +163,19 @@ impl CoverageDaemon {
     }
 }
 
-impl ManagedTask for CoverageDaemon {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        task_manager::spawn(self.run(shutdown))
+impl ChannelConsumer for CoverageDaemon {
+    type Item = FileInfoStream<CoverageObjectIngestReport>;
+    type Error = anyhow::Error;
+
+    async fn recv(&mut self) -> Option<Self::Item> {
+        self.coverage_objs.recv().await
+    }
+
+    async fn handle(&mut self, file: Self::Item) -> anyhow::Result<()> {
+        let start = Instant::now();
+        self.process_file(file).await?;
+        metrics::histogram!("coverage_object_processing_time").record(start.elapsed());
+        Ok(())
     }
 }
 

--- a/mobile_verifier/src/data_session.rs
+++ b/mobile_verifier/src/data_session.rs
@@ -1,14 +1,11 @@
 use chrono::{DateTime, Utc};
 use file_store::{file_info_poller::FileInfoStream, file_source, BucketClient};
 use file_store_oracles::{mobile_transfer::ValidDataTransferSession, FileType};
-use futures::{
-    stream::{Stream, StreamExt, TryStreamExt},
-    TryFutureExt,
-};
+use futures::stream::{Stream, StreamExt, TryStreamExt};
 use helium_crypto::PublicKeyBinary;
 use sqlx::{PgPool, Pool, Postgres, Row, Transaction};
 use std::{collections::HashMap, ops::Range, time::Instant};
-use task_manager::{ManagedTask, TaskManager};
+use task_manager::{ChannelConsumer, ManagedTask, TaskManager};
 use tokio::sync::mpsc::Receiver;
 
 use crate::Settings;
@@ -45,7 +42,7 @@ impl DataSessionIngestor {
 
         Ok(TaskManager::builder()
             .add_task(data_session_ingest_server)
-            .add_task(data_session_ingestor)
+            .add_task(task_manager::channel_consumer(data_session_ingestor))
             .build())
     }
 
@@ -54,32 +51,6 @@ impl DataSessionIngestor {
         receiver: Receiver<FileInfoStream<ValidDataTransferSession>>,
     ) -> Self {
         Self { pool, receiver }
-    }
-
-    pub async fn run(mut self, shutdown: triggered::Listener) -> anyhow::Result<()> {
-        tracing::info!("starting DataSessionIngestor");
-        tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    biased;
-                    _ = shutdown.clone() => {
-                        tracing::info!("DataSessionIngestor shutting down");
-                        break;
-                    }
-                    Some(file) = self.receiver.recv() => {
-                        let start = Instant::now();
-                        self.process_file(file).await?;
-                        metrics::histogram!("valid_data_transfer_session_processing_time")
-                            .record(start.elapsed());
-                    }
-                }
-            }
-
-            Ok(())
-        })
-        .map_err(anyhow::Error::from)
-        .and_then(|result| async move { result })
-        .await
     }
 
     async fn process_file(
@@ -110,9 +81,19 @@ impl DataSessionIngestor {
     }
 }
 
-impl ManagedTask for DataSessionIngestor {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        task_manager::spawn(self.run(shutdown))
+impl ChannelConsumer for DataSessionIngestor {
+    type Item = FileInfoStream<ValidDataTransferSession>;
+    type Error = anyhow::Error;
+
+    async fn recv(&mut self) -> Option<Self::Item> {
+        self.receiver.recv().await
+    }
+
+    async fn handle(&mut self, file: Self::Item) -> anyhow::Result<()> {
+        let start = Instant::now();
+        self.process_file(file).await?;
+        metrics::histogram!("valid_data_transfer_session_processing_time").record(start.elapsed());
+        Ok(())
     }
 }
 

--- a/price/src/backfill.rs
+++ b/price/src/backfill.rs
@@ -10,7 +10,8 @@ use futures::StreamExt;
 use helium_iceberg::{BatchedWriter, BatchedWriterConfig};
 use helium_proto::PriceReportV1;
 use sqlx::{PgPool, Pool, Postgres};
-use task_manager::{ManagedTask, TaskManager};
+use std::ops::ControlFlow;
+use task_manager::{ChannelConsumer, ManagedTask, TaskManager};
 use tokio::sync::mpsc::Receiver;
 
 #[derive(Debug, clap::Args)]
@@ -156,37 +157,11 @@ impl PriceReportBackfiller {
         Ok(TaskManager::builder()
             .add_task(batched_task)
             .add_task(server)
-            .add_task(backfiller)
+            .add_task(task_manager::channel_consumer(backfiller))
             .build())
     }
 
-    async fn run(mut self, mut shutdown: triggered::Listener) -> Result<()> {
-        tracing::info!("price backfiller starting");
-        loop {
-            if self.done {
-                tracing::info!("price backfiller complete");
-                return Ok(());
-            }
-            tokio::select! {
-                biased;
-                _ = &mut shutdown => {
-                    tracing::info!("price backfiller shutting down");
-                    return Ok(());
-                }
-                file = self.reports.recv() => {
-                    self.handle(file).await?;
-                }
-            }
-        }
-    }
-
-    async fn handle(&mut self, file: Option<FileInfoStream<PriceReportV1>>) -> Result<()> {
-        let Some(file_info_stream) = file else {
-            tracing::info!("price backfiller completed (channel closed)");
-            self.done = true;
-            return Ok(());
-        };
-
+    async fn process(&mut self, file_info_stream: FileInfoStream<PriceReportV1>) -> Result<()> {
         let file_info = file_info_stream.file_info.clone();
         tracing::info!(
             file = %file_info,
@@ -243,9 +218,32 @@ impl PriceReportBackfiller {
     }
 }
 
-impl ManagedTask for PriceReportBackfiller {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        task_manager::spawn(self.run(shutdown))
+impl ChannelConsumer for PriceReportBackfiller {
+    type Item = FileInfoStream<PriceReportV1>;
+    type Error = anyhow::Error;
+
+    async fn recv(&mut self) -> Option<Self::Item> {
+        self.reports.recv().await
+    }
+
+    async fn on_start(&mut self) -> Result<ControlFlow<()>> {
+        tracing::info!("price backfiller starting");
+        if self.done {
+            tracing::info!("price backfiller complete");
+            Ok(ControlFlow::Break(()))
+        } else {
+            Ok(ControlFlow::Continue(()))
+        }
+    }
+
+    async fn handle(&mut self, file_info_stream: Self::Item) -> Result<()> {
+        self.process(file_info_stream).await
+    }
+
+    async fn on_receiver_closed(&mut self) -> Result<ControlFlow<()>> {
+        tracing::info!("price backfiller completed (channel closed)");
+        self.done = true;
+        Ok(ControlFlow::Break(()))
     }
 }
 

--- a/price/src/main.rs
+++ b/price/src/main.rs
@@ -135,7 +135,9 @@ impl Server {
             );
         }
 
-        task_manager.add(PriceGenerator::new(settings, sinks).await?);
+        task_manager.add(task_manager::periodic(
+            PriceGenerator::new(settings, sinks).await?,
+        ));
 
         task_manager.start().await?;
         Ok(())

--- a/price/src/price_generator.rs
+++ b/price/src/price_generator.rs
@@ -5,8 +5,8 @@ use futures::TryFutureExt;
 use helium_proto::{BlockchainTokenTypeV1, PriceReportV1};
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, time::Duration};
-use task_manager::ManagedTask;
-use tokio::{fs, time};
+use task_manager::Periodic;
+use tokio::fs;
 
 const LATEST_PRICE_FILE: &str = "hnt.latest";
 const TOKEN: &str = "hnt";
@@ -37,9 +37,30 @@ pub struct PriceGenerator {
     sinks: Vec<Box<dyn PriceSink>>,
 }
 
-impl ManagedTask for PriceGenerator {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        task_manager::spawn(self.run(shutdown))
+impl Periodic for PriceGenerator {
+    type Error = anyhow::Error;
+
+    fn interval(&self) -> Duration {
+        self.interval_duration
+    }
+
+    async fn on_start(&mut self) -> Result<()> {
+        tracing::info!(token = TOKEN, "starting price generator");
+        self.last_price_opt = self.read_price_file().await;
+        Ok(())
+    }
+
+    async fn tick(&mut self) -> Result<()> {
+        match self.default_price {
+            Some(price) => {
+                let price = Price::new(Utc::now(), price);
+                self.write_price_to_sink(&price).await?;
+            }
+            None => {
+                self.retrieve_and_update_price().await?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -65,34 +86,6 @@ impl PriceGenerator {
             latest_price_file: settings.cache.join(LATEST_PRICE_FILE),
             sinks,
         })
-    }
-
-    pub async fn run(mut self, mut shutdown: triggered::Listener) -> Result<()> {
-        tracing::info!(token = TOKEN, "starting price generator");
-
-        let mut trigger = time::interval(self.interval_duration);
-        self.last_price_opt = self.read_price_file().await;
-
-        loop {
-            tokio::select! {
-                biased;
-                _ = &mut shutdown => break,
-                _ = trigger.tick() => {
-                    match self.default_price {
-                        Some(price) => {
-                            let price = Price::new(Utc::now(), price);
-                            self.write_price_to_sink(&price).await?;
-                        }
-                        None => {
-                            self.retrieve_and_update_price().await?;
-                        }
-                    }
-                }
-            }
-        }
-
-        tracing::info!(token = TOKEN, "stopping price generator");
-        Ok(())
     }
 
     async fn write_price_to_sink(&self, price: &Price) -> Result<()> {

--- a/task_manager/src/channel_consumer.rs
+++ b/task_manager/src/channel_consumer.rs
@@ -1,0 +1,315 @@
+//! A trait for tasks that consume items from one or more channels.
+//!
+//! Implement [`ChannelConsumer`] for the unit of work that processes each
+//! item, then wrap with [`channel_consumer`] when registering with a
+//! [`crate::TaskManager`].
+
+use std::{future::Future, ops::ControlFlow};
+
+use crate::{spawn, BoxError, ManagedTask, TaskFuture};
+
+/// A task that processes items received from a channel (or several).
+///
+/// The adapter handles the [`tokio::select!`] loop, shutdown coordination, and
+/// `ManagedTask` impl. Implementors describe the per-item work, where the next
+/// item comes from, and (optionally) one-shot setup or handling of source
+/// closure.
+///
+/// # Cancel safety
+///
+/// [`recv`](ChannelConsumer::recv) is called inside a `tokio::select!`. If
+/// shutdown wins the select, the `recv` future is dropped without yielding an
+/// item, so its implementation **must be cancel-safe**.
+/// [`tokio::sync::mpsc::Receiver::recv`] is cancel-safe per tokio's contract,
+/// and `tokio::select!` composed of cancel-safe branches is itself cancel-safe.
+///
+/// # Single-channel example
+///
+/// ```ignore
+/// struct Ingestor { rx: Receiver<File>, /* … */ }
+///
+/// impl task_manager::ChannelConsumer for Ingestor {
+///     type Item = File;
+///     type Error = anyhow::Error;
+///
+///     async fn recv(&mut self) -> Option<File> {
+///         self.rx.recv().await
+///     }
+///
+///     async fn handle(&mut self, file: File) -> anyhow::Result<()> {
+///         self.process_file(file).await
+///     }
+/// }
+/// ```
+///
+/// # Multi-channel example
+///
+/// ```ignore
+/// enum Msg { A(Foo), B(Bar) }
+///
+/// impl task_manager::ChannelConsumer for MyTask {
+///     type Item = Msg;
+///     type Error = anyhow::Error;
+///
+///     async fn recv(&mut self) -> Option<Msg> {
+///         tokio::select! {
+///             m = self.chan_a.recv() => m.map(Msg::A),
+///             m = self.chan_b.recv() => m.map(Msg::B),
+///         }
+///     }
+///
+///     async fn handle(&mut self, msg: Msg) -> anyhow::Result<()> {
+///         match msg {
+///             Msg::A(foo) => self.handle_a(foo).await,
+///             Msg::B(bar) => self.handle_b(bar).await,
+///         }
+///     }
+/// }
+/// ```
+pub trait ChannelConsumer: Send + Sync + 'static {
+    type Item: Send + 'static;
+    type Error: Into<BoxError> + Send;
+
+    /// Wait for the next item. Return `None` when the source(s) are exhausted.
+    ///
+    /// Must be cancel-safe — if this future is dropped before completing, no
+    /// item should be silently lost.
+    fn recv(&mut self) -> impl Future<Output = Option<Self::Item>> + Send;
+
+    /// Process a single item.
+    fn handle(&mut self, item: Self::Item) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Optional one-shot setup. Returning [`ControlFlow::Break`] skips the loop
+    /// entirely (useful for tasks constructed in a no-op state).
+    fn on_start(&mut self) -> impl Future<Output = Result<ControlFlow<()>, Self::Error>> + Send {
+        async { Ok(ControlFlow::Continue(())) }
+    }
+
+    /// Called when [`recv`](ChannelConsumer::recv) returns `None`. Default:
+    /// exit the loop gracefully ([`ControlFlow::Break`]). Override to either
+    /// return an error or keep looping (e.g. if `None` only means one of
+    /// several sources closed and the others can still produce).
+    fn on_receiver_closed(
+        &mut self,
+    ) -> impl Future<Output = Result<ControlFlow<()>, Self::Error>> + Send {
+        async { Ok(ControlFlow::Break(())) }
+    }
+}
+
+/// Wrap a [`ChannelConsumer`] task so it can be registered with
+/// [`crate::TaskManager`].
+pub fn channel_consumer<T: ChannelConsumer>(task: T) -> impl ManagedTask {
+    ChannelConsumerAdapter(task)
+}
+
+struct ChannelConsumerAdapter<T>(T);
+
+impl<T: ChannelConsumer> ManagedTask for ChannelConsumerAdapter<T> {
+    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> TaskFuture {
+        let mut task = self.0;
+        spawn(async move {
+            if let ControlFlow::Break(()) = task.on_start().await.map_err(Into::into)? {
+                return Ok::<(), BoxError>(());
+            }
+
+            let mut shutdown = shutdown;
+            loop {
+                let received = tokio::select! {
+                    biased;
+                    _ = &mut shutdown => return Ok(()),
+                    msg = task.recv() => msg,
+                };
+
+                match received {
+                    Some(item) => task.handle(item).await.map_err(Into::into)?,
+                    None => match task.on_receiver_closed().await.map_err(Into::into)? {
+                        ControlFlow::Break(()) => return Ok(()),
+                        ControlFlow::Continue(()) => continue,
+                    },
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
+
+    use tokio::sync::mpsc;
+
+    use crate::TaskManager;
+
+    use super::*;
+
+    struct CountingConsumer {
+        rx: mpsc::Receiver<u32>,
+        handled: Arc<AtomicUsize>,
+        started: Arc<AtomicUsize>,
+        closed: Arc<AtomicUsize>,
+        fail_on: Option<u32>,
+        on_close_break: bool,
+        skip_on_start: bool,
+    }
+
+    impl ChannelConsumer for CountingConsumer {
+        type Item = u32;
+        type Error = std::io::Error;
+
+        async fn recv(&mut self) -> Option<Self::Item> {
+            self.rx.recv().await
+        }
+
+        async fn handle(&mut self, item: u32) -> Result<(), Self::Error> {
+            if Some(item) == self.fail_on {
+                return Err(std::io::Error::other("boom"));
+            }
+            self.handled.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn on_start(&mut self) -> Result<ControlFlow<()>, Self::Error> {
+            self.started.fetch_add(1, Ordering::SeqCst);
+            if self.skip_on_start {
+                Ok(ControlFlow::Break(()))
+            } else {
+                Ok(ControlFlow::Continue(()))
+            }
+        }
+
+        async fn on_receiver_closed(&mut self) -> Result<ControlFlow<()>, Self::Error> {
+            self.closed.fetch_add(1, Ordering::SeqCst);
+            if self.on_close_break {
+                Ok(ControlFlow::Break(()))
+            } else {
+                Err(std::io::Error::other("unexpected close"))
+            }
+        }
+    }
+
+    fn build(
+        rx: mpsc::Receiver<u32>,
+        on_close_break: bool,
+        skip_on_start: bool,
+        fail_on: Option<u32>,
+    ) -> (
+        CountingConsumer,
+        Arc<AtomicUsize>,
+        Arc<AtomicUsize>,
+        Arc<AtomicUsize>,
+    ) {
+        let handled = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(AtomicUsize::new(0));
+        let closed = Arc::new(AtomicUsize::new(0));
+        (
+            CountingConsumer {
+                rx,
+                handled: handled.clone(),
+                started: started.clone(),
+                closed: closed.clone(),
+                fail_on,
+                on_close_break,
+                skip_on_start,
+            },
+            handled,
+            started,
+            closed,
+        )
+    }
+
+    #[tokio::test]
+    async fn handles_items_then_exits_on_close() {
+        let (tx, rx) = mpsc::channel(8);
+        let (consumer, handled, started, closed) = build(rx, true, false, None);
+
+        let manager = TaskManager::builder()
+            .add_task(channel_consumer(consumer))
+            .build();
+        let (_trigger, shutdown) = triggered::trigger();
+
+        tx.send(1).await.unwrap();
+        tx.send(2).await.unwrap();
+        tx.send(3).await.unwrap();
+        drop(tx);
+
+        let result = Box::new(manager).start_task(shutdown).await;
+        assert!(result.is_ok(), "got {result:?}");
+        assert_eq!(handled.load(Ordering::SeqCst), 3);
+        assert_eq!(started.load(Ordering::SeqCst), 1);
+        assert_eq!(closed.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn on_receiver_closed_err_propagates() {
+        let (tx, rx) = mpsc::channel::<u32>(1);
+        let (consumer, _h, _s, closed) = build(rx, false, false, None);
+
+        let manager = TaskManager::builder()
+            .add_task(channel_consumer(consumer))
+            .build();
+        let (_trigger, shutdown) = triggered::trigger();
+
+        drop(tx);
+        let result = Box::new(manager).start_task(shutdown).await;
+        assert!(result.is_err());
+        assert_eq!(closed.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn on_start_break_skips_loop() {
+        let (_tx, rx) = mpsc::channel::<u32>(1);
+        let (consumer, handled, started, closed) = build(rx, true, true, None);
+
+        let manager = TaskManager::builder()
+            .add_task(channel_consumer(consumer))
+            .build();
+        let (_trigger, shutdown) = triggered::trigger();
+
+        let result = Box::new(manager).start_task(shutdown).await;
+        assert!(result.is_ok());
+        assert_eq!(started.load(Ordering::SeqCst), 1);
+        assert_eq!(handled.load(Ordering::SeqCst), 0);
+        assert_eq!(closed.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn handle_error_propagates() {
+        let (tx, rx) = mpsc::channel(4);
+        let (consumer, _h, _s, _c) = build(rx, true, false, Some(42));
+
+        let manager = TaskManager::builder()
+            .add_task(channel_consumer(consumer))
+            .build();
+        let (_trigger, shutdown) = triggered::trigger();
+
+        tx.send(1).await.unwrap();
+        tx.send(42).await.unwrap();
+
+        let result = Box::new(manager).start_task(shutdown).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn shutdown_breaks_loop_cleanly() {
+        let (tx, rx) = mpsc::channel::<u32>(1);
+        let (consumer, _h, _s, _c) = build(rx, true, false, None);
+
+        let manager = TaskManager::builder()
+            .add_task(channel_consumer(consumer))
+            .build();
+        let (trigger, shutdown) = triggered::trigger();
+
+        let handle = tokio::spawn(async move { Box::new(manager).start_task(shutdown).await });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        trigger.trigger();
+        drop(tx);
+        let result = handle.await.expect("join");
+        assert!(result.is_ok(), "got {result:?}");
+    }
+}

--- a/task_manager/src/lib.rs
+++ b/task_manager/src/lib.rs
@@ -21,6 +21,8 @@
 //!     .await?;
 //! ```
 
+mod channel_consumer;
+mod periodic;
 mod select_all;
 
 use std::pin::pin;
@@ -28,6 +30,9 @@ use std::pin::pin;
 use crate::select_all::select_all;
 use futures::{future::BoxFuture, Future, FutureExt, StreamExt, TryFutureExt};
 use tokio::signal;
+
+pub use crate::channel_consumer::{channel_consumer, ChannelConsumer};
+pub use crate::periodic::{periodic, Periodic};
 
 /// A boxed error type for task errors from user code.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/task_manager/src/periodic.rs
+++ b/task_manager/src/periodic.rs
@@ -1,0 +1,163 @@
+//! A trait for periodic interval-driven tasks.
+//!
+//! Implement [`Periodic`] for the unit of work you want to run on an interval,
+//! then wrap with [`periodic`] when registering with a [`crate::TaskManager`].
+
+use std::{future::Future, time::Duration};
+
+use crate::{spawn, BoxError, ManagedTask, TaskFuture};
+
+/// A task that runs a fixed unit of work on an interval.
+///
+/// The adapter handles the [`tokio::select!`] loop, shutdown coordination, and
+/// `ManagedTask` impl. Implementors only describe the interval, the per-tick
+/// work, and (optionally) one-shot setup.
+///
+/// # Example
+///
+/// ```ignore
+/// use std::time::Duration;
+///
+/// struct Purger { pool: PgPool, interval: Duration }
+///
+/// impl task_manager::Periodic for Purger {
+///     type Error = anyhow::Error;
+///     fn interval(&self) -> Duration { self.interval }
+///     async fn tick(&mut self) -> anyhow::Result<()> {
+///         purge(&self.pool).await
+///     }
+/// }
+///
+/// TaskManager::builder()
+///     .add_task(task_manager::periodic(purger))
+///     .build()
+///     .start()
+///     .await?;
+/// ```
+pub trait Periodic: Send + Sync + 'static {
+    type Error: Into<BoxError> + Send;
+
+    /// The interval between ticks.
+    fn interval(&self) -> Duration;
+
+    /// Work to perform on each tick.
+    fn tick(&mut self) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Optional one-shot setup, awaited once before entering the loop.
+    fn on_start(&mut self) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        async { Ok(()) }
+    }
+}
+
+/// Wrap a [`Periodic`] task so it can be registered with [`crate::TaskManager`].
+pub fn periodic<T: Periodic>(task: T) -> impl ManagedTask {
+    PeriodicAdapter(task)
+}
+
+struct PeriodicAdapter<T>(T);
+
+impl<T: Periodic> ManagedTask for PeriodicAdapter<T> {
+    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> TaskFuture {
+        let mut task = self.0;
+        spawn(async move {
+            task.on_start().await.map_err(Into::into)?;
+            let mut shutdown = shutdown;
+            let mut timer = tokio::time::interval(task.interval());
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = &mut shutdown => return Ok::<(), BoxError>(()),
+                    _ = timer.tick() => task.tick().await.map_err(Into::into)?,
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use crate::TaskManager;
+
+    use super::*;
+
+    struct CountingPeriodic {
+        ticks: Arc<AtomicUsize>,
+        started: Arc<AtomicUsize>,
+        interval: Duration,
+        fail_on_tick: Option<usize>,
+    }
+
+    impl Periodic for CountingPeriodic {
+        type Error = std::io::Error;
+
+        fn interval(&self) -> Duration {
+            self.interval
+        }
+
+        async fn tick(&mut self) -> Result<(), Self::Error> {
+            let n = self.ticks.fetch_add(1, Ordering::SeqCst) + 1;
+            if Some(n) == self.fail_on_tick {
+                return Err(std::io::Error::other("boom"));
+            }
+            Ok(())
+        }
+
+        async fn on_start(&mut self) -> Result<(), Self::Error> {
+            self.started.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn shutdown_breaks_loop_cleanly() {
+        let ticks = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(AtomicUsize::new(0));
+        let task = periodic(CountingPeriodic {
+            ticks: ticks.clone(),
+            started: started.clone(),
+            interval: Duration::from_millis(10),
+            fail_on_tick: None,
+        });
+
+        let manager = TaskManager::builder().add_task(task).build();
+        let (trigger, shutdown) = triggered::trigger();
+
+        let handle = tokio::spawn(async move { Box::new(manager).start_task(shutdown).await });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        trigger.trigger();
+        let result = handle.await.expect("join");
+
+        assert!(result.is_ok(), "got {result:?}");
+        assert_eq!(
+            started.load(Ordering::SeqCst),
+            1,
+            "on_start should run once"
+        );
+        assert!(ticks.load(Ordering::SeqCst) >= 1, "at least one tick");
+    }
+
+    #[tokio::test]
+    async fn tick_error_propagates() {
+        let ticks = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(AtomicUsize::new(0));
+        let task = periodic(CountingPeriodic {
+            ticks: ticks.clone(),
+            started: started.clone(),
+            interval: Duration::from_millis(5),
+            fail_on_tick: Some(2),
+        });
+
+        let manager = TaskManager::builder().add_task(task).build();
+        let (_trigger, shutdown) = triggered::trigger();
+
+        let result = Box::new(manager).start_task(shutdown).await;
+        assert!(result.is_err(), "expected error, got {result:?}");
+        assert_eq!(started.load(Ordering::SeqCst), 1);
+    }
+}


### PR DESCRIPTION
In many places, we have 2 dominant task types:
- periodic :: waits for an interval to process
- channel consumer :: waits on a channel for processing data

None of this prevents us from using the escape hatch of implementing `ManagedTask` ourselves, but it does provide some helper utils when we know the shape of how we're handling data.