### PR TITLE
Send all service provider rewards to Network entity key

### DIFF
--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -16,9 +16,6 @@ pub const DEFAULT_PREC: u32 = 15;
 // Percent of total emissions allocated for service provider rewards
 const SERVICE_PROVIDER_PERCENT: Decimal = dec!(0.24);
 
-// Fixed price of service provider rewards to be given to Helium Mobile Service Rewards
-pub const HELIUM_MOBILE_SERVICE_REWARD_BONES: u64 = 45_000_000_000;
-
 /// Returns the equivalent amount of Hnt bones for a specified amount of Data Credits
 pub fn dc_to_hnt_bones(dc_amount: Decimal, hnt_bone_price: Decimal) -> Decimal {
     let dc_in_usd = dc_amount * DC_USD_PRICE;
@@ -42,8 +39,6 @@ pub(crate) fn floor_to_u64(value: Decimal) -> u64 {
 pub enum RewardableEntityKey {
     #[strum(serialize = "Helium Mobile")]
     Network,
-    #[strum(serialize = "Helium Mobile Service Rewards")]
-    Subscriber,
 }
 
 #[cfg(test)]

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -13,7 +13,7 @@ use db_store::meta;
 use file_store::{file_sink::FileSinkClient, file_upload::FileUpload, traits::TimestampEncode};
 use file_store_oracles::traits::{FileSinkCommitStrategy, FileSinkRollTime, FileSinkWriteExt};
 
-use crate::reward_shares::{RewardableEntityKey, HELIUM_MOBILE_SERVICE_REWARD_BONES};
+use crate::reward_shares::RewardableEntityKey;
 use helium_proto::{
     reward_manifest::RewardData::MobileRewardData,
     services::poc_mobile::{
@@ -413,51 +413,34 @@ pub async fn reward_service_providers(
     // HIP-149: a flat 24% of total emissions (see `reward_shares::emissions_split`).
     let sp_reward_amount = hip_149_reward_pools(reward_info).service_provider;
 
-    let subscriber_amount = std::cmp::min(sp_reward_amount, HELIUM_MOBILE_SERVICE_REWARD_BONES);
-    let network_amount = sp_reward_amount.saturating_sub(subscriber_amount);
-
-    // Write a ServiceProviderReward for HeliumMobile Subscriber Wallet for 450 HNT
-    let subscriber_share = proto::ServiceProviderReward {
-        service_provider_id: ServiceProvider::HeliumMobile.into(),
-        rewardable_entity_key: RewardableEntityKey::Subscriber.to_string(),
-        amount: subscriber_amount,
-    };
-
-    // Remaining rewards goes to HeliumMobile Network Wallet
+    // The entire service-provider pool goes to the HeliumMobile Network Wallet.
     let network_share = proto::ServiceProviderReward {
         service_provider_id: ServiceProvider::HeliumMobile.into(),
         rewardable_entity_key: RewardableEntityKey::Network.to_string(),
-        amount: network_amount,
+        amount: sp_reward_amount,
     };
 
     if let Some((writers, id)) = reward_ctx {
         use iceberg::service_provider_reward::IcebergServiceProviderReward;
-        let start = reward_info.epoch_period.start;
-        let end = reward_info.epoch_period.end;
 
         writers
             .write_service_provider(
                 id,
-                vec![
-                    IcebergServiceProviderReward::from_sp_reward(&subscriber_share, start, end),
-                    IcebergServiceProviderReward::from_sp_reward(&network_share, start, end),
-                ],
+                vec![IcebergServiceProviderReward::from_sp_reward(
+                    &network_share,
+                    reward_info.epoch_period.start,
+                    reward_info.epoch_period.end,
+                )],
             )
             .await?;
     }
 
-    let subscriber_reward = proto::MobileRewardShare {
-        start_period: reward_info.epoch_period.start.encode_timestamp(),
-        end_period: reward_info.epoch_period.end.encode_timestamp(),
-        reward: Some(ProtoReward::ServiceProviderReward(subscriber_share)),
-    };
     let network_reward = proto::MobileRewardShare {
         start_period: reward_info.epoch_period.start.encode_timestamp(),
         end_period: reward_info.epoch_period.end.encode_timestamp(),
         reward: Some(ProtoReward::ServiceProviderReward(network_share)),
     };
 
-    mobile_rewards.write(subscriber_reward, []).await?.await??;
     mobile_rewards.write(network_reward, []).await?.await??;
 
     Ok(())

--- a/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
+++ b/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
@@ -16,42 +16,25 @@ async fn test_service_provider_rewards(_pool: PgPool) -> anyhow::Result<()> {
 
     let rewards = mobile_rewards.finish().await?;
 
-    // Verify two ServiceProviderRewards
-    assert_eq!(rewards.sp_rewards.len(), 2);
+    // The entire service-provider pool goes to the HeliumMobile Network wallet.
+    assert_eq!(rewards.sp_rewards.len(), 1);
 
-    // Verify first reward is 450HNT to HeliumMobile Subscriber wallet
-    let subscriber_reward = rewards.sp_rewards.first().expect("sp reward");
-    assert_eq!(
-        subscriber_reward.service_provider_id,
-        ServiceProvider::HeliumMobile as i32
-    );
-    assert_eq!(
-        subscriber_reward.rewardable_entity_key,
-        "Helium Mobile Service Rewards"
-    );
-    assert_eq!(
-        reward_shares::HELIUM_MOBILE_SERVICE_REWARD_BONES,
-        subscriber_reward.amount
-    );
-
-    // Verify second reward is to HeliumMobile Network wallet with remaining amount
-    let network_reward = rewards.sp_rewards.get(1).expect("sp reward");
+    let network_reward = rewards.sp_rewards.first().expect("sp reward");
     assert_eq!(
         network_reward.service_provider_id,
         ServiceProvider::HeliumMobile as i32
     );
-    assert_eq!(network_reward.rewardable_entity_key, "Helium Mobile");
-
-    // confirm the total rewards allocated matches expectations
-    let expected_sum = reward_shares::hip_149_reward_pools(&reward_info).service_provider;
     assert_eq!(
-        expected_sum - reward_shares::HELIUM_MOBILE_SERVICE_REWARD_BONES,
-        network_reward.amount
+        network_reward.rewardable_entity_key,
+        RewardableEntityKey::Network.to_string()
     );
 
+    // confirm the total rewards allocated matches the full 24% pool
+    let expected_sum = reward_shares::hip_149_reward_pools(&reward_info).service_provider;
+    assert_eq!(expected_sum, network_reward.amount);
+
     // confirm the rewarded percentage amount matches expectations
-    let percent = (Decimal::from(network_reward.amount + subscriber_reward.amount)
-        / reward_info.epoch_emissions)
+    let percent = (Decimal::from(network_reward.amount) / reward_info.epoch_emissions)
         .round_dp_with_strategy(2, RoundingStrategy::MidpointNearestEven);
     assert_eq!(percent, dec!(0.24));
 
@@ -68,50 +51,6 @@ async fn test_service_provider_rewards(_pool: PgPool) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[sqlx::test]
-async fn should_not_reward_service_provider_negative_amount(_pool: PgPool) -> anyhow::Result<()> {
-    let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
-
-    let mut reward_info = reward_info_24_hours();
-    // Total reward amount of 350 HNT (6% delegation carved out on-chain).
-    reward_info.epoch_emissions = Decimal::from(35_000_000_000u64);
-    reward_info.hnt_rewards_issued = Decimal::from(35_000_000_000u64 - 35_000_000_000u64 * 6 / 100);
-    reward_info.delegation_rewards_issued = Decimal::from(35_000_000_000u64 * 6 / 100);
-
-    rewarder::reward_service_providers(mobile_rewards_client, &reward_info, None).await?;
-
-    let rewards = mobile_rewards.finish().await?;
-
-    // Verify two ServiceProviderRewards
-    assert_eq!(rewards.sp_rewards.len(), 2);
-
-    // Subscriber reward should be clamped to 84 HNT (24% of 350HNT)
-    let subscriber_reward = rewards.sp_rewards.first().expect("sp reward");
-    assert_eq!(
-        subscriber_reward.service_provider_id,
-        ServiceProvider::HeliumMobile as i32
-    );
-    assert_eq!(
-        subscriber_reward.rewardable_entity_key,
-        RewardableEntityKey::Subscriber.to_string()
-    );
-    assert_eq!(8_400_000_000, subscriber_reward.amount);
-
-    // Network reward should be 0 as Subscriber wallet received the full reward amount
-    let network_reward = rewards.sp_rewards.get(1).expect("sp reward");
-    assert_eq!(
-        network_reward.service_provider_id,
-        ServiceProvider::HeliumMobile as i32
-    );
-    assert_eq!(
-        network_reward.rewardable_entity_key,
-        RewardableEntityKey::Network.to_string()
-    );
-    assert_eq!(0, network_reward.amount);
-
-    Ok(())
-}
-
 /// HIP-149: the service-provider pool is a flat 24% of *total* emissions, so the
 /// 3× cap / backstop — which shifts HNT between issued and delegation — must leave
 /// it untouched. Run a capped and a backstopped epoch at the same emissions and
@@ -119,7 +58,6 @@ async fn should_not_reward_service_provider_negative_amount(_pool: PgPool) -> an
 /// cap/backstop tests, which show the data pool absorbing the whole shift.
 #[sqlx::test]
 async fn test_service_provider_flat_across_cap_and_backstop(_pool: PgPool) -> anyhow::Result<()> {
-    // 1e12 emissions keeps the 24% cut (240e9) clear of the 45e9 subscriber floor.
     const EMISSIONS: u64 = 1_000_000_000_000;
 
     async fn sp_total(hnt_issued: u64, delegation: u64) -> anyhow::Result<u64> {


### PR DESCRIPTION
## Summary

Distribute the entire HIP-149 service-provider pool (a flat 24% of emissions) to the `RewardableEntityKey::Network` entity key.

Previously `reward_service_providers` split the pool into two `ServiceProviderReward` records: a fixed `min(pool, 450 HNT)` share keyed to the `Subscriber` wallet ("Helium Mobile Service Rewards") and the remainder to the `Network` wallet ("Helium Mobile"). This change emits a single reward for the full pool to `Network`.

## Changes

- `mobile_verifier/src/rewarder.rs` — `reward_service_providers` now builds one `ServiceProviderReward` (Network) with the full pool amount, doing a single iceberg write and a single file-sink write.
- `mobile_verifier/src/reward_shares.rs` — removed the now-unused `HELIUM_MOBILE_SERVICE_REWARD_BONES` constant and the `RewardableEntityKey::Subscriber` variant, leaving `Network` as the sole variant.
- `mobile_verifier/tests/integrations/rewarder_sp_rewards.rs` — updated `test_service_provider_rewards` to expect a single Network reward equal to the full 24% pool; removed the obsolete `should_not_reward_service_provider_negative_amount` clamp test; kept `test_service_provider_flat_across_cap_and_backstop`.

## Testing

- `cargo check -p mobile-verifier --tests` — clean, no dead-code/unused-import warnings.
- `cargo nextest run -p mobile-verifier` for `rewarder_sp_rewards`, other `rewarder` tests, and `reward_shares` unit tests — all pass. (The Trino-stack-dependent `rewarder_dc_trino` test was excluded as it requires the full Polaris/Trino stack.)