### PR TITLE
add cli to pull gateways that location has changed since given timestamp

### DIFF
--- a/mobile_config_cli/src/client.rs
+++ b/mobile_config_cli/src/client.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cmds::gateway::{GatewayInfo, GatewayInfoStream, GatewayInfoStreamV3},
+    cmds::gateway::{GatewayInfo, GatewayInfoStream, GatewayInfoStreamV3, GatewayInfoStreamV4},
     current_timestamp, NetworkKeyRole, Result,
 };
 
@@ -13,7 +13,8 @@ use helium_proto::{
         AuthorizationListResV1, AuthorizationVerifyReqV1, AuthorizationVerifyResV1,
         CarrierIncentivePromotionListReqV1, CarrierIncentivePromotionListResV1, EntityVerifyReqV1,
         EntityVerifyResV1, GatewayInfoAtTimestampReqV1, GatewayInfoBatchReqV1, GatewayInfoReqV1,
-        GatewayInfoResV2, GatewayInfoStreamReqV3, GatewayInfoStreamResV2, GatewayInfoStreamResV3,
+        GatewayInfoResV2, GatewayInfoStreamReqV3, GatewayInfoStreamReqV4, GatewayInfoStreamResV2,
+        GatewayInfoStreamResV3, GatewayInfoStreamResV4,
     },
     Message,
 };
@@ -326,6 +327,44 @@ impl GatewayClient {
 
         Ok(stream)
     }
+
+    pub async fn info_stream_v4(
+        &mut self,
+        batch_size: u32,
+        min_location_changed_at: u64,
+        keypair: &Keypair,
+    ) -> Result<GatewayInfoStreamV4> {
+        let mut request = GatewayInfoStreamReqV4 {
+            batch_size,
+            signer: keypair.public_key().into(),
+            signature: vec![],
+            device_types: vec![],
+            min_updated_at: 0,
+            min_location_changed_at,
+            min_owner_changed_at: 0,
+        };
+        request.signature = request.sign(keypair)?;
+        let config_pubkey = self.server_pubkey.clone();
+        let stream = self
+            .client
+            .info_stream_v4(request)
+            .await?
+            .into_inner()
+            .filter_map(|res| async move { res.ok() })
+            .map(move |res| (res, config_pubkey.clone()))
+            .filter_map(|(res, pubkey)| async move {
+                match res.verify(&pubkey) {
+                    Ok(()) => Some(res),
+                    Err(err) => {
+                        tracing::error!(?err, "Response verification failed");
+                        None
+                    }
+                }
+            })
+            .boxed();
+
+        Ok(stream)
+    }
 }
 
 pub trait MsgSign: Message + std::clone::Clone {
@@ -355,6 +394,7 @@ impl_sign!(GatewayInfoReqV1, signature);
 impl_sign!(GatewayInfoBatchReqV1, signature);
 impl_sign!(GatewayInfoAtTimestampReqV1, signature);
 impl_sign!(GatewayInfoStreamReqV3, signature);
+impl_sign!(GatewayInfoStreamReqV4, signature);
 impl_sign!(CarrierIncentivePromotionListReqV1, signature);
 
 pub trait MsgVerify: Message + std::clone::Clone {
@@ -386,4 +426,5 @@ impl_verify!(EntityVerifyResV1, signature);
 impl_verify!(GatewayInfoResV2, signature);
 impl_verify!(GatewayInfoStreamResV2, signature);
 impl_verify!(GatewayInfoStreamResV3, signature);
+impl_verify!(GatewayInfoStreamResV4, signature);
 impl_verify!(CarrierIncentivePromotionListResV1, signature);

--- a/mobile_config_cli/src/cmds/gateway.rs
+++ b/mobile_config_cli/src/cmds/gateway.rs
@@ -1,13 +1,14 @@
 use super::{
-    DeviceTypeCounts, GetHotspot, GetHotspotAtTimestamp, GetHotspotBatch, PathBufKeypair,
-    PubkeyToHex,
+    DeviceTypeCounts, GetHotspot, GetHotspotAtTimestamp, GetHotspotBatch, LocationChangedAt,
+    PathBufKeypair, PubkeyToHex,
 };
 use crate::{client, Msg, PrettyJson, Result};
 use angry_purple_tiger::AnimalName;
 use futures::StreamExt;
 use helium_crypto::PublicKey;
 use helium_proto::services::mobile_config::{
-    DeviceTypeV2, GatewayInfoStreamResV3, GatewayInfoV2 as GatewayInfoProto,
+    DeviceTypeV2, GatewayInfoStreamResV3, GatewayInfoStreamResV4,
+    GatewayInfoV2 as GatewayInfoProto, GatewayInfoV4 as GatewayInfoV4Proto,
     GatewayMetadataV2 as GatewayMetadataProto,
 };
 use mobile_config::gateway::service::info::{DeploymentInfo, DeviceType};
@@ -16,6 +17,7 @@ use std::{collections::HashMap, str::FromStr};
 
 pub type GatewayInfoStream = futures::stream::BoxStream<'static, GatewayInfo>;
 pub type GatewayInfoStreamV3 = futures::stream::BoxStream<'static, GatewayInfoStreamResV3>;
+pub type GatewayInfoStreamV4 = futures::stream::BoxStream<'static, GatewayInfoStreamResV4>;
 
 #[derive(Debug, Serialize)]
 pub struct GatewayInfo {
@@ -139,6 +141,88 @@ pub async fn device_type_counts(args: DeviceTypeCounts) -> Result<Msg> {
     let output = serde_json::json!({
         "counts": counts,
         "total": total
+    });
+
+    Msg::ok(serde_json::to_string_pretty(&output)?)
+}
+
+#[derive(Debug, Serialize)]
+pub struct GatewayInfoV4 {
+    name: String,
+    pubkey: PublicKey,
+    device_type: String,
+    location: Option<String>,
+    lat: Option<f64>,
+    lon: Option<f64>,
+    location_changed_at: Option<u64>,
+    num_location_asserts: u64,
+    created_at: u64,
+    updated_at: u64,
+    owner: String,
+    owner_changed_at: u64,
+}
+
+impl TryFrom<GatewayInfoV4Proto> for GatewayInfoV4 {
+    type Error = anyhow::Error;
+
+    fn try_from(info: GatewayInfoV4Proto) -> Result<Self, Self::Error> {
+        let device_type = DeviceTypeV2::try_from(info.device_type)
+            .map(|dt| format!("{dt:?}"))
+            .unwrap_or_else(|_| format!("Unknown({})", info.device_type));
+        let pubkey = PublicKey::try_from(info.address)?;
+        let name: AnimalName = pubkey.clone().into();
+
+        let location_info = info.metadata.and_then(|md| md.location_info);
+        let (location, lat, lon, location_changed_at) = match location_info {
+            Some(loc) => {
+                let latlng: h3o::LatLng = h3o::CellIndex::from_str(&loc.location)?.into();
+                (
+                    Some(loc.location),
+                    Some(latlng.lat()),
+                    Some(latlng.lng()),
+                    Some(loc.location_changed_at),
+                )
+            }
+            None => (None, None, None, None),
+        };
+
+        Ok(Self {
+            name: name.to_string(),
+            pubkey,
+            device_type,
+            location,
+            lat,
+            lon,
+            location_changed_at,
+            num_location_asserts: info.num_location_asserts,
+            created_at: info.created_at,
+            updated_at: info.updated_at,
+            owner: info.owner,
+            owner_changed_at: info.owner_changed_at,
+        })
+    }
+}
+
+pub async fn location_changed_at(args: LocationChangedAt) -> Result<Msg> {
+    let mut client = client::GatewayClient::new(&args.config_host, &args.config_pubkey).await?;
+    let stream = client
+        .info_stream_v4(
+            args.batch_size,
+            args.min_location_changed_at,
+            &args.keypair.to_keypair()?,
+        )
+        .await?;
+
+    let gateways = stream
+        .flat_map(|response| futures::stream::iter(response.gateways))
+        .filter_map(|gateway| async move { GatewayInfoV4::try_from(gateway).ok() })
+        .collect::<Vec<GatewayInfoV4>>()
+        .await;
+
+    let output = serde_json::json!({
+        "min_location_changed_at": args.min_location_changed_at,
+        "count": gateways.len(),
+        "gateways": gateways,
     });
 
     Msg::ok(serde_json::to_string_pretty(&output)?)

--- a/mobile_config_cli/src/cmds/mod.rs
+++ b/mobile_config_cli/src/cmds/mod.rs
@@ -171,6 +171,9 @@ pub enum GatewayCommands {
     InfoAtTimestamp(GetHotspotAtTimestamp),
     /// Stream all gateways and print counts by device type
     DeviceTypeCounts(DeviceTypeCounts),
+    /// Stream all gateways whose location changed at or after the given
+    /// Unix epoch timestamp (in seconds)
+    LocationChangedAt(LocationChangedAt),
     /// Convert a base58 hotspot pubkey to the hex bytes stored in
     /// `gateways.address` (BYTEA) in the mobile-config database
     PubkeyToHex(PubkeyToHex),
@@ -184,6 +187,22 @@ pub struct PubkeyToHex {
 
 #[derive(Debug, Args)]
 pub struct DeviceTypeCounts {
+    #[arg(short, long, default_value = "5000")]
+    pub batch_size: u32,
+    #[arg(from_global)]
+    pub keypair: PathBuf,
+    #[arg(from_global)]
+    pub config_host: String,
+    #[arg(from_global)]
+    pub config_pubkey: String,
+}
+
+#[derive(Debug, Args)]
+pub struct LocationChangedAt {
+    /// Unix epoch timestamp (in seconds). Only hotspots whose location changed
+    /// at or after this time are returned.
+    #[arg(long)]
+    pub min_location_changed_at: u64,
     #[arg(short, long, default_value = "5000")]
     pub batch_size: u32,
     #[arg(from_global)]

--- a/mobile_config_cli/src/main.rs
+++ b/mobile_config_cli/src/main.rs
@@ -50,6 +50,9 @@ pub async fn handle_cli(cli: Cli) -> Result<Msg> {
             cmds::GatewayCommands::DeviceTypeCounts(args) => {
                 gateway::device_type_counts(args).await
             }
+            cmds::GatewayCommands::LocationChangedAt(args) => {
+                gateway::location_changed_at(args).await
+            }
             cmds::GatewayCommands::PubkeyToHex(args) => gateway::pubkey_to_hex(args),
         },
     }


### PR DESCRIPTION
## Add `gateway location-changed-at` CLI command to mobile-config-cli

### Summary

Adds a new `location-changed-at` subcommand under `mobile-config-cli gateway` that streams all hotspots whose location changed at or after a given timestamp, using the `gateway_info_stream_req_v4` RPC.

### Usage

```
mobile-config-cli gateway location-changed-at --min-location-changed-at <UNIX_SECONDS> [--batch-size 5000]
```

Outputs pretty JSON with the filter value, a match count, and per-gateway details: `name`, `pubkey`, `device_type`, `location`/`lat`/`lon`, `location_changed_at`, `num_location_asserts`, `created_at`, `updated_at`, `owner`, `owner_changed_at`.

### Changes

- **`cmds/mod.rs`** — new `LocationChangedAt` command variant + args struct (`--min-location-changed-at`, optional `--batch-size` default 5000, global keypair/host/pubkey).
- **`client.rs`** — new `info_stream_v4` method on `GatewayClient` that builds, signs, and streams a `GatewayInfoStreamReqV4` (`min_location_changed_at` set; other filters left at 0); registered `impl_sign!`/`impl_verify!` for the V4 req/res types.
- **`cmds/gateway.rs`** — serializable `GatewayInfoV4` summary with `TryFrom<GatewayInfoV4Proto>`, plus the `location_changed_at` handler.
- **`main.rs`** — wired the new subcommand into dispatch.

### Notes

- Server filter semantics are "location changed **at or after**" the given timestamp (matches the proto's `min_location_changed_at` field).
- `cargo check` and `cargo clippy` pass clean for `mobile-config-cli`.