### PR TITLE
Bound iceberg stream poller watermark db with timed pruning

### DIFF
--- a/helium_iceberg/src/stream/poller.rs
+++ b/helium_iceberg/src/stream/poller.rs
@@ -40,7 +40,7 @@ const DEFAULT_QUEUE_SIZE: usize = 5;
 /// window. Kept well above `poll_duration` since it's pure housekeeping — the
 /// table only accrues rows between prunes, and the first tick fires
 /// immediately so a restart also trims any pre-existing bloat.
-const DEFAULT_PRUNE_DURATION: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+const DEFAULT_PRUNE_DURATION: std::time::Duration = std::time::Duration::from_mins(60);
 
 /// Env var supplying the default watermark-db directory when `db_dir` isn't set
 /// explicitly (and no `pool` is provided).

--- a/helium_iceberg/src/stream/poller.rs
+++ b/helium_iceberg/src/stream/poller.rs
@@ -36,6 +36,12 @@ use crate::{Error, Result};
 const DEFAULT_POLL_DURATION: std::time::Duration = std::time::Duration::from_secs(30);
 const DEFAULT_QUEUE_SIZE: usize = 5;
 
+/// How often the poller prunes the watermark db down to its retained history
+/// window. Kept well above `poll_duration` since it's pure housekeeping — the
+/// table only accrues rows between prunes, and the first tick fires
+/// immediately so a restart also trims any pre-existing bloat.
+const DEFAULT_PRUNE_DURATION: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+
 /// Env var supplying the default watermark-db directory when `db_dir` isn't set
 /// explicitly (and no `pool` is provided).
 const DB_DIR_ENV: &str = "ICEBERG_STREAM_DB_DIR";
@@ -116,6 +122,10 @@ pub struct IcebergStreamPollerConfig<Message> {
     db_dir: PathBuf,
     #[builder(default = "DEFAULT_POLL_DURATION")]
     poll_duration: std::time::Duration,
+    /// How often to prune the watermark db to its retained history window.
+    /// Defaults to hourly; housekeeping only, so it needn't be frequent.
+    #[builder(default = "DEFAULT_PRUNE_DURATION")]
+    prune_duration: std::time::Duration,
     #[builder(default = "DEFAULT_QUEUE_SIZE")]
     queue_size: usize,
     #[builder(default = r#""default".to_string()"#)]
@@ -499,12 +509,29 @@ where
         );
 
         let sender = self.sender.clone();
+        // Housekeeping on a clone of the store (a cheap ref-counted pool handle),
+        // so the prune branch doesn't borrow `self` while the poll branch holds
+        // it mutably. The first tick fires immediately, trimming any pre-existing
+        // bloat on startup.
+        let store = self.store.clone();
+        let mut prune_interval = tokio::time::interval(self.config.prune_duration);
         loop {
             tokio::select! {
                 biased;
                 _ = shutdown.clone() => {
                     tracing::info!(table = table_name, %process_name, "stopping IcebergStreamPoller");
                     break;
+                }
+                _ = prune_interval.tick() => {
+                    if let Err(err) = store.prune_history().await {
+                        tracing::warn!(
+                            table = table_name,
+                            %process_name,
+                            ?err,
+                            "failed to prune watermark history"
+                        );
+                    }
+                    continue;
                 }
                 result = futures::future::try_join(
                     sender.reserve().map_err(|_| Error::ConsumerDropped {

--- a/helium_iceberg/src/stream/state.rs
+++ b/helium_iceberg/src/stream/state.rs
@@ -25,6 +25,14 @@ use sqlx::SqlitePool;
 use std::path::Path;
 use std::time::Duration;
 
+/// How many of the most recent processed-snapshot rows to retain per
+/// `(process_name, table_name)`. Only the highest `sequence_number` is ever
+/// read back (the watermark); the rest are kept purely as history to aid
+/// troubleshooting. The poller calls [`StreamState::prune_history`] on a timer
+/// to trim everything older than this so the db stays bounded rather than
+/// growing forever.
+const HISTORY_LIMIT: i64 = 100;
+
 /// Metadata describing a single Iceberg snapshot consumed as a stream event.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SnapshotMeta {
@@ -116,6 +124,10 @@ impl StreamState {
     /// Record a snapshot as processed, advancing the durable watermark. A
     /// single autocommitting statement, idempotent on the snapshot key, so a
     /// reprocessed snapshot (after a crash before recording) is a no-op.
+    ///
+    /// This only ever appends; bounding the table's growth is
+    /// [`prune_history`](Self::prune_history)'s job, which the poller runs on a
+    /// timer to keep it off this per-snapshot hot path.
     pub(crate) async fn record(&self, snapshot: &SnapshotMeta) -> Result<()> {
         sqlx::query(
             r#"
@@ -136,6 +148,34 @@ impl StreamState {
         .map(|_| ())
         .map_err(Error::from)
     }
+
+    /// Delete all but the [`HISTORY_LIMIT`] highest-`sequence_number` rows for
+    /// this stream, keeping the watermark plus a bounded window of history.
+    /// Runs independently of [`record`](Self::record) — the poller drives it on
+    /// a timer — so it never adds latency to the per-snapshot commit path.
+    pub(crate) async fn prune_history(&self) -> Result<()> {
+        sqlx::query(
+            r#"
+            DELETE FROM iceberg_snapshots_processed
+            WHERE process_name = ? AND table_name = ?
+              AND sequence_number NOT IN (
+                  SELECT sequence_number FROM iceberg_snapshots_processed
+                  WHERE process_name = ? AND table_name = ?
+                  ORDER BY sequence_number DESC
+                  LIMIT ?
+              )
+            "#,
+        )
+        .bind(&self.process_name)
+        .bind(&self.table_name)
+        .bind(&self.process_name)
+        .bind(&self.table_name)
+        .bind(HISTORY_LIMIT)
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+        .map_err(Error::from)
+    }
 }
 
 #[cfg(test)]
@@ -149,6 +189,60 @@ mod tests {
             timestamp: Utc::now(),
             operation: Operation::Append,
         }
+    }
+
+    async fn row_count(store: &StreamState) -> i64 {
+        sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*) FROM iceberg_snapshots_processed
+            WHERE process_name = ? AND table_name = ?
+            "#,
+        )
+        .bind(&store.process_name)
+        .bind(&store.table_name)
+        .fetch_one(&store.pool)
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn prune_history_keeps_recent_window_and_watermark() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = StreamState::open(dir.path().join("wm.db"), "default", "t")
+            .await
+            .unwrap();
+
+        // Record well past the retention window; record alone never prunes.
+        let total = HISTORY_LIMIT + 50;
+        for seq in 1..=total {
+            store.record(&meta(seq)).await.unwrap();
+        }
+        assert_eq!(row_count(&store).await, total);
+
+        store.prune_history().await.unwrap();
+
+        // Only the most recent HISTORY_LIMIT rows are kept...
+        assert_eq!(row_count(&store).await, HISTORY_LIMIT);
+        // ...and the watermark is still the highest sequence number seen.
+        assert_eq!(
+            store.latest_sequence_number().await.unwrap(),
+            Some(total)
+        );
+
+        // The retained window is the newest rows, so the oldest surviving
+        // sequence number is `total - HISTORY_LIMIT + 1`.
+        let min_seq = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT MIN(sequence_number) FROM iceberg_snapshots_processed
+            WHERE process_name = ? AND table_name = ?
+            "#,
+        )
+        .bind(&store.process_name)
+        .bind(&store.table_name)
+        .fetch_one(&store.pool)
+        .await
+        .unwrap();
+        assert_eq!(min_seq, total - HISTORY_LIMIT + 1);
     }
 
     #[tokio::test]

--- a/helium_iceberg/src/stream/state.rs
+++ b/helium_iceberg/src/stream/state.rs
@@ -224,10 +224,7 @@ mod tests {
         // Only the most recent HISTORY_LIMIT rows are kept...
         assert_eq!(row_count(&store).await, HISTORY_LIMIT);
         // ...and the watermark is still the highest sequence number seen.
-        assert_eq!(
-            store.latest_sequence_number().await.unwrap(),
-            Some(total)
-        );
+        assert_eq!(store.latest_sequence_number().await.unwrap(), Some(total));
 
         // The retained window is the newest rows, so the oldest surviving
         // sequence number is `total - HISTORY_LIMIT + 1`.


### PR DESCRIPTION
## What

The iceberg stream info poller records its progress in a per-poller SQLite watermark db (`iceberg_snapshots_processed`). It appended one row per processed snapshot and **never removed any**, so the db grew without bound — even though only `MAX(sequence_number)` is ever read back.

This adds a bounded-history maintenance routine:

- **`StreamState::prune_history`** (`state.rs`) — deletes all but the most recent 100 rows per `(process_name, table_name)`, keeping the watermark plus a small window of history for troubleshooting.
- **Timer-driven from the poller run loop** (`poller.rs`) — a new `prune_duration` config (default hourly) adds a `tokio::select!` branch that prunes on a timer, rather than on every `record`. This keeps maintenance off the per-snapshot commit hot path.

## Why

Left unbounded, the watermark db grows one row per snapshot forever. On a long-running poller against a frequently-committing table (30s default poll interval), that table accumulates rows indefinitely, all of them dead weight since only the max is read.

## Notes for reviewers

- The prune branch operates on a **clone of the store** (a ref-counted `SqlitePool` handle) so it doesn't borrow `self` while the poll branch holds it mutably — same pattern already used for `sender`.
- The interval's first tick fires immediately, so a restart also trims any pre-existing bloat on startup, then settles into the hourly cadence.
- A prune failure logs a warning rather than failing the poller — it's housekeeping, not correctness-critical.
- Between prunes the table can grow to ~100 + (snapshots per interval); still bounded and small.
- Rows are deleted but disk isn't reclaimed (no `VACUUM`); negligible at this steady-state size.
- Covered by `prune_history_keeps_recent_window_and_watermark` in `state.rs`.