### PR TITLE
Iceberg write Invalid POC

### DIFF
--- a/helium_iceberg/src/table_creator.rs
+++ b/helium_iceberg/src/table_creator.rs
@@ -526,6 +526,23 @@ impl TableDefinition {
         &self.namespace
     }
 
+    /// Return this definition with a different table name, leaving the
+    /// namespace, schema, partitioning, and sort order unchanged. Useful for
+    /// deriving a sibling table (e.g. an `invalid_` variant) from an existing
+    /// definition without redeclaring its schema.
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Append a field to this definition's schema. Fields are added after the
+    /// existing ones; partition and sort sources are resolved by name, so the
+    /// position of the appended field does not affect them.
+    pub fn with_field(mut self, field: FieldDefinition) -> Self {
+        self.fields.push(field);
+        self
+    }
+
     /// Build the Iceberg schema from field definitions.
     fn build_schema(&self) -> Result<Schema> {
         let mut next_id: i32 = 1;

--- a/mobile_packet_verifier/src/accumulate.rs
+++ b/mobile_packet_verifier/src/accumulate.rs
@@ -14,7 +14,9 @@ use sqlx::{Postgres, Transaction};
 use crate::{
     banning::BannedRadios,
     bytes_to_dc, event_ids,
-    iceberg::session::IcebergDataTransferSession,
+    iceberg::{
+        invalid_session::IcebergInvalidDataTransferSession, session::IcebergDataTransferSession,
+    },
     pending_burns::{self, DataTransferSession},
     MobileConfigResolverExt,
 };
@@ -22,6 +24,7 @@ use crate::{
 #[derive(Default)]
 pub struct AccumulatedSessions {
     pub iceberg_sessions: Vec<IcebergDataTransferSession>,
+    pub invalid_iceberg_sessions: Vec<IcebergInvalidDataTransferSession>,
     pub proto_sessions: Vec<VerifiedDataTransferIngestReportV1>,
     pub db_sessions: Vec<DataTransferSession>,
 }
@@ -51,9 +54,14 @@ pub async fn accumulate_sessions(
             .proto_sessions
             .push(report.to_verified_proto(report_validity));
 
-        // go to iceberg only if it's valid, even if it's zero rewardable bytes
+        // go to iceberg only if it's valid, even if it's zero rewardable bytes;
+        // rejected reports go to the sibling invalid table tagged with the status
         if report_validity == ReportStatus::Valid {
             result.iceberg_sessions.push(report.to_iceberg_session());
+        } else {
+            result
+                .invalid_iceberg_sessions
+                .push(report.to_invalid_iceberg_session(report_validity));
         }
 
         if report_validity != ReportStatus::Valid {
@@ -81,6 +89,9 @@ trait DataTransferIngestReportExt {
     fn to_data_transfer_session(&self, file_ts: DateTime<Utc>) -> DataTransferSession;
 
     fn to_iceberg_session(&self) -> IcebergDataTransferSession;
+
+    fn to_invalid_iceberg_session(&self, status: ReportStatus)
+        -> IcebergInvalidDataTransferSession;
 
     fn no_rewardable_bytes(&self) -> bool;
 
@@ -112,6 +123,16 @@ impl DataTransferIngestReportExt for DataTransferSessionIngestReport {
 
     fn to_iceberg_session(&self) -> IcebergDataTransferSession {
         IcebergDataTransferSession::from(self.clone())
+    }
+
+    fn to_invalid_iceberg_session(
+        &self,
+        status: ReportStatus,
+    ) -> IcebergInvalidDataTransferSession {
+        IcebergInvalidDataTransferSession::new(
+            IcebergDataTransferSession::from(self.clone()),
+            status,
+        )
     }
 
     fn no_rewardable_bytes(&self) -> bool {

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -3,7 +3,7 @@ use crate::{
     banning::{self, BannedRadios},
     burner::Burner,
     event_ids::EventIdPurger,
-    iceberg::{self, DataTransferWriter},
+    iceberg::{self, DataTransferWriter, InvalidDataTransferWriter},
     pending_burns,
     settings::Settings,
     MobileConfigClients, MobileConfigResolverExt,
@@ -132,6 +132,7 @@ where
 pub async fn handle_data_transfer_session_file(
     txn: &mut Transaction<'_, Postgres>,
     iceberg_writer: Option<&iceberg::DataTransferWriter>,
+    invalid_iceberg_writer: Option<&iceberg::InvalidDataTransferWriter>,
     write_id: &str,
     banned_radios: BannedRadios,
     mobile_config: &impl MobileConfigResolverExt,
@@ -145,6 +146,7 @@ pub async fn handle_data_transfer_session_file(
 
     let AccumulatedSessions {
         iceberg_sessions,
+        invalid_iceberg_sessions,
         proto_sessions,
         db_sessions,
     } = sessions;
@@ -162,6 +164,8 @@ pub async fn handle_data_transfer_session_file(
     }
 
     iceberg::maybe_write_idempotent(iceberg_writer, write_id, iceberg_sessions).await?;
+    iceberg::maybe_write_idempotent(invalid_iceberg_writer, write_id, invalid_iceberg_sessions)
+        .await?;
 
     Ok(())
 }
@@ -179,6 +183,7 @@ pub struct IngestReports {
     reports: Receiver<FileInfoStream<DataTransferSessionIngestReport>>,
     verified_sink: FileSinkClient<VerifiedDataTransferIngestReportV1>,
     iceberg_writer: Option<DataTransferWriter>,
+    invalid_iceberg_writer: Option<InvalidDataTransferWriter>,
 }
 
 impl IngestReports {
@@ -187,12 +192,14 @@ impl IngestReports {
         reports: Receiver<FileInfoStream<DataTransferSessionIngestReport>>,
         verified_sink: FileSinkClient<VerifiedDataTransferIngestReportV1>,
         iceberg_writer: Option<DataTransferWriter>,
+        invalid_iceberg_writer: Option<InvalidDataTransferWriter>,
     ) -> Self {
         Self {
             pool,
             reports,
             verified_sink,
             iceberg_writer,
+            invalid_iceberg_writer,
         }
     }
 
@@ -226,11 +233,13 @@ impl IngestReports {
         let mut transaction = self.pool.begin().await?;
 
         let banned_radios = banning::get_banned_radios(&mut transaction, ts).await?;
+        println!("banned: {banned_radios:?}");
         let reports = file.into_stream(&mut transaction).await?;
 
         handle_data_transfer_session_file(
             &mut transaction,
             self.iceberg_writer.as_ref(),
+            self.invalid_iceberg_writer.as_ref(),
             &write_id,
             banned_radios,
             mobile_config,
@@ -294,14 +303,15 @@ impl Cmd {
             )
             .await?;
 
-        let (session_writer, burned_session_writer) =
+        let (session_writer, invalid_session_writer, burned_session_writer) =
             if let Some(ref iceberg_settings) = settings.iceberg_settings {
                 tracing::info!("iceberg settings provided, connecting...");
-                let (session, burned) = iceberg::get_writers(iceberg_settings).await?;
-                (Some(session), Some(burned))
+                let (session, invalid_session, burned) =
+                    iceberg::get_writers(iceberg_settings).await?;
+                (Some(session), Some(invalid_session), Some(burned))
             } else {
                 tracing::info!("no iceberg settings provided");
-                (None, None)
+                (None, None, None)
             };
 
         let burner = Burner::new(
@@ -309,7 +319,7 @@ impl Cmd {
             solana,
             settings.txn_confirmation_retry_attempts,
             settings.txn_confirmation_check_interval,
-            burned_session_writer.clone(),
+            burned_session_writer,
         );
 
         let (reports, reports_server) = file_source::continuous_source()
@@ -326,7 +336,8 @@ impl Cmd {
             pool.clone(),
             reports,
             verified_sessions,
-            session_writer.clone(),
+            session_writer,
+            invalid_session_writer,
         );
 
         let daemon = Daemon::new(

--- a/mobile_packet_verifier/src/iceberg/invalid_session.rs
+++ b/mobile_packet_verifier/src/iceberg/invalid_session.rs
@@ -1,0 +1,77 @@
+//! `data_transfer.invalid_sessions` — rejected data transfer sessions.
+//!
+//! Same schema as [`super::session`] (`data_transfer.sessions`) plus a `reason`
+//! column recording the `ReportStatus` that rejected the session. The table
+//! definition is derived from the valid one so the two never drift, and rows
+//! are built from an already-converted [`IcebergDataTransferSession`] so the
+//! field mapping is shared, not duplicated.
+
+use chrono::{DateTime, FixedOffset};
+use helium_iceberg::{FieldDefinition, TableDefinition};
+use helium_proto::services::poc_mobile::verified_data_transfer_ingest_report_v1::ReportStatus;
+use serde::{Deserialize, Serialize};
+use trino_rust_client::Trino;
+
+use super::{session::IcebergDataTransferSession, NAMESPACE, REASON_COLUMN};
+
+pub const TABLE_NAME: &str = "invalid_sessions";
+
+#[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
+pub struct IcebergInvalidDataTransferSession {
+    pub report_received_timestamp: DateTime<FixedOffset>,
+    pub request_pub_key: String,
+    pub rewardable_bytes: u64,
+    pub carrier_id: String,
+    pub sampling: bool,
+    pub data_transfer_event_pub_key: String,
+    pub upload_bytes: u64,
+    pub download_bytes: u64,
+    pub radio_access_technology: String,
+    pub event_id: String,
+    pub payer: String,
+    pub timestamp: DateTime<FixedOffset>,
+    pub reason: String,
+}
+
+impl IcebergInvalidDataTransferSession {
+    /// Tag an already-converted session with the status that rejected it.
+    pub fn new(session: IcebergDataTransferSession, status: ReportStatus) -> Self {
+        Self {
+            report_received_timestamp: session.report_received_timestamp,
+            request_pub_key: session.request_pub_key,
+            rewardable_bytes: session.rewardable_bytes,
+            carrier_id: session.carrier_id,
+            sampling: session.sampling,
+            data_transfer_event_pub_key: session.data_transfer_event_pub_key,
+            upload_bytes: session.upload_bytes,
+            download_bytes: session.download_bytes,
+            radio_access_technology: session.radio_access_technology,
+            event_id: session.event_id,
+            payer: session.payer,
+            timestamp: session.timestamp,
+            reason: status.as_str_name().to_string(),
+        }
+    }
+}
+
+/// Reuses the `data_transfer.sessions` definition, renamed and with a `reason`
+/// column.
+pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {
+    Ok(super::session::table_definition()?
+        .with_name(TABLE_NAME)
+        .with_field(FieldDefinition::required_string(REASON_COLUMN)))
+}
+
+pub async fn get_all(
+    trino: &trino_rust_client::Client,
+) -> anyhow::Result<Vec<IcebergInvalidDataTransferSession>> {
+    let all = match trino
+        .get_all(format!("SELECT * from {NAMESPACE}.{TABLE_NAME}"))
+        .await
+    {
+        Ok(all) => all.into_vec(),
+        Err(trino_rust_client::error::Error::EmptyData) => vec![],
+        Err(err) => return Err(err.into()),
+    };
+    Ok(all)
+}

--- a/mobile_packet_verifier/src/iceberg/mod.rs
+++ b/mobile_packet_verifier/src/iceberg/mod.rs
@@ -3,19 +3,33 @@ use helium_iceberg::{BoxedDataWriter, IntoBoxedDataWriter};
 use serde::Serialize;
 
 pub mod burned_session;
+pub mod invalid_session;
 pub mod session;
 
 pub use burned_session::IcebergBurnedDataTransferSession;
+pub use invalid_session::IcebergInvalidDataTransferSession;
 pub use session::IcebergDataTransferSession;
 
 pub const NAMESPACE: &str = "data_transfer";
 
+/// Column appended to the `invalid_sessions` table, recording why a session was
+/// rejected (a `ReportStatus` string name).
+pub const REASON_COLUMN: &str = "reason";
+
+// Valid sessions go to `data_transfer.sessions`; rejected sessions go to the
+// sibling `data_transfer.invalid_sessions` (same schema plus a `reason` column).
+// Burned sessions have no invalid counterpart.
 pub type DataTransferWriter = BoxedDataWriter<IcebergDataTransferSession>;
+pub type InvalidDataTransferWriter = BoxedDataWriter<IcebergInvalidDataTransferSession>;
 pub type BurnedDataTransferWriter = BoxedDataWriter<IcebergBurnedDataTransferSession>;
 
 pub async fn get_writers(
     settings: &helium_iceberg::Settings,
-) -> anyhow::Result<(DataTransferWriter, BurnedDataTransferWriter)> {
+) -> anyhow::Result<(
+    DataTransferWriter,
+    InvalidDataTransferWriter,
+    BurnedDataTransferWriter,
+)> {
     let catalog = settings.connect().await.context("connecting to catalog")?;
 
     catalog.create_namespace_if_not_exists(NAMESPACE).await?;
@@ -23,11 +37,18 @@ pub async fn get_writers(
     let session_writer = catalog
         .create_table_if_not_exists(session::table_definition()?)
         .await?;
+    let invalid_session_writer = catalog
+        .create_table_if_not_exists(invalid_session::table_definition()?)
+        .await?;
     let burned_session_writer = catalog
         .create_table_if_not_exists(burned_session::table_definition()?)
         .await?;
 
-    Ok((session_writer.boxed(), burned_session_writer.boxed()))
+    Ok((
+        session_writer.boxed(),
+        invalid_session_writer.boxed(),
+        burned_session_writer.boxed(),
+    ))
 }
 
 /// Optional idempotent append — no-op when `writer` is `None` (iceberg

--- a/mobile_packet_verifier/src/iceberg/session.rs
+++ b/mobile_packet_verifier/src/iceberg/session.rs
@@ -10,20 +10,20 @@ pub const TABLE_NAME: &str = "sessions";
 
 #[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
 pub struct IcebergDataTransferSession {
-    report_received_timestamp: DateTime<FixedOffset>,
+    pub report_received_timestamp: DateTime<FixedOffset>,
     // -- request
-    request_pub_key: String,
-    rewardable_bytes: u64,
-    carrier_id: String,
-    sampling: bool,
+    pub request_pub_key: String,
+    pub rewardable_bytes: u64,
+    pub carrier_id: String,
+    pub sampling: bool,
     // -- request -- data transfer usage
-    data_transfer_event_pub_key: String,
-    upload_bytes: u64,
-    download_bytes: u64,
-    radio_access_technology: String,
-    event_id: String,
-    payer: String,
-    timestamp: DateTime<FixedOffset>,
+    pub data_transfer_event_pub_key: String,
+    pub upload_bytes: u64,
+    pub download_bytes: u64,
+    pub radio_access_technology: String,
+    pub event_id: String,
+    pub payer: String,
+    pub timestamp: DateTime<FixedOffset>,
 }
 
 pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {

--- a/mobile_packet_verifier/tests/integrations/accumulate_sessions.rs
+++ b/mobile_packet_verifier/tests/integrations/accumulate_sessions.rs
@@ -522,6 +522,86 @@ async fn allows_expired_ban_type_data_transfer_keys(pool: PgPool) -> anyhow::Res
     Ok(())
 }
 
+#[sqlx::test]
+async fn rejected_sessions_go_to_the_invalid_table_with_a_reason(
+    pool: PgPool,
+) -> anyhow::Result<()> {
+    let harness = common::setup_iceberg().await?;
+    let session_writer = harness
+        .get_table_writer::<iceberg::IcebergDataTransferSession>(iceberg::session::TABLE_NAME)
+        .await?;
+    let invalid_session_writer = harness
+        .get_table_writer::<iceberg::IcebergInvalidDataTransferSession>(
+            iceberg::invalid_session::TABLE_NAME,
+        )
+        .await?;
+
+    let valid_gateway = PublicKeyBinary::from(vec![1]);
+    let invalid_gateway = PublicKeyBinary::from(vec![2]);
+
+    let reports = vec![make_report(&valid_gateway), make_report(&invalid_gateway)];
+
+    let mut txn = pool.begin().await?;
+    let (verified_tx, _verified_rx) = tokio::sync::mpsc::channel(10);
+    let verified_sink = FileSinkClient::new(verified_tx, "test");
+    let banned_radios = banning::get_banned_radios(&mut txn, Utc::now()).await?;
+
+    handle_data_transfer_session_file(
+        &mut txn,
+        Some(&session_writer),
+        Some(&invalid_session_writer),
+        "test_write_id",
+        banned_radios,
+        // Only `valid_gateway` is a known gateway; the other is rejected.
+        &TestMobileConfig::valid_gateways(vec![valid_gateway.clone()]),
+        &verified_sink,
+        Utc::now(),
+        futures::stream::iter(reports),
+    )
+    .await?;
+    txn.commit().await?;
+
+    let trino = harness.trino();
+
+    // The valid session went to the sessions table only.
+    let valids = iceberg::session::get_all(trino).await?;
+    assert_eq!(valids.len(), 1);
+
+    // The rejected session went to invalid_sessions, tagged with its status.
+    let invalids = iceberg::invalid_session::get_all(trino).await?;
+    assert_eq!(invalids.len(), 1);
+    assert_eq!(invalids[0].reason, "invalid_gateway_key");
+    assert_eq!(
+        invalids[0].data_transfer_event_pub_key,
+        invalid_gateway.to_string()
+    );
+
+    Ok(())
+}
+
+fn make_report(gateway: &PublicKeyBinary) -> DataTransferSessionIngestReport {
+    DataTransferSessionIngestReport {
+        received_timestamp: Utc::now(),
+        report: DataTransferSessionReq {
+            rewardable_bytes: 1_000,
+            pub_key: gateway.clone(),
+            signature: vec![],
+            carrier_id: CarrierIdV2::Carrier9,
+            sampling: false,
+            data_transfer_usage: DataTransferEvent {
+                pub_key: gateway.clone(),
+                upload_bytes: 1_000,
+                download_bytes: 1_000,
+                radio_access_technology: DataTransferRadioAccessTechnology::Wlan,
+                event_id: format!("event-{gateway}"),
+                payer: PublicKeyBinary::from(vec![0]),
+                timestamp: Utc::now(),
+                signature: vec![],
+            },
+        },
+    }
+}
+
 async fn run_accumulate_sessions(
     pool: &PgPool,
     reports: Vec<DataTransferSessionIngestReport>,
@@ -540,6 +620,7 @@ async fn run_accumulate_sessions(
     handle_data_transfer_session_file(
         &mut txn,
         iceberg_writer.as_ref(),
+        None,
         "test_write_id",
         banned_radios,
         &mobile_config,

--- a/mobile_packet_verifier/tests/integrations/burn_metric.rs
+++ b/mobile_packet_verifier/tests/integrations/burn_metric.rs
@@ -100,6 +100,7 @@ async fn run_accumulate_sessions(
     handle_data_transfer_session_file(
         &mut txn,
         iceberg_writer.as_ref(),
+        None,
         "test_write_id",
         banned_radios,
         &mobile_config,

--- a/mobile_packet_verifier/tests/integrations/common/mod.rs
+++ b/mobile_packet_verifier/tests/integrations/common/mod.rs
@@ -6,6 +6,7 @@ use mobile_packet_verifier::{iceberg, MobileConfigResolverExt};
 pub async fn setup_iceberg() -> anyhow::Result<IcebergTestHarness> {
     let harness = IcebergTestHarness::new_with_tables([
         iceberg::session::table_definition()?,
+        iceberg::invalid_session::table_definition()?,
         iceberg::burned_session::table_definition()?,
     ])
     .await?;
@@ -66,6 +67,13 @@ impl TestMobileConfig {
         Self {
             valid_gateways: ValidKeys::All,
             valid_routing_keys: ValidKeys::Only(valid),
+        }
+    }
+
+    pub fn valid_keys(gws: Vec<PublicKeyBinary>, routing: Vec<PublicKeyBinary>) -> Self {
+        Self {
+            valid_gateways: ValidKeys::Only(gws),
+            valid_routing_keys: ValidKeys::Only(routing),
         }
     }
 }

--- a/mobile_packet_verifier/tests/integrations/daemon.rs
+++ b/mobile_packet_verifier/tests/integrations/daemon.rs
@@ -1,9 +1,13 @@
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use file_store::{
     aws_local::AwsLocal, file_sink::FileSinkClient, file_source, file_upload, BucketClient,
     FileInfo,
 };
 use file_store_oracles::{
+    mobile_ban::{
+        BanAction, BanDetails, BanReason, BanReport, BanRequest, BanType,
+        VerifiedBanIngestReportStatus, VerifiedBanReport,
+    },
     mobile_session::{DataTransferEvent, DataTransferSessionIngestReport, DataTransferSessionReq},
     traits::{FileSinkCommitStrategy, FileSinkRollTime, FileSinkWriteExt},
     FileType,
@@ -17,6 +21,7 @@ use helium_proto::services::{
     },
 };
 use mobile_packet_verifier::{
+    banning::handle_verified_ban_report,
     burner::Burner,
     daemon::{Daemon, IngestReports},
     iceberg,
@@ -37,16 +42,25 @@ fn make_ingest_report(
     event_id: &str,
 ) -> DataTransferSessionIngestReportV1 {
     let key = PublicKeyBinary::from(vec![1]);
+    make_ingest_report_with_keys(timestamp, event_id, key.clone(), key).into()
+}
+
+fn make_ingest_report_with_keys(
+    timestamp: chrono::DateTime<Utc>,
+    event_id: &str,
+    gw_pubkey: PublicKeyBinary,
+    routing_pubkey: PublicKeyBinary,
+) -> DataTransferSessionIngestReportV1 {
     DataTransferSessionIngestReport {
         received_timestamp: timestamp,
         report: DataTransferSessionReq {
             rewardable_bytes: 1_000,
-            pub_key: key.clone(),
+            pub_key: routing_pubkey,
             signature: vec![],
             carrier_id: CarrierIdV2::Carrier9,
             sampling: false,
             data_transfer_usage: DataTransferEvent {
-                pub_key: key,
+                pub_key: gw_pubkey,
                 upload_bytes: 500,
                 download_bytes: 500,
                 radio_access_technology: DataTransferRadioAccessTechnology::Wlan,
@@ -58,6 +72,33 @@ fn make_ingest_report(
         },
     }
     .into()
+}
+
+fn make_ban_report(
+    received_timestamp: DateTime<Utc>,
+    hotspot_pubkey: &PublicKeyBinary,
+    expiration: Option<DateTime<Utc>>,
+) -> VerifiedBanReport {
+    VerifiedBanReport {
+        verified_timestamp: received_timestamp,
+        status: VerifiedBanIngestReportStatus::Valid,
+        report: BanReport {
+            received_timestamp,
+            report: BanRequest {
+                hotspot_pubkey: hotspot_pubkey.clone(),
+                timestamp: received_timestamp,
+                ban_pubkey: PublicKeyBinary::from(vec![0]),
+                signature: vec![],
+                ban_action: BanAction::Ban(BanDetails {
+                    hotspot_serial: "test-serial".to_string(),
+                    message: "test-ban".to_string(),
+                    reason: BanReason::LocationGaming,
+                    ban_type: BanType::All,
+                    expiration_timestamp: expiration,
+                }),
+            },
+        },
+    }
 }
 
 fn mk_data_transfer_session(
@@ -177,6 +218,7 @@ async fn daemon_processes_ingest_reports(pool: PgPool) -> anyhow::Result<()> {
         reports,
         verified_sessions_sink,
         Some(session_writer),
+        None,
     );
 
     let daemon = Daemon::new(
@@ -302,6 +344,7 @@ async fn daemon_burns_sessions(pool: PgPool) -> anyhow::Result<()> {
         reports_rx,
         FileSinkClient::new(verified_tx, "test"),
         None,
+        None,
     );
 
     let daemon = Daemon::new(
@@ -394,6 +437,9 @@ async fn daemon_full_flow(pool: PgPool) -> anyhow::Result<()> {
     let session_writer = harness
         .get_table_writer(iceberg::session::TABLE_NAME)
         .await?;
+    let invalid_session_writer = harness
+        .get_table_writer(iceberg::invalid_session::TABLE_NAME)
+        .await?;
     let burned_writer = harness
         .get_table_writer(iceberg::burned_session::TABLE_NAME)
         .await?;
@@ -405,12 +451,39 @@ async fn daemon_full_flow(pool: PgPool) -> anyhow::Result<()> {
     let start_time = file_time - Duration::minutes(1);
     let payer = PublicKeyBinary::from(vec![0]);
 
+    let valid_gw = PublicKeyBinary::from(vec![1]);
+    let invalid_gw = PublicKeyBinary::from(vec![2]);
+    let banned_gw = PublicKeyBinary::from(vec![3]);
+
+    let valid_routing = PublicKeyBinary::from(vec![4]);
+    let invalid_routing = PublicKeyBinary::from(vec![5]);
+
+    let mk_report = |label: &str, gw: &PublicKeyBinary, routing: &PublicKeyBinary| {
+        make_ingest_report_with_keys(file_time, label, gw.clone(), routing.clone())
+    };
+
+    let ingest_report = mk_report("full-flow-event-1", &valid_gw, &valid_routing);
+    let duplicate_report = ingest_report.clone();
+    let banned_report = mk_report("banned-event-1", &banned_gw, &valid_routing);
+    let unknown_gw_report = mk_report("unknown-gw-event-1", &invalid_gw, &valid_routing);
+    let invalid_routing_report = mk_report("invalid-routing-event-1", &valid_gw, &invalid_routing);
     awsl.put_protos_at_time(
         FileType::DataTransferSessionIngestReport.to_string(),
-        vec![make_ingest_report(file_time, "full-flow-event-1")],
+        vec![
+            ingest_report,
+            duplicate_report,
+            banned_report,
+            unknown_gw_report,
+            invalid_routing_report,
+        ],
         file_time,
     )
     .await?;
+
+    // Bans are not injected into the Daemon, so we ban through the DB.
+    let mut conn = pool.acquire().await?;
+    let ban_report = make_ban_report(Utc::now() - Duration::hours(2), &banned_gw, None);
+    handle_verified_ban_report(&mut conn, ban_report).await?;
 
     // Both file sinks share one FileUpload client / server pair.
     let cache_dir = tempfile::tempdir()?;
@@ -459,6 +532,7 @@ async fn daemon_full_flow(pool: PgPool) -> anyhow::Result<()> {
         reports,
         verified_sessions_sink,
         Some(session_writer),
+        Some(invalid_session_writer),
     );
 
     let daemon = Daemon::new(
@@ -470,7 +544,7 @@ async fn daemon_full_flow(pool: PgPool) -> anyhow::Result<()> {
         std::time::Duration::from_millis(500),
         ingest_reports,
         burner,
-        common::TestMobileConfig::all_valid(),
+        common::TestMobileConfig::valid_keys(vec![valid_gw], vec![valid_routing]),
     );
 
     // On BurnSuccess, manually commit the Automatic FileSink so the rolled file
@@ -531,6 +605,13 @@ async fn daemon_full_flow(pool: PgPool) -> anyhow::Result<()> {
         session_rows.len(),
         1,
         "expected 1 iceberg session from ingest"
+    );
+
+    let invalid_session_rows = iceberg::invalid_session::get_all(harness.trino()).await?;
+    assert_eq!(
+        invalid_session_rows.len(),
+        4,
+        "expected 4 iceberg invalid session from ingest"
     );
 
     let burned_rows = iceberg::burned_session::get_all(harness.trino()).await?;

--- a/mobile_packet_verifier/tests/integrations/daemon.rs
+++ b/mobile_packet_verifier/tests/integrations/daemon.rs
@@ -42,7 +42,7 @@ fn make_ingest_report(
     event_id: &str,
 ) -> DataTransferSessionIngestReportV1 {
     let key = PublicKeyBinary::from(vec![1]);
-    make_ingest_report_with_keys(timestamp, event_id, key.clone(), key).into()
+    make_ingest_report_with_keys(timestamp, event_id, key.clone(), key)
 }
 
 fn make_ingest_report_with_keys(

--- a/mobile_verifier/src/banning/ingestor.rs
+++ b/mobile_verifier/src/banning/ingestor.rs
@@ -122,11 +122,20 @@ impl BanIngestor {
         let mut stream = file_info_stream.into_stream(&mut txn).await?;
 
         let mut iceberg_records = vec![];
+        let mut invalid_iceberg_records = vec![];
 
         while let Some(report) = stream.next().await {
             let verified_report = process_ban_report(&mut txn, &self.auth_verifier, report).await?;
-            if verified_report.is_valid() && self.iceberg_writer.is_some() {
-                iceberg_records.push(iceberg::IcebergBan::from(&verified_report));
+            if self.iceberg_writer.is_some() {
+                let record = iceberg::IcebergBan::from(&verified_report);
+                if verified_report.is_valid() {
+                    iceberg_records.push(record);
+                } else {
+                    invalid_iceberg_records.push(iceberg::IcebergInvalidBan::new(
+                        record,
+                        verified_report.status,
+                    ));
+                }
             }
             let status = verified_report.status.as_str_name();
             self.verified_sink
@@ -134,8 +143,11 @@ impl BanIngestor {
                 .await?;
         }
 
-        iceberg::maybe_write_idempotent(self.iceberg_writer.as_ref(), &write_id, iceberg_records)
-            .await?;
+        if let Some(writer) = self.iceberg_writer.as_ref() {
+            writer
+                .write(&write_id, iceberg_records, invalid_iceberg_records)
+                .await?;
+        }
 
         self.verified_sink.commit().await?;
         txn.commit().await?;

--- a/mobile_verifier/src/heartbeats/mod.rs
+++ b/mobile_verifier/src/heartbeats/mod.rs
@@ -459,16 +459,25 @@ pub(crate) async fn process_validated_heartbeats(
     iceberg_ctx: Option<(&crate::iceberg::HeartbeatWriter, &str)>,
 ) -> anyhow::Result<()> {
     let mut iceberg_records = Vec::new();
+    let mut invalid_iceberg_records = Vec::new();
     let mut validated_heartbeats = pin!(validated_heartbeats);
     while let Some(validated_heartbeat) = validated_heartbeats.next().await.transpose()? {
         validated_heartbeat.write(heartbeat_sink).await?;
 
-        if !validated_heartbeat.is_valid() {
-            continue;
+        if iceberg_ctx.is_some() {
+            let record = crate::iceberg::IcebergHeartbeat::from(&validated_heartbeat);
+            if validated_heartbeat.is_valid() {
+                iceberg_records.push(record);
+            } else {
+                invalid_iceberg_records.push(crate::iceberg::IcebergInvalidHeartbeat::new(
+                    record,
+                    validated_heartbeat.validity,
+                ));
+            }
         }
 
-        if iceberg_ctx.is_some() {
-            iceberg_records.push(crate::iceberg::IcebergHeartbeat::from(&validated_heartbeat));
+        if !validated_heartbeat.is_valid() {
+            continue;
         }
 
         if let Some(coverage_claim_time) = coverage_claim_time_cache
@@ -502,7 +511,7 @@ pub(crate) async fn process_validated_heartbeats(
 
     if let Some((writer, id)) = iceberg_ctx {
         writer
-            .write_idempotent(id, iceberg_records)
+            .write(id, iceberg_records, invalid_iceberg_records)
             .await
             .context("writing heartbeats idempotently")?;
     }

--- a/mobile_verifier/src/iceberg/ban.rs
+++ b/mobile_verifier/src/iceberg/ban.rs
@@ -9,16 +9,16 @@ pub const TABLE_NAME: &str = "bans";
 
 #[derive(Default, Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
 pub struct IcebergBan {
-    pubkey: String,
-    ban_pubkey: String,
-    report_timestamp: DateTime<FixedOffset>,
-    received_timestamp: DateTime<FixedOffset>,
-    is_ban: bool,
-    hotspot_serial: Option<String>,
-    message: Option<String>,
-    ban_reason: Option<String>,
-    ban_type: Option<String>,
-    expiration_timestamp: Option<DateTime<FixedOffset>>,
+    pub(crate) pubkey: String,
+    pub(crate) ban_pubkey: String,
+    pub(crate) report_timestamp: DateTime<FixedOffset>,
+    pub(crate) received_timestamp: DateTime<FixedOffset>,
+    pub(crate) is_ban: bool,
+    pub(crate) hotspot_serial: Option<String>,
+    pub(crate) message: Option<String>,
+    pub(crate) ban_reason: Option<String>,
+    pub(crate) ban_type: Option<String>,
+    pub(crate) expiration_timestamp: Option<DateTime<FixedOffset>>,
 }
 
 pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {

--- a/mobile_verifier/src/iceberg/ban.rs
+++ b/mobile_verifier/src/iceberg/ban.rs
@@ -9,16 +9,16 @@ pub const TABLE_NAME: &str = "bans";
 
 #[derive(Default, Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
 pub struct IcebergBan {
-    pub(crate) pubkey: String,
-    pub(crate) ban_pubkey: String,
-    pub(crate) report_timestamp: DateTime<FixedOffset>,
-    pub(crate) received_timestamp: DateTime<FixedOffset>,
-    pub(crate) is_ban: bool,
-    pub(crate) hotspot_serial: Option<String>,
-    pub(crate) message: Option<String>,
-    pub(crate) ban_reason: Option<String>,
-    pub(crate) ban_type: Option<String>,
-    pub(crate) expiration_timestamp: Option<DateTime<FixedOffset>>,
+    pub pubkey: String,
+    pub ban_pubkey: String,
+    pub report_timestamp: DateTime<FixedOffset>,
+    pub received_timestamp: DateTime<FixedOffset>,
+    pub is_ban: bool,
+    pub hotspot_serial: Option<String>,
+    pub message: Option<String>,
+    pub ban_reason: Option<String>,
+    pub ban_type: Option<String>,
+    pub expiration_timestamp: Option<DateTime<FixedOffset>>,
 }
 
 pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {

--- a/mobile_verifier/src/iceberg/heartbeat.rs
+++ b/mobile_verifier/src/iceberg/heartbeat.rs
@@ -13,18 +13,18 @@ pub const TABLE_NAME: &str = "heartbeats";
 
 #[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
 pub struct IcebergHeartbeat {
-    pub(crate) hotspot_pubkey: String,
-    pub(crate) received_timestamp: DateTime<FixedOffset>,
-    pub(crate) heartbeat_timestamp: DateTime<FixedOffset>,
-    pub(crate) device_type: Option<String>,
-    pub(crate) lat: f64,
-    pub(crate) lon: f64,
-    pub(crate) coverage_object: String,
-    pub(crate) location_validation_timestamp: Option<DateTime<FixedOffset>>,
-    pub(crate) distance_to_asserted: Option<i64>,
-    pub(crate) asserted_location: Option<String>,
-    pub(crate) location_trust_score_multiplier: f64,
-    pub(crate) location_source: String,
+    pub hotspot_pubkey: String,
+    pub received_timestamp: DateTime<FixedOffset>,
+    pub heartbeat_timestamp: DateTime<FixedOffset>,
+    pub device_type: Option<String>,
+    pub lat: f64,
+    pub lon: f64,
+    pub coverage_object: String,
+    pub location_validation_timestamp: Option<DateTime<FixedOffset>>,
+    pub distance_to_asserted: Option<i64>,
+    pub asserted_location: Option<String>,
+    pub location_trust_score_multiplier: f64,
+    pub location_source: String,
 }
 
 pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {

--- a/mobile_verifier/src/iceberg/heartbeat.rs
+++ b/mobile_verifier/src/iceberg/heartbeat.rs
@@ -13,18 +13,18 @@ pub const TABLE_NAME: &str = "heartbeats";
 
 #[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
 pub struct IcebergHeartbeat {
-    hotspot_pubkey: String,
-    received_timestamp: DateTime<FixedOffset>,
-    heartbeat_timestamp: DateTime<FixedOffset>,
-    device_type: Option<String>,
-    lat: f64,
-    lon: f64,
-    coverage_object: String,
-    location_validation_timestamp: Option<DateTime<FixedOffset>>,
-    distance_to_asserted: Option<i64>,
-    asserted_location: Option<String>,
-    location_trust_score_multiplier: f64,
-    location_source: String,
+    pub(crate) hotspot_pubkey: String,
+    pub(crate) received_timestamp: DateTime<FixedOffset>,
+    pub(crate) heartbeat_timestamp: DateTime<FixedOffset>,
+    pub(crate) device_type: Option<String>,
+    pub(crate) lat: f64,
+    pub(crate) lon: f64,
+    pub(crate) coverage_object: String,
+    pub(crate) location_validation_timestamp: Option<DateTime<FixedOffset>>,
+    pub(crate) distance_to_asserted: Option<i64>,
+    pub(crate) asserted_location: Option<String>,
+    pub(crate) location_trust_score_multiplier: f64,
+    pub(crate) location_source: String,
 }
 
 pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {

--- a/mobile_verifier/src/iceberg/invalid_ban.rs
+++ b/mobile_verifier/src/iceberg/invalid_ban.rs
@@ -1,0 +1,70 @@
+//! `poc.invalid_bans` — rejected ban reports.
+//!
+//! Same schema as [`super::ban`] (`poc.bans`) plus a `reason` column recording
+//! the `VerifiedBanIngestReportStatus` that rejected the row.
+
+use chrono::{DateTime, FixedOffset};
+use file_store_oracles::mobile_ban::proto::VerifiedBanIngestReportStatus;
+use helium_iceberg::{FieldDefinition, TableDefinition};
+use serde::{Deserialize, Serialize};
+use trino_rust_client::Trino;
+
+use super::{ban::IcebergBan, NAMESPACE, REASON_COLUMN};
+
+pub const TABLE_NAME: &str = "invalid_bans";
+
+#[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
+pub struct IcebergInvalidBan {
+    pub pubkey: String,
+    pub ban_pubkey: String,
+    pub report_timestamp: DateTime<FixedOffset>,
+    pub received_timestamp: DateTime<FixedOffset>,
+    pub is_ban: bool,
+    pub hotspot_serial: Option<String>,
+    pub message: Option<String>,
+    pub ban_reason: Option<String>,
+    pub ban_type: Option<String>,
+    pub expiration_timestamp: Option<DateTime<FixedOffset>>,
+    pub reason: String,
+}
+
+impl IcebergInvalidBan {
+    /// Tag an already-converted ban with the status that rejected it.
+    pub fn new(ban: IcebergBan, status: VerifiedBanIngestReportStatus) -> Self {
+        Self {
+            pubkey: ban.pubkey,
+            ban_pubkey: ban.ban_pubkey,
+            report_timestamp: ban.report_timestamp,
+            received_timestamp: ban.received_timestamp,
+            is_ban: ban.is_ban,
+            hotspot_serial: ban.hotspot_serial,
+            message: ban.message,
+            ban_reason: ban.ban_reason,
+            ban_type: ban.ban_type,
+            expiration_timestamp: ban.expiration_timestamp,
+            reason: super::reason_without_prefix(
+                status.as_str_name(),
+                "verified_ban_ingest_report_status_",
+            ),
+        }
+    }
+}
+
+/// Reuses the `poc.bans` definition, renamed and with a `reason` column.
+pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {
+    Ok(super::ban::table_definition()?
+        .with_name(TABLE_NAME)
+        .with_field(FieldDefinition::required_string(REASON_COLUMN)))
+}
+
+pub async fn get_all(trino: &trino_rust_client::Client) -> anyhow::Result<Vec<IcebergInvalidBan>> {
+    let all = match trino
+        .get_all(format!("SELECT * from {NAMESPACE}.{TABLE_NAME}"))
+        .await
+    {
+        Ok(all) => all.into_vec(),
+        Err(trino_rust_client::error::Error::EmptyData) => vec![],
+        Err(err) => return Err(err.into()),
+    };
+    Ok(all)
+}

--- a/mobile_verifier/src/iceberg/invalid_heartbeat.rs
+++ b/mobile_verifier/src/iceberg/invalid_heartbeat.rs
@@ -1,0 +1,76 @@
+//! `poc.invalid_heartbeats` — rejected heartbeats.
+//!
+//! Same schema as [`super::heartbeat`] (`poc.heartbeats`) plus a `reason`
+//! column recording the `HeartbeatValidity` that rejected the row. The table
+//! definition is derived from the valid one so the two never drift, and rows
+//! are built from an already-converted [`IcebergHeartbeat`] so the field
+//! mapping is shared, not duplicated.
+
+use chrono::{DateTime, FixedOffset};
+use helium_iceberg::{FieldDefinition, TableDefinition};
+use helium_proto::services::poc_mobile::HeartbeatValidity;
+use serde::{Deserialize, Serialize};
+use trino_rust_client::Trino;
+
+use super::{heartbeat::IcebergHeartbeat, NAMESPACE, REASON_COLUMN};
+
+pub const TABLE_NAME: &str = "invalid_heartbeats";
+
+#[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
+pub struct IcebergInvalidHeartbeat {
+    pub hotspot_pubkey: String,
+    pub received_timestamp: DateTime<FixedOffset>,
+    pub heartbeat_timestamp: DateTime<FixedOffset>,
+    pub device_type: Option<String>,
+    pub lat: f64,
+    pub lon: f64,
+    pub coverage_object: String,
+    pub location_validation_timestamp: Option<DateTime<FixedOffset>>,
+    pub distance_to_asserted: Option<i64>,
+    pub asserted_location: Option<String>,
+    pub location_trust_score_multiplier: f64,
+    pub location_source: String,
+    pub reason: String,
+}
+
+impl IcebergInvalidHeartbeat {
+    /// Tag an already-converted heartbeat with the validity that rejected it.
+    pub fn new(heartbeat: IcebergHeartbeat, validity: HeartbeatValidity) -> Self {
+        Self {
+            hotspot_pubkey: heartbeat.hotspot_pubkey,
+            received_timestamp: heartbeat.received_timestamp,
+            heartbeat_timestamp: heartbeat.heartbeat_timestamp,
+            device_type: heartbeat.device_type,
+            lat: heartbeat.lat,
+            lon: heartbeat.lon,
+            coverage_object: heartbeat.coverage_object,
+            location_validation_timestamp: heartbeat.location_validation_timestamp,
+            distance_to_asserted: heartbeat.distance_to_asserted,
+            asserted_location: heartbeat.asserted_location,
+            location_trust_score_multiplier: heartbeat.location_trust_score_multiplier,
+            location_source: heartbeat.location_source,
+            reason: super::reason_without_prefix(validity.as_str_name(), "heartbeat_validity_"),
+        }
+    }
+}
+
+/// Reuses the `poc.heartbeats` definition, renamed and with a `reason` column.
+pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {
+    Ok(super::heartbeat::table_definition()?
+        .with_name(TABLE_NAME)
+        .with_field(FieldDefinition::required_string(REASON_COLUMN)))
+}
+
+pub async fn get_all(
+    trino: &trino_rust_client::Client,
+) -> anyhow::Result<Vec<IcebergInvalidHeartbeat>> {
+    let all = match trino
+        .get_all(format!("SELECT * from {NAMESPACE}.{TABLE_NAME}"))
+        .await
+    {
+        Ok(all) => all.into_vec(),
+        Err(trino_rust_client::error::Error::EmptyData) => vec![],
+        Err(err) => return Err(err.into()),
+    };
+    Ok(all)
+}

--- a/mobile_verifier/src/iceberg/invalid_speedtest.rs
+++ b/mobile_verifier/src/iceberg/invalid_speedtest.rs
@@ -1,0 +1,63 @@
+//! `poc.invalid_speedtests` — rejected speedtests.
+//!
+//! Same schema as [`super::speedtest`] (`poc.speedtests`) plus a `reason`
+//! column recording the `SpeedtestVerificationResult` that rejected the row.
+
+use chrono::{DateTime, FixedOffset};
+use helium_iceberg::{FieldDefinition, TableDefinition};
+use helium_proto::services::poc_mobile::SpeedtestVerificationResult;
+use serde::{Deserialize, Serialize};
+use trino_rust_client::Trino;
+
+use super::{speedtest::IcebergSpeedtest, NAMESPACE, REASON_COLUMN};
+
+pub const TABLE_NAME: &str = "invalid_speedtests";
+
+#[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
+pub struct IcebergInvalidSpeedtest {
+    pub hotspot_pubkey: String,
+    pub serial: String,
+    pub received_timestamp: DateTime<FixedOffset>,
+    pub timestamp: DateTime<FixedOffset>,
+    pub upload_speed: u64,
+    pub download_speed: u64,
+    pub latency: u32,
+    pub reason: String,
+}
+
+impl IcebergInvalidSpeedtest {
+    /// Tag an already-converted speedtest with the result that rejected it.
+    pub fn new(speedtest: IcebergSpeedtest, result: SpeedtestVerificationResult) -> Self {
+        Self {
+            hotspot_pubkey: speedtest.hotspot_pubkey,
+            serial: speedtest.serial,
+            received_timestamp: speedtest.received_timestamp,
+            timestamp: speedtest.timestamp,
+            upload_speed: speedtest.upload_speed,
+            download_speed: speedtest.download_speed,
+            latency: speedtest.latency,
+            reason: super::reason_without_prefix(result.as_str_name(), "speedtest_"),
+        }
+    }
+}
+
+/// Reuses the `poc.speedtests` definition, renamed and with a `reason` column.
+pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {
+    Ok(super::speedtest::table_definition()?
+        .with_name(TABLE_NAME)
+        .with_field(FieldDefinition::required_string(REASON_COLUMN)))
+}
+
+pub async fn get_all(
+    trino: &trino_rust_client::Client,
+) -> anyhow::Result<Vec<IcebergInvalidSpeedtest>> {
+    let all = match trino
+        .get_all(format!("SELECT * from {NAMESPACE}.{TABLE_NAME}"))
+        .await
+    {
+        Ok(all) => all.into_vec(),
+        Err(trino_rust_client::error::Error::EmptyData) => vec![],
+        Err(err) => return Err(err.into()),
+    };
+    Ok(all)
+}

--- a/mobile_verifier/src/iceberg/invalid_speedtest_avg.rs
+++ b/mobile_verifier/src/iceberg/invalid_speedtest_avg.rs
@@ -1,0 +1,70 @@
+//! `poc.invalid_speedtest_avgs` — rejected speedtest averages.
+//!
+//! Same schema as [`super::speedtest_avg`] (`poc.speedtest_avgs`), including the
+//! nested `speedtests` sample list, plus a `reason` column recording the
+//! `SpeedtestAvgValidity` that rejected the row.
+
+use chrono::{DateTime, FixedOffset};
+use helium_iceberg::{FieldDefinition, TableDefinition};
+use helium_proto::services::poc_mobile::SpeedtestAvgValidity;
+use serde::{Deserialize, Serialize};
+use trino_rust_client::Trino;
+
+use super::{
+    speedtest_avg::{IcebergSpeedtestAvg, IcebergSpeedtestAvgSample},
+    NAMESPACE, REASON_COLUMN,
+};
+
+pub const TABLE_NAME: &str = "invalid_speedtest_avgs";
+
+#[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
+pub struct IcebergInvalidSpeedtestAvg {
+    pub hotspot_pubkey: String,
+    pub upload_speed_avg_bps: u64,
+    pub download_speed_avg_bps: u64,
+    pub latency_avg_ms: u32,
+    pub reward_multiplier: f32,
+    pub sample_count: u32,
+    pub timestamp: DateTime<FixedOffset>,
+    pub speedtests: Vec<IcebergSpeedtestAvgSample>,
+    pub reason: String,
+}
+
+impl IcebergInvalidSpeedtestAvg {
+    /// Tag an already-converted average with the validity that rejected it.
+    pub fn new(average: IcebergSpeedtestAvg, validity: SpeedtestAvgValidity) -> Self {
+        Self {
+            hotspot_pubkey: average.hotspot_pubkey,
+            upload_speed_avg_bps: average.upload_speed_avg_bps,
+            download_speed_avg_bps: average.download_speed_avg_bps,
+            latency_avg_ms: average.latency_avg_ms,
+            reward_multiplier: average.reward_multiplier,
+            sample_count: average.sample_count,
+            timestamp: average.timestamp,
+            speedtests: average.speedtests,
+            reason: super::reason_without_prefix(validity.as_str_name(), "speedtest_avg_validity_"),
+        }
+    }
+}
+
+/// Reuses the `poc.speedtest_avgs` definition, renamed and with a `reason`
+/// column.
+pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {
+    Ok(super::speedtest_avg::table_definition()?
+        .with_name(TABLE_NAME)
+        .with_field(FieldDefinition::required_string(REASON_COLUMN)))
+}
+
+pub async fn get_all(
+    trino: &trino_rust_client::Client,
+) -> anyhow::Result<Vec<IcebergInvalidSpeedtestAvg>> {
+    let all = match trino
+        .get_all(format!("SELECT * from {NAMESPACE}.{TABLE_NAME}"))
+        .await
+    {
+        Ok(all) => all.into_vec(),
+        Err(trino_rust_client::error::Error::EmptyData) => vec![],
+        Err(err) => return Err(err.into()),
+    };
+    Ok(all)
+}

--- a/mobile_verifier/src/iceberg/mod.rs
+++ b/mobile_verifier/src/iceberg/mod.rs
@@ -5,25 +5,49 @@ use serde::Serialize;
 pub mod ban;
 pub mod gateway_reward;
 pub mod heartbeat;
+pub mod invalid_ban;
+pub mod invalid_heartbeat;
+pub mod invalid_speedtest;
+pub mod invalid_speedtest_avg;
 pub mod radio_reward;
 pub mod radio_reward_covered_hex;
 pub mod service_provider_reward;
 pub mod speedtest;
 pub mod speedtest_avg;
 pub mod unallocated_reward;
+pub mod valid_invalid;
 
 pub use ban::IcebergBan;
 pub use heartbeat::IcebergHeartbeat;
+pub use invalid_ban::IcebergInvalidBan;
+pub use invalid_heartbeat::IcebergInvalidHeartbeat;
+pub use invalid_speedtest::IcebergInvalidSpeedtest;
+pub use invalid_speedtest_avg::IcebergInvalidSpeedtestAvg;
 pub use speedtest::IcebergSpeedtest;
 pub use speedtest_avg::IcebergSpeedtestAvg;
+pub use valid_invalid::ValidInvalidWriter;
 
 pub const NAMESPACE: &str = "poc";
 pub const REWARDS_NAMESPACE: &str = "rewards";
 
-pub type BanWriter = BoxedDataWriter<IcebergBan>;
-pub type HeartbeatWriter = BoxedDataWriter<IcebergHeartbeat>;
-pub type SpeedtestWriter = BoxedDataWriter<IcebergSpeedtest>;
-pub type SpeedtestAvgWriter = BoxedDataWriter<IcebergSpeedtestAvg>;
+/// Column appended to every `invalid_*` table, recording why a record was
+/// rejected (a validity/status enum's string name).
+pub const REASON_COLUMN: &str = "reason";
+
+/// Strip a protobuf enum's `as_str_name()` prefix so a stored reason reads
+/// `gateway_not_found` rather than `heartbeat_validity_gateway_not_found`.
+/// Falls back to the full name if the prefix isn't present.
+pub(crate) fn reason_without_prefix(name: &str, prefix: &str) -> String {
+    name.strip_prefix(prefix).unwrap_or(name).to_string()
+}
+
+// POC tables write accepted records to `poc.<table>` and rejected records to a
+// sibling `poc.invalid_<table>` (same schema plus a `reason` column). See
+// `helium_iceberg::ValidInvalidWriter`.
+pub type BanWriter = ValidInvalidWriter<IcebergBan, IcebergInvalidBan>;
+pub type HeartbeatWriter = ValidInvalidWriter<IcebergHeartbeat, IcebergInvalidHeartbeat>;
+pub type SpeedtestWriter = ValidInvalidWriter<IcebergSpeedtest, IcebergInvalidSpeedtest>;
+pub type SpeedtestAvgWriter = ValidInvalidWriter<IcebergSpeedtestAvg, IcebergInvalidSpeedtestAvg>;
 
 pub struct PocWriters {
     pub ban: Option<BanWriter>,
@@ -47,22 +71,32 @@ impl PocWriters {
         let catalog = settings.connect().await.context("connecting to catalog")?;
         catalog.create_namespace_if_not_exists(NAMESPACE).await?;
 
-        let ban = catalog
-            .create_table_if_not_exists(ban::table_definition()?)
-            .await?
-            .boxed();
-        let heartbeat = catalog
-            .create_table_if_not_exists(heartbeat::table_definition()?)
-            .await?
-            .boxed();
-        let speedtest = catalog
-            .create_table_if_not_exists(speedtest::table_definition()?)
-            .await?
-            .boxed();
-        let speedtest_avg = catalog
-            .create_table_if_not_exists(speedtest_avg::table_definition()?)
-            .await?
-            .boxed();
+        // Each writer creates its valid table plus the sibling `invalid_*`
+        // table (same schema + a `reason` column; see the `invalid_*` modules).
+        let ban = ValidInvalidWriter::create(
+            &catalog,
+            ban::table_definition()?,
+            invalid_ban::table_definition()?,
+        )
+        .await?;
+        let heartbeat = ValidInvalidWriter::create(
+            &catalog,
+            heartbeat::table_definition()?,
+            invalid_heartbeat::table_definition()?,
+        )
+        .await?;
+        let speedtest = ValidInvalidWriter::create(
+            &catalog,
+            speedtest::table_definition()?,
+            invalid_speedtest::table_definition()?,
+        )
+        .await?;
+        let speedtest_avg = ValidInvalidWriter::create(
+            &catalog,
+            speedtest_avg::table_definition()?,
+            invalid_speedtest_avg::table_definition()?,
+        )
+        .await?;
 
         Ok(Self {
             ban: Some(ban),

--- a/mobile_verifier/src/iceberg/speedtest.rs
+++ b/mobile_verifier/src/iceberg/speedtest.rs
@@ -9,13 +9,13 @@ pub const TABLE_NAME: &str = "speedtests";
 
 #[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
 pub struct IcebergSpeedtest {
-    hotspot_pubkey: String,
-    serial: String,
-    received_timestamp: DateTime<FixedOffset>,
-    timestamp: DateTime<FixedOffset>,
-    upload_speed: u64,
-    download_speed: u64,
-    latency: u32,
+    pub(crate) hotspot_pubkey: String,
+    pub(crate) serial: String,
+    pub(crate) received_timestamp: DateTime<FixedOffset>,
+    pub(crate) timestamp: DateTime<FixedOffset>,
+    pub(crate) upload_speed: u64,
+    pub(crate) download_speed: u64,
+    pub(crate) latency: u32,
 }
 
 pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {

--- a/mobile_verifier/src/iceberg/speedtest.rs
+++ b/mobile_verifier/src/iceberg/speedtest.rs
@@ -9,13 +9,13 @@ pub const TABLE_NAME: &str = "speedtests";
 
 #[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
 pub struct IcebergSpeedtest {
-    pub(crate) hotspot_pubkey: String,
-    pub(crate) serial: String,
-    pub(crate) received_timestamp: DateTime<FixedOffset>,
-    pub(crate) timestamp: DateTime<FixedOffset>,
-    pub(crate) upload_speed: u64,
-    pub(crate) download_speed: u64,
-    pub(crate) latency: u32,
+    pub hotspot_pubkey: String,
+    pub serial: String,
+    pub received_timestamp: DateTime<FixedOffset>,
+    pub timestamp: DateTime<FixedOffset>,
+    pub upload_speed: u64,
+    pub download_speed: u64,
+    pub latency: u32,
 }
 
 pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {

--- a/mobile_verifier/src/iceberg/valid_invalid.rs
+++ b/mobile_verifier/src/iceberg/valid_invalid.rs
@@ -1,0 +1,70 @@
+//! Bundles a valid-table writer with its invalid-table sibling so the two
+//! travel together as one handle.
+//!
+//! The two tables are ordinary Iceberg tables — the invalid one is defined in
+//! its own `invalid_*` module, reusing the valid table's schema plus a `reason`
+//! column (see [`crate::iceberg`]). This bundle only pairs the writers; it has
+//! no special serialization, and each side writes a plain record struct.
+
+use anyhow::Context;
+use helium_iceberg::{BoxedDataWriter, Catalog, IntoBoxedDataWriter, TableDefinition};
+use serde::Serialize;
+
+/// A writer pair: accepted records go to the valid table, rejected records to
+/// the invalid sibling. Construct with [`ValidInvalidWriter::create`].
+pub struct ValidInvalidWriter<V, I> {
+    valid: BoxedDataWriter<V>,
+    invalid: BoxedDataWriter<I>,
+}
+
+impl<V, I> ValidInvalidWriter<V, I>
+where
+    V: Serialize + Send + Sync + 'static,
+    I: Serialize + Send + Sync + 'static,
+{
+    /// Create both tables (each only if it does not already exist) from their
+    /// definitions and bundle their writers. The namespace must already exist.
+    pub async fn create(
+        catalog: &Catalog,
+        valid_definition: TableDefinition,
+        invalid_definition: TableDefinition,
+    ) -> anyhow::Result<Self> {
+        let valid = catalog
+            .create_table_if_not_exists::<V>(valid_definition)
+            .await
+            .context("creating valid table")?
+            .boxed();
+        let invalid = catalog
+            .create_table_if_not_exists::<I>(invalid_definition)
+            .await
+            .context("creating invalid table")?
+            .boxed();
+
+        Ok(Self { valid, invalid })
+    }
+
+    /// Idempotently append accepted records to the valid table.
+    pub async fn write_valid(&self, id: &str, records: Vec<V>) -> anyhow::Result<()> {
+        self.valid
+            .write_idempotent(id, records)
+            .await
+            .context("writing valid records")
+    }
+
+    /// Idempotently append rejected records to the invalid table.
+    pub async fn write_invalid(&self, id: &str, records: Vec<I>) -> anyhow::Result<()> {
+        self.invalid
+            .write_idempotent(id, records)
+            .await
+            .context("writing invalid records")
+    }
+
+    /// Idempotently append both sides, keyed by the same `id`. The two tables
+    /// are independent, so the shared `id` is safe — each tracks its own
+    /// idempotency. On partial failure a retry completes whichever write did
+    /// not commit.
+    pub async fn write(&self, id: &str, valid: Vec<V>, invalid: Vec<I>) -> anyhow::Result<()> {
+        self.write_valid(id, valid).await?;
+        self.write_invalid(id, invalid).await
+    }
+}

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -176,7 +176,9 @@ where
         let mut speedtests = file.into_stream(&mut transaction).await?;
 
         let mut iceberg_records = Vec::new();
+        let mut invalid_iceberg_records = Vec::new();
         let mut iceberg_avg_records = Vec::new();
+        let mut invalid_iceberg_avg_records = Vec::new();
 
         while let Some(speedtest_report) = speedtests.next().await {
             let result = self.validate_speedtest(&speedtest_report).await?;
@@ -194,25 +196,38 @@ where
                 if self.iceberg_writer.is_some() {
                     iceberg_records.push(iceberg::IcebergSpeedtest::from(&speedtest_report));
                 }
-                if self.speedtest_avg_iceberg_writer.is_some()
-                    && average.validity == SpeedtestAvgValidity::Valid
-                {
-                    iceberg_avg_records.push(iceberg::IcebergSpeedtestAvg::from(&average));
+                if self.speedtest_avg_iceberg_writer.is_some() {
+                    let avg_record = iceberg::IcebergSpeedtestAvg::from(&average);
+                    if average.validity == SpeedtestAvgValidity::Valid {
+                        iceberg_avg_records.push(avg_record);
+                    } else {
+                        invalid_iceberg_avg_records.push(iceberg::IcebergInvalidSpeedtestAvg::new(
+                            avg_record,
+                            average.validity,
+                        ));
+                    }
                 }
+            } else if self.iceberg_writer.is_some() {
+                invalid_iceberg_records.push(iceberg::IcebergInvalidSpeedtest::new(
+                    iceberg::IcebergSpeedtest::from(&speedtest_report),
+                    result,
+                ));
             }
             // write out paper trail of speedtest validity
             self.write_verified_speedtest(speedtest_report, result)
                 .await?;
         }
 
-        iceberg::maybe_write_idempotent(self.iceberg_writer.as_ref(), &write_id, iceberg_records)
-            .await?;
-        iceberg::maybe_write_idempotent(
-            self.speedtest_avg_iceberg_writer.as_ref(),
-            &write_id,
-            iceberg_avg_records,
-        )
-        .await?;
+        if let Some(writer) = self.iceberg_writer.as_ref() {
+            writer
+                .write(&write_id, iceberg_records, invalid_iceberg_records)
+                .await?;
+        }
+        if let Some(writer) = self.speedtest_avg_iceberg_writer.as_ref() {
+            writer
+                .write(&write_id, iceberg_avg_records, invalid_iceberg_avg_records)
+                .await?;
+        }
 
         self.speedtest_avg_file_sink.commit().await?;
         self.verified_speedtest_file_sink.commit().await?;


### PR DESCRIPTION
This pull request introduces a new pattern for handling and storing invalid (rejected) records for bans, heartbeats, speedtests, and speedtest averages in the `mobile_verifier` service. Now, for each type of record, invalid entries are written to sibling `invalid_*` tables with an added `reason` column explaining why the record was rejected. This is achieved through a new `ValidInvalidWriter` abstraction and supporting data structures. The changes also make the schema for valid and invalid tables consistent and easier to maintain.

The most important changes are:

**1. Introduction of Invalid Record Tables and Writers**
- Added new modules and data structures for `invalid_ban`, `invalid_heartbeat`, `invalid_speedtest`, and `invalid_speedtest_avg`, each mirroring the schema of their valid counterpart and adding a `reason` column for the rejection cause. These modules include constructors for easy conversion from valid to invalid records. [[1]](diffhunk://#diff-83332e43af5bb186f3afad67b22ca1c8135bba200b679a82dd480d51d9178e7bR1-R70) [[2]](diffhunk://#diff-b45912c70016cbf8360026293c1a70c42d6e83e2507496dc8a94020f2339722fR1-R76) [[3]](diffhunk://#diff-9c771514f7231253903ce5c078585d278837f2ba03c2c1c208cf36e4dec8c5cfR1-R63) [[4]](diffhunk://#diff-72c9d481a1b510f911caa99bf54f78f089974bf02d2992a2a18f9620aaba63bbR1-R70)
- Introduced the `ValidInvalidWriter` abstraction, which writes valid records to the main table and invalid records to the corresponding `invalid_*` table, and updated all writer types to use this pattern. [[1]](diffhunk://#diff-83343c7356b65d845d1945c27ccbeab3b943aa6eac710a4121e45843e891ebf6R8-R50) [[2]](diffhunk://#diff-83343c7356b65d845d1945c27ccbeab3b943aa6eac710a4121e45843e891ebf6L50-R99)

**2. Schema and API Improvements**
- Added helper methods to `TableDefinition` (`with_name`, `with_field`) to simplify deriving sibling table definitions for invalid records, ensuring schemas stay in sync.
- Updated the field visibility of record structs (e.g., `IcebergBan`, `IcebergHeartbeat`, `IcebergSpeedtest`) to allow construction of invalid record variants. [[1]](diffhunk://#diff-753d55e763f57fb504307620a28cfa50c3cefb4f27aee5fdf5e836541cf44eb1L12-R21) [[2]](diffhunk://#diff-79f2292520839b79cd74005a97c5106546acca0661df9ec293f8892e59d69731L17-R28) [[3]](diffhunk://#diff-a39d16cde72dbd7540f2e86ffa6e0aabe3be06ba9118dbd32dd8b035482fc267L12-R18)

**3. Ingestion Pipeline Updates**
- Modified the ban and heartbeat ingestion logic to collect both valid and invalid records, writing each to their appropriate tables using the new writer abstraction. [[1]](diffhunk://#diff-5fab30f95d86e5f7d43b4580023aead4d4690bde5fb7fdebea12102ead37cc52R145-R170) [[2]](diffhunk://#diff-5ded0a45305c5fbd258aba4c38fcbc14b69f0ead2ff5ecebd3c71dd3693fc1deR463-R481) [[3]](diffhunk://#diff-5ded0a45305c5fbd258aba4c38fcbc14b69f0ead2ff5ecebd3c71dd3693fc1deL506-R515)

**4. Utility Improvements**
- Added a utility function to strip enum prefixes from rejection reasons for cleaner storage in the `reason` column.

These changes make the handling of invalid data explicit, auditable, and easier to maintain, while keeping valid and invalid table schemas tightly coupled and reducing code duplication.