### PR TITLE
Force RequestChecksumCalculation::WhenRequired on all connections to s3

### DIFF
--- a/file_store/src/lib.rs
+++ b/file_store/src/lib.rs
@@ -96,7 +96,12 @@ pub async fn new_client(
 
     let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
 
-    let mut s3_config = aws_sdk_s3::config::Builder::from(&config);
+    // Force `WhenRequired`: the newer aws-sdk-s3 default (`when_supported`) adds a
+    // trailing checksum via `Content-Encoding: aws-chunked`, which triggered
+    // intermittent S3 RequestTimeout errors on PutObject. This reverts to the plain
+    // upload path. TLS still protects integrity in transit.
+    let mut s3_config = aws_sdk_s3::config::Builder::from(&config)
+        .request_checksum_calculation(aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired);
 
     if let Some(region_str) = region {
         s3_config = s3_config.region(aws_config::Region::new(region_str));


### PR DESCRIPTION
Disable the SDK's default request checksums (`when_supported`, introduced with
newer aws-sdk-s3). That default wraps every PutObject in `Content-Encoding:
aws-chunked` with a trailing CRC checksum; that streaming/trailer framing caused
intermittent S3 `RequestTimeout` errors ("socket... not read from or written to
within the timeout period") on uploads, independent of file size. `WhenRequired`
restores the plain-body upload path that worked prior to the SDK bump. S3 uploads
remain integrity-protected in transit by TLS.