### PR TITLE
HIP-149: size data-transfer rewards as residual of hnt_rewards_issued

### DIFF
--- a/mobile_config/src/sub_dao_epoch_reward_info.rs
+++ b/mobile_config/src/sub_dao_epoch_reward_info.rs
@@ -11,7 +11,21 @@ pub struct EpochRewardInfo {
     pub epoch_address: String,
     pub sub_dao_address: String,
     pub epoch_period: Range<DateTime<Utc>>,
+    /// Total mobile sub-DAO emissions for the epoch (100%): the HNT this rewarder
+    /// distributes (`hnt_rewards_issued`) plus the delegation rewards already paid
+    /// to veHNT holders on-chain.
     pub epoch_emissions: Decimal,
+    /// The slice of `epoch_emissions` this rewarder is responsible for
+    /// distributing (service providers + data transfer). Under the HIP-149 3×
+    /// cap / backstop the chain shifts HNT between this and the delegation
+    /// rewards, so it is no longer a fixed 94% of `epoch_emissions`; the rewarder
+    /// must distribute exactly this amount — no more, no less.
+    pub hnt_rewards_issued: Decimal,
+    /// The portion of `epoch_emissions` paid to veHNT delegators on-chain
+    /// (`epoch_emissions - hnt_rewards_issued`). The rewarder does not distribute
+    /// this; it is carried so the full on-chain split is available without another
+    /// mobile-config change.
+    pub delegation_rewards_issued: Decimal,
     pub rewards_issued_at: DateTime<Utc>,
 }
 
@@ -49,14 +63,17 @@ impl TryFrom<SubDaoEpochRewardInfoProto> for EpochRewardInfo {
 
     fn try_from(info: SubDaoEpochRewardInfoProto) -> Result<Self, Self::Error> {
         let epoch_period: EpochInfo = info.epoch.into();
-        let epoch_rewards = Decimal::from(info.hnt_rewards_issued + info.delegation_rewards_issued);
+        let hnt_rewards_issued = Decimal::from(info.hnt_rewards_issued);
+        let delegation_rewards_issued = Decimal::from(info.delegation_rewards_issued);
 
         Ok(Self {
             epoch_day: info.epoch,
             epoch_address: info.epoch_address,
             sub_dao_address: info.sub_dao_address,
             epoch_period: epoch_period.period,
-            epoch_emissions: epoch_rewards,
+            epoch_emissions: hnt_rewards_issued + delegation_rewards_issued,
+            hnt_rewards_issued,
+            delegation_rewards_issued,
             rewards_issued_at: info.rewards_issued_at.to_timestamp()?,
         })
     }

--- a/mobile_verifier/examples/compare_new_dc_vs_manifest.rs
+++ b/mobile_verifier/examples/compare_new_dc_vs_manifest.rs
@@ -42,14 +42,12 @@ use mobile_config::client::sub_dao_client::{SubDaoClient, SubDaoEpochRewardInfoR
 use mobile_verifier::{
     iceberg::burned_session,
     resolve_subdao_pubkey,
-    reward_shares::{
-        data_transfer::{self, GatewayDataTransfer},
-        get_scheduled_tokens_for_data_transfer,
-    },
+    reward_shares::data_transfer::{self, GatewayDataTransfer},
     Settings,
 };
 use prost::Message;
 use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 
 const MANIFEST_PREFIX: &str = "network_reward_manifest_v1";
 
@@ -182,7 +180,9 @@ async fn main() -> anyhow::Result<()> {
         // reconstructed integer pool if emissions can't be obtained.
         let (pool, pool_src) = match args.emissions {
             Some(em) => (
-                get_scheduled_tokens_for_data_transfer(Decimal::from(em)),
+                // Reconstruct the historical (pre-HIP-149) 70% pool; this tool
+                // compares the new DC allocator against old 70%-era manifests.
+                Decimal::from(em) * dec!(0.7),
                 format!("0.7 × emissions {em} (--emissions)"),
             ),
             None => match sub_dao_client
@@ -192,7 +192,7 @@ async fn main() -> anyhow::Result<()> {
                 .await
             {
                 Ok(Some(info)) => (
-                    get_scheduled_tokens_for_data_transfer(info.epoch_emissions),
+                    info.epoch_emissions * dec!(0.7),
                     format!("0.7 × emissions {} (mobile-config)", info.epoch_emissions),
                 ),
                 Ok(None) => {

--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -19,14 +19,17 @@ use futures::{Stream, StreamExt};
 use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_mobile as proto;
 use radio_reward_v2::RadioRewardV2Ext;
-use rust_decimal::prelude::*;
+use rust_decimal::{prelude::*, RoundingStrategy};
 use rust_decimal_macros::dec;
 use std::{collections::HashMap, ops::Range};
 use strum_macros::{Display, EnumString};
 use uuid::Uuid;
 
 pub mod data_transfer;
+pub mod emissions_split;
 mod radio_reward_v2;
+
+pub use emissions_split::hip_149_reward_pools;
 
 /// Maximum amount of the total emissions pool allocated for data transfer
 /// rewards
@@ -506,17 +509,21 @@ impl CalculatedPocRewardShares {
     }
 }
 
-pub fn get_scheduled_tokens_for_data_transfer(total_emission_pool: Decimal) -> Decimal {
-    total_emission_pool * MAX_DATA_TRANSFER_REWARDS_PERCENT
-}
-
 pub fn get_scheduled_tokens_for_poc(total_emission_pool: Decimal) -> Decimal {
     let poc_percent = MAX_DATA_TRANSFER_REWARDS_PERCENT + POC_REWARDS_PERCENT;
     total_emission_pool * poc_percent
 }
 
-pub fn get_scheduled_tokens_for_service_providers(total_emission_pool: Decimal) -> Decimal {
-    total_emission_pool * SERVICE_PROVIDER_PERCENT
+/// Floor a non-negative `Decimal` to `u64` bones using the reward rounding
+/// convention (`ToZero`). Shared by every reward pool so percentage splits always
+/// round the same direction — never up, which is what lets the residual data
+/// pool absorb the dropped sub-bone without over-allocating. Values above
+/// `u64::MAX` saturate, which never happens for a real reward pool.
+pub(crate) fn floor_to_u64(value: Decimal) -> u64 {
+    value
+        .round_dp_with_strategy(0, RoundingStrategy::ToZero)
+        .to_u64()
+        .unwrap_or(0)
 }
 
 #[derive(Display, EnumString)]
@@ -619,6 +626,12 @@ mod test {
             sub_dao_address: SUB_DAO_ADDRESS.into(),
             epoch_period: (now - epoch_duration)..now,
             epoch_emissions: Decimal::from(EMISSIONS_POOL_IN_BONES_1_HOUR),
+            // 6% is carved out for veHNT delegators on-chain; the rewarder
+            // distributes the remaining ~94%.
+            hnt_rewards_issued: Decimal::from(
+                EMISSIONS_POOL_IN_BONES_1_HOUR - EMISSIONS_POOL_IN_BONES_1_HOUR * 6 / 100,
+            ),
+            delegation_rewards_issued: Decimal::from(EMISSIONS_POOL_IN_BONES_1_HOUR * 6 / 100),
             rewards_issued_at: now,
         }
     }
@@ -636,6 +649,12 @@ mod test {
             sub_dao_address: SUB_DAO_ADDRESS.into(),
             epoch_period: (now - epoch_duration)..now,
             epoch_emissions: Decimal::from(EMISSIONS_POOL_IN_BONES_24_HOURS),
+            // 6% is carved out for veHNT delegators on-chain; the rewarder
+            // distributes the remaining ~94%.
+            hnt_rewards_issued: Decimal::from(
+                EMISSIONS_POOL_IN_BONES_24_HOURS - EMISSIONS_POOL_IN_BONES_24_HOURS * 6 / 100,
+            ),
+            delegation_rewards_issued: Decimal::from(EMISSIONS_POOL_IN_BONES_24_HOURS * 6 / 100),
             rewards_issued_at: now,
         }
     }
@@ -644,12 +663,6 @@ mod test {
     fn test_poc_scheduled_tokens() {
         let v = get_scheduled_tokens_for_poc(dec!(100));
         assert_eq!(dec!(70), v, "poc gets 70%");
-    }
-
-    #[test]
-    fn test_service_provider_scheduled_tokens() {
-        let v = get_scheduled_tokens_for_service_providers(dec!(100));
-        assert_eq!(dec!(24), v, "service providers get 24%");
     }
 
     #[test]

--- a/mobile_verifier/src/reward_shares/data_transfer.rs
+++ b/mobile_verifier/src/reward_shares/data_transfer.rs
@@ -27,8 +27,9 @@ use std::ops::Range;
 use chrono::{DateTime, Utc};
 use file_store::traits::TimestampEncode;
 use helium_crypto::PublicKeyBinary;
-use rust_decimal::{prelude::*, Decimal, RoundingStrategy};
+use rust_decimal::Decimal;
 
+use super::floor_to_u64;
 use crate::iceberg::gateway_reward::IcebergGatewayReward;
 
 mod proto {
@@ -129,16 +130,6 @@ pub fn allocate<K>(
         // assert that saturation never actually triggers.
         unallocated: pool_bones.saturating_sub(allocated),
     }
-}
-
-/// Floor a non-negative `Decimal` to a `u64` (`ToZero` matches the existing
-/// reward rounding). Values above `u64::MAX` saturate, which never happens for a
-/// real reward pool.
-fn floor_to_u64(value: Decimal) -> u64 {
-    value
-        .round_dp_with_strategy(0, RoundingStrategy::ToZero)
-        .to_u64()
-        .unwrap_or(0)
 }
 
 // ================================================================

--- a/mobile_verifier/src/reward_shares/emissions_split.rs
+++ b/mobile_verifier/src/reward_shares/emissions_split.rs
@@ -1,0 +1,235 @@
+//! HIP-149 sub-DAO reward split.
+//!
+//! Each epoch the chain hands the rewarder two figures via [`EpochRewardInfo`]:
+//! `epoch_emissions` (the 100% total) and `hnt_rewards_issued` (the slice this
+//! rewarder must distribute). The remainder — `delegation_rewards_issued` — is
+//! paid to veHNT delegators on-chain and is never touched here.
+//!
+//! The rewarder splits `hnt_rewards_issued` into two pools:
+//!
+//! * **Service providers** — a flat 24% of *total* emissions. HIP-149 keeps this
+//!   fixed regardless of the cap/backstop.
+//! * **Data transfer** — the *residual*: `hnt_rewards_issued − service_provider`.
+//!
+//! Making data transfer the residual (rather than a fixed 70%) is what keeps the
+//! split exact under HIP-149. The 3× cap moves HNT out of the data bucket and
+//! into delegation, shrinking `hnt_rewards_issued`; the backstop re-emits HNT
+//! into it, growing `hnt_rewards_issued`. A fixed `0.70 × emissions` would
+//! over-allocate when earnings run over the cap (minting HNT that was moved to
+//! delegators) and under-allocate when they fall under the backstop (stranding
+//! the re-emitted HNT). The residual
+//! instead absorbs the shift — and the sub-bone dropped when flooring the
+//! service-provider 24% — so
+//!
+//! ```text
+//! service_provider + data_transfer == floor(hnt_rewards_issued)
+//! ```
+//!
+//! holds exactly, every epoch. The proptests below pin that invariant across the
+//! full input range.
+
+use mobile_config::sub_dao_epoch_reward_info::EpochRewardInfo;
+use rust_decimal::Decimal;
+
+use super::{floor_to_u64, SERVICE_PROVIDER_PERCENT};
+
+/// The two pools the rewarder distributes, in HNT bones. By construction
+/// `service_provider + data_transfer == floor(hnt_rewards_issued)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RewardPools {
+    pub service_provider: u64,
+    pub data_transfer: u64,
+}
+
+/// Split an epoch's `hnt_rewards_issued` into the service-provider and
+/// data-transfer pools (see module docs).
+pub fn hip_149_reward_pools(reward_info: &EpochRewardInfo) -> RewardPools {
+    split(reward_info.epoch_emissions, reward_info.hnt_rewards_issued)
+}
+
+/// Core split, factored out from [`hip_149_reward_pools`] for property testing.
+/// `total_emissions` is the 100% pool; `hnt_rewards_issued` is the rewarder's
+/// slice of it.
+fn split(total_emissions: Decimal, hnt_rewards_issued: Decimal) -> RewardPools {
+    let hnt = floor_to_u64(hnt_rewards_issued);
+
+    // Service providers take a flat 24% of *total* emissions, floored. We never
+    // round *up* — that is what guarantees the service-provider pool can't push
+    // the distributed total past `hnt_rewards_issued`. The `.min(hnt)` clamp
+    // keeps the residual non-negative even if the chain ever reported delegation
+    // above 76% of total (beyond what the 3× cap can produce, since it can move
+    // at most the 70% data bucket): in that case service providers simply take
+    // whatever HNT was issued.
+    let service_provider = floor_to_u64(total_emissions * SERVICE_PROVIDER_PERCENT).min(hnt);
+
+    // Data transfer is the residual. `service_provider <= hnt`, so this never
+    // underflows, and the sub-bone dropped by flooring above lands here rather
+    // than leaking — keeping `service_provider + data_transfer == hnt` exact.
+    let data_transfer = hnt - service_provider;
+
+    RewardPools {
+        service_provider,
+        data_transfer,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    const MAX_BONES: u64 = 10_000_000_000_000_000; // ~ HNT max supply, in bones
+
+    fn run(total: u64, hnt: u64) -> RewardPools {
+        split(Decimal::from(total), Decimal::from(hnt))
+    }
+
+    // The expected service-provider pool, reconstructed independently of `split`.
+    fn expected_sp(total: u64, hnt: u64) -> u64 {
+        floor_to_u64(Decimal::from(total) * SERVICE_PROVIDER_PERCENT).min(hnt)
+    }
+
+    #[test]
+    fn baseline_6pct_delegation_is_70_24() {
+        // total = 100, delegation = 6 → hnt = 94. SP = 24, data = 70.
+        assert_eq!(
+            run(100, 94),
+            RewardPools {
+                service_provider: 24,
+                data_transfer: 70
+            }
+        );
+    }
+
+    #[test]
+    fn cap_shrinks_data_only() {
+        // 3× cap moved 14 from data → delegation: delegation 6+14=20, hnt = 80.
+        // SP stays at 24% of total; data absorbs the whole 14 (70 → 56).
+        assert_eq!(
+            run(100, 80),
+            RewardPools {
+                service_provider: 24,
+                data_transfer: 56
+            }
+        );
+    }
+
+    #[test]
+    fn backstop_grows_data_only() {
+        // Backstop re-emitted HNT into the data bucket: hnt = 98 (> 94).
+        // SP unchanged; data absorbs the boost (70 → 74).
+        assert_eq!(
+            run(100, 98),
+            RewardPools {
+                service_provider: 24,
+                data_transfer: 74
+            }
+        );
+    }
+
+    #[test]
+    fn no_delegation_gives_sp_24_data_76() {
+        assert_eq!(
+            run(100, 100),
+            RewardPools {
+                service_provider: 24,
+                data_transfer: 76
+            }
+        );
+    }
+
+    #[test]
+    fn extreme_cap_clamps_sp_to_issued_hnt() {
+        // Out-of-spec: only 20 HNT issued though 24% of total would be 24. SP
+        // takes all 20, data is 0 — still accounts for exactly `hnt`.
+        assert_eq!(
+            run(100, 20),
+            RewardPools {
+                service_provider: 20,
+                data_transfer: 0
+            }
+        );
+    }
+
+    #[test]
+    fn zero_hnt_allocates_nothing() {
+        assert_eq!(
+            run(100, 0),
+            RewardPools {
+                service_provider: 0,
+                data_transfer: 0
+            }
+        );
+    }
+
+    proptest! {
+        /// THE invariant: the rewarder distributes exactly `hnt_rewards_issued`,
+        /// never more (minting HNT that was moved to delegators) nor less
+        /// (stranding re-emitted HNT). Inputs are generated as (hnt, delegation)
+        /// so `total = hnt + delegation` and `hnt <= total` always — covering the
+        /// cap (large delegation), the backstop (~0 delegation), and the baseline.
+        #[test]
+        fn never_over_or_under_allocates_hnt(
+            hnt in 0u64..=MAX_BONES,
+            delegation in 0u64..=MAX_BONES,
+        ) {
+            let total = hnt + delegation;
+            let pools = run(total, hnt);
+            prop_assert_eq!(
+                pools.service_provider + pools.data_transfer,
+                hnt,
+                "sp {} + data {} != hnt {}",
+                pools.service_provider,
+                pools.data_transfer,
+                hnt
+            );
+        }
+
+        /// Neither pool can exceed the issued HNT (and, being u64, neither can go
+        /// negative).
+        #[test]
+        fn pools_are_bounded_by_issued_hnt(
+            hnt in 0u64..=MAX_BONES,
+            delegation in 0u64..=MAX_BONES,
+        ) {
+            let total = hnt + delegation;
+            let pools = run(total, hnt);
+            prop_assert!(pools.service_provider <= hnt);
+            prop_assert!(pools.data_transfer <= hnt);
+        }
+
+        /// Service providers get a flat 24% of *total* emissions, independent of
+        /// how the cap/backstop split that total between hnt and delegation —
+        /// except in the out-of-spec regime where less than 24% was issued, where
+        /// SP is clamped to what's available.
+        #[test]
+        fn service_provider_is_24pct_of_total(
+            hnt in 0u64..=MAX_BONES,
+            delegation in 0u64..=MAX_BONES,
+        ) {
+            let total = hnt + delegation;
+            let pools = run(total, hnt);
+            prop_assert_eq!(pools.service_provider, expected_sp(total, hnt));
+        }
+
+        /// Holding total emissions fixed, data transfer tracks issued HNT
+        /// one-for-one — the cap (less hnt) shrinks it, the backstop (more hnt)
+        /// grows it — while the service-provider pool is unchanged, as long as a
+        /// full 24% of total was issued (clamp not engaged).
+        #[test]
+        fn data_tracks_hnt_one_for_one_with_sp_fixed(
+            (total, hnt_a, hnt_b) in (1u64..=MAX_BONES).prop_flat_map(|total| {
+                let sp = floor_to_u64(Decimal::from(total) * SERVICE_PROVIDER_PERCENT);
+                (Just(total), sp..=total, sp..=total)
+            })
+        ) {
+            let a = run(total, hnt_a);
+            let b = run(total, hnt_b);
+            prop_assert_eq!(a.service_provider, b.service_provider);
+            prop_assert_eq!(
+                a.data_transfer as i128 - b.data_transfer as i128,
+                hnt_a as i128 - hnt_b as i128
+            );
+        }
+    }
+}

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -7,9 +7,8 @@ use crate::{
     iceberg, resolve_subdao_pubkey,
     reward_shares::{
         data_transfer::{self, into_proto_rewards, to_iceberg_rewards, DataTransferAllocation},
-        get_scheduled_tokens_for_data_transfer, get_scheduled_tokens_for_service_providers,
-        CalculatedPocRewardShares, CoverageShares, DataTransferAndPocAllocatedRewardBuckets,
-        TransferRewards,
+        hip_149_reward_pools, CalculatedPocRewardShares, CoverageShares,
+        DataTransferAndPocAllocatedRewardBuckets, TransferRewards,
     },
     speedtests,
     speedtests_average::SpeedtestAverages,
@@ -366,7 +365,10 @@ pub async fn reward_dc_hip_149(
         .load_data_sessions(&reward_info.epoch_period)
         .await?;
 
-    let pool = get_scheduled_tokens_for_data_transfer(reward_info.epoch_emissions);
+    // HIP-149: data transfer is the residual of `hnt_rewards_issued` after the
+    // flat 24% service-provider cut, so the cap/backstop shift is absorbed here
+    // rather than over-/under-allocating. See `reward_shares::emissions_split`.
+    let pool = Decimal::from(hip_149_reward_pools(reward_info).data_transfer);
     let demand = rewardable.reward_sum(&price_info);
     let total_bytes = rewardable.total_bytes();
 
@@ -652,11 +654,8 @@ pub async fn reward_service_providers(
     reward_info: &EpochRewardInfo,
     reward_ctx: Option<(&iceberg::RewardWriters, &str)>,
 ) -> anyhow::Result<()> {
-    let total_sp_rewards = get_scheduled_tokens_for_service_providers(reward_info.epoch_emissions);
-    let sp_reward_amount = total_sp_rewards
-        .round_dp_with_strategy(0, RoundingStrategy::ToZero)
-        .to_u64()
-        .unwrap_or(0);
+    // HIP-149: a flat 24% of total emissions (see `reward_shares::emissions_split`).
+    let sp_reward_amount = hip_149_reward_pools(reward_info).service_provider;
 
     let subscriber_amount = std::cmp::min(sp_reward_amount, HELIUM_MOBILE_SERVICE_REWARD_BONES);
     let network_amount = sp_reward_amount.saturating_sub(subscriber_amount);

--- a/mobile_verifier/tests/integrations/common/mod.rs
+++ b/mobile_verifier/tests/integrations/common/mod.rs
@@ -177,6 +177,12 @@ pub fn reward_info_24_hours() -> EpochRewardInfo {
         sub_dao_address: SUB_DAO_ADDRESS.into(),
         epoch_period: (now - epoch_duration)..now,
         epoch_emissions: Decimal::from(EMISSIONS_POOL_IN_BONES_24_HOURS),
+        // 6% is carved out for veHNT delegators on-chain; the rewarder
+        // distributes the remaining ~94%.
+        hnt_rewards_issued: Decimal::from(
+            EMISSIONS_POOL_IN_BONES_24_HOURS - EMISSIONS_POOL_IN_BONES_24_HOURS * 6 / 100,
+        ),
+        delegation_rewards_issued: Decimal::from(EMISSIONS_POOL_IN_BONES_24_HOURS * 6 / 100),
         rewards_issued_at: now,
     }
 }

--- a/mobile_verifier/tests/integrations/reward_dc_hip_149.rs
+++ b/mobile_verifier/tests/integrations/reward_dc_hip_149.rs
@@ -93,10 +93,7 @@ async fn test_dc_rewards(pool: PgPool) -> anyhow::Result<()> {
     // unallocated) equal the data-transfer allocation.
     let dc_sum = rewards.dc_transfer_sum();
     let unallocated_sum = rewards.unallocated_sum();
-    let expected_sum =
-        reward_shares::get_scheduled_tokens_for_data_transfer(reward_info.epoch_emissions)
-            .to_u64()
-            .unwrap();
+    let expected_sum = reward_shares::hip_149_reward_pools(&reward_info).data_transfer;
     assert_eq!(dc_sum + unallocated_sum, expected_sum);
 
     // Only rounding dust is left over, not a real share.
@@ -162,10 +159,7 @@ async fn test_poc_inputs_are_ignored(pool: PgPool) -> anyhow::Result<()> {
     assert_eq!(rewardable_total, rewardable_sum);
 
     // The whole data-transfer pool is accounted for.
-    let expected_sum =
-        reward_shares::get_scheduled_tokens_for_data_transfer(reward_info.epoch_emissions)
-            .to_u64()
-            .unwrap();
+    let expected_sum = reward_shares::hip_149_reward_pools(&reward_info).data_transfer;
     assert_eq!(
         rewards.dc_transfer_sum() + rewards.unallocated_sum(),
         expected_sum
@@ -201,10 +195,7 @@ async fn test_no_data_sessions_unallocate_whole_pool(pool: PgPool) -> anyhow::Re
     assert!(rewards.gateway_rewards.is_empty());
     assert_eq!(rewards.unallocated.len(), 1);
 
-    let expected_sum =
-        reward_shares::get_scheduled_tokens_for_data_transfer(reward_info.epoch_emissions)
-            .to_u64()
-            .unwrap();
+    let expected_sum = reward_shares::hip_149_reward_pools(&reward_info).data_transfer;
     assert_eq!(rewards.unallocated_sum(), expected_sum);
 
     Ok(())
@@ -260,10 +251,7 @@ async fn test_unequal_dc_rewards_proportionally(pool: PgPool) -> anyhow::Result<
     assert!((r3 - (3 * r1)).abs() <= 3, "expected ~3x: {r1} vs {r3}");
 
     // The whole pool is still distributed.
-    let expected_sum =
-        reward_shares::get_scheduled_tokens_for_data_transfer(reward_info.epoch_emissions)
-            .to_u64()
-            .unwrap();
+    let expected_sum = reward_shares::hip_149_reward_pools(&reward_info).data_transfer;
     assert_eq!(
         rewards.dc_transfer_sum() + rewards.unallocated_sum(),
         expected_sum
@@ -324,10 +312,7 @@ async fn test_oversubscribed_distributes_whole_pool(pool: PgPool) -> anyhow::Res
     }
 
     // ...but the whole pool is still distributed.
-    let expected_sum =
-        reward_shares::get_scheduled_tokens_for_data_transfer(reward_info.epoch_emissions)
-            .to_u64()
-            .unwrap();
+    let expected_sum = reward_shares::hip_149_reward_pools(&reward_info).data_transfer;
     assert_eq!(
         rewards.dc_transfer_sum() + rewards.unallocated_sum(),
         expected_sum
@@ -363,10 +348,7 @@ async fn test_single_hotspot_takes_whole_pool(pool: PgPool) -> anyhow::Result<()
 
     // The lone hotspot's share is 100% of the pool, so it consumes it whole with
     // no rounding remainder.
-    let expected_sum =
-        reward_shares::get_scheduled_tokens_for_data_transfer(reward_info.epoch_emissions)
-            .to_u64()
-            .unwrap();
+    let expected_sum = reward_shares::hip_149_reward_pools(&reward_info).data_transfer;
     assert_eq!(rewards.gateway_rewards.len(), 1);
     assert_eq!(rewards.gateway_rewards[0].dc_transfer_reward, expected_sum);
     assert_eq!(rewards.unallocated_sum(), 0);

--- a/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
+++ b/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
@@ -43,10 +43,7 @@ async fn test_service_provider_rewards(_pool: PgPool) -> anyhow::Result<()> {
     assert_eq!(network_reward.rewardable_entity_key, "Helium Mobile");
 
     // confirm the total rewards allocated matches expectations
-    let expected_sum =
-        reward_shares::get_scheduled_tokens_for_service_providers(reward_info.epoch_emissions)
-            .to_u64()
-            .unwrap();
+    let expected_sum = reward_shares::hip_149_reward_pools(&reward_info).service_provider;
     assert_eq!(
         expected_sum - reward_shares::HELIUM_MOBILE_SERVICE_REWARD_BONES,
         network_reward.amount
@@ -76,8 +73,10 @@ async fn should_not_reward_service_provider_negative_amount(_pool: PgPool) -> an
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
 
     let mut reward_info = reward_info_24_hours();
-    // Total reward amount of 350 HNT
+    // Total reward amount of 350 HNT (6% delegation carved out on-chain).
     reward_info.epoch_emissions = Decimal::from(35_000_000_000u64);
+    reward_info.hnt_rewards_issued = Decimal::from(35_000_000_000u64 - 35_000_000_000u64 * 6 / 100);
+    reward_info.delegation_rewards_issued = Decimal::from(35_000_000_000u64 * 6 / 100);
 
     rewarder::reward_service_providers(mobile_rewards_client, &reward_info, None).await?;
 


### PR DESCRIPTION
The 3x cap and backstop shift HNT between `hnt_rewards_issued` and `delegation_rewards_issued`, so a fixed 70% data transfer share would over-allocate (over the cap) and under-allocate (under the backstop) the HNT the rewarder is handed. Carry both `hnt_rewards_issued` and `delegation_rewards_issued` through `EpochRewardInfo` (the latter for completeness; the rewarder doesn't distribute it) and split `hnt_rewards_issued` as:

  service providers = flat 24% of total emissions
  data transfer     = hnt_rewards_issued - service providers (residual)

so `service_provider + data_transfer == hnt_rewards_issued` exactly, every epoch. New reward_shares::emissions_split holds the split, with proptests pinning that invariant across the cap / backstop / baseline range.

Cleanup:
- centralize `floor_to_u64` so every reward pool rounds the same way (ToZero)
- drop now-unused `get_scheduled_tokens_for_{data_transfer,service_providers}`
