### PR TITLE
Add JWT file watcher to `trino_client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11759,10 +11759,16 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "humantime-serde",
+ "notify",
  "serde",
  "serde_json",
+ "task-manager",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
+ "triggered",
  "trino-rust-client",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11763,12 +11763,10 @@ dependencies = [
  "notify",
  "serde",
  "serde_json",
- "task-manager",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "triggered",
  "trino-rust-client",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,18 +3168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4570,11 +4558,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.4",
  "inotify-sys",
  "libc",
 ]
@@ -5236,23 +5224,12 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -5584,20 +5561,29 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.9.4",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 0.8.11",
+ "mio",
+ "notify-types",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -11337,7 +11323,7 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.0.4",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -11706,17 +11692,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11739,11 +11714,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,14 +35,59 @@ edition = "2021"
 
 [workspace.dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
+async-trait = "*"
+base64 = ">=0.21"
+bincode = "1"
+blake3 = "*"
 bs58 = { version = "0.5.1", features = ["check"] }
-thiserror = "1"
+bytes = "*"
+chrono = { version = "0", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+config = { version = "0", default-features = false, features = ["toml"] }
+csv = "*"
+derive_builder = "0"
+futures = "*"
+futures-util = "*"
+h3o = { version = "0", features = ["serde"] }
+helium-crypto = { version = "0.9.3", default-features = false }
+hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
+  "disktree",
+] }
+http = "1"
+http-serde = "2"
+humantime = "2"
+humantime-serde = "1"
+itertools = "0.14"
+metrics = ">=0.22"
+metrics-exporter-prometheus = "0"
+notify = { version = "8.2", default-features = false }
+rand = "0.8"
+reqwest = { version = "0", default-features = false, features = [
+  "gzip",
+  "json",
+  "http2",
+  "default-tls",
+] }
+retainer = "*"
+rust_decimal = { version = "1", features = ["macros"] }
+rust_decimal_macros = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-http-serde = "2"
-http = "1"
-chrono = { version = "0", features = ["serde"] }
+sha2 = "0.10"
+sqlx = { version = "0.8", default-features = false, features = [
+  "postgres",
+  "uuid",
+  "rust_decimal",
+  "chrono",
+  "migrate",
+  "macros",
+  "runtime-tokio",
+  "tls-rustls-aws-lc-rs",
+] }
+strum = { version = "0", features = ["derive"] }
+strum_macros = "0"
+tempfile = "3"
+thiserror = "1"
 tokio = { version = "1", default-features = false, features = [
   "fs",
   "macros",
@@ -54,62 +99,18 @@ tokio = { version = "1", default-features = false, features = [
   "time",
 ] }
 tokio-stream = "0"
-sqlx = { version = "0.8", default-features = false, features = [
-  "postgres",
-  "uuid",
-  "rust_decimal",
-  "chrono",
-  "migrate",
-  "macros",
-  "runtime-tokio",
-  "tls-rustls-aws-lc-rs",
-] }
-helium-crypto = { version = "0.9.3", default-features = false }
-hextree = { git = "https://github.com/jaykickliter/HexTree", branch = "main", features = [
-  "disktree",
-] }
-reqwest = { version = "0", default-features = false, features = [
-  "gzip",
-  "json",
-  "http2",
-  "default-tls",
-] }
-humantime = "2"
-humantime-serde = "1"
-metrics = ">=0.22"
-metrics-exporter-prometheus = "0"
+tokio-util = "0"
+tower-http = { version = "0", features = ["trace"] }
 tracing = "0"
 tracing-subscriber = { version = "0", default-features = false, features = [
   "env-filter",
   "registry",
   "fmt",
 ] }
-rust_decimal = { version = "1", features = ["macros"] }
-rust_decimal_macros = "1"
-base64 = ">=0.21"
-sha2 = "0.10"
 triggered = "0"
-futures = "*"
-futures-util = "*"
-config = { version = "0", default-features = false, features = ["toml"] }
-h3o = { version = "0", features = ["serde"] }
-xorf = { version = "0", features = ["serde"] }
-bytes = "*"
-bincode = "1"
 twox-hash = "1"
-async-trait = "*"
-blake3 = "*"
-retainer = "*"
-rand = "0.8"
-itertools = "0.14"
-tokio-util = "0"
 uuid = { version = "1", features = ["v4", "serde"] }
-tower-http = { version = "0", features = ["trace"] }
-derive_builder = "0"
-tempfile = "3"
-csv = "*"
-strum = { version = "0", features = ["derive"] }
-strum_macros = "0"
+xorf = { version = "0", features = ["serde"] }
 
 ### AWS
 aws-config = "1.8"

--- a/custom_tracing/Cargo.toml
+++ b/custom_tracing/Cargo.toml
@@ -6,27 +6,23 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 axum = { version = ">=0.7", features = ["tracing"], optional = true }
 bs58 = { workspace = true }
 helium-crypto = { workspace = true }
 tonic = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
-notify = { version = "6", default-features = false }
-serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "signal"] }
-tower-http = { version = "0", features = ["trace"] }
+notify = { workspace = true }
+serde ={ workspace = true }
+tokio = { workspace = true }
+tower-http ={ workspace = true }
 tower-layer = { version = "0" }
-tracing = "0"
-tracing-subscriber = { version = "0", default-features = true, features = [
-    "env-filter",
-    "registry",
-    "fmt",
-] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 
 [target.'cfg(target_os = "macos")'.dependencies]
-notify = { version = "6", default-features = false, features = [
+notify = { workspace = true, default-features = false, features = [
     "macos_fsevent",
 ] }
 

--- a/trino_client/Cargo.toml
+++ b/trino_client/Cargo.toml
@@ -7,11 +7,27 @@ license.workspace = true
 
 [dependencies]
 chrono = { workspace = true }
+humantime-serde = { workspace = true }
+notify = { version = "6", default-features = false }
 serde = { workspace = true }
+task-manager = { path = "../task_manager", optional = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+triggered = { workspace = true }
 trino-rust-client = "0.9"
+
+[features]
+default = []
+task-manager = ["dep:task-manager"]
+
+[target.'cfg(target_os = "macos")'.dependencies]
+notify = { version = "6", default-features = false, features = [
+  "macos_fsevent",
+] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/trino_client/Cargo.toml
+++ b/trino_client/Cargo.toml
@@ -10,16 +10,10 @@ chrono = { workspace = true }
 humantime-serde = { workspace = true }
 notify = { version = "6", default-features = false }
 serde = { workspace = true }
-task-manager = { path = "../task_manager", optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-triggered = { workspace = true }
 trino-rust-client = "0.9"
-
-[features]
-default = []
-task-manager = ["dep:task-manager"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 notify = { version = "6", default-features = false, features = [

--- a/trino_client/Cargo.toml
+++ b/trino_client/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 [dependencies]
 chrono = { workspace = true }
 humantime-serde = { workspace = true }
-notify = { version = "6", default-features = false }
+notify = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
@@ -16,9 +16,7 @@ tracing = { workspace = true }
 trino-rust-client = "0.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-notify = { version = "6", default-features = false, features = [
-  "macos_fsevent",
-] }
+notify = { workspace = true, features = ["macos_fsevent"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/trino_client/src/builder.rs
+++ b/trino_client/src/builder.rs
@@ -64,11 +64,7 @@ impl ClientBuilder {
         self
     }
 
-    pub fn jwt_file_auth(
-        mut self,
-        path: impl Into<PathBuf>,
-        refresh_interval: Duration,
-    ) -> Self {
+    pub fn jwt_file_auth(mut self, path: impl Into<PathBuf>, refresh_interval: Duration) -> Self {
         self.auth = Some(AuthSettings::JwtFile {
             path: path.into(),
             refresh_interval,

--- a/trino_client/src/builder.rs
+++ b/trino_client/src/builder.rs
@@ -1,6 +1,8 @@
 use crate::error::Result;
 use crate::settings::{AuthSettings, Settings};
 use crate::Client;
+use std::path::PathBuf;
+use std::time::Duration;
 
 pub struct ClientBuilder {
     host: String,
@@ -58,6 +60,18 @@ impl ClientBuilder {
     pub fn jwt_auth(mut self, token: impl Into<String>) -> Self {
         self.auth = Some(AuthSettings::Jwt {
             token: token.into(),
+        });
+        self
+    }
+
+    pub fn jwt_file_auth(
+        mut self,
+        path: impl Into<PathBuf>,
+        refresh_interval: Duration,
+    ) -> Self {
+        self.auth = Some(AuthSettings::JwtFile {
+            path: path.into(),
+            refresh_interval,
         });
         self
     }

--- a/trino_client/src/error.rs
+++ b/trino_client/src/error.rs
@@ -15,9 +15,6 @@ pub enum Error {
     #[error("notify error: {0}")]
     Watcher(#[from] notify::Error),
 
-    #[error("no tokio runtime available to spawn jwt watcher")]
-    NoTokioRuntime,
-
     #[error("watch channel send: {0}")]
     WatchSend(String),
 

--- a/trino_client/src/error.rs
+++ b/trino_client/src/error.rs
@@ -15,8 +15,8 @@ pub enum Error {
     #[error("notify error: {0}")]
     Watcher(#[from] notify::Error),
 
-    #[error("watch_jwt requires AuthSettings::JwtFile")]
-    JwtWatchUnsupported,
+    #[error("no tokio runtime available to spawn jwt watcher")]
+    NoTokioRuntime,
 
     #[error("watch channel send: {0}")]
     WatchSend(String),

--- a/trino_client/src/error.rs
+++ b/trino_client/src/error.rs
@@ -1,8 +1,5 @@
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("failed to build trino client: {0}")]
-    Build(String),
-
     #[error("missing bind parameter: {0}")]
     MissingParameter(String),
 
@@ -12,11 +9,8 @@ pub enum Error {
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("notify error: {0}")]
-    Watcher(#[from] notify::Error),
-
-    #[error("watch channel send: {0}")]
-    WatchSend(String),
+    #[error(transparent)]
+    JwtWatcher(#[from] crate::jwt_watcher::JwtWatcherError),
 
     #[error(transparent)]
     Client(#[from] trino_rust_client::error::Error),

--- a/trino_client/src/error.rs
+++ b/trino_client/src/error.rs
@@ -9,6 +9,18 @@ pub enum Error {
     #[error("invalid parameter value: {0}")]
     InvalidParam(String),
 
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("notify error: {0}")]
+    Watcher(#[from] notify::Error),
+
+    #[error("watch_jwt requires AuthSettings::JwtFile")]
+    JwtWatchUnsupported,
+
+    #[error("watch channel send: {0}")]
+    WatchSend(String),
+
     #[error(transparent)]
     Client(#[from] trino_rust_client::error::Error),
 }

--- a/trino_client/src/jwt_watcher.rs
+++ b/trino_client/src/jwt_watcher.rs
@@ -70,8 +70,14 @@ impl notify::EventHandler for JwtWatcher {
             return;
         }
 
-        if let Err(err) = self.create_and_send_new_inner() {
-            tracing::error!(?err, "failed to refresh trino client");
+        match self.create_and_send_new_inner() {
+            Ok(()) => {}
+            Err(Error::WatchSend(_)) => {
+                // All receivers have been dropped — we're on the way down.
+                // Benign during shutdown; loud at `error!` would be noise.
+                tracing::debug!("jwt refresh skipped: no receivers");
+            }
+            Err(err) => tracing::error!(?err, "failed to refresh trino client"),
         }
     }
 }
@@ -113,23 +119,17 @@ mod tests {
     }
 
     #[test]
-    fn from_settings_errors_without_tokio_runtime() {
-        // Use a fresh thread that has no tokio runtime context. The current
-        // process's runtime (if any from another test) would not be visible
-        // here.
-        let handle = std::thread::spawn(|| {
-            let dir = tempfile::tempdir().unwrap();
-            let path = dir.path().join("token.jwt");
-            std::fs::write(&path, b"some-token").unwrap();
-            let settings = base_settings(Some(AuthSettings::JwtFile {
-                path,
-                refresh_interval: Duration::from_millis(50),
-            }));
-            Client::from_settings(&settings)
-        });
-        let result = handle.join().unwrap();
-        let err = result.err().expect("expected error");
-        assert!(matches!(err, Error::NoTokioRuntime), "got: {err:?}");
+    fn from_settings_works_without_tokio_runtime() {
+        // Constructor is fully synchronous: no runtime is required.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("token.jwt");
+        std::fs::write(&path, b"some-token").unwrap();
+        let settings = base_settings(Some(AuthSettings::JwtFile {
+            path,
+            refresh_interval: Duration::from_millis(50),
+        }));
+        let client = Client::from_settings(&settings).expect("constructor must not require tokio");
+        drop(client);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/trino_client/src/jwt_watcher.rs
+++ b/trino_client/src/jwt_watcher.rs
@@ -1,10 +1,8 @@
-use crate::error::{Error, Result};
 use crate::settings::Settings;
-use crate::{build_inner_client, InnerClient};
+use crate::{build_inner_client, TrinoClientSendError, TrinoClientSender};
 use notify::{Config, PollWatcher, RecursiveMode, Watcher};
 use std::path::Path;
 use std::time::Duration;
-use tokio::sync::watch;
 
 /// Watches a JWT token file on disk and pushes a freshly-built Trino client
 /// through the provided `watch::Sender` whenever the file changes.
@@ -14,12 +12,29 @@ use tokio::sync::watch;
 /// Dropping it stops polling.
 pub(crate) struct JwtWatcher {
     settings: Settings,
-    updater: watch::Sender<InnerClient>,
+    updater: TrinoClientSender,
 }
+
+#[derive(Debug, thiserror::Error)]
+pub enum JwtWatcherError {
+    #[error("failed to build trino client: {0}")]
+    Build(#[from] trino_rust_client::error::Error),
+
+    #[error("failed to read: {0}")]
+    Read(#[from] std::io::Error),
+
+    #[error("notify: {0}")]
+    Notify(#[from] notify::Error),
+
+    #[error("watch channel send: {0}")]
+    WatchSend(#[from] TrinoClientSendError),
+}
+
+type Result<T> = std::result::Result<T, JwtWatcherError>;
 
 impl JwtWatcher {
     /// Build the watcher and ensure the token file is readable up front.
-    pub(crate) fn new(settings: Settings, updater: watch::Sender<InnerClient>) -> Result<Self> {
+    pub(crate) fn new(settings: Settings, updater: TrinoClientSender) -> Result<Self> {
         let jwt_watcher = Self { settings, updater };
         // Ensure we can read the token file before we continue.
         let _ = jwt_watcher.settings.resolve_jwt_token()?;
@@ -45,9 +60,7 @@ impl JwtWatcher {
     fn create_and_send_new_inner(&self) -> Result<()> {
         let jwt_token = self.settings.resolve_jwt_token()?;
         let new_inner = build_inner_client(&self.settings, jwt_token.as_deref())?;
-        self.updater
-            .send(new_inner)
-            .map_err(|e| Error::WatchSend(e.to_string()))?;
+        self.updater.send(new_inner)?;
         tracing::info!("created new inner trino client");
         Ok(())
     }
@@ -72,7 +85,7 @@ impl notify::EventHandler for JwtWatcher {
 
         match self.create_and_send_new_inner() {
             Ok(()) => {}
-            Err(Error::WatchSend(_)) => {
+            Err(JwtWatcherError::WatchSend(_)) => {
                 // All receivers have been dropped — we're on the way down.
                 // Benign during shutdown; loud at `error!` would be noise.
                 tracing::debug!("jwt refresh skipped: no receivers");
@@ -118,21 +131,7 @@ mod tests {
         assert!(matches!(err, Error::Io(_)));
     }
 
-    #[test]
-    fn from_settings_works_without_tokio_runtime() {
-        // Constructor is fully synchronous: no runtime is required.
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("token.jwt");
-        std::fs::write(&path, b"some-token").unwrap();
-        let settings = base_settings(Some(AuthSettings::JwtFile {
-            path,
-            refresh_interval: Duration::from_millis(50),
-        }));
-        let client = Client::from_settings(&settings).expect("constructor must not require tokio");
-        drop(client);
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[tokio::test]
     async fn jwt_file_change_refreshes_inner_client() {
         let mut token_file = tempfile::NamedTempFile::new().unwrap();
         token_file.write_all(b"initial-token").unwrap();

--- a/trino_client/src/jwt_watcher.rs
+++ b/trino_client/src/jwt_watcher.rs
@@ -117,7 +117,9 @@ mod tests {
             path: PathBuf::from("/nonexistent/path/to/token.jwt"),
             refresh_interval: Duration::from_millis(50),
         }));
-        let err = Client::from_settings(&settings).err().expect("expected error");
+        let err = Client::from_settings(&settings)
+            .err()
+            .expect("expected error");
         assert!(matches!(err, Error::Io(_)));
     }
 

--- a/trino_client/src/jwt_watcher.rs
+++ b/trino_client/src/jwt_watcher.rs
@@ -1,25 +1,45 @@
 use crate::error::{Error, Result};
 use crate::settings::Settings;
 use crate::{build_inner_client, InnerClient};
-use notify::Watcher;
-use std::future::Future;
+use notify::{Config, PollWatcher, RecursiveMode, Watcher};
 use std::path::Path;
 use std::time::Duration;
 use tokio::sync::watch;
 
 /// Watches a JWT token file on disk and pushes a freshly-built Trino client
 /// through the provided `watch::Sender` whenever the file changes.
-pub struct JwtWatcher {
+///
+/// The watcher is owned by a `PollWatcher` returned from [`JwtWatcher::start`];
+/// keeping the `PollWatcher` alive keeps the internal polling thread running.
+/// Dropping it stops polling.
+pub(crate) struct JwtWatcher {
     settings: Settings,
     updater: watch::Sender<InnerClient>,
 }
 
 impl JwtWatcher {
-    pub fn new(settings: Settings, updater: watch::Sender<InnerClient>) -> Result<Self> {
+    /// Build the watcher and ensure the token file is readable up front.
+    pub(crate) fn new(settings: Settings, updater: watch::Sender<InnerClient>) -> Result<Self> {
         let jwt_watcher = Self { settings, updater };
         // Ensure we can read the token file before we continue.
         let _ = jwt_watcher.settings.resolve_jwt_token()?;
         Ok(jwt_watcher)
+    }
+
+    /// Construct and start the `PollWatcher`. The returned handle owns the
+    /// internal polling thread; keep it alive for as long as you want refresh
+    /// events to be processed.
+    pub(crate) fn start(
+        self,
+        token_path: &Path,
+        refresh_interval: Duration,
+    ) -> Result<PollWatcher> {
+        let config = Config::default()
+            .with_poll_interval(refresh_interval)
+            .with_compare_contents(true);
+        let mut watcher = PollWatcher::new(self, config)?;
+        watcher.watch(token_path, RecursiveMode::NonRecursive)?;
+        Ok(watcher)
     }
 
     fn create_and_send_new_inner(&self) -> Result<()> {
@@ -30,29 +50,6 @@ impl JwtWatcher {
             .map_err(|e| Error::WatchSend(e.to_string()))?;
         tracing::info!("created new inner trino client");
         Ok(())
-    }
-
-    pub fn make_watcher(
-        self,
-        token_path: &Path,
-        refresh_interval: Duration,
-        shutdown: triggered::Listener,
-    ) -> Result<impl Future<Output = Result<()>>> {
-        use notify::{Config, PollWatcher, RecursiveMode};
-
-        let config = Config::default()
-            .with_poll_interval(refresh_interval)
-            .with_compare_contents(true);
-        let mut watcher = PollWatcher::new(self, config)?;
-
-        watcher.watch(token_path, RecursiveMode::NonRecursive)?;
-
-        Ok(async move {
-            let _watcher = watcher;
-            shutdown.await;
-            tracing::info!("jwt watcher shutting down");
-            Ok(())
-        })
     }
 }
 
@@ -104,14 +101,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn watch_jwt_errors_without_jwt_file_auth() {
-        let client = Client::from_settings(&base_settings(None)).unwrap();
-        let (_trigger, listener) = triggered::trigger();
-        let err = client.watch_jwt(listener).err().expect("expected error");
-        assert!(matches!(err, Error::JwtWatchUnsupported));
-    }
-
-    #[tokio::test]
     async fn from_settings_fails_when_jwt_file_path_missing() {
         let settings = base_settings(Some(AuthSettings::JwtFile {
             path: PathBuf::from("/nonexistent/path/to/token.jwt"),
@@ -123,8 +112,28 @@ mod tests {
         assert!(matches!(err, Error::Io(_)));
     }
 
+    #[test]
+    fn from_settings_errors_without_tokio_runtime() {
+        // Use a fresh thread that has no tokio runtime context. The current
+        // process's runtime (if any from another test) would not be visible
+        // here.
+        let handle = std::thread::spawn(|| {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("token.jwt");
+            std::fs::write(&path, b"some-token").unwrap();
+            let settings = base_settings(Some(AuthSettings::JwtFile {
+                path,
+                refresh_interval: Duration::from_millis(50),
+            }));
+            Client::from_settings(&settings)
+        });
+        let result = handle.join().unwrap();
+        let err = result.err().expect("expected error");
+        assert!(matches!(err, Error::NoTokioRuntime), "got: {err:?}");
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn watch_jwt_refreshes_on_file_change() {
+    async fn jwt_file_change_refreshes_inner_client() {
         let mut token_file = tempfile::NamedTempFile::new().unwrap();
         token_file.write_all(b"initial-token").unwrap();
         token_file.flush().unwrap();
@@ -137,10 +146,6 @@ mod tests {
         let client = Client::from_settings(&settings).unwrap();
         let initial = client.inner();
         let initial_ptr = Arc::as_ptr(&initial);
-
-        let (trigger, listener) = triggered::trigger();
-        let watcher_fut = client.watch_jwt(listener).unwrap();
-        let watcher_handle = tokio::spawn(watcher_fut);
 
         // Give the watcher time to settle, then rewrite the token file.
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -159,7 +164,7 @@ mod tests {
         }
         assert!(swapped, "watcher did not refresh the inner client");
 
-        trigger.trigger();
-        watcher_handle.await.unwrap().unwrap();
+        // Dropping the client must tear down the watcher task; this is
+        // exercised by the implicit `drop(client)` at scope exit.
     }
 }

--- a/trino_client/src/jwt_watcher.rs
+++ b/trino_client/src/jwt_watcher.rs
@@ -1,0 +1,163 @@
+use crate::error::{Error, Result};
+use crate::settings::Settings;
+use crate::{build_inner_client, InnerClient};
+use notify::Watcher;
+use std::future::Future;
+use std::path::Path;
+use std::time::Duration;
+use tokio::sync::watch;
+
+/// Watches a JWT token file on disk and pushes a freshly-built Trino client
+/// through the provided `watch::Sender` whenever the file changes.
+pub struct JwtWatcher {
+    settings: Settings,
+    updater: watch::Sender<InnerClient>,
+}
+
+impl JwtWatcher {
+    pub fn new(settings: Settings, updater: watch::Sender<InnerClient>) -> Result<Self> {
+        let jwt_watcher = Self { settings, updater };
+        // Ensure we can read the token file before we continue.
+        let _ = jwt_watcher.settings.resolve_jwt_token()?;
+        Ok(jwt_watcher)
+    }
+
+    fn create_and_send_new_inner(&self) -> Result<()> {
+        let jwt_token = self.settings.resolve_jwt_token()?;
+        let new_inner = build_inner_client(&self.settings, jwt_token.as_deref())?;
+        self.updater
+            .send(new_inner)
+            .map_err(|e| Error::WatchSend(e.to_string()))?;
+        tracing::info!("created new inner trino client");
+        Ok(())
+    }
+
+    pub fn make_watcher(
+        self,
+        token_path: &Path,
+        refresh_interval: Duration,
+        shutdown: triggered::Listener,
+    ) -> Result<impl Future<Output = Result<()>>> {
+        use notify::{Config, PollWatcher, RecursiveMode};
+
+        let config = Config::default()
+            .with_poll_interval(refresh_interval)
+            .with_compare_contents(true);
+        let mut watcher = PollWatcher::new(self, config)?;
+
+        watcher.watch(token_path, RecursiveMode::NonRecursive)?;
+
+        Ok(async move {
+            let _watcher = watcher;
+            shutdown.await;
+            tracing::info!("jwt watcher shutting down");
+            Ok(())
+        })
+    }
+}
+
+impl notify::EventHandler for JwtWatcher {
+    fn handle_event(&mut self, res: notify::Result<notify::Event>) {
+        let event = match res {
+            Ok(event) => event,
+            Err(err) => {
+                tracing::error!(?err, "jwt watcher received error event");
+                return;
+            }
+        };
+
+        tracing::debug!(?event, "jwt watcher event");
+        let should_handle = event.kind.is_modify() || event.kind.is_create();
+        if !should_handle {
+            tracing::debug!("ignoring jwt watcher event");
+            return;
+        }
+
+        if let Err(err) = self.create_and_send_new_inner() {
+            tracing::error!(?err, "failed to refresh trino client");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{AuthSettings, Client, Error, Settings};
+    use std::io::Write;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn base_settings(auth: Option<AuthSettings>) -> Settings {
+        // `trino-rust-client` rejects JWT auth with `secure: false`, so default
+        // to HTTPS for these tests. None of the tests actually issue requests.
+        let secure = matches!(auth, Some(AuthSettings::JwtFile { .. }));
+        Settings {
+            host: "localhost".into(),
+            port: 8080,
+            user: "alice".into(),
+            catalog: None,
+            schema: None,
+            secure,
+            insecure_skip_tls_verify: true,
+            auth,
+        }
+    }
+
+    #[tokio::test]
+    async fn watch_jwt_errors_without_jwt_file_auth() {
+        let client = Client::from_settings(&base_settings(None)).unwrap();
+        let (_trigger, listener) = triggered::trigger();
+        let err = client.watch_jwt(listener).err().expect("expected error");
+        assert!(matches!(err, Error::JwtWatchUnsupported));
+    }
+
+    #[tokio::test]
+    async fn from_settings_fails_when_jwt_file_path_missing() {
+        let settings = base_settings(Some(AuthSettings::JwtFile {
+            path: PathBuf::from("/nonexistent/path/to/token.jwt"),
+            refresh_interval: Duration::from_millis(50),
+        }));
+        let err = Client::from_settings(&settings).err().expect("expected error");
+        assert!(matches!(err, Error::Io(_)));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn watch_jwt_refreshes_on_file_change() {
+        let mut token_file = tempfile::NamedTempFile::new().unwrap();
+        token_file.write_all(b"initial-token").unwrap();
+        token_file.flush().unwrap();
+
+        let settings = base_settings(Some(AuthSettings::JwtFile {
+            path: token_file.path().to_path_buf(),
+            refresh_interval: Duration::from_millis(50),
+        }));
+
+        let client = Client::from_settings(&settings).unwrap();
+        let initial = client.inner();
+        let initial_ptr = Arc::as_ptr(&initial);
+
+        let (trigger, listener) = triggered::trigger();
+        let watcher_fut = client.watch_jwt(listener).unwrap();
+        let watcher_handle = tokio::spawn(watcher_fut);
+
+        // Give the watcher time to settle, then rewrite the token file.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        std::fs::write(token_file.path(), b"refreshed-token").unwrap();
+
+        // Poll for up to ~2s for the Arc to be swapped.
+        let mut swapped = false;
+        for _ in 0..40 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let current = client.inner();
+            if !Arc::ptr_eq(&initial, &current) {
+                swapped = true;
+                assert_ne!(initial_ptr, Arc::as_ptr(&current));
+                break;
+            }
+        }
+        assert!(swapped, "watcher did not refresh the inner client");
+
+        trigger.trigger();
+        watcher_handle.await.unwrap().unwrap();
+    }
+}

--- a/trino_client/src/lib.rs
+++ b/trino_client/src/lib.rs
@@ -9,13 +9,13 @@ mod statement;
 
 pub use builder::ClientBuilder;
 pub use error::{Error, Result};
-pub use jwt_watcher::JwtWatcher;
 pub use settings::{AuthSettings, Settings};
 pub use statement::{Param, Statement, TypedStatement};
 
-use std::future::Future;
+use jwt_watcher::JwtWatcher;
 use std::sync::Arc;
 use tokio::sync::watch;
+use tokio::task::JoinHandle;
 use trino_rust_client::auth::Auth;
 use trino_rust_client::ClientBuilder as UpstreamClientBuilder;
 
@@ -41,64 +41,86 @@ impl<T: SqlQuery + ?Sized> SqlQuery for &T {
 
 #[derive(Clone)]
 pub struct Client {
+    inner: Arc<ClientInner>,
+}
+
+struct ClientInner {
     inner_rx: watch::Receiver<InnerClient>,
-    updater: watch::Sender<InnerClient>,
     settings: Settings,
+    // Aborted on Drop. `None` for non-`JwtFile` auth.
+    watcher_task: Option<JoinHandle<()>>,
+}
+
+impl Drop for ClientInner {
+    fn drop(&mut self) {
+        if let Some(handle) = self.watcher_task.take() {
+            handle.abort();
+        }
+    }
 }
 
 impl Client {
+    /// Build a client from settings. If `settings.auth` is
+    /// [`AuthSettings::JwtFile`], a background task is spawned on the current
+    /// tokio runtime to watch the token file and swap the inner Trino client
+    /// each time the file changes. The task is automatically aborted when the
+    /// last clone of the returned `Client` is dropped.
+    ///
+    /// Returns [`Error::NoTokioRuntime`] when called outside any tokio runtime
+    /// with `JwtFile` auth.
     pub fn from_settings(settings: &Settings) -> Result<Self> {
         let token = settings.resolve_jwt_token()?;
-        let inner = build_inner_client(settings, token.as_deref())?;
-        let (updater, inner_rx) = watch::channel(inner);
-        Ok(Self {
-            inner_rx,
-            updater,
-            settings: settings.clone(),
-        })
-    }
+        let initial = build_inner_client(settings, token.as_deref())?;
+        let (updater, inner_rx) = watch::channel(initial);
 
-    pub fn from_inner(inner: trino_rust_client::Client, settings: Settings) -> Self {
-        let (updater, inner_rx) = watch::channel(Arc::new(inner));
-        Self {
-            inner_rx,
-            updater,
-            settings,
-        }
+        let watcher_task = match &settings.auth {
+            Some(AuthSettings::JwtFile {
+                path,
+                refresh_interval,
+            }) => {
+                // Refuse to silently no-op outside a runtime.
+                let rt =
+                    tokio::runtime::Handle::try_current().map_err(|_| Error::NoTokioRuntime)?;
+
+                let watcher = JwtWatcher::new(settings.clone(), updater)?;
+                let poll_watcher = watcher.start(path, *refresh_interval)?;
+
+                // The spawned task's only job is to keep `poll_watcher` alive.
+                // Aborting it via the JoinHandle on Drop releases the watcher,
+                // which stops its internal polling thread.
+                Some(rt.spawn(async move {
+                    let _watcher = poll_watcher;
+                    std::future::pending::<()>().await;
+                }))
+            }
+            _ => {
+                // No watcher: keep `updater` alive on `Client` only via
+                // `inner_rx` — but `watch::Receiver` doesn't hold the sender
+                // alive. We don't need to refresh the inner client, so just
+                // drop the sender. The receiver still holds the last value.
+                drop(updater);
+                None
+            }
+        };
+
+        Ok(Self {
+            inner: Arc::new(ClientInner {
+                inner_rx,
+                settings: settings.clone(),
+                watcher_task,
+            }),
+        })
     }
 
     /// Returns the current inner client. JWT refreshes swap the value behind
     /// this `Arc`, so callers should call `inner()` per request rather than
     /// caching the returned `Arc` long-term.
     pub fn inner(&self) -> InnerClient {
-        self.inner_rx.borrow().clone()
+        self.inner.inner_rx.borrow().clone()
     }
 
     pub fn settings(&self) -> &Settings {
-        &self.settings
-    }
-
-    /// Spawns a JWT token-file watcher and returns a future that runs until
-    /// `shutdown` is triggered. The watcher rebuilds the inner Trino client
-    /// each time the token file changes, so callers continue to use a single
-    /// `Client` across token rotations.
-    ///
-    /// Returns [`Error::JwtWatchUnsupported`] when `auth` is not
-    /// [`AuthSettings::JwtFile`].
-    pub fn watch_jwt(
-        &self,
-        shutdown: triggered::Listener,
-    ) -> Result<impl Future<Output = Result<()>>> {
-        let (path, refresh_interval) = match &self.settings.auth {
-            Some(AuthSettings::JwtFile {
-                path,
-                refresh_interval,
-            }) => (path.clone(), *refresh_interval),
-            _ => return Err(Error::JwtWatchUnsupported),
-        };
-
-        let watcher = JwtWatcher::new(self.settings.clone(), self.updater.clone())?;
-        watcher.make_watcher(&path, refresh_interval, shutdown)
+        &self.inner.settings
     }
 
     pub async fn execute<S: SqlStatement>(&self, sql_statement: S) -> Result<()> {
@@ -129,13 +151,6 @@ impl Client {
             Err(trino_rust_client::error::Error::EmptyData) => Ok(Vec::new()),
             Err(e) => Err(e.into()),
         }
-    }
-}
-
-#[cfg(feature = "task-manager")]
-impl task_manager::ManagedTask for Client {
-    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
-        task_manager::spawn(async move { self.watch_jwt(shutdown)?.await })
     }
 }
 

--- a/trino_client/src/lib.rs
+++ b/trino_client/src/lib.rs
@@ -3,16 +3,23 @@ pub use trino_rust_client::Trino as TrinoFromRow;
 
 mod builder;
 mod error;
+mod jwt_watcher;
 mod settings;
 mod statement;
 
 pub use builder::ClientBuilder;
 pub use error::{Error, Result};
+pub use jwt_watcher::JwtWatcher;
 pub use settings::{AuthSettings, Settings};
 pub use statement::{Param, Statement, TypedStatement};
 
+use std::future::Future;
+use std::sync::Arc;
+use tokio::sync::watch;
 use trino_rust_client::auth::Auth;
 use trino_rust_client::ClientBuilder as UpstreamClientBuilder;
+
+pub type InnerClient = Arc<trino_rust_client::Client>;
 
 pub trait SqlStatement {
     fn to_statement(&self) -> Statement;
@@ -32,46 +39,66 @@ impl<T: SqlQuery + ?Sized> SqlQuery for &T {
     type Row = T::Row;
 }
 
+#[derive(Clone)]
 pub struct Client {
-    inner: trino_rust_client::Client,
+    inner_rx: watch::Receiver<InnerClient>,
+    updater: watch::Sender<InnerClient>,
+    settings: Settings,
 }
 
 impl Client {
     pub fn from_settings(settings: &Settings) -> Result<Self> {
-        let mut builder = UpstreamClientBuilder::new(&settings.user, &settings.host)
-            .port(settings.port)
-            .secure(settings.secure);
-
-        if let Some(catalog) = &settings.catalog {
-            builder = builder.catalog(catalog);
-        }
-        if let Some(schema) = &settings.schema {
-            builder = builder.schema(schema);
-        }
-        if settings.insecure_skip_tls_verify {
-            builder = builder.no_verify(true);
-        }
-        if let Some(auth) = &settings.auth {
-            builder = builder.auth(match auth {
-                AuthSettings::Basic { username, password } => {
-                    Auth::Basic(username.clone(), password.clone())
-                }
-                AuthSettings::Jwt { token } => Auth::Jwt(token.clone()),
-            });
-        }
-
-        let inner = builder
-            .build()
-            .map_err(|e| Error::Build(format!("{e:?}")))?;
-        Ok(Self { inner })
+        let token = settings.resolve_jwt_token()?;
+        let inner = build_inner_client(settings, token.as_deref())?;
+        let (updater, inner_rx) = watch::channel(inner);
+        Ok(Self {
+            inner_rx,
+            updater,
+            settings: settings.clone(),
+        })
     }
 
-    pub fn from_inner(inner: trino_rust_client::Client) -> Self {
-        Self { inner }
+    pub fn from_inner(inner: trino_rust_client::Client, settings: Settings) -> Self {
+        let (updater, inner_rx) = watch::channel(Arc::new(inner));
+        Self {
+            inner_rx,
+            updater,
+            settings,
+        }
     }
 
-    pub fn inner(&self) -> &trino_rust_client::Client {
-        &self.inner
+    /// Returns the current inner client. JWT refreshes swap the value behind
+    /// this `Arc`, so callers should call `inner()` per request rather than
+    /// caching the returned `Arc` long-term.
+    pub fn inner(&self) -> InnerClient {
+        self.inner_rx.borrow().clone()
+    }
+
+    pub fn settings(&self) -> &Settings {
+        &self.settings
+    }
+
+    /// Spawns a JWT token-file watcher and returns a future that runs until
+    /// `shutdown` is triggered. The watcher rebuilds the inner Trino client
+    /// each time the token file changes, so callers continue to use a single
+    /// `Client` across token rotations.
+    ///
+    /// Returns [`Error::JwtWatchUnsupported`] when `auth` is not
+    /// [`AuthSettings::JwtFile`].
+    pub fn watch_jwt(
+        &self,
+        shutdown: triggered::Listener,
+    ) -> Result<impl Future<Output = Result<()>>> {
+        let (path, refresh_interval) = match &self.settings.auth {
+            Some(AuthSettings::JwtFile {
+                path,
+                refresh_interval,
+            }) => (path.clone(), *refresh_interval),
+            _ => return Err(Error::JwtWatchUnsupported),
+        };
+
+        let watcher = JwtWatcher::new(self.settings.clone(), self.updater.clone())?;
+        watcher.make_watcher(&path, refresh_interval, shutdown)
     }
 
     pub async fn execute<S: SqlStatement>(&self, sql_statement: S) -> Result<()> {
@@ -88,7 +115,7 @@ impl Client {
     }
 
     pub async fn execute_raw(&self, sql: impl Into<String>) -> Result<()> {
-        self.inner.execute(sql.into()).await?;
+        self.inner().execute(sql.into()).await?;
         Ok(())
     }
 
@@ -97,10 +124,58 @@ impl Client {
         T: trino_rust_client::Trino + 'static,
         for<'de> T: serde::Deserialize<'de> + serde::Serialize,
     {
-        match self.inner.get_all::<T>(sql.into()).await {
+        match self.inner().get_all::<T>(sql.into()).await {
             Ok(ds) => Ok(ds.into_vec()),
             Err(trino_rust_client::error::Error::EmptyData) => Ok(Vec::new()),
             Err(e) => Err(e.into()),
         }
     }
+}
+
+#[cfg(feature = "task-manager")]
+impl task_manager::ManagedTask for Client {
+    fn start_task(
+        self: Box<Self>,
+        shutdown: triggered::Listener,
+    ) -> task_manager::TaskFuture {
+        task_manager::spawn(async move { self.watch_jwt(shutdown)?.await })
+    }
+}
+
+pub(crate) fn build_inner_client(
+    settings: &Settings,
+    jwt_override: Option<&str>,
+) -> Result<InnerClient> {
+    let mut builder = UpstreamClientBuilder::new(&settings.user, &settings.host)
+        .port(settings.port)
+        .secure(settings.secure);
+
+    if let Some(catalog) = &settings.catalog {
+        builder = builder.catalog(catalog);
+    }
+    if let Some(schema) = &settings.schema {
+        builder = builder.schema(schema);
+    }
+    if settings.insecure_skip_tls_verify {
+        builder = builder.no_verify(true);
+    }
+    match &settings.auth {
+        Some(AuthSettings::Basic { username, password }) => {
+            builder = builder.auth(Auth::Basic(username.clone(), password.clone()));
+        }
+        Some(AuthSettings::Jwt { token }) => {
+            builder = builder.auth(Auth::Jwt(token.clone()));
+        }
+        Some(AuthSettings::JwtFile { .. }) => {
+            if let Some(token) = jwt_override {
+                builder = builder.auth(Auth::Jwt(token.to_owned()));
+            }
+        }
+        None => {}
+    }
+
+    let inner = builder
+        .build()
+        .map_err(|e| Error::Build(format!("{e:?}")))?;
+    Ok(Arc::new(inner))
 }

--- a/trino_client/src/lib.rs
+++ b/trino_client/src/lib.rs
@@ -12,6 +12,8 @@ pub use error::{Error, Result};
 pub use settings::{AuthSettings, Settings};
 pub use statement::{Param, Statement, TypedStatement};
 
+pub use jwt_watcher::JwtWatcherError;
+
 use jwt_watcher::JwtWatcher;
 use notify::PollWatcher;
 use std::sync::Arc;
@@ -19,7 +21,10 @@ use tokio::sync::watch;
 use trino_rust_client::auth::Auth;
 use trino_rust_client::ClientBuilder as UpstreamClientBuilder;
 
-pub type InnerClient = Arc<trino_rust_client::Client>;
+type TrinoClient = Arc<trino_rust_client::Client>;
+type TrinoClientSender = watch::Sender<TrinoClient>;
+type TrinoClientReceiver = watch::Receiver<TrinoClient>;
+type TrinoClientSendError = watch::error::SendError<TrinoClient>;
 
 pub trait SqlStatement {
     fn to_statement(&self) -> Statement;
@@ -49,8 +54,7 @@ struct ClientInner {
     // internal polling thread to stop *before* the watch::Receiver disappears,
     // minimizing the race where a tick observes a closed channel.
     _watcher: Option<PollWatcher>,
-    inner_rx: watch::Receiver<InnerClient>,
-    settings: Settings,
+    inner_rx: TrinoClientReceiver,
 }
 
 impl Client {
@@ -72,19 +76,13 @@ impl Client {
                 path,
                 refresh_interval,
             }) => Some(JwtWatcher::new(settings.clone(), updater)?.start(path, *refresh_interval)?),
-            _ => {
-                // No watcher: the receiver still holds the last value even
-                // after the sender is dropped.
-                drop(updater);
-                None
-            }
+            _ => None,
         };
 
         Ok(Self {
             inner: Arc::new(ClientInner {
                 _watcher: watcher,
                 inner_rx,
-                settings: settings.clone(),
             }),
         })
     }
@@ -92,12 +90,8 @@ impl Client {
     /// Returns the current inner client. JWT refreshes swap the value behind
     /// this `Arc`, so callers should call `inner()` per request rather than
     /// caching the returned `Arc` long-term.
-    pub fn inner(&self) -> InnerClient {
+    fn inner(&self) -> TrinoClient {
         self.inner.inner_rx.borrow().clone()
-    }
-
-    pub fn settings(&self) -> &Settings {
-        &self.inner.settings
     }
 
     pub async fn execute<S: SqlStatement>(&self, sql_statement: S) -> Result<()> {
@@ -134,7 +128,7 @@ impl Client {
 pub(crate) fn build_inner_client(
     settings: &Settings,
     jwt_override: Option<&str>,
-) -> Result<InnerClient> {
+) -> std::result::Result<TrinoClient, trino_rust_client::error::Error> {
     let mut builder = UpstreamClientBuilder::new(&settings.user, &settings.host)
         .port(settings.port)
         .secure(settings.secure);
@@ -163,8 +157,6 @@ pub(crate) fn build_inner_client(
         None => {}
     }
 
-    let inner = builder
-        .build()
-        .map_err(|e| Error::Build(format!("{e:?}")))?;
+    let inner = builder.build()?;
     Ok(Arc::new(inner))
 }

--- a/trino_client/src/lib.rs
+++ b/trino_client/src/lib.rs
@@ -134,10 +134,7 @@ impl Client {
 
 #[cfg(feature = "task-manager")]
 impl task_manager::ManagedTask for Client {
-    fn start_task(
-        self: Box<Self>,
-        shutdown: triggered::Listener,
-    ) -> task_manager::TaskFuture {
+    fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
         task_manager::spawn(async move { self.watch_jwt(shutdown)?.await })
     }
 }

--- a/trino_client/src/lib.rs
+++ b/trino_client/src/lib.rs
@@ -13,9 +13,9 @@ pub use settings::{AuthSettings, Settings};
 pub use statement::{Param, Statement, TypedStatement};
 
 use jwt_watcher::JwtWatcher;
+use notify::PollWatcher;
 use std::sync::Arc;
 use tokio::sync::watch;
-use tokio::task::JoinHandle;
 use trino_rust_client::auth::Auth;
 use trino_rust_client::ClientBuilder as UpstreamClientBuilder;
 
@@ -45,59 +45,36 @@ pub struct Client {
 }
 
 struct ClientInner {
+    // Declared first so it drops first: dropping the `PollWatcher` signals its
+    // internal polling thread to stop *before* the watch::Receiver disappears,
+    // minimizing the race where a tick observes a closed channel.
+    _watcher: Option<PollWatcher>,
     inner_rx: watch::Receiver<InnerClient>,
     settings: Settings,
-    // Aborted on Drop. `None` for non-`JwtFile` auth.
-    watcher_task: Option<JoinHandle<()>>,
-}
-
-impl Drop for ClientInner {
-    fn drop(&mut self) {
-        if let Some(handle) = self.watcher_task.take() {
-            handle.abort();
-        }
-    }
 }
 
 impl Client {
     /// Build a client from settings. If `settings.auth` is
-    /// [`AuthSettings::JwtFile`], a background task is spawned on the current
-    /// tokio runtime to watch the token file and swap the inner Trino client
-    /// each time the file changes. The task is automatically aborted when the
-    /// last clone of the returned `Client` is dropped.
+    /// [`AuthSettings::JwtFile`], a background `notify::PollWatcher` is started
+    /// that watches the token file and swaps the inner Trino client each time
+    /// the file changes. The watcher's polling thread stops automatically when
+    /// the last clone of the returned `Client` is dropped.
     ///
-    /// Returns [`Error::NoTokioRuntime`] when called outside any tokio runtime
-    /// with `JwtFile` auth.
+    /// This is a fully synchronous constructor — it does not require a tokio
+    /// runtime to be active.
     pub fn from_settings(settings: &Settings) -> Result<Self> {
         let token = settings.resolve_jwt_token()?;
         let initial = build_inner_client(settings, token.as_deref())?;
         let (updater, inner_rx) = watch::channel(initial);
 
-        let watcher_task = match &settings.auth {
+        let watcher = match &settings.auth {
             Some(AuthSettings::JwtFile {
                 path,
                 refresh_interval,
-            }) => {
-                // Refuse to silently no-op outside a runtime.
-                let rt =
-                    tokio::runtime::Handle::try_current().map_err(|_| Error::NoTokioRuntime)?;
-
-                let watcher = JwtWatcher::new(settings.clone(), updater)?;
-                let poll_watcher = watcher.start(path, *refresh_interval)?;
-
-                // The spawned task's only job is to keep `poll_watcher` alive.
-                // Aborting it via the JoinHandle on Drop releases the watcher,
-                // which stops its internal polling thread.
-                Some(rt.spawn(async move {
-                    let _watcher = poll_watcher;
-                    std::future::pending::<()>().await;
-                }))
-            }
+            }) => Some(JwtWatcher::new(settings.clone(), updater)?.start(path, *refresh_interval)?),
             _ => {
-                // No watcher: keep `updater` alive on `Client` only via
-                // `inner_rx` — but `watch::Receiver` doesn't hold the sender
-                // alive. We don't need to refresh the inner client, so just
-                // drop the sender. The receiver still holds the last value.
+                // No watcher: the receiver still holds the last value even
+                // after the sender is dropped.
                 drop(updater);
                 None
             }
@@ -105,9 +82,9 @@ impl Client {
 
         Ok(Self {
             inner: Arc::new(ClientInner {
+                _watcher: watcher,
                 inner_rx,
                 settings: settings.clone(),
-                watcher_task,
             }),
         })
     }

--- a/trino_client/src/settings.rs
+++ b/trino_client/src/settings.rs
@@ -1,4 +1,3 @@
-use crate::error::Result;
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -53,7 +52,7 @@ impl Settings {
     /// - `JwtFile { path, .. }`: reads the file, trims whitespace, and returns
     ///   `None` if the resulting string is empty.
     /// - `Basic` or `None`: returns `None`.
-    pub fn resolve_jwt_token(&self) -> Result<Option<String>> {
+    pub fn resolve_jwt_token(&self) -> std::io::Result<Option<String>> {
         match &self.auth {
             Some(AuthSettings::Jwt { token }) => Ok(Some(token.clone())),
             Some(AuthSettings::JwtFile { path, .. }) => {

--- a/trino_client/src/settings.rs
+++ b/trino_client/src/settings.rs
@@ -1,4 +1,7 @@
+use crate::error::Result;
 use serde::Deserialize;
+use std::path::PathBuf;
+use std::time::Duration;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Settings {
@@ -32,12 +35,71 @@ pub enum AuthSettings {
     Jwt {
         token: String,
     },
+    JwtFile {
+        path: PathBuf,
+        #[serde(
+            with = "humantime_serde",
+            default = "default_jwt_refresh_interval"
+        )]
+        refresh_interval: Duration,
+    },
+}
+
+fn default_jwt_refresh_interval() -> Duration {
+    Duration::from_secs(60)
+}
+
+impl Settings {
+    /// Resolve the JWT token to send with requests.
+    ///
+    /// - `Jwt { token }`: returns the literal token.
+    /// - `JwtFile { path, .. }`: reads the file, trims whitespace, and returns
+    ///   `None` if the resulting string is empty.
+    /// - `Basic` or `None`: returns `None`.
+    pub fn resolve_jwt_token(&self) -> Result<Option<String>> {
+        match &self.auth {
+            Some(AuthSettings::Jwt { token }) => Ok(Some(token.clone())),
+            Some(AuthSettings::JwtFile { path, .. }) => {
+                let token = std::fs::read_to_string(path)?;
+                let token = token.trim().to_owned();
+                if token.is_empty() {
+                    tracing::warn!(path = %path.display(), "jwt token file is empty");
+                    Ok(None)
+                } else {
+                    tracing::info!(path = %path.display(), "jwt token loaded");
+                    Ok(Some(token))
+                }
+            }
+            _ => Ok(None),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::io::Write;
+
+    fn write_token_file(contents: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    fn settings_with_auth(auth: Option<AuthSettings>) -> Settings {
+        Settings {
+            host: "localhost".into(),
+            port: 8080,
+            user: "alice".into(),
+            catalog: None,
+            schema: None,
+            secure: false,
+            insecure_skip_tls_verify: false,
+            auth,
+        }
+    }
 
     #[test]
     fn deserializes_minimal_settings() {
@@ -111,6 +173,47 @@ mod tests {
     }
 
     #[test]
+    fn deserializes_jwt_file_auth_default_interval() {
+        let s: Settings = serde_json::from_value(json!({
+            "host": "trino.example.com",
+            "port": 443,
+            "user": "alice",
+            "secure": true,
+            "auth": { "type": "jwt_file", "path": "/var/run/trino.jwt" },
+        }))
+        .unwrap();
+        match s.auth.unwrap() {
+            AuthSettings::JwtFile { path, refresh_interval } => {
+                assert_eq!(path, PathBuf::from("/var/run/trino.jwt"));
+                assert_eq!(refresh_interval, Duration::from_secs(60));
+            }
+            _ => panic!("expected jwt_file auth"),
+        }
+    }
+
+    #[test]
+    fn deserializes_jwt_file_auth_custom_interval() {
+        let s: Settings = serde_json::from_value(json!({
+            "host": "trino.example.com",
+            "port": 443,
+            "user": "alice",
+            "secure": true,
+            "auth": {
+                "type": "jwt_file",
+                "path": "/var/run/trino.jwt",
+                "refresh_interval": "30s",
+            },
+        }))
+        .unwrap();
+        match s.auth.unwrap() {
+            AuthSettings::JwtFile { refresh_interval, .. } => {
+                assert_eq!(refresh_interval, Duration::from_secs(30));
+            }
+            _ => panic!("expected jwt_file auth"),
+        }
+    }
+
+    #[test]
     fn deserializes_tls_options() {
         let s: Settings = serde_json::from_value(json!({
             "host": "trino.example.com",
@@ -122,5 +225,77 @@ mod tests {
         .unwrap();
         assert!(s.secure);
         assert!(!s.insecure_skip_tls_verify);
+    }
+
+    #[test]
+    fn resolve_jwt_no_auth_returns_none() {
+        let s = settings_with_auth(None);
+        assert_eq!(s.resolve_jwt_token().unwrap(), None);
+    }
+
+    #[test]
+    fn resolve_jwt_basic_returns_none() {
+        let s = settings_with_auth(Some(AuthSettings::Basic {
+            username: "alice".into(),
+            password: Some("hunter2".into()),
+        }));
+        assert_eq!(s.resolve_jwt_token().unwrap(), None);
+    }
+
+    #[test]
+    fn resolve_jwt_static_returns_token() {
+        let s = settings_with_auth(Some(AuthSettings::Jwt {
+            token: "ey.static".into(),
+        }));
+        assert_eq!(s.resolve_jwt_token().unwrap(), Some("ey.static".into()));
+    }
+
+    #[test]
+    fn resolve_jwt_file_returns_token() {
+        let f = write_token_file("my-secret-token");
+        let s = settings_with_auth(Some(AuthSettings::JwtFile {
+            path: f.path().to_path_buf(),
+            refresh_interval: Duration::from_secs(60),
+        }));
+        assert_eq!(s.resolve_jwt_token().unwrap(), Some("my-secret-token".into()));
+    }
+
+    #[test]
+    fn resolve_jwt_file_trims_whitespace() {
+        let f = write_token_file("  my-secret-token\n");
+        let s = settings_with_auth(Some(AuthSettings::JwtFile {
+            path: f.path().to_path_buf(),
+            refresh_interval: Duration::from_secs(60),
+        }));
+        assert_eq!(s.resolve_jwt_token().unwrap(), Some("my-secret-token".into()));
+    }
+
+    #[test]
+    fn resolve_jwt_file_empty_returns_none() {
+        let f = write_token_file("");
+        let s = settings_with_auth(Some(AuthSettings::JwtFile {
+            path: f.path().to_path_buf(),
+            refresh_interval: Duration::from_secs(60),
+        }));
+        assert_eq!(s.resolve_jwt_token().unwrap(), None);
+    }
+
+    #[test]
+    fn resolve_jwt_file_whitespace_only_returns_none() {
+        let f = write_token_file("   \n\t  ");
+        let s = settings_with_auth(Some(AuthSettings::JwtFile {
+            path: f.path().to_path_buf(),
+            refresh_interval: Duration::from_secs(60),
+        }));
+        assert_eq!(s.resolve_jwt_token().unwrap(), None);
+    }
+
+    #[test]
+    fn resolve_jwt_file_missing_returns_err() {
+        let s = settings_with_auth(Some(AuthSettings::JwtFile {
+            path: PathBuf::from("/nonexistent/path/to/token.jwt"),
+            refresh_interval: Duration::from_secs(60),
+        }));
+        assert!(s.resolve_jwt_token().is_err());
     }
 }

--- a/trino_client/src/settings.rs
+++ b/trino_client/src/settings.rs
@@ -37,10 +37,7 @@ pub enum AuthSettings {
     },
     JwtFile {
         path: PathBuf,
-        #[serde(
-            with = "humantime_serde",
-            default = "default_jwt_refresh_interval"
-        )]
+        #[serde(with = "humantime_serde", default = "default_jwt_refresh_interval")]
         refresh_interval: Duration,
     },
 }
@@ -183,7 +180,10 @@ mod tests {
         }))
         .unwrap();
         match s.auth.unwrap() {
-            AuthSettings::JwtFile { path, refresh_interval } => {
+            AuthSettings::JwtFile {
+                path,
+                refresh_interval,
+            } => {
                 assert_eq!(path, PathBuf::from("/var/run/trino.jwt"));
                 assert_eq!(refresh_interval, Duration::from_secs(60));
             }
@@ -206,7 +206,9 @@ mod tests {
         }))
         .unwrap();
         match s.auth.unwrap() {
-            AuthSettings::JwtFile { refresh_interval, .. } => {
+            AuthSettings::JwtFile {
+                refresh_interval, ..
+            } => {
                 assert_eq!(refresh_interval, Duration::from_secs(30));
             }
             _ => panic!("expected jwt_file auth"),
@@ -257,7 +259,10 @@ mod tests {
             path: f.path().to_path_buf(),
             refresh_interval: Duration::from_secs(60),
         }));
-        assert_eq!(s.resolve_jwt_token().unwrap(), Some("my-secret-token".into()));
+        assert_eq!(
+            s.resolve_jwt_token().unwrap(),
+            Some("my-secret-token".into())
+        );
     }
 
     #[test]
@@ -267,7 +272,10 @@ mod tests {
             path: f.path().to_path_buf(),
             refresh_interval: Duration::from_secs(60),
         }));
-        assert_eq!(s.resolve_jwt_token().unwrap(), Some("my-secret-token".into()));
+        assert_eq!(
+            s.resolve_jwt_token().unwrap(),
+            Some("my-secret-token".into())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

JWTs rotate in production; without a refresh mechanism, the inner Trino client (and its containing service) would need to restart on each rotation. This ports the `JwtWatcher` pattern from glacon-rs into the `trino_client` crate.

- New `AuthSettings::JwtFile { path, refresh_interval }` variant — polls the token file via `notify::PollWatcher` and rebuilds the inner client on change.
- `Client` now holds a `watch::Receiver<Arc<...>>`, so token refreshes swap the inner client behind a single `Client` handle used by all callers.
- `Client::watch_jwt(shutdown)` exposes the watcher future. Static `Jwt`/`Basic`/anonymous auth keep working unchanged.
- Opt-in `task-manager` cargo feature provides a `ManagedTask` impl for `Client`, mirroring glacon-rs's `add_task(client.clone())` pattern.

