### PR TITLE
Set mobile-packet-verifer burn rate to $0.10 per GB

### DIFF
--- a/mobile_packet_verifier/src/lib.rs
+++ b/mobile_packet_verifier/src/lib.rs
@@ -19,7 +19,7 @@ pub mod pending_burns;
 pub mod pending_txns;
 pub mod settings;
 
-const BYTES_PER_DC: u64 = 20_000;
+const BYTES_PER_DC: u64 = 100_000;
 
 pub fn bytes_to_dc(bytes: u64) -> u64 {
     let bytes = bytes.max(BYTES_PER_DC);
@@ -86,8 +86,8 @@ mod tests {
     #[test]
     fn test_bytes_to_dc() {
         assert_eq!(1, bytes_to_dc(1));
-        assert_eq!(1, bytes_to_dc(20_000));
-        assert_eq!(2, bytes_to_dc(20_001));
+        assert_eq!(1, bytes_to_dc(100_000));
+        assert_eq!(2, bytes_to_dc(100_001));
     }
 }
 

--- a/mobile_packet_verifier/tests/integrations/burner.rs
+++ b/mobile_packet_verifier/tests/integrations/burner.rs
@@ -39,7 +39,7 @@ fn burn_checks_for_sufficient_balance(pool: PgPool) -> anyhow::Result<()> {
     save_data_transfer_sessions(
         &pool,
         &[
-            (&payer_insufficent, &payer_insufficent, 1_000_000_000), // exceed balance
+            (&payer_insufficent, &payer_insufficent, 2_000_000_000), // exceed balance
             (&payer_sufficient, &payer_sufficient, 1_000_000),       // within balance
         ],
     )


### PR DESCRIPTION
## Reduce mobile data-transfer pricing from $0.50/GB to $0.10/GB

### Summary
Lowers the price of mobile data transfer by 5×, from **$0.50/GB** to **$0.10/GB**.

The per-GB price is the implicit product of two constants:
- `BYTES_PER_DC = 20_000` — transferred bytes per Data Credit (the **burn** side, `mobile_packet_verifier`)
- `DC_USD_PRICE = $0.00001` — fixed network-wide USD price of a DC (the **reward** side, `mobile_verifier`)
old: 1 GB = 1,000,000,000 bytes ÷ 20,000 = 50,000 DC × $0.00001 = $0.50
new: 1 GB = 1,000,000,000 bytes ÷ 100,000 = 10,000 DC × $0.00001 = $0.10

### Approach
Changed `BYTES_PER_DC` from `20_000` → `100_000` so each DC covers 5× more bytes. This is the correct lever because:
- `DC_USD_PRICE` is the fixed, network-wide price of a Data Credit used across **all** Helium reward conversions — changing it would alter every DC-denominated reward, not just data transfer.
- `BYTES_PER_DC` is the single source of truth. The burn side computes `num_dcs` via `bytes_to_dc()` and persists it to `hotspot_data_transfer_sessions.num_dcs`; the reward side reads that pre-computed value directly rather than re-deriving from bytes. So one constant change flows through to **both** burning and rewarding for all new sessions.
### Changes
- **`mobile_packet_verifier/src/lib.rs`** — `BYTES_PER_DC: 20_000 → 100_000`; updated the `test_bytes_to_dc` unit test to the new 100,000-byte boundary.
- **`mobile_packet_verifier/tests/integrations/burner.rs`** — bumped the insufficient-balance payer's traffic from `1_000_000_000` → `2_000_000_000` bytes. The test calibrated this amount to overshoot a 10,000-DC balance under the old rate; under the new rate it landed exactly at the balance, so the "insufficient" payer was no longer insufficient. The new value keeps a clear 2× overshoot, preserving the test's intent.
### Behavioral notes
- **Effective on deploy, for new sessions only.** Historical rows in `hotspot_data_transfer_sessions` keep their already-computed `num_dcs` (old $0.50/GB rate) — burns are irreversible, so no migration applies.
- **Minimum charge unchanged in DC terms** (1 DC) but now covers more data: any session ≤ 100,000 bytes burns exactly 1 DC, where the floor was previously 20,000 bytes.
- **Payers burn 5× less DC** for the same traffic, and hotspot data-transfer rewards (derived from `num_dcs`) scale down proportionally — both sides move together by design.