### PR TITLE
Drop ingest of Coverage Objects

### DIFF
--- a/mobile_verifier/migrations/53_wifi_heartbeats_coverage_object_nullable.sql
+++ b/mobile_verifier/migrations/53_wifi_heartbeats_coverage_object_nullable.sql
@@ -1,0 +1,4 @@
+-- Coverage-object ingestion has been removed and heartbeats are no longer
+-- validated against a coverage object, so a valid heartbeat may not carry a
+-- coverage_object uuid. Allow the column to be null.
+ALTER TABLE wifi_heartbeats ALTER COLUMN coverage_object DROP NOT NULL;

--- a/mobile_verifier/src/boosting_oracles/data_sets.rs
+++ b/mobile_verifier/src/boosting_oracles/data_sets.rs
@@ -24,10 +24,7 @@ use sqlx::{FromRow, PgPool, QueryBuilder};
 use task_manager::{ManagedTask, TaskManager};
 use tokio::{fs::File, io::AsyncWriteExt, time::Instant};
 
-use crate::{
-    coverage::{NewCoverageObjectNotification, SignalLevel},
-    Settings,
-};
+use crate::{coverage::SignalLevel, Settings};
 
 use hex_assignments::{
     assignment::HexAssignments, footfall::Footfall, landtype::Landtype,
@@ -200,7 +197,6 @@ pub struct DataSetDownloaderDaemon {
     bucket_client: BucketClient,
     data_set_processor: FileSinkClient<proto::OracleBoostingReportV1>,
     data_set_directory: PathBuf,
-    new_coverage_object_notification: NewCoverageObjectNotification,
     poll_duration: Duration,
 }
 
@@ -256,7 +252,6 @@ impl DataSetDownloaderDaemon {
         settings: &Settings,
         file_upload: FileUpload,
         bucket_client: BucketClient,
-        new_coverage_object_notification: NewCoverageObjectNotification,
     ) -> anyhow::Result<impl ManagedTask> {
         tracing::info!("Creating data set downloader task");
         let (oracle_boosting_reports, oracle_boosting_reports_server) =
@@ -275,7 +270,6 @@ impl DataSetDownloaderDaemon {
             bucket_client,
             oracle_boosting_reports,
             settings.data_sets_directory.clone(),
-            new_coverage_object_notification,
             settings.data_sets_poll_duration,
         );
 
@@ -294,7 +288,6 @@ impl DataSetDownloaderDaemon {
         bucket_client: BucketClient,
         data_set_processor: FileSinkClient<proto::OracleBoostingReportV1>,
         data_set_directory: PathBuf,
-        new_coverage_object_notification: NewCoverageObjectNotification,
         poll_duration: Duration,
     ) -> Self {
         Self {
@@ -303,7 +296,6 @@ impl DataSetDownloaderDaemon {
             bucket_client,
             data_set_processor,
             data_set_directory,
-            new_coverage_object_notification,
             poll_duration,
         }
     }
@@ -434,23 +426,9 @@ impl DataSetDownloaderDaemon {
 
         let mut wakeup = Instant::now() + self.poll_duration;
         loop {
-            #[rustfmt::skip]
-            tokio::select! {
-                _ = self.new_coverage_object_notification.await_new_coverage_object() => {
-                    // If we see a new coverage object, we want to assign only those hexes
-                    // that don't have an assignment
-                    if is_hex_boost_data_ready(&self.data_sets) {
-                        self.data_set_processor.set_unassigned_oracle_boosting_assignments(
-                            &self.pool,
-                            &self.data_sets,
-                        ).await?;
-                    }
-                },
-                _ = tokio::time::sleep_until(wakeup) => {
-                    self.check_for_new_data_sets().await?;
-                    wakeup = Instant::now() + self.poll_duration;
-                }
-            }
+            tokio::time::sleep_until(wakeup).await;
+            self.check_for_new_data_sets().await?;
+            wakeup = Instant::now() + self.poll_duration;
         }
     }
 }

--- a/mobile_verifier/src/cli/server.rs
+++ b/mobile_verifier/src/cli/server.rs
@@ -1,23 +1,15 @@
 use std::time::Duration;
 
 use crate::{
-    banning::ingestor::BanIngestor,
-    boosting_oracles::DataSetDownloaderDaemon,
-    coverage::{new_coverage_object_notification_channel, CoverageDaemon},
-    data_session::DataSessionIngestor,
-    geofence::Geofence,
-    heartbeats::wifi::WifiHeartbeatDaemon,
-    iceberg,
-    rewarder::Rewarder,
-    speedtests::SpeedtestDaemon,
-    telemetry,
-    unique_connections::ingestor::UniqueConnectionsIngestor,
-    Settings,
+    banning::ingestor::BanIngestor, boosting_oracles::DataSetDownloaderDaemon,
+    data_session::DataSessionIngestor, geofence::Geofence, heartbeats::wifi::WifiHeartbeatDaemon,
+    iceberg, rewarder::Rewarder, speedtests::SpeedtestDaemon, telemetry,
+    unique_connections::ingestor::UniqueConnectionsIngestor, Settings,
 };
 use anyhow::Result;
 use file_store::file_upload;
 use file_store_oracles::traits::{FileSinkCommitStrategy, FileSinkRollTime, FileSinkWriteExt};
-use helium_proto::services::poc_mobile::{Heartbeat, SeniorityUpdate};
+use helium_proto::services::poc_mobile::Heartbeat;
 use mobile_config::client::{sub_dao_client::SubDaoClient, AuthorizationClient, GatewayClient};
 use task_manager::TaskManager;
 
@@ -51,16 +43,6 @@ impl Cmd {
         )
         .await?;
 
-        // Seniority updates
-        let (seniority_updates, seniority_updates_server) = SeniorityUpdate::file_sink(
-            &settings.cache,
-            file_upload.clone(),
-            FileSinkCommitStrategy::Manual,
-            FileSinkRollTime::Duration(Duration::from_secs(15 * 60)),
-            env!("CARGO_PKG_NAME"),
-        )
-        .await?;
-
         let usa_and_mexico_region_paths = settings.usa_and_mexico_region_paths()?;
         tracing::info!(
             ?usa_and_mexico_region_paths,
@@ -71,9 +53,6 @@ impl Cmd {
             usa_and_mexico_region_paths,
             settings.usa_and_mexico_fencing_resolution()?,
         )?;
-
-        let (new_coverage_obj_notifier, new_coverage_obj_notification) =
-            new_coverage_object_notification_channel();
 
         let ingest_bucket_client = settings.buckets.ingest.connect().await;
 
@@ -100,7 +79,6 @@ impl Cmd {
         TaskManager::builder()
             .add_task(file_upload_server)
             .add_task(valid_heartbeats_server)
-            .add_task(seniority_updates_server)
             .add_task(
                 WifiHeartbeatDaemon::create_managed_task(
                     pool.clone(),
@@ -108,7 +86,6 @@ impl Cmd {
                     ingest_bucket_client.clone(),
                     gateway_client.clone(),
                     valid_heartbeats,
-                    seniority_updates,
                     usa_and_mexico_geofence,
                     poc_writers.heartbeat,
                 )
@@ -127,23 +104,11 @@ impl Cmd {
                 .await?,
             )
             .add_task(
-                CoverageDaemon::create_managed_task(
-                    pool.clone(),
-                    settings,
-                    file_upload.clone(),
-                    ingest_bucket_client.clone(),
-                    auth_client.clone(),
-                    new_coverage_obj_notifier,
-                )
-                .await?,
-            )
-            .add_task(
                 DataSetDownloaderDaemon::create_managed_task(
                     pool.clone(),
                     settings,
                     file_upload.clone(),
                     settings.buckets.data_sets.connect().await,
-                    new_coverage_obj_notification,
                 )
                 .await?,
             )

--- a/mobile_verifier/src/coverage.rs
+++ b/mobile_verifier/src/coverage.rs
@@ -1,14 +1,7 @@
-use crate::{cell_type::CellType, seniority::Seniority, IsAuthorized, Settings};
+use crate::{cell_type::CellType, seniority::Seniority, IsAuthorized};
 use chrono::{DateTime, Utc};
-use file_store::{
-    file_info_poller::FileInfoStream, file_sink::FileSinkClient, file_source,
-    file_upload::FileUpload, traits::TimestampEncode, BucketClient,
-};
-use file_store_oracles::{
-    mobile::coverage::CoverageObjectIngestReport,
-    traits::{FileSinkCommitStrategy, FileSinkRollTime, FileSinkWriteExt},
-    FileType,
-};
+use file_store::{file_sink::FileSinkClient, traits::TimestampEncode};
+use file_store_oracles::mobile::coverage::CoverageObjectIngestReport;
 use futures::{
     stream::{BoxStream, Stream, StreamExt},
     TryStreamExt,
@@ -21,17 +14,10 @@ use helium_proto::services::{
 };
 use hex_assignments::assignment::HexAssignments;
 use hextree::Cell;
-use mobile_config::client::AuthorizationClient;
 use retainer::{entry::CacheReadGuard, Cache};
 
 use sqlx::{FromRow, PgPool, Pool, Postgres, QueryBuilder, Transaction, Type};
-use std::{
-    pin::pin,
-    sync::Arc,
-    time::{Duration, Instant},
-};
-use task_manager::{ChannelConsumer, ManagedTask, TaskManager};
-use tokio::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::Arc;
 use uuid::Uuid;
 
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Type)]
@@ -64,143 +50,6 @@ impl From<SignalLevel> for coverage_map::SignalLevel {
             SignalLevel::High => coverage_map::SignalLevel::High,
         }
     }
-}
-
-pub struct CoverageDaemon {
-    pool: Pool<Postgres>,
-    auth_client: AuthorizationClient,
-    coverage_objs: Receiver<FileInfoStream<CoverageObjectIngestReport>>,
-    coverage_obj_sink: FileSinkClient<proto::CoverageObjectV1>,
-    new_coverage_object_notifier: NewCoverageObjectNotifier,
-}
-
-impl CoverageDaemon {
-    pub async fn create_managed_task(
-        pool: Pool<Postgres>,
-        settings: &Settings,
-        file_upload: FileUpload,
-        bucket_client: BucketClient,
-        auth_client: AuthorizationClient,
-        new_coverage_object_notifier: NewCoverageObjectNotifier,
-    ) -> anyhow::Result<impl ManagedTask> {
-        let (valid_coverage_objs, valid_coverage_objs_server) = proto::CoverageObjectV1::file_sink(
-            settings.store_base_path(),
-            file_upload.clone(),
-            FileSinkCommitStrategy::Manual,
-            FileSinkRollTime::Duration(Duration::from_secs(15 * 60)),
-            env!("CARGO_PKG_NAME"),
-        )
-        .await?;
-
-        let (coverage_objs, coverage_objs_server) = file_source::continuous_source()
-            .state(pool.clone())
-            .bucket_client(bucket_client)
-            .lookback_start_after(settings.start_after)
-            .prefix(FileType::CoverageObjectIngestReport.to_string())
-            .create()
-            .await?;
-
-        let coverage_daemon = CoverageDaemon::new(
-            pool,
-            auth_client,
-            coverage_objs,
-            valid_coverage_objs,
-            new_coverage_object_notifier,
-        );
-
-        Ok(TaskManager::builder()
-            .add_task(valid_coverage_objs_server)
-            .add_task(coverage_objs_server)
-            .add_task(task_manager::channel_consumer(coverage_daemon))
-            .build())
-    }
-
-    pub fn new(
-        pool: PgPool,
-        auth_client: AuthorizationClient,
-        coverage_objs: Receiver<FileInfoStream<CoverageObjectIngestReport>>,
-        coverage_obj_sink: FileSinkClient<proto::CoverageObjectV1>,
-        new_coverage_object_notifier: NewCoverageObjectNotifier,
-    ) -> Self {
-        Self {
-            pool,
-            auth_client,
-            coverage_objs,
-            coverage_obj_sink,
-            new_coverage_object_notifier,
-        }
-    }
-
-    async fn process_file(
-        &self,
-        file: FileInfoStream<CoverageObjectIngestReport>,
-    ) -> anyhow::Result<()> {
-        tracing::info!("Processing coverage object file {}", file.file_info.key);
-
-        let mut transaction = self.pool.begin().await?;
-        let reports = file.into_stream(&mut transaction).await?;
-
-        let mut validated_coverage_objects = pin!(CoverageObject::validate_coverage_objects(
-            &self.auth_client,
-            reports
-        ));
-
-        while let Some(coverage_object) = validated_coverage_objects.next().await.transpose()? {
-            coverage_object.write(&self.coverage_obj_sink).await?;
-            if coverage_object.is_valid() {
-                coverage_object.save(&mut transaction).await?;
-            }
-        }
-
-        self.coverage_obj_sink.commit().await?;
-        transaction.commit().await?;
-
-        // Tell the data set manager to update the assignments.
-        self.new_coverage_object_notifier.notify();
-
-        Ok(())
-    }
-}
-
-impl ChannelConsumer for CoverageDaemon {
-    type Item = FileInfoStream<CoverageObjectIngestReport>;
-    type Error = anyhow::Error;
-
-    async fn recv(&mut self) -> Option<Self::Item> {
-        self.coverage_objs.recv().await
-    }
-
-    async fn handle(&mut self, file: Self::Item) -> anyhow::Result<()> {
-        let start = Instant::now();
-        self.process_file(file).await?;
-        metrics::histogram!("coverage_object_processing_time").record(start.elapsed());
-        Ok(())
-    }
-}
-
-pub struct NewCoverageObjectNotifier(Sender<()>);
-
-impl NewCoverageObjectNotifier {
-    fn notify(&self) {
-        let _ = self.0.try_send(());
-    }
-}
-
-pub struct NewCoverageObjectNotification(Receiver<()>);
-
-impl NewCoverageObjectNotification {
-    pub async fn await_new_coverage_object(&mut self) {
-        let _ = self.0.recv().await;
-    }
-}
-
-pub fn new_coverage_object_notification_channel(
-) -> (NewCoverageObjectNotifier, NewCoverageObjectNotification) {
-    let (tx, rx) = channel(1);
-    (
-        NewCoverageObjectNotifier(tx),
-        NewCoverageObjectNotification(rx),
-    )
 }
 
 #[derive(Clone)]

--- a/mobile_verifier/src/heartbeats/mod.rs
+++ b/mobile_verifier/src/heartbeats/mod.rs
@@ -2,10 +2,7 @@ pub mod last_location;
 pub mod wifi;
 
 use crate::{
-    cell_type::CellType,
-    coverage::{self, CoverageClaimTimeCache, CoverageObjectCache, CoverageObjectMeta},
-    geofence::GeofenceValidator,
-    seniority::{Seniority, SeniorityUpdate},
+    cell_type::CellType, coverage::CoverageObjectMeta, geofence::GeofenceValidator,
     GatewayResolution, GatewayResolver,
 };
 use anyhow::{anyhow, Context};
@@ -160,7 +157,6 @@ impl ValidatedHeartbeat {
         distance_to_asserted: Option<i64>,
         asserted_location: Option<u64>,
         device_type: Option<DeviceType>,
-        coverage_meta: Option<CoverageObjectMeta>,
         validity: proto::HeartbeatValidity,
     ) -> Self {
         Self {
@@ -170,7 +166,7 @@ impl ValidatedHeartbeat {
             distance_to_asserted,
             asserted_location,
             device_type,
-            coverage_meta,
+            coverage_meta: None,
             validity,
         }
     }
@@ -178,25 +174,11 @@ impl ValidatedHeartbeat {
     fn new_invalid(
         heartbeat: Heartbeat,
         cell_type: CellType,
-        coverage_meta: CoverageObjectMeta,
         validity: proto::HeartbeatValidity,
     ) -> Self {
         Self {
             heartbeat,
             cell_type,
-            location_trust_score_multiplier: dec!(0),
-            distance_to_asserted: None,
-            asserted_location: None,
-            device_type: None,
-            coverage_meta: Some(coverage_meta),
-            validity,
-        }
-    }
-
-    fn new_no_coverage(heartbeat: Heartbeat, validity: proto::HeartbeatValidity) -> Self {
-        Self {
-            heartbeat,
-            cell_type: CellType::CellTypeNone,
             location_trust_score_multiplier: dec!(0),
             distance_to_asserted: None,
             asserted_location: None,
@@ -210,36 +192,66 @@ impl ValidatedHeartbeat {
     pub async fn validate(
         mut heartbeat: Heartbeat,
         gateway_info_resolver: &impl GatewayResolver,
-        coverage_object_cache: &CoverageObjectCache,
         last_location_cache: &LocationCache,
-        max_distance_to_coverage: u32,
         epoch: &Range<DateTime<Utc>>,
         geofence: &impl GeofenceValidator,
     ) -> anyhow::Result<Self> {
-        let Some(coverage_object_uuid) = heartbeat.coverage_object else {
-            return Ok(Self::new_no_coverage(
-                heartbeat,
-                proto::HeartbeatValidity::BadCoverageObject,
-            ));
+        // The gateway's device type (from mobile-config) is the source of the
+        // cell/radio type; heartbeats are no longer validated against a coverage
+        // object.
+        //
+        let gw_info = gateway_info_resolver
+            .resolve_gateway(&heartbeat.hotspot_key, &heartbeat.timestamp)
+            .await?;
+
+        let (asserted_location, device_type) = match gw_info {
+            GatewayResolution::AssertedLocation(location, device_type) => (location, device_type),
+            GatewayResolution::GatewayNotFound => {
+                return Ok(Self::new_invalid(
+                    heartbeat,
+                    CellType::CellTypeNone,
+                    proto::HeartbeatValidity::GatewayNotFound,
+                ))
+            }
+            GatewayResolution::GatewayNotAsserted => {
+                return Ok(Self::new_invalid(
+                    heartbeat,
+                    CellType::CellTypeNone,
+                    proto::HeartbeatValidity::GatewayNotAsserted,
+                ))
+            }
+            GatewayResolution::DataOnly => {
+                return Ok(Self::new_invalid(
+                    heartbeat,
+                    CellType::CellTypeNone,
+                    proto::HeartbeatValidity::InvalidDeviceType,
+                ))
+            }
         };
 
-        let Some(coverage_object) = coverage_object_cache
-            .fetch_coverage_object(&coverage_object_uuid, heartbeat.key())
-            .await?
-        else {
-            return Ok(Self::new_no_coverage(
-                heartbeat,
-                proto::HeartbeatValidity::NoSuchCoverageObject,
-            ));
+        let (cell_type, radio_type) = match device_type {
+            DeviceType::WifiIndoor => (
+                CellType::NovaGenericWifiIndoor,
+                coverage_point_calculator::RadioType::IndoorWifi,
+            ),
+            DeviceType::WifiOutdoor => (
+                CellType::NovaGenericWifiOutdoor,
+                coverage_point_calculator::RadioType::OutdoorWifi,
+            ),
+            // Data-only gateways are rejected above; CBRS is deprecated.
+            DeviceType::WifiDataOnly | DeviceType::Cbrs => {
+                return Ok(Self::new_invalid(
+                    heartbeat,
+                    CellType::CellTypeNone,
+                    proto::HeartbeatValidity::InvalidDeviceType,
+                ))
+            }
         };
-
-        let cell_type = coverage_object.to_cell_type();
 
         if !heartbeat.operation_mode {
             return Ok(Self::new_invalid(
                 heartbeat,
                 cell_type,
-                coverage_object.meta,
                 proto::HeartbeatValidity::NotOperational,
             ));
         }
@@ -248,7 +260,6 @@ impl ValidatedHeartbeat {
             return Ok(Self::new_invalid(
                 heartbeat,
                 cell_type,
-                coverage_object.meta,
                 proto::HeartbeatValidity::HeartbeatOutsideRange,
             ));
         }
@@ -257,7 +268,6 @@ impl ValidatedHeartbeat {
             return Ok(Self::new_invalid(
                 heartbeat,
                 cell_type,
-                coverage_object.meta,
                 proto::HeartbeatValidity::InvalidLatLon,
             ));
         };
@@ -266,103 +276,66 @@ impl ValidatedHeartbeat {
             return Ok(Self::new_invalid(
                 heartbeat,
                 cell_type,
-                coverage_object.meta,
                 proto::HeartbeatValidity::UnsupportedLocation,
             ));
         }
 
-        match gateway_info_resolver
-            .resolve_gateway(&heartbeat.hotspot_key, &heartbeat.timestamp)
-            .await?
-        {
-            GatewayResolution::DataOnly => Ok(Self::new_invalid(
-                heartbeat,
-                cell_type,
-                coverage_object.meta,
-                proto::HeartbeatValidity::InvalidDeviceType,
-            )),
-            GatewayResolution::GatewayNotFound => Ok(Self::new_invalid(
-                heartbeat,
-                cell_type,
-                coverage_object.meta,
-                proto::HeartbeatValidity::GatewayNotFound,
-            )),
-            GatewayResolution::GatewayNotAsserted => Ok(Self::new_invalid(
-                heartbeat,
-                cell_type,
-                coverage_object.meta,
-                proto::HeartbeatValidity::GatewayNotAsserted,
-            )),
-            GatewayResolution::AssertedLocation(location, device_type) => {
-                let asserted_latlng: LatLng = CellIndex::try_from(location)?.into();
-                let is_valid = match heartbeat.location_validation_timestamp {
-                    None => {
-                        if let Some(last_location) = last_location_cache
-                            .get(&heartbeat.hotspot_key, heartbeat.timestamp)
-                            .await?
-                        {
-                            heartbeat.lat = last_location.lat;
-                            heartbeat.lon = last_location.lon;
-                            heartbeat.location_validation_timestamp =
-                                Some(last_location.location_validation_timestamp);
-                            // Can't panic, previous lat and lon must be valid.
-                            hb_latlng = heartbeat.centered_latlng().unwrap();
-                            true
-                        } else {
-                            false
-                        }
-                    }
-                    Some(location_validation_timestamp) => {
-                        last_location_cache
-                            .set(
-                                &heartbeat.hotspot_key,
-                                LastLocation::from_heartbeat(
-                                    &heartbeat,
-                                    location_validation_timestamp,
-                                ),
-                            )
-                            .await;
-                        true
-                    }
-                };
-
-                let distance_to_asserted = asserted_latlng.distance_m(hb_latlng).round() as i64;
-                let max_distance = coverage_object.max_distance_m(hb_latlng).round() as u32;
-
-                let location_trust_score_multiplier = if !is_valid {
-                    dec!(0)
-                } else if max_distance >= max_distance_to_coverage {
-                    // Furthest hex in Heartbeat exceeds allowed coverage distance
-                    dec!(0)
+        let asserted_latlng: LatLng = CellIndex::try_from(asserted_location)?.into();
+        let is_valid = match heartbeat.location_validation_timestamp {
+            None => {
+                if let Some(last_location) = last_location_cache
+                    .get(&heartbeat.hotspot_key, heartbeat.timestamp)
+                    .await?
+                {
+                    heartbeat.lat = last_location.lat;
+                    heartbeat.lon = last_location.lon;
+                    heartbeat.location_validation_timestamp =
+                        Some(last_location.location_validation_timestamp);
+                    // Can't panic, previous lat and lon must be valid.
+                    hb_latlng = heartbeat.centered_latlng().unwrap();
+                    true
                 } else {
-                    // HIP-119 maximum asserted distance check
-                    coverage_point_calculator::asserted_distance_to_trust_multiplier(
-                        coverage_object.to_radio_type(),
-                        distance_to_asserted as u32,
-                    )
-                };
-
-                Ok(Self::new(
-                    heartbeat,
-                    cell_type,
-                    location_trust_score_multiplier,
-                    Some(distance_to_asserted),
-                    Some(location),
-                    Some(device_type),
-                    Some(coverage_object.meta),
-                    proto::HeartbeatValidity::Valid,
-                ))
+                    false
+                }
             }
-        }
+            Some(validation_ts) => {
+                last_location_cache
+                    .set(
+                        &heartbeat.hotspot_key,
+                        LastLocation::from_heartbeat(&heartbeat, validation_ts),
+                    )
+                    .await;
+                true
+            }
+        };
+
+        let distance_to_asserted = asserted_latlng.distance_m(hb_latlng).round() as i64;
+
+        let location_trust_score_multiplier = if !is_valid {
+            dec!(0)
+        } else {
+            // HIP-119 maximum asserted distance check
+            coverage_point_calculator::asserted_distance_to_trust_multiplier(
+                radio_type,
+                distance_to_asserted as u32,
+            )
+        };
+
+        Ok(Self::new(
+            heartbeat,
+            cell_type,
+            location_trust_score_multiplier,
+            Some(distance_to_asserted),
+            Some(asserted_location),
+            Some(device_type),
+            proto::HeartbeatValidity::Valid,
+        ))
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn validate_heartbeats<'a>(
         heartbeats: impl Stream<Item = Heartbeat> + 'a,
         gateway_info_resolver: &'a impl GatewayResolver,
-        coverage_object_cache: &'a CoverageObjectCache,
         last_location_cache: &'a LocationCache,
-        max_distance_to_coverage: u32,
         epoch: &'a Range<DateTime<Utc>>,
         geofence: &'a impl GeofenceValidator,
     ) -> impl Stream<Item = anyhow::Result<Self>> + 'a {
@@ -370,9 +343,7 @@ impl ValidatedHeartbeat {
             Self::validate(
                 heartbeat,
                 gateway_info_resolver,
-                coverage_object_cache,
                 last_location_cache,
-                max_distance_to_coverage,
                 epoch,
                 geofence,
             )
@@ -415,14 +386,6 @@ impl ValidatedHeartbeat {
     }
 
     pub async fn save(self, exec: &mut PgTransaction<'_>) -> anyhow::Result<()> {
-        coverage::set_invalidated_at(
-            exec,
-            self.heartbeat.timestamp,
-            self.coverage_meta.as_ref().map(|x| x.inserted_at),
-            self.heartbeat.key(),
-            self.heartbeat.coverage_object,
-        )
-        .await?;
         let truncated_timestamp = self.truncated_timestamp()?;
         sqlx::query(
             r#"
@@ -452,9 +415,7 @@ impl ValidatedHeartbeat {
 pub(crate) async fn process_validated_heartbeats(
     validated_heartbeats: impl Stream<Item = anyhow::Result<ValidatedHeartbeat>>,
     heartbeat_cache: &Cache<(String, DateTime<Utc>), ()>,
-    coverage_claim_time_cache: &CoverageClaimTimeCache,
     heartbeat_sink: &FileSinkClient<proto::Heartbeat>,
-    seniority_sink: &FileSinkClient<proto::SeniorityUpdate>,
     transaction: &mut PgTransaction<'_>,
     iceberg_ctx: Option<(&crate::iceberg::HeartbeatWriter, &str)>,
 ) -> anyhow::Result<()> {
@@ -478,26 +439,6 @@ pub(crate) async fn process_validated_heartbeats(
 
         if !validated_heartbeat.is_valid() {
             continue;
-        }
-
-        if let Some(coverage_claim_time) = coverage_claim_time_cache
-            .fetch_coverage_claim_time(
-                validated_heartbeat.heartbeat.key(),
-                &validated_heartbeat.heartbeat.coverage_object,
-                &mut *transaction,
-            )
-            .await?
-        {
-            let latest_seniority =
-                Seniority::fetch_latest(validated_heartbeat.heartbeat.key(), &mut *transaction)
-                    .await?;
-            let seniority_update = SeniorityUpdate::determine_update_action(
-                &validated_heartbeat,
-                coverage_claim_time,
-                latest_seniority,
-            )?;
-            seniority_update.write(seniority_sink).await?;
-            seniority_update.execute(&mut *transaction).await?;
         }
 
         let key = validated_heartbeat.heartbeat.id()?;
@@ -533,7 +474,7 @@ pub async fn clear_heartbeats(
 
 #[cfg(test)]
 mod test {
-    use crate::seniority::SeniorityUpdateAction;
+    use crate::seniority::{Seniority, SeniorityUpdate, SeniorityUpdateAction};
 
     use super::*;
     use file_store_oracles::wifi_heartbeat::WifiHeartbeat;

--- a/mobile_verifier/src/heartbeats/wifi.rs
+++ b/mobile_verifier/src/heartbeats/wifi.rs
@@ -1,9 +1,6 @@
 use super::{process_validated_heartbeats, Heartbeat, ValidatedHeartbeat};
 use crate::{
-    coverage::{CoverageClaimTimeCache, CoverageObjectCache},
-    geofence::GeofenceValidator,
-    heartbeats::LocationCache,
-    iceberg, GatewayResolver, Settings,
+    geofence::GeofenceValidator, heartbeats::LocationCache, iceberg, GatewayResolver, Settings,
 };
 use chrono::{DateTime, Duration, Utc};
 use file_store::{
@@ -25,9 +22,7 @@ pub struct WifiHeartbeatDaemon<GIR, GFV> {
     pool: PgPool,
     gateway_info_resolver: GIR,
     heartbeats: Receiver<FileInfoStream<WifiHeartbeatIngestReport>>,
-    max_distance_to_coverage: u32,
     heartbeat_sink: FileSinkClient<proto::Heartbeat>,
-    seniority_sink: FileSinkClient<proto::SeniorityUpdate>,
     geofence: GFV,
     iceberg_writer: Option<iceberg::HeartbeatWriter>,
 }
@@ -44,7 +39,6 @@ where
         bucket_client: BucketClient,
         gateway_resolver: GIR,
         valid_heartbeats: FileSinkClient<proto::Heartbeat>,
-        seniority_updates: FileSinkClient<proto::SeniorityUpdate>,
         geofence: GFV,
         iceberg_writer: Option<iceberg::HeartbeatWriter>,
     ) -> anyhow::Result<impl ManagedTask> {
@@ -61,9 +55,7 @@ where
             pool,
             gateway_resolver,
             wifi_heartbeats,
-            settings.max_distance_from_coverage,
             valid_heartbeats,
-            seniority_updates,
             geofence,
             iceberg_writer,
         );
@@ -74,14 +66,11 @@ where
             .build())
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pool: sqlx::Pool<sqlx::Postgres>,
         gateway_info_resolver: GIR,
         heartbeats: Receiver<FileInfoStream<WifiHeartbeatIngestReport>>,
-        max_distance_to_coverage: u32,
         heartbeat_sink: FileSinkClient<proto::Heartbeat>,
-        seniority_sink: FileSinkClient<proto::SeniorityUpdate>,
         geofence: GFV,
         iceberg_writer: Option<iceberg::HeartbeatWriter>,
     ) -> Self {
@@ -89,9 +78,7 @@ where
             pool,
             gateway_info_resolver,
             heartbeats,
-            max_distance_to_coverage,
             heartbeat_sink,
-            seniority_sink,
             geofence,
             iceberg_writer,
         }
@@ -108,8 +95,6 @@ where
                 .await
         });
 
-        let coverage_claim_time_cache = CoverageClaimTimeCache::new();
-        let coverage_object_cache = CoverageObjectCache::new(&self.pool);
         let location_cache = LocationCache::new(&self.pool);
 
         loop {
@@ -124,8 +109,6 @@ where
                     self.process_file(
                         file,
                         &heartbeat_cache,
-                        &coverage_claim_time_cache,
-                        &coverage_object_cache,
                         &location_cache
                     ).await?;
                     metrics::histogram!("wifi_heartbeat_processing_time")
@@ -141,8 +124,6 @@ where
         &self,
         file: FileInfoStream<WifiHeartbeatIngestReport>,
         heartbeat_cache: &Cache<(String, DateTime<Utc>), ()>,
-        coverage_claim_time_cache: &CoverageClaimTimeCache,
-        coverage_object_cache: &CoverageObjectCache,
         location_cache: &LocationCache,
     ) -> anyhow::Result<()> {
         tracing::info!(
@@ -162,22 +143,17 @@ where
             ValidatedHeartbeat::validate_heartbeats(
                 heartbeats,
                 &self.gateway_info_resolver,
-                coverage_object_cache,
                 location_cache,
-                self.max_distance_to_coverage,
                 &epoch,
                 &self.geofence,
             ),
             heartbeat_cache,
-            coverage_claim_time_cache,
             &self.heartbeat_sink,
-            &self.seniority_sink,
             &mut transaction,
             iceberg_ctx,
         )
         .await?;
         self.heartbeat_sink.commit().await?;
-        self.seniority_sink.commit().await?;
         transaction.commit().await?;
         Ok(())
     }

--- a/mobile_verifier/src/lib.rs
+++ b/mobile_verifier/src/lib.rs
@@ -57,17 +57,14 @@ impl GatewayResolver for mobile_config::GatewayClient {
         gateway_query_timestamp: &DateTime<Utc>,
     ) -> Result<GatewayResolution, ClientError> {
         use mobile_config::gateway::client::GatewayInfoResolver;
-        use mobile_config::gateway::service::info::{DeviceType, GatewayInfo};
+        use mobile_config::gateway::service::info::GatewayInfo;
 
         match self
             .resolve_gateway_info(address, gateway_query_timestamp)
             .await?
         {
             None => Ok(GatewayResolution::GatewayNotFound),
-            Some(GatewayInfo {
-                device_type: DeviceType::WifiDataOnly,
-                ..
-            }) => Ok(GatewayResolution::DataOnly),
+            Some(info) if info.is_data_only() => Ok(GatewayResolution::DataOnly),
             Some(GatewayInfo {
                 metadata: Some(metadata),
                 device_type,

--- a/mobile_verifier/src/settings.rs
+++ b/mobile_verifier/src/settings.rs
@@ -39,10 +39,6 @@ pub struct Settings {
     pub config_client: mobile_config::ClientSettings,
     #[serde(default = "default_start_after")]
     pub start_after: DateTime<Utc>,
-    /// Max distance in meters between the heartbeat and all of the hexes in
-    /// its respective coverage object
-    #[serde(default = "default_max_distance_from_coverage")]
-    pub max_distance_from_coverage: u32,
     /// Directory in which new oracle boosting data sets are downloaded into
     #[serde(default = "default_data_sets_directory")]
     pub data_sets_directory: PathBuf,
@@ -65,11 +61,6 @@ pub struct Settings {
 
 fn default_fencing_resolution() -> u8 {
     7
-}
-
-fn default_max_distance_from_coverage() -> u32 {
-    // Default is 3 km
-    3000
 }
 
 fn default_log() -> String {

--- a/mobile_verifier/tests/integrations/boosting_oracles.rs
+++ b/mobile_verifier/tests/integrations/boosting_oracles.rs
@@ -17,10 +17,7 @@ use hex_assignments::{Assignment, HexBoostData};
 use mobile_verifier::{
     banning::BannedRadios,
     boosting_oracles::DataSetDownloaderDaemon,
-    coverage::{
-        new_coverage_object_notification_channel, CoverageClaimTimeCache, CoverageObject,
-        CoverageObjectCache,
-    },
+    coverage::{CoverageClaimTimeCache, CoverageObject},
     geofence::GeofenceValidator,
     heartbeats::{last_location::LocationCache, Heartbeat, HeartbeatReward, ValidatedHeartbeat},
     reward_shares::CoverageShares,
@@ -140,7 +137,6 @@ async fn test_dataset_downloader(pool: PgPool) {
             .expect("failed to write file to aws");
     }
 
-    let (_, new_coverage_obj_notification) = new_coverage_object_notification_channel();
     let (sender, _receiver) = file_sink::message_channel(100);
     let file_sink_client = file_sink::FileSinkClient::new(sender, "fake");
     let tmpdir = tempfile::tempdir().expect("unable to create temporary directory");
@@ -151,7 +147,6 @@ async fn test_dataset_downloader(pool: PgPool) {
         awsl.bucket_client(),
         file_sink_client,
         tmpdir.path().to_path_buf(),
-        new_coverage_obj_notification,
         std::time::Duration::from_secs(4),
     );
 
@@ -426,7 +421,6 @@ async fn test_footfall_and_urbanization_and_landtype_and_service_provider_overri
     let hb_pubkey = pub_key.clone();
     let heartbeats = heartbeats(13, start, &hb_pubkey, -105.272404746, 40.019418356, uuid);
 
-    let coverage_objects = CoverageObjectCache::new(&pool);
     let coverage_claim_time_cache = CoverageClaimTimeCache::new();
     let location_cache = LocationCache::new(&pool);
 
@@ -434,9 +428,7 @@ async fn test_footfall_and_urbanization_and_landtype_and_service_provider_overri
     let mut heartbeats = pin!(ValidatedHeartbeat::validate_heartbeats(
         stream::iter(heartbeats.map(Heartbeat::from)),
         &GatewayClientAllOwnersValid,
-        &coverage_objects,
         &location_cache,
-        2000,
         &epoch,
         &MockGeofence,
     ));

--- a/mobile_verifier/tests/integrations/last_location.rs
+++ b/mobile_verifier/tests/integrations/last_location.rs
@@ -6,7 +6,7 @@ use h3o::LatLng;
 use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_mobile::{self as proto, LocationSource};
 use mobile_verifier::{
-    coverage::{CoverageObject, CoverageObjectCache},
+    coverage::CoverageObject,
     geofence::GeofenceValidator,
     heartbeats::{last_location::LocationCache, Heartbeat, ValidatedHeartbeat},
 };
@@ -35,7 +35,6 @@ async fn heartbeat_uses_last_good_location_when_invalid_location(
     let epoch_start = Utc::now() - Duration::days(1);
     let epoch_end = epoch_start + Duration::days(2);
 
-    let coverage_objects = CoverageObjectCache::new(&pool);
     let location_cache = LocationCache::new(&pool);
 
     let mut transaction = pool.begin().await?;
@@ -47,9 +46,7 @@ async fn heartbeat_uses_last_good_location_when_invalid_location(
             .location_validation_timestamp(Utc::now())
             .build(),
         &GatewayClientAllOwnersValid,
-        &coverage_objects,
         &location_cache,
-        u32::MAX,
         &(epoch_start..epoch_end),
         &MockGeofence,
     )
@@ -65,9 +62,7 @@ async fn heartbeat_uses_last_good_location_when_invalid_location(
             .latlng((0.0, 0.0))
             .build(),
         &GatewayClientAllOwnersValid,
-        &coverage_objects,
         &location_cache,
-        u32::MAX,
         &(epoch_start..epoch_end),
         &MockGeofence,
     )
@@ -97,7 +92,6 @@ async fn heartbeat_will_use_last_good_location_from_db(pool: PgPool) -> anyhow::
     let epoch_start = Utc::now() - Duration::days(1);
     let epoch_end = epoch_start + Duration::days(2);
 
-    let coverage_objects = CoverageObjectCache::new(&pool);
     let location_cache = LocationCache::new(&pool);
 
     let mut transaction = pool.begin().await?;
@@ -109,9 +103,7 @@ async fn heartbeat_will_use_last_good_location_from_db(pool: PgPool) -> anyhow::
             .location_validation_timestamp(Utc::now())
             .build(),
         &GatewayClientAllOwnersValid,
-        &coverage_objects,
         &location_cache,
-        u32::MAX,
         &(epoch_start..epoch_end),
         &MockGeofence,
     )
@@ -132,9 +124,7 @@ async fn heartbeat_will_use_last_good_location_from_db(pool: PgPool) -> anyhow::
             .latlng((0.0, 0.0))
             .build(),
         &GatewayClientAllOwnersValid,
-        &coverage_objects,
         &location_cache,
-        u32::MAX,
         &(epoch_start..epoch_end),
         &MockGeofence,
     )
@@ -166,7 +156,6 @@ async fn heartbeat_does_not_use_last_good_location_when_more_than_24_hours(
     let epoch_start = Utc::now() - Duration::days(1);
     let epoch_end = epoch_start + Duration::days(2);
 
-    let coverage_objects = CoverageObjectCache::new(&pool);
     let location_cache = LocationCache::new(&pool);
 
     let mut transaction = pool.begin().await?;
@@ -182,9 +171,7 @@ async fn heartbeat_does_not_use_last_good_location_when_more_than_24_hours(
             .timestamp(location_validation_timestamp - Duration::hours(24) + Duration::seconds(1))
             .build(),
         &GatewayClientAllOwnersValid,
-        &coverage_objects,
         &location_cache,
-        u32::MAX,
         &(epoch_start..epoch_end),
         &MockGeofence,
     )
@@ -202,9 +189,7 @@ async fn heartbeat_does_not_use_last_good_location_when_more_than_24_hours(
             .latlng((0.0, 0.0))
             .build(),
         &GatewayClientAllOwnersValid,
-        &coverage_objects,
         &location_cache,
-        u32::MAX,
         &(epoch_start..epoch_end),
         &MockGeofence,
     )

--- a/mobile_verifier/tests/integrations/modeled_coverage.rs
+++ b/mobile_verifier/tests/integrations/modeled_coverage.rs
@@ -298,7 +298,6 @@ async fn process_wifi_input(
     coverage_objs: impl Iterator<Item = CoverageObjectIngestReport>,
     heartbeats: impl Iterator<Item = WifiHeartbeatIngestReport>,
 ) -> anyhow::Result<()> {
-    let coverage_objects = CoverageObjectCache::new(pool);
     let coverage_claim_time_cache = CoverageClaimTimeCache::new();
     let location_cache = LocationCache::new(pool);
 
@@ -322,9 +321,7 @@ async fn process_wifi_input(
     let mut heartbeats = pin!(ValidatedHeartbeat::validate_heartbeats(
         stream::iter(heartbeats.map(Heartbeat::from)),
         &GatewayClientAllOwnersValid,
-        &coverage_objects,
         &location_cache,
-        2000,
         epoch,
         &MockGeofence,
     ));
@@ -718,7 +715,6 @@ async fn ensure_lower_trust_score_for_distant_heartbeats(pool: PgPool) -> anyhow
     transaction.commit().await?;
 
     let max_covered_distance = 5_000;
-    let coverage_object_cache = CoverageObjectCache::new(&pool);
     let location_cache = LocationCache::new(&pool);
 
     let mk_heartbeat = |latlng: LatLng| WifiHeartbeatIngestReport {
@@ -739,9 +735,7 @@ async fn ensure_lower_trust_score_for_distant_heartbeats(pool: PgPool) -> anyhow
         ValidatedHeartbeat::validate(
             mk_heartbeat(latlng).into(),
             &GatewayClientAllOwnersValid,
-            &coverage_object_cache,
             &location_cache,
-            max_covered_distance,
             &(DateTime::<Utc>::MIN_UTC..DateTime::<Utc>::MAX_UTC),
             &MockGeofence,
         )


### PR DESCRIPTION
Coverage Objects are no longer being used to validate heartbeats as POC has gone away.

- Coverage Object ingestion has been removed
- Heartbeats are not long invalidated for coverage object reasons
- Heartbeat validation now uses mobile-config for device_type
- Seniority dropped from heartbeat flow
- MIGRATION: wifi_heartbeats.coverage_object is NULLABLE
- Coverage Object notification to DataSetDownloader removed
  - DataSetDownloader will be removed in future PR