### PR TITLE
Add gaurd for reward pipeline waiting on burned data transfers

### DIFF
--- a/mobile_verifier/src/data_session.rs
+++ b/mobile_verifier/src/data_session.rs
@@ -245,19 +245,26 @@ pub async fn aggregate_hotspot_data_sessions_to_dc<'a>(
     data_sessions_to_dc(stream).await
 }
 
-pub async fn count_hotspot_data_sessions(
+/// Count burned data-transfer sessions **past the end** of the reward period —
+/// what the reward guard gates on.
+///
+/// This is a freshness signal, not a tally of the epoch's sessions: like the
+/// heartbeat/speedtest checks, a session burned at or after the period end tells
+/// us the burn pipeline has caught up beyond the window we're rewarding, so the
+/// epoch's burns are complete. Sessions *within* the epoch don't prove that —
+/// more could still be arriving.
+pub async fn count_hotspot_data_sessions_past_period(
     exec: impl sqlx::PgExecutor<'_>,
-    epoch: &Range<DateTime<Utc>>,
+    reward_period: &Range<DateTime<Utc>>,
 ) -> sqlx::Result<u64> {
     let count: i64 = sqlx::query_scalar(
         r#"
         SELECT count(*)
         FROM hotspot_data_transfer_sessions
-        WHERE burn_timestamp >= $1 AND burn_timestamp < $2
+        WHERE burn_timestamp >= $1
         "#,
     )
-    .bind(epoch.start)
-    .bind(epoch.end)
+    .bind(reward_period.end)
     .fetch_one(exec)
     .await?;
 
@@ -367,31 +374,19 @@ impl DataSessionSource {
         }
     }
 
-    pub async fn count_data_sessions(&self, epoch: &Range<DateTime<Utc>>) -> anyhow::Result<u64> {
-        match self {
-            DataSessionSource::Postgres { pool } => {
-                Ok(count_hotspot_data_sessions(pool, epoch).await?)
-            }
-            DataSessionSource::Compare { pool, trino } => {
-                let postgres = count_hotspot_data_sessions(pool, epoch).await?;
-                match crate::iceberg::burned_session::count_burned_sessions(trino, epoch).await {
-                    Ok(iceberg) => {
-                        let iceberg = iceberg as i64;
-                        let postgres = postgres as i64;
-                        let divergance = (iceberg - postgres).abs();
-                        crate::telemetry::data_session::count_divergence(divergance);
-                    }
-                    Err(err) => {
-                        tracing::error!(
-                            ?err,
-                            "failed to count data sessions from trino for comparison"
-                        )
-                    }
-                }
-
-                Ok(postgres)
-            }
-        }
+    /// The guard's count: source (Postgres, during the migration) data sessions
+    /// burned **past the end** of the reward period. The reward run reads from
+    /// this source, so this is what gates rewarding; Trino's readiness is tracked
+    /// separately as a non-blocking metric in [`Self::record_trino_readiness`].
+    pub async fn count_data_sessions_past_period(
+        &self,
+        reward_period: &Range<DateTime<Utc>>,
+    ) -> anyhow::Result<u64> {
+        let pool = match self {
+            DataSessionSource::Postgres { pool } => pool,
+            DataSessionSource::Compare { pool, .. } => pool,
+        };
+        Ok(count_hotspot_data_sessions_past_period(pool, reward_period).await?)
     }
 }
 

--- a/mobile_verifier/src/data_session.rs
+++ b/mobile_verifier/src/data_session.rs
@@ -245,6 +245,25 @@ pub async fn aggregate_hotspot_data_sessions_to_dc<'a>(
     data_sessions_to_dc(stream).await
 }
 
+pub async fn count_hotspot_data_sessions(
+    exec: impl sqlx::PgExecutor<'_>,
+    epoch: &Range<DateTime<Utc>>,
+) -> sqlx::Result<u64> {
+    let count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT count(*)
+        FROM hotspot_data_transfer_sessions
+        WHERE burn_timestamp >= $1 AND burn_timestamp < $2
+        "#,
+    )
+    .bind(epoch.start)
+    .bind(epoch.end)
+    .fetch_one(exec)
+    .await?;
+
+    Ok(count as u64)
+}
+
 pub async fn data_sessions_to_dc(
     stream: impl Stream<Item = Result<HotspotDataSession, sqlx::Error>>,
 ) -> Result<RewardableDataByHotspot, sqlx::Error> {
@@ -343,6 +362,33 @@ impl DataSessionSource {
                         "failed to read data sessions from trino for comparison"
                     ),
                 }
+                Ok(postgres)
+            }
+        }
+    }
+
+    pub async fn count_data_sessions(&self, epoch: &Range<DateTime<Utc>>) -> anyhow::Result<u64> {
+        match self {
+            DataSessionSource::Postgres { pool } => {
+                Ok(count_hotspot_data_sessions(pool, epoch).await?)
+            }
+            DataSessionSource::Compare { pool, trino } => {
+                let postgres = count_hotspot_data_sessions(pool, epoch).await?;
+                match crate::iceberg::burned_session::count_burned_sessions(trino, epoch).await {
+                    Ok(iceberg) => {
+                        let iceberg = iceberg as i64;
+                        let postgres = postgres as i64;
+                        let divergance = (iceberg - postgres).abs();
+                        crate::telemetry::data_session::count_divergence(divergance);
+                    }
+                    Err(err) => {
+                        tracing::error!(
+                            ?err,
+                            "failed to count data sessions from trino for comparison"
+                        )
+                    }
+                }
+
                 Ok(postgres)
             }
         }

--- a/mobile_verifier/src/data_session.rs
+++ b/mobile_verifier/src/data_session.rs
@@ -326,25 +326,6 @@ impl DataSessionSource {
         }
     }
 
-    /// Record, as a metric, whether Trino's burned-session data is ready for this
-    /// reward period — data exists past the period end, the same freshness signal
-    /// the heartbeat/speedtest checks use. No-op without Trino, and it never
-    /// blocks: a query failure is reported as "not ready" rather than propagated.
-    pub async fn record_trino_readiness(&self, reward_period: &Range<DateTime<Utc>>) {
-        let DataSessionSource::Compare { trino, .. } = self else {
-            return;
-        };
-        let ready =
-            match crate::iceberg::burned_session::no_burned_sessions(trino, reward_period).await {
-                Ok(empty) => !empty,
-                Err(err) => {
-                    tracing::error!(?err, "failed to check trino burned-session readiness");
-                    false
-                }
-            };
-        crate::telemetry::data_session::trino_ready(ready);
-    }
-
     pub async fn load_data_sessions(
         &self,
         epoch: &Range<DateTime<Utc>>,
@@ -374,19 +355,32 @@ impl DataSessionSource {
         }
     }
 
-    /// The guard's count: source (Postgres, during the migration) data sessions
-    /// burned **past the end** of the reward period. The reward run reads from
-    /// this source, so this is what gates rewarding; Trino's readiness is tracked
-    /// separately as a non-blocking metric in [`Self::record_trino_readiness`].
+    /// Burned data sessions past the reward period end — the freshness signal the
+    /// reward guard gates on (see [`count_hotspot_data_sessions_past_period`]). The
+    /// count comes from Postgres, the source rewarding reads during the migration,
+    /// so Postgres is the only backend that gates.
+    ///
+    /// When a Trino client is configured the same freshness check is run against
+    /// Trino and recorded via [`record_trino_readiness`], so we can confirm both
+    /// backends become ready together — but Trino never gates and a Trino failure
+    /// is never propagated. Mirrors [`Self::load_data_sessions`]: check both,
+    /// observe Trino, continue with the Postgres result.
     pub async fn count_data_sessions_past_period(
         &self,
         reward_period: &Range<DateTime<Utc>>,
     ) -> anyhow::Result<u64> {
-        let pool = match self {
-            DataSessionSource::Postgres { pool } => pool,
-            DataSessionSource::Compare { pool, .. } => pool,
+        let postgres_count = match self {
+            DataSessionSource::Postgres { pool } => {
+                count_hotspot_data_sessions_past_period(pool, reward_period).await?
+            }
+            DataSessionSource::Compare { pool, trino } => {
+                let postgres_count =
+                    count_hotspot_data_sessions_past_period(pool, reward_period).await?;
+                record_trino_readiness(trino, reward_period).await;
+                postgres_count
+            }
         };
-        Ok(count_hotspot_data_sessions_past_period(pool, reward_period).await?)
+        Ok(postgres_count)
     }
 }
 
@@ -445,6 +439,26 @@ fn compare_data_sessions(postgres: &RewardableDataByHotspot, trino: &RewardableD
     crate::telemetry::data_session::dc_divergence(comparison.dc_delta as i64);
     crate::telemetry::data_session::bytes_divergence(comparison.bytes_delta as i64);
     crate::telemetry::data_session::hotspot_divergence(comparison.divergent_hotspots);
+}
+
+/// Run the same past-the-period freshness check the Postgres guard uses against
+/// Trino, recording the result as the `data_session_trino_ready` gauge so we can
+/// confirm Trino becomes ready alongside Postgres during the migration. Trino
+/// never gates the reward guard: a query failure is recorded as "not ready"
+/// rather than propagated.
+async fn record_trino_readiness(
+    trino: &trino_client::Client,
+    reward_period: &Range<DateTime<Utc>>,
+) {
+    let ready = match crate::iceberg::burned_session::no_burned_sessions(trino, reward_period).await
+    {
+        Ok(empty) => !empty,
+        Err(err) => {
+            tracing::error!(?err, "failed to check trino burned-session readiness");
+            false
+        }
+    };
+    crate::telemetry::data_session::trino_ready(ready);
 }
 
 #[cfg(test)]

--- a/mobile_verifier/src/iceberg/burned_session.rs
+++ b/mobile_verifier/src/iceberg/burned_session.rs
@@ -48,7 +48,7 @@ pub async fn aggregate_hotspot_data_sessions_to_dc(
     Ok(map)
 }
 
-/// True when no burned sessions exist past within the reward period — i.e.
+/// True when no burned sessions exist past the end of the reward period — i.e.
 /// the burn/write pipeline isn't current through the period we want to reward.
 ///
 /// Trino analogue of [`crate::rewarder::db::no_speedtests`] /
@@ -57,11 +57,13 @@ pub async fn no_burned_sessions(
     trino: &trino_client::Client,
     reward_period: &Range<DateTime<Utc>>,
 ) -> anyhow::Result<bool> {
-    let count = count_burned_sessions(trino, reward_period).await?;
+    let count = count_burned_sessions_past_period(trino, reward_period).await?;
     Ok(count == 0)
 }
 
-pub async fn count_burned_sessions(
+/// Count burned sessions past the end of the reward period — the freshness
+/// signal (see [`no_burned_sessions`]), not a tally of the epoch's sessions.
+async fn count_burned_sessions_past_period(
     trino: &trino_client::Client,
     reward_period: &Range<DateTime<Utc>>,
 ) -> anyhow::Result<u64> {
@@ -74,10 +76,9 @@ pub async fn count_burned_sessions(
         "
         SELECT COUNT(*) AS n
         FROM {NAMESPACE}.{TABLE_NAME}
-        WHERE burn_timestamp >= :start AND burn_timestamp < :end
+        WHERE burn_timestamp >= :end
         "
     ))
-    .bind("start", reward_period.start)
     .bind("end", reward_period.end)
     .typed::<Count>();
 

--- a/mobile_verifier/src/iceberg/burned_session.rs
+++ b/mobile_verifier/src/iceberg/burned_session.rs
@@ -48,7 +48,7 @@ pub async fn aggregate_hotspot_data_sessions_to_dc(
     Ok(map)
 }
 
-/// True when no burned sessions exist past the end of the reward period — i.e.
+/// True when no burned sessions exist past within the reward period — i.e.
 /// the burn/write pipeline isn't current through the period we want to reward.
 ///
 /// Trino analogue of [`crate::rewarder::db::no_speedtests`] /
@@ -57,19 +57,32 @@ pub async fn no_burned_sessions(
     trino: &trino_client::Client,
     reward_period: &Range<DateTime<Utc>>,
 ) -> anyhow::Result<bool> {
+    let count = count_burned_sessions(trino, reward_period).await?;
+    Ok(count == 0)
+}
+
+pub async fn count_burned_sessions(
+    trino: &trino_client::Client,
+    reward_period: &Range<DateTime<Utc>>,
+) -> anyhow::Result<u64> {
     #[derive(Trino, Serialize, Deserialize)]
     struct Count {
-        n: i64,
+        n: u64,
     }
 
     let stmt = trino_client::Statement::new(format!(
-        "SELECT COUNT(*) AS n FROM {NAMESPACE}.{TABLE_NAME} WHERE burn_timestamp >= :end"
+        "
+        SELECT COUNT(*) AS n
+        FROM {NAMESPACE}.{TABLE_NAME}
+        WHERE burn_timestamp >= :start AND burn_timestamp < :end
+        "
     ))
+    .bind("start", reward_period.start)
     .bind("end", reward_period.end)
     .typed::<Count>();
 
     let count = trino.get_all(stmt).await?.first().map_or(0, |row| row.n);
-    Ok(count == 0)
+    Ok(count)
 }
 
 /// Statement that sums DC and rewardable bytes per hotspot over the half-open

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -238,13 +238,6 @@ where
             tracing::info!("Complete data checks are disabled for this reward period");
         }
 
-        // Postgres data is current, so rewards will run. Record (as a metric)
-        // whether Trino's burned-session data was ready too. Non-blocking: Trino
-        // is being validated, not yet trusted to gate rewards.
-        self.data_session_source
-            .record_trino_readiness(reward_period)
-            .await;
-
         Ok(true)
     }
 

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -225,6 +225,11 @@ where
                 return Ok(false);
             }
 
+            if db::no_data_transfer_sessions(&self.data_session_source, reward_period).await? {
+                tracing::info!("No Burned Data Transfer Sessions found past reward period");
+                return Ok(false);
+            }
+
             if check_for_unprocessed_data_sets(&self.pool, reward_period.end).await? {
                 tracing::info!("Data sets still need to be processed");
                 return Ok(false);

--- a/mobile_verifier/src/rewarder/db.rs
+++ b/mobile_verifier/src/rewarder/db.rs
@@ -69,7 +69,7 @@ pub async fn no_data_transfer_sessions(
     // postgres/trino. When that is verified, this function along with many
     // other things will be candidates for cleanup.
     let count = data_session_source
-        .count_data_sessions(reward_period)
+        .count_data_sessions_past_period(reward_period)
         .await?;
     Ok(count == 0)
 }
@@ -146,6 +146,46 @@ mod tests {
         assert!(no_speedtests(&pool, &reward_period).await?);
         assert!(no_unique_connections(&pool, &reward_period).await?);
 
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn data_transfer_guard_requires_burns_past_period(pool: PgPool) -> anyhow::Result<()> {
+        let reward_period = Utc::now() - chrono::Duration::days(1)..Utc::now();
+        let source = DataSessionSource::new(pool.clone(), None);
+
+        // Empty -> not ready.
+        assert!(no_data_transfer_sessions(&source, &reward_period).await?);
+
+        // A session burned *within* the epoch is not a completeness signal — more
+        // could still be arriving — so the guard still holds.
+        save_data_session(&pool, reward_period.start).await?;
+        assert!(no_data_transfer_sessions(&source, &reward_period).await?);
+
+        // A session burned at/after the period end tells us the burns are in.
+        save_data_session(&pool, reward_period.end).await?;
+        assert!(!no_data_transfer_sessions(&source, &reward_period).await?);
+
+        Ok(())
+    }
+
+    async fn save_data_session(pool: &PgPool, burn_timestamp: DateTime<Utc>) -> anyhow::Result<()> {
+        let keypair = Keypair::generate(KeyTag::default(), &mut OsRng);
+        let pubkey: PublicKeyBinary = keypair.public_key().to_owned().into();
+        let mut txn = pool.begin().await?;
+        crate::data_session::HotspotDataSession {
+            pub_key: pubkey.clone(),
+            payer: pubkey,
+            upload_bytes: 0,
+            download_bytes: 0,
+            rewardable_bytes: 0,
+            num_dcs: 1,
+            received_timestamp: burn_timestamp,
+            burn_timestamp,
+        }
+        .save(&mut txn)
+        .await?;
+        txn.commit().await?;
         Ok(())
     }
 

--- a/mobile_verifier/src/rewarder/db.rs
+++ b/mobile_verifier/src/rewarder/db.rs
@@ -3,6 +3,8 @@ use std::ops::Range;
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 
+use crate::data_session::DataSessionSource;
+
 /// Heartbeats are sent constantly throughout the day.
 ///
 /// If there are heartbeats that exists past the end of the rewardable period,
@@ -56,6 +58,19 @@ pub async fn no_unique_connections(
     .fetch_one(pool)
     .await?;
 
+    Ok(count == 0)
+}
+
+pub async fn no_data_transfer_sessions(
+    data_session_source: &DataSessionSource,
+    reward_period: &Range<DateTime<Utc>>,
+) -> anyhow::Result<bool> {
+    // We delegate here because we are still verifying parity between
+    // postgres/trino. When that is verified, this function along with many
+    // other things will be candidates for cleanup.
+    let count = data_session_source
+        .count_data_sessions(reward_period)
+        .await?;
     Ok(count == 0)
 }
 

--- a/mobile_verifier/src/telemetry.rs
+++ b/mobile_verifier/src/telemetry.rs
@@ -54,7 +54,6 @@ pub mod data_session {
     const DC_DIVERGENCE: &str = "data_session_dc_divergence";
     const BYTES_DIVERGENCE: &str = "data_session_bytes_divergence";
     const HOTSPOT_DIVERGENCE: &str = "data_session_hotspot_divergence";
-    const COUNT_DIVERGENCE: &str = "data_session_count_divergence";
 
     /// "When rewards need to run, was the Trino data ready?" — 1.0 when burned
     /// sessions exist past the reward period end, else 0.0. Emitted once per
@@ -84,10 +83,5 @@ pub mod data_session {
     /// (mismatched totals or present in only one source).
     pub fn hotspot_divergence(count: u64) {
         metrics::gauge!(HOTSPOT_DIVERGENCE).set(count as f64);
-    }
-
-    /// Signed delta (trino - postgres) in total number of data sessions for the epoch
-    pub fn count_divergence(delta: i64) {
-        metrics::gauge!(COUNT_DIVERGENCE).set(delta as f64);
     }
 }

--- a/mobile_verifier/src/telemetry.rs
+++ b/mobile_verifier/src/telemetry.rs
@@ -54,6 +54,7 @@ pub mod data_session {
     const DC_DIVERGENCE: &str = "data_session_dc_divergence";
     const BYTES_DIVERGENCE: &str = "data_session_bytes_divergence";
     const HOTSPOT_DIVERGENCE: &str = "data_session_hotspot_divergence";
+    const COUNT_DIVERGENCE: &str = "data_session_count_divergence";
 
     /// "When rewards need to run, was the Trino data ready?" — 1.0 when burned
     /// sessions exist past the reward period end, else 0.0. Emitted once per
@@ -83,5 +84,10 @@ pub mod data_session {
     /// (mismatched totals or present in only one source).
     pub fn hotspot_divergence(count: u64) {
         metrics::gauge!(HOTSPOT_DIVERGENCE).set(count as f64);
+    }
+
+    /// Signed delta (trino - postgres) in total number of data sessions for the epoch
+    pub fn count_divergence(delta: i64) {
+        metrics::gauge!(COUNT_DIVERGENCE).set(delta as f64);
     }
 }


### PR DESCRIPTION
This is to gaurd against the scenario where Solana is down and no burns have made it for the day. An alarm will go off, and we can intervene at the data level or with the disable_complete_data_checks_until() function.

Also contains metrics for count differences between postgres and trino.

Until we fully transition the strangler, we're still using postgres as the source of truth. And are noting any count differences.