### PR TITLE
Remove mobile-config from mobile-verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5587,7 +5587,6 @@ dependencies = [
  "humantime-serde",
  "metrics",
  "metrics-exporter-prometheus",
- "mobile-config",
  "poc-metrics",
  "price",
  "proptest",

--- a/mobile_verifier/Cargo.toml
+++ b/mobile_verifier/Cargo.toml
@@ -52,7 +52,6 @@ custom-tracing = { path = "../custom_tracing" }
 db-store = { path = "../db_store" }
 file-store = { path = "../file_store" }
 file-store-oracles = { path = "../file_store_oracles" }
-mobile-config = { path = "../mobile_config" }
 poc-metrics = { path = "../metrics" }
 reward-scheduler = { path = "../reward_scheduler" }
 solana = { path = "../solana" }

--- a/mobile_verifier/pkg/settings-template.toml
+++ b/mobile_verifier/pkg/settings-template.toml
@@ -13,6 +13,19 @@ cache = "/var/data/verfied-reports"
 # the reward period + reward_offset; Default = 30 minutes
 # reward_offset_minutes = "30 minutes"
 
+# Comma-separated b58 public keys authorized to submit hotspot ban reports
+# (NetworkKeyRole::Banning). Replaces the mobile-config authorization lookup.
+# Default is empty (no keys authorized).
+# banning_authorized_keys = "key1,key2"
+
+# Comma-separated b58 public keys authorized to submit unique-connection reports
+# (NetworkKeyRole::MobileCarrier). Default is empty (no keys authorized).
+# mobile_carrier_authorized_keys = "key1,key2"
+
+# How often the in-memory snapshot of known gateways is refreshed from the Trino
+# inventory table (see [trino]). Default is 1 hour.
+# gateway_refresh_interval = "1 hour"
+
 [database]
 
 # Postgres Connection Information

--- a/mobile_verifier/pkg/settings-template.toml
+++ b/mobile_verifier/pkg/settings-template.toml
@@ -15,12 +15,13 @@ cache = "/var/data/verfied-reports"
 
 # Comma-separated b58 public keys authorized to submit hotspot ban reports
 # (NetworkKeyRole::Banning). Replaces the mobile-config authorization lookup.
-# Default is empty (no keys authorized).
-# banning_authorized_keys = "key1,key2"
+# Required: at least one key, or the service errors on startup.
+banning_authorized_keys = "key1,key2"
 
 # Comma-separated b58 public keys authorized to submit unique-connection reports
-# (NetworkKeyRole::MobileCarrier). Default is empty (no keys authorized).
-# mobile_carrier_authorized_keys = "key1,key2"
+# (NetworkKeyRole::MobileCarrier).
+# Required: at least one key, or the service errors on startup.
+mobile_carrier_authorized_keys = "key1,key2"
 
 # How often the in-memory snapshot of known gateways is refreshed from the Trino
 # inventory table (see [trino]). Default is 1 hour.

--- a/mobile_verifier/src/authorization.rs
+++ b/mobile_verifier/src/authorization.rs
@@ -1,0 +1,72 @@
+//! Static, settings-backed authorization allow-lists.
+//!
+//! Replaces the mobile-config gRPC authorization service. mobile-config served
+//! authorized keys from an admin-registered `registered_keys` table —
+//! effectively static config — so the verifier now reads the same allow-lists
+//! straight from its settings, one set per role. Mirrors the routing-key
+//! allow-list mobile-packet-verifier uses (`mobile_packet_verifier::routing`).
+
+use std::collections::HashSet;
+
+use helium_crypto::PublicKeyBinary;
+use helium_proto::services::mobile_config::NetworkKeyRole;
+
+/// The set of keys authorized for each role the verifier checks. Built from
+/// settings — see [`Settings::authorized_keys`](crate::Settings::authorized_keys).
+#[derive(Debug, Clone, Default)]
+pub struct AuthorizedKeys {
+    banning: HashSet<PublicKeyBinary>,
+    mobile_carrier: HashSet<PublicKeyBinary>,
+}
+
+impl AuthorizedKeys {
+    pub fn new(
+        banning: HashSet<PublicKeyBinary>,
+        mobile_carrier: HashSet<PublicKeyBinary>,
+    ) -> Self {
+        Self {
+            banning,
+            mobile_carrier,
+        }
+    }
+}
+
+/// A role-scoped authorization check. Kept as a trait (rather than using
+/// [`AuthorizedKeys`] directly at call sites) so tests can substitute a mock.
+pub trait AuthorizationVerifier: Send + Sync + 'static {
+    fn is_authorized(&self, address: &PublicKeyBinary, role: NetworkKeyRole) -> bool;
+}
+
+impl AuthorizationVerifier for AuthorizedKeys {
+    fn is_authorized(&self, address: &PublicKeyBinary, role: NetworkKeyRole) -> bool {
+        match role {
+            NetworkKeyRole::Banning => self.banning.contains(address),
+            NetworkKeyRole::MobileCarrier => self.mobile_carrier.contains(address),
+            // The verifier only authorizes the two roles above.
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(byte: u8) -> PublicKeyBinary {
+        PublicKeyBinary::from(vec![byte])
+    }
+
+    #[test]
+    fn authorizes_only_configured_keys_per_role() {
+        let keys = AuthorizedKeys::new(HashSet::from([key(1)]), HashSet::from([key(2)]));
+
+        assert!(keys.is_authorized(&key(1), NetworkKeyRole::Banning));
+        assert!(!keys.is_authorized(&key(2), NetworkKeyRole::Banning));
+
+        assert!(keys.is_authorized(&key(2), NetworkKeyRole::MobileCarrier));
+        assert!(!keys.is_authorized(&key(1), NetworkKeyRole::MobileCarrier));
+
+        // A role the verifier doesn't manage is never authorized.
+        assert!(!keys.is_authorized(&key(1), NetworkKeyRole::MobileRouter));
+    }
+}

--- a/mobile_verifier/src/banning/ingestor.rs
+++ b/mobile_verifier/src/banning/ingestor.rs
@@ -16,12 +16,14 @@ use file_store_oracles::{
 };
 use futures::StreamExt;
 use helium_proto::services::mobile_config::NetworkKeyRole;
-use mobile_config::client::{authorization_client::AuthorizationVerifier, AuthorizationClient};
 use sqlx::{PgConnection, PgPool};
 use task_manager::{ChannelConsumer, ManagedTask, TaskManager};
 use tokio::sync::mpsc::Receiver;
 
-use crate::{iceberg, Settings};
+use crate::{
+    authorization::{AuthorizationVerifier, AuthorizedKeys},
+    iceberg, Settings,
+};
 
 use super::db;
 
@@ -29,7 +31,7 @@ use super::db;
 
 pub struct BanIngestor {
     pool: PgPool,
-    auth_verifier: AuthorizationClient,
+    authorized_keys: AuthorizedKeys,
     report_rx: Receiver<FileInfoStream<BanReport>>,
     verified_sink: FileSinkClient<VerifiedBanIngestReportV1>,
     iceberg_writer: Option<iceberg::BanWriter>,
@@ -59,7 +61,7 @@ impl BanIngestor {
         pool: PgPool,
         file_upload: FileUpload,
         bucket_client: BucketClient,
-        auth_verifier: AuthorizationClient,
+        authorized_keys: AuthorizedKeys,
         settings: &Settings,
         iceberg_writer: Option<iceberg::BanWriter>,
     ) -> anyhow::Result<impl ManagedTask> {
@@ -82,7 +84,7 @@ impl BanIngestor {
 
         let ingestor = Self::new(
             pool,
-            auth_verifier,
+            authorized_keys,
             report_rx,
             verified_sink,
             iceberg_writer,
@@ -97,14 +99,14 @@ impl BanIngestor {
 
     pub fn new(
         pool: PgPool,
-        auth_verifier: AuthorizationClient,
+        authorized_keys: AuthorizedKeys,
         report_rx: Receiver<FileInfoStream<BanReport>>,
         verified_sink: FileSinkClient<VerifiedBanIngestReportV1>,
         iceberg_writer: Option<iceberg::BanWriter>,
     ) -> Self {
         Self {
             pool,
-            auth_verifier,
+            authorized_keys,
             report_rx,
             verified_sink,
             iceberg_writer,
@@ -125,7 +127,8 @@ impl BanIngestor {
         let mut invalid_iceberg_records = vec![];
 
         while let Some(report) = stream.next().await {
-            let verified_report = process_ban_report(&mut txn, &self.auth_verifier, report).await?;
+            let verified_report =
+                process_ban_report(&mut txn, &self.authorized_keys, report).await?;
             if self.iceberg_writer.is_some() {
                 let record = iceberg::IcebergBan::from(&verified_report);
                 if verified_report.is_valid() {
@@ -161,7 +164,7 @@ pub async fn process_ban_report(
     auth_verifier: &impl AuthorizationVerifier,
     report: BanReport,
 ) -> anyhow::Result<VerifiedBanReport> {
-    let status = get_verified_status(auth_verifier, &report.report.ban_pubkey).await?;
+    let status = get_verified_status(auth_verifier, &report.report.ban_pubkey);
 
     let verified_report = VerifiedBanReport {
         verified_timestamp: Utc::now(),
@@ -175,16 +178,12 @@ pub async fn process_ban_report(
     Ok(verified_report)
 }
 
-async fn get_verified_status(
+fn get_verified_status(
     auth_verifier: &impl AuthorizationVerifier,
     pubkey: &helium_crypto::PublicKeyBinary,
-) -> anyhow::Result<VerifiedBanIngestReportStatus> {
-    let is_authorized = auth_verifier
-        .verify_authorized_key(pubkey, NetworkKeyRole::Banning)
-        .await?;
-    let status = match is_authorized {
+) -> VerifiedBanIngestReportStatus {
+    match auth_verifier.is_authorized(pubkey, NetworkKeyRole::Banning) {
         true => VerifiedBanIngestReportStatus::Valid,
         false => VerifiedBanIngestReportStatus::InvalidBanKey,
-    };
-    Ok(status)
+    }
 }

--- a/mobile_verifier/src/cli/server.rs
+++ b/mobile_verifier/src/cli/server.rs
@@ -1,16 +1,15 @@
 use std::time::Duration;
 
 use crate::{
-    banning::ingestor::BanIngestor, data_session::DataSessionIngestor, geofence::Geofence,
-    heartbeats::wifi::WifiHeartbeatDaemon, iceberg, rewarder::Rewarder,
-    speedtests::SpeedtestDaemon, telemetry,
+    banning::ingestor::BanIngestor, data_session::DataSessionIngestor,
+    gateway::TrinoGatewayResolver, geofence::Geofence, heartbeats::wifi::WifiHeartbeatDaemon,
+    iceberg, rewarder::Rewarder, speedtests::SpeedtestDaemon, telemetry,
     unique_connections::ingestor::UniqueConnectionsIngestor, Settings,
 };
 use anyhow::Result;
 use file_store::file_upload;
 use file_store_oracles::traits::{FileSinkCommitStrategy, FileSinkRollTime, FileSinkWriteExt};
 use helium_proto::services::poc_mobile::Heartbeat;
-use mobile_config::client::{AuthorizationClient, GatewayClient};
 use task_manager::TaskManager;
 
 #[derive(Debug, clap::Args)]
@@ -28,10 +27,6 @@ impl Cmd {
         let (file_upload, file_upload_server) =
             file_upload::FileUpload::from_bucket_client(settings.buckets.output.connect().await)
                 .await;
-
-        // mobile config clients
-        let gateway_client = GatewayClient::from_settings(&settings.config_client)?;
-        let auth_client = AuthorizationClient::from_settings(&settings.config_client)?;
 
         let (valid_heartbeats, valid_heartbeats_server) = Heartbeat::file_sink(
             &settings.cache,
@@ -69,18 +64,28 @@ impl Cmd {
         // price from on-chain deployer-cap data, and reads/compares data-transfer
         // sessions against Postgres (see `data_session::DataSessionSource`).
         // Required — rewarding has no other price source. `from_settings` is
-        // synchronous and starts the JWT-file watcher if configured.
+        // synchronous and starts the JWT-file watcher if configured. It also
+        // backs the gateway resolver below (replacing mobile-config).
         let trino_client = trino_client::Client::from_settings(&settings.trino)?;
+
+        // Gateway resolution and authorization now come from Trino + settings
+        // instead of the mobile-config gRPC server.
+        let gateway_resolver =
+            TrinoGatewayResolver::new(trino_client.clone(), settings.gateway_refresh_interval)
+                .await;
+        let gateway_refresher = gateway_resolver.refresher();
+        let authorized_keys = settings.authorized_keys()?;
 
         TaskManager::builder()
             .add_task(file_upload_server)
             .add_task(valid_heartbeats_server)
+            .add_task(task_manager::periodic(gateway_refresher))
             .add_task(
                 WifiHeartbeatDaemon::create_managed_task(
                     pool.clone(),
                     settings,
                     ingest_bucket_client.clone(),
-                    gateway_client.clone(),
+                    gateway_resolver.clone(),
                     valid_heartbeats,
                     usa_and_mexico_geofence,
                     poc_writers.heartbeat,
@@ -93,7 +98,7 @@ impl Cmd {
                     settings,
                     file_upload.clone(),
                     ingest_bucket_client.clone(),
-                    gateway_client.clone(),
+                    gateway_resolver.clone(),
                     poc_writers.speedtest,
                     poc_writers.speedtest_avg,
                 )
@@ -105,7 +110,7 @@ impl Cmd {
                     settings,
                     file_upload.clone(),
                     ingest_bucket_client.clone(),
-                    auth_client.clone(),
+                    authorized_keys.clone(),
                 )
                 .await?,
             )
@@ -122,7 +127,7 @@ impl Cmd {
                     pool.clone(),
                     file_upload.clone(),
                     ingest_bucket_client.clone(),
-                    auth_client,
+                    authorized_keys,
                     settings,
                     poc_writers.ban,
                 )

--- a/mobile_verifier/src/gateway.rs
+++ b/mobile_verifier/src/gateway.rs
@@ -237,7 +237,8 @@ impl TrinoGatewayResolver {
         #[derive(Trino, serde::Serialize, serde::Deserialize)]
         struct Row {
             device_type: String,
-            asserted_hex: String,
+            // Nullable: an unasserted gateway has a NULL `asserted_hex`.
+            asserted_hex: Option<String>,
         }
 
         // The inventory table has one row per pubkey (unique index on `pub_key`).
@@ -258,7 +259,7 @@ impl TrinoGatewayResolver {
         Ok(rows
             .into_iter()
             .next()
-            .and_then(|row| row_to_meta(&row.device_type, &row.asserted_hex)))
+            .and_then(|row| row_to_meta(&row.device_type, row.asserted_hex.as_deref())))
     }
 }
 
@@ -334,10 +335,10 @@ impl Periodic for GatewaySnapshotRefresher {
 
 /// Build a [`GatewayMeta`] from the inventory's raw `device_type` / `asserted_hex`
 /// columns. Returns `None` for an unparseable device type (treated as unknown).
-/// An empty `asserted_hex` means the gateway is on-chain but unasserted.
-fn row_to_meta(device_type: &str, asserted_hex: &str) -> Option<GatewayMeta> {
+/// A NULL (or empty) `asserted_hex` means the gateway is on-chain but unasserted.
+fn row_to_meta(device_type: &str, asserted_hex: Option<&str>) -> Option<GatewayMeta> {
     let device_type = DeviceType::from_inventory(device_type)?;
-    let location = parse_asserted_location(asserted_hex);
+    let location = asserted_hex.and_then(parse_asserted_location);
     Some(GatewayMeta {
         device_type,
         location,
@@ -345,9 +346,9 @@ fn row_to_meta(device_type: &str, asserted_hex: &str) -> Option<GatewayMeta> {
 }
 
 /// Parse the inventory's `asserted_hex` column into an H3 cell index. The column
-/// holds the H3 index as a hex string (e.g. `8c2681a3064d9ff`); empty means
-/// unasserted. An unparseable non-empty value is logged and treated as
-/// unasserted.
+/// holds the H3 index as a hex string (e.g. `8c2681a3064d9ff`); a NULL (handled
+/// by the caller) or empty value means unasserted. An unparseable non-empty
+/// value is logged and treated as unasserted.
 fn parse_asserted_location(asserted_hex: &str) -> Option<u64> {
     let trimmed = asserted_hex
         .trim()
@@ -380,7 +381,8 @@ async fn load_known_gateways(
     struct Row {
         pub_key: String,
         device_type: String,
-        asserted_hex: String,
+        // Nullable: an unasserted gateway has a NULL `asserted_hex`.
+        asserted_hex: Option<String>,
     }
 
     let stmt = trino_client::Statement::new(format!(
@@ -398,7 +400,7 @@ async fn load_known_gateways(
                 continue;
             }
         };
-        if let Some(meta) = row_to_meta(&row.device_type, &row.asserted_hex) {
+        if let Some(meta) = row_to_meta(&row.device_type, row.asserted_hex.as_deref()) {
             known.insert(pubkey, meta);
         }
     }

--- a/mobile_verifier/src/gateway.rs
+++ b/mobile_verifier/src/gateway.rs
@@ -1,0 +1,470 @@
+//! Trino-backed gateway resolution.
+//!
+//! [`GatewayResolver`] answers "what is this gateway" for heartbeat and speedtest
+//! verification — its device type and asserted location. Gateway state is served
+//! from an in-memory snapshot of the on-chain inventory table (loaded at startup,
+//! kept fresh by [`GatewaySnapshotRefresher`]) with a per-pubkey Trino fallback.
+//!
+//! This replaces the mobile-config gRPC gateway client. It mirrors the
+//! mobile-packet-verifier resolver (`mobile_packet_verifier::gateway`), but keeps
+//! device type + location per pubkey rather than a bare "known" set.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+    time::{Duration, Instant},
+};
+
+use chrono::{DateTime, Utc};
+use helium_crypto::PublicKeyBinary;
+use retainer::Cache;
+use task_manager::Periodic;
+
+/// Fully-qualified `catalog.schema.table` for the on-chain mobile hotspot
+/// inventory queried by [`GatewayResolver::resolve_gateway`].
+pub const MOBILE_HOTSPOT_INVENTORY_TABLE: &str = "network.chain.mobile_hotspot_inventory";
+
+/// How often the fallback cache sweeps expired entries.
+const CACHE_EVICTION_FREQUENCY: Duration = Duration::from_mins(60);
+
+/// How soon to retry the inventory snapshot load after a failure, rather than
+/// waiting the full `refresh_interval`. Keeps a Trino outage from leaving the
+/// snapshot degraded for up to an hour.
+const GATEWAY_REFRESH_RETRY_INTERVAL: Duration = Duration::from_mins(1);
+
+/// The device type of an on-chain mobile hotspot. Local copy of what
+/// mobile-config used to serve; parsed from the inventory table's `device_type`
+/// column (snake_case, e.g. `wifi_indoor`).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub enum DeviceType {
+    Cbrs,
+    WifiIndoor,
+    WifiOutdoor,
+    WifiDataOnly,
+}
+
+impl DeviceType {
+    /// The inventory table's `device_type` string for this variant. Inverse of
+    /// [`DeviceType::from_inventory`].
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DeviceType::Cbrs => "cbrs",
+            DeviceType::WifiIndoor => "wifi_indoor",
+            DeviceType::WifiOutdoor => "wifi_outdoor",
+            DeviceType::WifiDataOnly => "wifi_data_only",
+        }
+    }
+
+    /// Parse the `device_type` value stored in `mobile_hotspot_inventory`.
+    /// Returns `None` for an unrecognized value.
+    pub fn from_inventory(s: &str) -> Option<Self> {
+        match s {
+            "cbrs" => Some(DeviceType::Cbrs),
+            "wifi_indoor" => Some(DeviceType::WifiIndoor),
+            "wifi_outdoor" => Some(DeviceType::WifiOutdoor),
+            "wifi_data_only" => Some(DeviceType::WifiDataOnly),
+            _ => None,
+        }
+    }
+}
+
+/// The outcome of resolving a gateway, in the precedence heartbeat/speedtest
+/// verification expects: not-on-chain, data-only, asserted (with location +
+/// device type), or on-chain-but-unasserted.
+#[derive(Copy, Clone, Debug)]
+pub enum GatewayResolution {
+    GatewayNotFound,
+    GatewayNotAsserted,
+    AssertedLocation(u64, DeviceType),
+    DataOnly,
+}
+
+impl GatewayResolution {
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, GatewayResolution::GatewayNotFound)
+    }
+}
+
+#[async_trait::async_trait]
+pub trait GatewayResolver: Clone + Send + Sync + 'static {
+    async fn resolve_gateway(
+        &self,
+        address: &PublicKeyBinary,
+        gateway_query_timestamp: &DateTime<Utc>,
+    ) -> anyhow::Result<GatewayResolution>;
+}
+
+/// A gateway's resolvable state: its device type and, when asserted, its
+/// location (H3 cell as `u64`). `location == None` means on-chain but unasserted.
+#[derive(Copy, Clone, Debug)]
+struct GatewayMeta {
+    device_type: DeviceType,
+    location: Option<u64>,
+}
+
+impl GatewayMeta {
+    fn resolution(&self) -> GatewayResolution {
+        // Precedence matches the old mobile-config resolver: data-only first,
+        // then asserted-with-location, else unasserted.
+        if self.device_type == DeviceType::WifiDataOnly {
+            GatewayResolution::DataOnly
+        } else if let Some(location) = self.location {
+            GatewayResolution::AssertedLocation(location, self.device_type)
+        } else {
+            GatewayResolution::GatewayNotAsserted
+        }
+    }
+}
+
+/// Resolver used by the running daemon.
+///
+/// Gateway state is served from an in-memory snapshot of every pubkey in the
+/// inventory table, loaded at startup and kept fresh by a companion
+/// [`GatewaySnapshotRefresher`] (see [`TrinoGatewayResolver::refresher`]).
+/// A lookup that misses the snapshot — an unknown gateway, or one onboarded
+/// since the last refresh — falls back to a per-pubkey Trino query, cached to
+/// avoid re-querying.
+#[derive(Clone)]
+pub struct TrinoGatewayResolver {
+    trino_client: trino_client::Client,
+    inventory_table: String,
+    known_gateways: Arc<RwLock<HashMap<PublicKeyBinary, GatewayMeta>>>,
+    fallback_cache: Arc<Cache<PublicKeyBinary, Option<GatewayMeta>>>,
+    refresh_interval: Duration,
+    /// When the startup snapshot was loaded (`None` if the load failed). Seeds
+    /// the refresher's first-refresh timing via [`TrinoGatewayResolver::refresher`].
+    snapshot_loaded_at: Option<Instant>,
+}
+
+impl TrinoGatewayResolver {
+    pub async fn new(trino_client: trino_client::Client, refresh_interval: Duration) -> Self {
+        Self::new_with_inventory_table(
+            trino_client,
+            MOBILE_HOTSPOT_INVENTORY_TABLE,
+            refresh_interval,
+        )
+        .await
+    }
+
+    /// Like [`new`](Self::new), but with an explicit inventory table name. Tests
+    /// use this to point at a per-test iceberg catalog (a two-part
+    /// `chain.mobile_hotspot_inventory` name resolves against the Trino client's
+    /// default catalog).
+    pub async fn new_with_inventory_table(
+        trino_client: trino_client::Client,
+        inventory_table: impl Into<String>,
+        refresh_interval: Duration,
+    ) -> Self {
+        let inventory_table = inventory_table.into();
+
+        // Load every known gateway once at startup so the resolver is ready
+        // before the daemon processes any files. A failure here is non-fatal: we
+        // start with an empty snapshot and the refresher retries soon, with the
+        // per-pubkey fallback covering lookups in the meantime.
+        let (initial, snapshot_loaded_at) =
+            match load_known_gateways(&trino_client, &inventory_table).await {
+                Ok(map) => {
+                    tracing::info!(count = map.len(), "loaded gateway inventory snapshot");
+                    (map, Some(Instant::now()))
+                }
+                Err(err) => {
+                    tracing::error!(
+                        ?err,
+                        "failed to load gateway inventory at startup; starting empty, will retry"
+                    );
+                    (HashMap::new(), None)
+                }
+            };
+        let known_gateways = Arc::new(RwLock::new(initial));
+
+        // Fallback cache for snapshot misses.
+        let fallback_cache = Arc::new(Cache::new());
+        let eviction = fallback_cache.clone();
+        tokio::spawn(async move { eviction.monitor(4, 0.25, CACHE_EVICTION_FREQUENCY).await });
+
+        Self {
+            trino_client,
+            inventory_table,
+            known_gateways,
+            fallback_cache,
+            refresh_interval,
+            snapshot_loaded_at,
+        }
+    }
+
+    /// The background task that keeps this resolver's snapshot fresh. Register it
+    /// with a [`task_manager::TaskManager`] via [`task_manager::periodic`].
+    /// Intended to be called once, right after construction.
+    pub fn refresher(&self) -> GatewaySnapshotRefresher {
+        GatewaySnapshotRefresher {
+            trino_client: self.trino_client.clone(),
+            inventory_table: self.inventory_table.clone(),
+            known_gateways: self.known_gateways.clone(),
+            refresh_interval: self.refresh_interval,
+            last_refresh: self.snapshot_loaded_at,
+        }
+    }
+
+    async fn resolve_meta(
+        &self,
+        public_key: &PublicKeyBinary,
+        gateway_query_time: &DateTime<Utc>,
+    ) -> anyhow::Result<Option<GatewayMeta>> {
+        // Fast path: the startup/refresh snapshot of every known gateway.
+        if let Some(meta) = self.known_gateways.read().unwrap().get(public_key).copied() {
+            return Ok(Some(meta));
+        }
+
+        // Miss: an unknown gateway, or one onboarded since the last refresh.
+        // Fall back to a per-pubkey query, cached to avoid re-querying.
+        if let Some(cached) = self.fallback_cache.get(public_key).await {
+            return Ok(*cached.value());
+        }
+
+        let meta = self.query_gateway(public_key, gateway_query_time).await?;
+        self.fallback_cache
+            .insert(public_key.clone(), meta, self.refresh_interval)
+            .await;
+        Ok(meta)
+    }
+
+    async fn query_gateway(
+        &self,
+        public_key: &PublicKeyBinary,
+        gateway_query_time: &DateTime<Utc>,
+    ) -> anyhow::Result<Option<GatewayMeta>> {
+        use trino_rust_client::Trino;
+        #[derive(Trino, serde::Serialize, serde::Deserialize)]
+        struct Row {
+            device_type: String,
+            asserted_hex: String,
+        }
+
+        // The inventory table has one row per pubkey (unique index on `pub_key`).
+        let stmt = trino_client::Statement::new(format!(
+            r#"
+            SELECT device_type, asserted_hex
+            FROM {}
+            WHERE pub_key = :address
+              AND inserted_at <= :timestamp
+            "#,
+            self.inventory_table
+        ))
+        .bind("address", public_key.to_string())
+        .bind("timestamp", *gateway_query_time)
+        .typed::<Row>();
+
+        let rows = self.trino_client.get_all(stmt).await?;
+        Ok(rows
+            .into_iter()
+            .next()
+            .and_then(|row| row_to_meta(&row.device_type, &row.asserted_hex)))
+    }
+}
+
+#[async_trait::async_trait]
+impl GatewayResolver for TrinoGatewayResolver {
+    async fn resolve_gateway(
+        &self,
+        address: &PublicKeyBinary,
+        gateway_query_timestamp: &DateTime<Utc>,
+    ) -> anyhow::Result<GatewayResolution> {
+        Ok(
+            match self.resolve_meta(address, gateway_query_timestamp).await? {
+                Some(meta) => meta.resolution(),
+                None => GatewayResolution::GatewayNotFound,
+            },
+        )
+    }
+}
+
+/// Periodically reloads the [`TrinoGatewayResolver`] snapshot from Trino.
+/// Registered with the daemon's `TaskManager` via [`task_manager::periodic`], so
+/// it is interleaved with file processing and stops on shutdown.
+///
+/// Ticks at [`GATEWAY_REFRESH_RETRY_INTERVAL`] but reloads only when due: once
+/// per `refresh_interval` while healthy, and on every tick after a failed load,
+/// so a Trino outage doesn't leave the snapshot stale for a full interval.
+pub struct GatewaySnapshotRefresher {
+    trino_client: trino_client::Client,
+    inventory_table: String,
+    known_gateways: Arc<RwLock<HashMap<PublicKeyBinary, GatewayMeta>>>,
+    refresh_interval: Duration,
+    last_refresh: Option<Instant>,
+}
+
+impl GatewaySnapshotRefresher {
+    // Periodic tasks don't allow for changing schedules. So we check at the
+    // minimum rate and early return when there's nothing to do.
+    fn should_run(&self) -> bool {
+        match self.last_refresh {
+            Some(last) => last.elapsed() >= self.refresh_interval,
+            None => true,
+        }
+    }
+}
+
+impl Periodic for GatewaySnapshotRefresher {
+    type Error = anyhow::Error;
+
+    fn interval(&self) -> Duration {
+        GATEWAY_REFRESH_RETRY_INTERVAL
+    }
+
+    async fn tick(&mut self) -> anyhow::Result<()> {
+        if !self.should_run() {
+            return Ok(());
+        }
+
+        match load_known_gateways(&self.trino_client, &self.inventory_table).await {
+            Ok(map) => {
+                let count = map.len();
+                *self.known_gateways.write().unwrap() = map;
+                self.last_refresh = Some(Instant::now());
+                tracing::info!(count, "refreshed gateway inventory snapshot");
+            }
+            Err(err) => tracing::warn!(
+                ?err,
+                "failed to refresh gateway inventory; keeping previous snapshot, retrying soon"
+            ),
+        }
+        Ok(())
+    }
+}
+
+/// Build a [`GatewayMeta`] from the inventory's raw `device_type` / `asserted_hex`
+/// columns. Returns `None` for an unparseable device type (treated as unknown).
+/// An empty `asserted_hex` means the gateway is on-chain but unasserted.
+fn row_to_meta(device_type: &str, asserted_hex: &str) -> Option<GatewayMeta> {
+    let device_type = DeviceType::from_inventory(device_type)?;
+    let location = parse_asserted_location(asserted_hex);
+    Some(GatewayMeta {
+        device_type,
+        location,
+    })
+}
+
+/// Parse the inventory's `asserted_hex` column into an H3 cell index. The column
+/// holds the H3 index as a hex string (e.g. `8c2681a3064d9ff`); empty means
+/// unasserted. An unparseable non-empty value is logged and treated as
+/// unasserted.
+fn parse_asserted_location(asserted_hex: &str) -> Option<u64> {
+    let trimmed = asserted_hex
+        .trim()
+        .strip_prefix("0x")
+        .unwrap_or(asserted_hex.trim());
+    if trimmed.is_empty() {
+        return None;
+    }
+    match u64::from_str_radix(trimmed, 16) {
+        Ok(location) => Some(location),
+        Err(err) => {
+            tracing::warn!(
+                ?err,
+                asserted_hex,
+                "unparseable asserted_hex; treating as unasserted"
+            );
+            None
+        }
+    }
+}
+
+/// Load every gateway's state from the inventory table into a map keyed by
+/// pubkey. The table has one row per pubkey (unique index on `pub_key`).
+async fn load_known_gateways(
+    trino_client: &trino_client::Client,
+    inventory_table: &str,
+) -> anyhow::Result<HashMap<PublicKeyBinary, GatewayMeta>> {
+    use trino_rust_client::Trino;
+    #[derive(Trino, serde::Serialize, serde::Deserialize)]
+    struct Row {
+        pub_key: String,
+        device_type: String,
+        asserted_hex: String,
+    }
+
+    let stmt = trino_client::Statement::new(format!(
+        "SELECT pub_key, device_type, asserted_hex FROM {inventory_table}"
+    ))
+    .typed::<Row>();
+    let rows = trino_client.get_all(stmt).await?;
+
+    let mut known = HashMap::with_capacity(rows.len());
+    for row in rows {
+        let pubkey = match row.pub_key.parse::<PublicKeyBinary>() {
+            Ok(pubkey) => pubkey,
+            Err(err) => {
+                tracing::warn!(?err, pub_key = %row.pub_key, "skipping unparseable gateway pubkey");
+                continue;
+            }
+        };
+        if let Some(meta) = row_to_meta(&row.device_type, &row.asserted_hex) {
+            known.insert(pubkey, meta);
+        }
+    }
+    Ok(known)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_type_round_trips_inventory_strings() {
+        for dt in [
+            DeviceType::Cbrs,
+            DeviceType::WifiIndoor,
+            DeviceType::WifiOutdoor,
+            DeviceType::WifiDataOnly,
+        ] {
+            assert_eq!(DeviceType::from_inventory(dt.as_str()), Some(dt));
+        }
+        assert_eq!(DeviceType::from_inventory("nonsense"), None);
+    }
+
+    #[test]
+    fn asserted_hex_parsing() {
+        assert_eq!(
+            parse_asserted_location("8c2681a3064d9ff"),
+            Some(0x8c2681a3064d9ff)
+        );
+        assert_eq!(
+            parse_asserted_location("0x8c2681a3064d9ff"),
+            Some(0x8c2681a3064d9ff)
+        );
+        assert_eq!(parse_asserted_location(""), None);
+        assert_eq!(parse_asserted_location("   "), None);
+        assert_eq!(parse_asserted_location("not-hex"), None);
+    }
+
+    #[test]
+    fn meta_resolution_precedence() {
+        // data-only beats everything, even with a location.
+        let data_only = GatewayMeta {
+            device_type: DeviceType::WifiDataOnly,
+            location: Some(1),
+        };
+        assert!(matches!(
+            data_only.resolution(),
+            GatewayResolution::DataOnly
+        ));
+
+        let asserted = GatewayMeta {
+            device_type: DeviceType::WifiIndoor,
+            location: Some(42),
+        };
+        assert!(matches!(
+            asserted.resolution(),
+            GatewayResolution::AssertedLocation(42, DeviceType::WifiIndoor)
+        ));
+
+        let unasserted = GatewayMeta {
+            device_type: DeviceType::WifiOutdoor,
+            location: None,
+        };
+        assert!(matches!(
+            unasserted.resolution(),
+            GatewayResolution::GatewayNotAsserted
+        ));
+    }
+}

--- a/mobile_verifier/src/gateway.rs
+++ b/mobile_verifier/src/gateway.rs
@@ -48,10 +48,10 @@ impl DeviceType {
     /// [`DeviceType::from_inventory`].
     pub fn as_str(&self) -> &'static str {
         match self {
-            DeviceType::Cbrs => "cbrs",
-            DeviceType::WifiIndoor => "wifi_indoor",
-            DeviceType::WifiOutdoor => "wifi_outdoor",
-            DeviceType::WifiDataOnly => "wifi_data_only",
+            DeviceType::Cbrs => "CBRS",
+            DeviceType::WifiIndoor => "WIFI_INDOOR",
+            DeviceType::WifiOutdoor => "WIFI_OUTDOOR",
+            DeviceType::WifiDataOnly => "WIFI_DATA_ONLY",
         }
     }
 
@@ -59,10 +59,10 @@ impl DeviceType {
     /// Returns `None` for an unrecognized value.
     pub fn from_inventory(s: &str) -> Option<Self> {
         match s {
-            "cbrs" => Some(DeviceType::Cbrs),
-            "wifi_indoor" => Some(DeviceType::WifiIndoor),
-            "wifi_outdoor" => Some(DeviceType::WifiOutdoor),
-            "wifi_data_only" => Some(DeviceType::WifiDataOnly),
+            "CBRS" => Some(DeviceType::Cbrs),
+            "WIFI_INDOOR" => Some(DeviceType::WifiIndoor),
+            "WIFI_OUTDOOR" => Some(DeviceType::WifiOutdoor),
+            "WIFI_DATA_ONLY" => Some(DeviceType::WifiDataOnly),
             _ => None,
         }
     }
@@ -410,6 +410,31 @@ async fn load_known_gateways(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    #[ignore = "manual query validation"]
+    async fn connect() -> anyhow::Result<()> {
+        // Test load_known_gateways against real trino backend.
+        // Grab the creds and insert them here, DO NOT COMMIT!!!
+
+        let trino_client = trino_client::Client::from_settings(&trino_client::Settings {
+            host: "xxx".to_string(),
+            port: 443,
+            user: "xxx".to_string(),
+            catalog: None,
+            schema: None,
+            secure: true,
+            insecure_skip_tls_verify: false,
+            auth: Some(trino_client::AuthSettings::Basic {
+                username: "xxx".to_string(),
+                password: Some("xxx".to_string()),
+            }),
+        })?;
+        let map = load_known_gateways(&trino_client, MOBILE_HOTSPOT_INVENTORY_TABLE).await?;
+        // println!("map count: {}", map.len());
+        assert!(!map.is_empty());
+        Ok(())
+    }
 
     #[test]
     fn device_type_round_trips_inventory_strings() {

--- a/mobile_verifier/src/heartbeats/mod.rs
+++ b/mobile_verifier/src/heartbeats/mod.rs
@@ -1,6 +1,7 @@
 pub mod last_location;
 pub mod wifi;
 
+use crate::DeviceType;
 use crate::{cell_type::CellType, geofence::GeofenceValidator, GatewayResolution, GatewayResolver};
 use anyhow::Context;
 use chrono::{DateTime, Duration, DurationRound, RoundingError, Utc};
@@ -10,7 +11,6 @@ use futures::stream::{Stream, StreamExt};
 use h3o::{CellIndex, LatLng};
 use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_mobile::{self as proto, LocationSource};
-use mobile_config::gateway::service::info::DeviceType;
 use retainer::Cache;
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use rust_decimal_macros::dec;

--- a/mobile_verifier/src/iceberg/heartbeat.rs
+++ b/mobile_verifier/src/iceberg/heartbeat.rs
@@ -4,9 +4,8 @@ use rust_decimal::prelude::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use trino_rust_client::Trino;
 
-use mobile_config::gateway::service::info::DeviceType;
-
 use crate::heartbeats::ValidatedHeartbeat;
+use crate::DeviceType;
 
 pub use super::NAMESPACE;
 pub const TABLE_NAME: &str = "heartbeats";

--- a/mobile_verifier/src/lib.rs
+++ b/mobile_verifier/src/lib.rs
@@ -1,9 +1,11 @@
 extern crate tls_init;
 
+pub mod authorization;
 pub mod banning;
 pub mod cell_type;
 pub mod cli;
 pub mod data_session;
+pub mod gateway;
 pub mod geofence;
 pub mod heartbeats;
 pub mod iceberg;
@@ -15,86 +17,12 @@ pub mod speedtests_average;
 pub mod telemetry;
 pub mod unique_connections;
 
+pub use authorization::{AuthorizationVerifier, AuthorizedKeys};
+pub use gateway::{DeviceType, GatewayResolution, GatewayResolver};
 pub use settings::Settings;
 
-use async_trait::async_trait;
-use chrono::{DateTime, Utc};
-use mobile_config::client::ClientError;
-use mobile_config::gateway::service::info::DeviceType;
 use rust_decimal::Decimal;
 use solana::SolPubkey;
-
-pub enum GatewayResolution {
-    GatewayNotFound,
-    GatewayNotAsserted,
-    AssertedLocation(u64, DeviceType),
-    DataOnly,
-}
-
-impl GatewayResolution {
-    pub fn is_not_found(&self) -> bool {
-        matches!(self, GatewayResolution::GatewayNotFound)
-    }
-}
-
-#[async_trait::async_trait]
-pub trait GatewayResolver: Clone + Send + Sync + 'static {
-    async fn resolve_gateway(
-        &self,
-        address: &helium_crypto::PublicKeyBinary,
-        gateway_query_timestamp: &DateTime<Utc>,
-    ) -> Result<GatewayResolution, ClientError>;
-}
-
-#[async_trait]
-impl GatewayResolver for mobile_config::GatewayClient {
-    async fn resolve_gateway(
-        &self,
-        address: &helium_crypto::PublicKeyBinary,
-        gateway_query_timestamp: &DateTime<Utc>,
-    ) -> Result<GatewayResolution, ClientError> {
-        use mobile_config::gateway::client::GatewayInfoResolver;
-        use mobile_config::gateway::service::info::GatewayInfo;
-
-        match self
-            .resolve_gateway_info(address, gateway_query_timestamp)
-            .await?
-        {
-            None => Ok(GatewayResolution::GatewayNotFound),
-            Some(info) if info.is_data_only() => Ok(GatewayResolution::DataOnly),
-            Some(GatewayInfo {
-                metadata: Some(metadata),
-                device_type,
-                ..
-            }) => Ok(GatewayResolution::AssertedLocation(
-                metadata.location,
-                device_type,
-            )),
-            Some(_) => Ok(GatewayResolution::GatewayNotAsserted),
-        }
-    }
-}
-
-#[async_trait]
-pub trait IsAuthorized {
-    async fn is_authorized(
-        &self,
-        address: &helium_crypto::PublicKeyBinary,
-        role: helium_proto::services::mobile_config::NetworkKeyRole,
-    ) -> Result<bool, ClientError>;
-}
-
-#[async_trait]
-impl IsAuthorized for mobile_config::client::AuthorizationClient {
-    async fn is_authorized(
-        &self,
-        address: &helium_crypto::PublicKeyBinary,
-        role: helium_proto::services::mobile_config::NetworkKeyRole,
-    ) -> Result<bool, ClientError> {
-        use mobile_config::client::authorization_client::AuthorizationVerifier;
-        self.verify_authorized_key(address, role).await
-    }
-}
 
 #[derive(Clone, Debug)]
 pub struct PriceInfo {

--- a/mobile_verifier/src/reward_shares/emissions_split.rs
+++ b/mobile_verifier/src/reward_shares/emissions_split.rs
@@ -28,7 +28,7 @@
 //! holds exactly, every epoch. The proptests below pin that invariant across the
 //! full input range.
 
-use mobile_config::sub_dao_epoch_reward_info::EpochRewardInfo;
+use crate::rewarder::EpochRewardInfo;
 use rust_decimal::Decimal;
 
 use super::{floor_to_u64, SERVICE_PROVIDER_PERCENT};

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -23,7 +23,6 @@ use helium_proto::{
     MobileRewardData as ManifestMobileRewardData, MobileRewardToken, RewardManifest,
     ServiceProvider,
 };
-use mobile_config::{sub_dao_epoch_reward_info::EpochRewardInfo, EpochInfo};
 use reward_scheduler::Scheduler;
 use rust_decimal::{prelude::*, Decimal};
 use solana::Token;
@@ -34,6 +33,8 @@ use tokio::time::sleep;
 
 mod db;
 pub mod epoch_reward_info;
+
+pub use epoch_reward_info::{EpochInfo, EpochRewardInfo};
 
 const REWARDS_NOT_CURRENT_DELAY_PERIOD: i64 = 5;
 

--- a/mobile_verifier/src/rewarder/epoch_reward_info.rs
+++ b/mobile_verifier/src/rewarder/epoch_reward_info.rs
@@ -33,10 +33,54 @@
 //! [`PriceInfo::price_in_bones`]: crate::PriceInfo
 
 use anyhow::Context;
-use chrono::{DateTime, Utc};
-use mobile_config::{sub_dao_epoch_reward_info::EpochRewardInfo, EpochInfo};
+use chrono::{DateTime, Duration, Utc};
 use rust_decimal::Decimal;
+use std::ops::Range;
 use trino_rust_client::Trino;
+
+/// The time period covered by a reward epoch. Epoch `n` is the `n`-th UTC day
+/// since the Unix epoch. Local copy of the type mobile-config used to serve;
+/// kept here now that the epoch reward inputs are read from Trino.
+#[derive(Clone, Debug)]
+pub struct EpochInfo {
+    pub period: Range<DateTime<Utc>>,
+}
+
+impl From<u64> for EpochInfo {
+    fn from(next_reward_epoch: u64) -> Self {
+        let start_time = DateTime::UNIX_EPOCH + Duration::days(next_reward_epoch as i64);
+        let end_time = start_time + Duration::days(1);
+        EpochInfo {
+            period: start_time..end_time,
+        }
+    }
+}
+
+/// The on-chain HIP-149 reward inputs for a single epoch. Local copy of the type
+/// mobile-config used to serve over gRPC; the values are now recovered from
+/// Trino (see [`resolve`]).
+#[derive(Clone, Debug)]
+pub struct EpochRewardInfo {
+    pub epoch_day: u64,
+    pub epoch_address: String,
+    pub sub_dao_address: String,
+    pub epoch_period: Range<DateTime<Utc>>,
+    /// Total mobile sub-DAO emissions for the epoch (100%): the HNT this rewarder
+    /// distributes (`hnt_rewards_issued`) plus the delegation rewards already paid
+    /// to veHNT holders on-chain.
+    pub epoch_emissions: Decimal,
+    /// The slice of `epoch_emissions` this rewarder is responsible for
+    /// distributing (service providers + data transfer). Under the HIP-149 3×
+    /// cap / backstop the chain shifts HNT between this and the delegation
+    /// rewards, so it is no longer a fixed 94% of `epoch_emissions`; the rewarder
+    /// must distribute exactly this amount — no more, no less.
+    pub hnt_rewards_issued: Decimal,
+    /// The portion of `epoch_emissions` paid to veHNT delegators on-chain
+    /// (`epoch_emissions - hnt_rewards_issued`). The rewarder does not distribute
+    /// this; it is carried so the full on-chain split is available.
+    pub delegation_rewards_issued: Decimal,
+    pub rewards_issued_at: DateTime<Utc>,
+}
 
 /// `10^(hnt_decimals - pyth_exponent - 5)` — the DC→HNT scale factor the chain's
 /// backstop applies (`compute_backstop`). With HNT's fixed 8 decimals and the

--- a/mobile_verifier/src/settings.rs
+++ b/mobile_verifier/src/settings.rs
@@ -1,9 +1,14 @@
+use crate::authorization::AuthorizedKeys;
+use anyhow::Context;
 use chrono::{DateTime, Utc};
 use config::{Config, ConfigError, Environment, File};
+use helium_crypto::PublicKeyBinary;
 use humantime_serde::re::humantime;
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashSet,
     path::{Path, PathBuf},
+    str::FromStr,
     time::Duration,
 };
 
@@ -34,7 +39,19 @@ pub struct Settings {
     pub database: db_store::Settings,
     #[serde(default)]
     pub metrics: poc_metrics::Settings,
-    pub config_client: mobile_config::ClientSettings,
+    /// Public keys authorized to submit hotspot ban reports
+    /// (`NetworkKeyRole::Banning`). Comma-separated b58 keys. Replaces the
+    /// mobile-config authorization lookup.
+    #[serde(default)]
+    pub banning_authorized_keys: String,
+    /// Public keys authorized to submit unique-connection reports
+    /// (`NetworkKeyRole::MobileCarrier`). Comma-separated b58 keys.
+    #[serde(default)]
+    pub mobile_carrier_authorized_keys: String,
+    /// How often the in-memory snapshot of known gateways is refreshed from the
+    /// Trino inventory table (see [`crate::gateway`]).
+    #[serde(with = "humantime_serde", default = "default_gateway_refresh_interval")]
+    pub gateway_refresh_interval: Duration,
     #[serde(default = "default_start_after")]
     pub start_after: DateTime<Utc>,
     pub iceberg_settings: Option<helium_iceberg::Settings>,
@@ -54,6 +71,10 @@ pub struct Settings {
 
 fn default_fencing_resolution() -> u8 {
     7
+}
+
+fn default_gateway_refresh_interval() -> Duration {
+    humantime::parse_duration("1 hour").unwrap()
 }
 
 fn default_log() -> String {
@@ -126,4 +147,27 @@ impl Settings {
     pub fn store_base_path(&self) -> &std::path::Path {
         std::path::Path::new(&self.cache)
     }
+
+    /// The static per-role authorization allow-lists, parsed from settings.
+    /// Replaces the mobile-config authorization service.
+    pub fn authorized_keys(&self) -> anyhow::Result<AuthorizedKeys> {
+        Ok(AuthorizedKeys::new(
+            parse_authorized_keys(&self.banning_authorized_keys)
+                .context("parsing banning_authorized_keys")?,
+            parse_authorized_keys(&self.mobile_carrier_authorized_keys)
+                .context("parsing mobile_carrier_authorized_keys")?,
+        ))
+    }
+}
+
+/// Parse a comma-separated list of b58 public keys into a set. Blank entries are
+/// ignored, so an empty string yields an empty (deny-all) allow-list.
+fn parse_authorized_keys(keys: &str) -> anyhow::Result<HashSet<PublicKeyBinary>> {
+    keys.split(',')
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(|key| {
+            PublicKeyBinary::from_str(key).with_context(|| format!("invalid authorized key: {key}"))
+        })
+        .collect()
 }

--- a/mobile_verifier/src/settings.rs
+++ b/mobile_verifier/src/settings.rs
@@ -40,12 +40,14 @@ pub struct Settings {
     #[serde(default)]
     pub metrics: poc_metrics::Settings,
     /// Public keys authorized to submit hotspot ban reports
-    /// (`NetworkKeyRole::Banning`). Comma-separated b58 keys. Replaces the
-    /// mobile-config authorization lookup.
+    /// (`NetworkKeyRole::Banning`). Comma-separated b58 keys. Required — at least
+    /// one key; see [`Settings::authorized_keys`]. Replaces the mobile-config
+    /// authorization lookup.
     #[serde(default)]
     pub banning_authorized_keys: String,
     /// Public keys authorized to submit unique-connection reports
-    /// (`NetworkKeyRole::MobileCarrier`). Comma-separated b58 keys.
+    /// (`NetworkKeyRole::MobileCarrier`). Comma-separated b58 keys. Required — at
+    /// least one key; see [`Settings::authorized_keys`].
     #[serde(default)]
     pub mobile_carrier_authorized_keys: String,
     /// How often the in-memory snapshot of known gateways is refreshed from the
@@ -148,26 +150,64 @@ impl Settings {
         std::path::Path::new(&self.cache)
     }
 
-    /// The static per-role authorization allow-lists, parsed from settings.
-    /// Replaces the mobile-config authorization service.
+    /// The static per-role authorization allow-lists, parsed from settings. Both
+    /// lists are required: an empty list is an error (mirrors mobile-packet-verifier's
+    /// `routing_keys`), so a misconfiguration fails at startup rather than
+    /// silently rejecting every report.
     pub fn authorized_keys(&self) -> anyhow::Result<AuthorizedKeys> {
         Ok(AuthorizedKeys::new(
-            parse_authorized_keys(&self.banning_authorized_keys)
-                .context("parsing banning_authorized_keys")?,
-            parse_authorized_keys(&self.mobile_carrier_authorized_keys)
-                .context("parsing mobile_carrier_authorized_keys")?,
+            parse_authorized_keys("banning_authorized_keys", &self.banning_authorized_keys)?,
+            parse_authorized_keys(
+                "mobile_carrier_authorized_keys",
+                &self.mobile_carrier_authorized_keys,
+            )?,
         ))
     }
 }
 
-/// Parse a comma-separated list of b58 public keys into a set. Blank entries are
-/// ignored, so an empty string yields an empty (deny-all) allow-list.
-fn parse_authorized_keys(keys: &str) -> anyhow::Result<HashSet<PublicKeyBinary>> {
-    keys.split(',')
+/// Parse a comma-separated list of b58 public keys into a non-empty set. Blank
+/// entries are ignored; a list that yields no keys is an error, since each
+/// authorized-key role must be configured.
+fn parse_authorized_keys(setting: &str, keys: &str) -> anyhow::Result<HashSet<PublicKeyBinary>> {
+    let parsed: HashSet<PublicKeyBinary> = keys
+        .split(',')
         .map(str::trim)
         .filter(|key| !key.is_empty())
         .map(|key| {
-            PublicKeyBinary::from_str(key).with_context(|| format!("invalid authorized key: {key}"))
+            PublicKeyBinary::from_str(key)
+                .with_context(|| format!("settings parsing {setting}: {key}"))
         })
-        .collect()
+        .collect::<anyhow::Result<_>>()?;
+
+    if parsed.is_empty() {
+        anyhow::bail!("no keys provided in settings for {setting}");
+    }
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_authorized_keys;
+
+    const KEY: &str = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6";
+
+    #[test]
+    fn empty_authorized_keys_is_an_error() {
+        assert!(parse_authorized_keys("banning_authorized_keys", "").is_err());
+        // Whitespace / stray commas still yield no keys — also an error.
+        assert!(parse_authorized_keys("banning_authorized_keys", "  , ,").is_err());
+    }
+
+    #[test]
+    fn invalid_key_is_an_error() {
+        assert!(parse_authorized_keys("banning_authorized_keys", "not-a-b58-key").is_err());
+    }
+
+    #[test]
+    fn parses_and_dedupes_keys() {
+        let keys =
+            parse_authorized_keys("mobile_carrier_authorized_keys", &format!("{KEY}, {KEY}"))
+                .expect("valid keys");
+        assert_eq!(keys.len(), 1);
+    }
 }

--- a/mobile_verifier/src/speedtests.rs
+++ b/mobile_verifier/src/speedtests.rs
@@ -3,6 +3,7 @@ use crate::{
     speedtests_average::{SpeedtestAverage, SPEEDTEST_LAPSE},
     Settings,
 };
+use crate::{GatewayResolution, GatewayResolver};
 use chrono::{DateTime, Utc};
 use file_store::{
     file_info_poller::FileInfoStream, file_sink::FileSinkClient, file_source,
@@ -19,7 +20,6 @@ use helium_proto::services::poc_mobile::{
     SpeedtestAvg as SpeedtestAvgProto, SpeedtestAvgValidity, SpeedtestIngestReportV1,
     SpeedtestVerificationResult as SpeedtestResult, VerifiedSpeedtest as VerifiedSpeedtestProto,
 };
-use mobile_config::gateway::client::GatewayInfoResolver;
 use sqlx::{postgres::PgRow, FromRow, PgPool, PgTransaction, Row};
 use std::{
     collections::HashMap,
@@ -72,7 +72,7 @@ pub struct SpeedtestDaemon<GIR> {
 
 impl<GIR> SpeedtestDaemon<GIR>
 where
-    GIR: GatewayInfoResolver,
+    GIR: GatewayResolver,
 {
     pub async fn create_managed_task(
         pool: PgPool,
@@ -248,14 +248,15 @@ where
 
         match self
             .gateway_info_resolver
-            .resolve_gateway_info(&speedtest.report.pubkey, &speedtest.received_timestamp)
+            .resolve_gateway(&speedtest.report.pubkey, &speedtest.received_timestamp)
             .await?
         {
-            Some(gw_info) if gw_info.is_data_only() => {
-                Ok(SpeedtestResult::SpeedtestInvalidDeviceType)
+            GatewayResolution::DataOnly => Ok(SpeedtestResult::SpeedtestInvalidDeviceType),
+            GatewayResolution::GatewayNotFound => Ok(SpeedtestResult::SpeedtestGatewayNotFound),
+            // Asserted or on-chain-but-unasserted, non-data-only: valid.
+            GatewayResolution::AssertedLocation(_, _) | GatewayResolution::GatewayNotAsserted => {
+                Ok(SpeedtestResult::SpeedtestValid)
             }
-            Some(_) => Ok(SpeedtestResult::SpeedtestValid),
-            None => Ok(SpeedtestResult::SpeedtestGatewayNotFound),
         }
     }
 
@@ -281,7 +282,7 @@ where
 
 impl<GIR> ManagedTask for SpeedtestDaemon<GIR>
 where
-    GIR: GatewayInfoResolver,
+    GIR: GatewayResolver,
 {
     fn start_task(self: Box<Self>, shutdown: triggered::Listener) -> task_manager::TaskFuture {
         task_manager::spawn(self.run(shutdown))

--- a/mobile_verifier/src/telemetry.rs
+++ b/mobile_verifier/src/telemetry.rs
@@ -1,6 +1,5 @@
-use crate::rewarder;
+use crate::rewarder::{self, EpochInfo};
 use chrono::{DateTime, Utc};
-use mobile_config::EpochInfo;
 use sqlx::{Pool, Postgres};
 
 const LAST_REWARDED_END_TIME: &str = "last_rewarded_end_time";

--- a/mobile_verifier/src/unique_connections/ingestor.rs
+++ b/mobile_verifier/src/unique_connections/ingestor.rs
@@ -18,12 +18,11 @@ use helium_proto::services::{
         VerifiedUniqueConnectionsIngestReportStatus, VerifiedUniqueConnectionsIngestReportV1,
     },
 };
-use mobile_config::client::authorization_client::AuthorizationVerifier;
 use sqlx::PgPool;
 use task_manager::{ManagedTask, TaskManager};
 use tokio::sync::mpsc::Receiver;
 
-use crate::Settings;
+use crate::{authorization::AuthorizationVerifier, Settings};
 
 use super::db;
 
@@ -129,9 +128,8 @@ where
         let mut verified = vec![];
 
         while let Some(unique_connections_report) = stream.next().await {
-            let verified_report_status = self
-                .verify_unique_connection_report(&unique_connections_report.report)
-                .await;
+            let verified_report_status =
+                self.verify_unique_connection_report(&unique_connections_report.report);
 
             let is_valid = matches!(
                 verified_report_status,
@@ -164,20 +162,18 @@ where
         Ok(())
     }
 
-    async fn verify_unique_connection_report(
+    fn verify_unique_connection_report(
         &self,
         report: &UniqueConnectionReq,
     ) -> VerifiedUniqueConnectionsIngestReportStatus {
-        if !self.verify_known_carrier_key(&report.carrier_key).await {
+        if !self.verify_known_carrier_key(&report.carrier_key) {
             return VerifiedUniqueConnectionsIngestReportStatus::InvalidCarrierKey;
         }
         VerifiedUniqueConnectionsIngestReportStatus::Valid
     }
 
-    async fn verify_known_carrier_key(&self, public_key: &PublicKeyBinary) -> bool {
+    fn verify_known_carrier_key(&self, public_key: &PublicKeyBinary) -> bool {
         self.authorization_verifier
-            .verify_authorized_key(public_key, NetworkKeyRole::MobileCarrier)
-            .await
-            .unwrap_or_default()
+            .is_authorized(public_key, NetworkKeyRole::MobileCarrier)
     }
 }

--- a/mobile_verifier/tests/integrations/banning.rs
+++ b/mobile_verifier/tests/integrations/banning.rs
@@ -4,23 +4,16 @@ use file_store_oracles::mobile_ban::{
 };
 use helium_crypto::PublicKeyBinary;
 use helium_proto::services::mobile_config::NetworkKeyRole;
-use mobile_config::{
-    client::{authorization_client::AuthorizationVerifier, ClientError},
-    EpochInfo,
-};
+use mobile_verifier::authorization::AuthorizationVerifier;
 use mobile_verifier::banning::{ingestor::process_ban_report, BannedRadios};
+use mobile_verifier::rewarder::EpochInfo;
 use sqlx::PgPool;
 
 struct AllVerified;
 
-#[async_trait::async_trait]
 impl AuthorizationVerifier for AllVerified {
-    async fn verify_authorized_key(
-        &self,
-        _pubkey: &PublicKeyBinary,
-        _role: NetworkKeyRole,
-    ) -> Result<bool, ClientError> {
-        Ok(true)
+    fn is_authorized(&self, _address: &PublicKeyBinary, _role: NetworkKeyRole) -> bool {
+        true
     }
 }
 
@@ -359,14 +352,9 @@ async fn expired_bans_are_not_used(pool: PgPool) -> anyhow::Result<()> {
 async fn unverified_requests_are_not_written_to_db(pool: PgPool) -> anyhow::Result<()> {
     struct NoneVerified;
 
-    #[async_trait::async_trait]
     impl AuthorizationVerifier for NoneVerified {
-        async fn verify_authorized_key(
-            &self,
-            _pubkey: &PublicKeyBinary,
-            _role: NetworkKeyRole,
-        ) -> Result<bool, ClientError> {
-            Ok(false)
+        fn is_authorized(&self, _address: &PublicKeyBinary, _role: NetworkKeyRole) -> bool {
+            false
         }
     }
 

--- a/mobile_verifier/tests/integrations/common/mod.rs
+++ b/mobile_verifier/tests/integrations/common/mod.rs
@@ -7,9 +7,8 @@ use helium_proto::services::poc_mobile::{
     RadioReward, RadioRewardV2, ServiceProviderReward, SpeedtestAvg, SubscriberReward,
     UnallocatedReward,
 };
-use mobile_config::gateway::service::info::DeviceType;
-use mobile_config::{client::ClientError, sub_dao_epoch_reward_info::EpochRewardInfo};
-use mobile_verifier::{GatewayResolution, GatewayResolver, PriceInfo};
+use mobile_verifier::rewarder::EpochRewardInfo;
+use mobile_verifier::{DeviceType, GatewayResolution, GatewayResolver, PriceInfo};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use solana::Token;
@@ -31,7 +30,7 @@ impl GatewayResolver for GatewayClientAllOwnersValid {
         &self,
         _address: &PublicKeyBinary,
         _gateway_query_timestamp: &DateTime<Utc>,
-    ) -> Result<GatewayResolution, ClientError> {
+    ) -> anyhow::Result<GatewayResolution> {
         Ok(GatewayResolution::AssertedLocation(
             0x8c2681a3064d9ff,
             DeviceType::WifiIndoor,

--- a/mobile_verifier/tests/integrations/gateway_trino.rs
+++ b/mobile_verifier/tests/integrations/gateway_trino.rs
@@ -1,0 +1,169 @@
+//! End-to-end test of [`TrinoGatewayResolver`] against a real Trino, seeding the
+//! on-chain `mobile_hotspot_inventory` table the resolver reads from.
+//!
+//! The production resolver targets `network.chain.mobile_hotspot_inventory`. The
+//! test harness only serves iceberg tables in a per-test catalog, so we recreate
+//! the table here (only the columns the resolver's SQL touches) and pass a
+//! fully-qualified `<catalog>.chain.mobile_hotspot_inventory` name to
+//! [`TrinoGatewayResolver::new_with_inventory_table`] — production uses
+//! [`gateway::MOBILE_HOTSPOT_INVENTORY_TABLE`].
+
+use std::time::Duration;
+
+use chrono::{DateTime, FixedOffset, Utc};
+use helium_crypto::PublicKeyBinary;
+use helium_iceberg::{FieldDefinition, IcebergTestHarness, PartitionDefinition, TableDefinition};
+use mobile_verifier::gateway::{
+    DeviceType, GatewayResolution, GatewayResolver, TrinoGatewayResolver,
+};
+use serde::Serialize;
+
+const NAMESPACE: &str = "chain";
+const TABLE_NAME: &str = "mobile_hotspot_inventory";
+
+/// A location H3 cell, written to `asserted_hex` as a lowercase hex string (the
+/// on-chain encoding) and expected back as this `u64`.
+const LOCATION: u64 = 0x8c2681a3064d9ff;
+
+/// Only the columns [`TrinoGatewayResolver`] queries: `pub_key`, `device_type`,
+/// `asserted_hex` and `inserted_at` (the as-of filter).
+#[derive(Serialize)]
+struct InventoryRow {
+    pub_key: String,
+    device_type: String,
+    asserted_hex: String,
+    inserted_at: DateTime<FixedOffset>,
+}
+
+fn row(pub_key: &PublicKeyBinary, device_type: &str, asserted_hex: &str) -> InventoryRow {
+    // A fixed past instant; the resolver's `inserted_at <= now` fallback filter
+    // is satisfied by any past time.
+    let inserted_at: DateTime<FixedOffset> = "2024-01-01T00:00:00Z".parse().unwrap();
+    InventoryRow {
+        pub_key: pub_key.to_string(),
+        device_type: device_type.to_string(),
+        asserted_hex: asserted_hex.to_string(),
+        inserted_at,
+    }
+}
+
+fn inventory_table() -> anyhow::Result<TableDefinition> {
+    Ok(TableDefinition::builder(NAMESPACE, TABLE_NAME)
+        .with_fields([
+            FieldDefinition::required_string("pub_key"),
+            FieldDefinition::required_string("device_type"),
+            FieldDefinition::required_string("asserted_hex"),
+            FieldDefinition::required_timestamptz("inserted_at"),
+        ])
+        .with_partition(PartitionDefinition::day("inserted_at", "inserted_at_day"))
+        .build()?)
+}
+
+async fn harness() -> anyhow::Result<IcebergTestHarness> {
+    Ok(IcebergTestHarness::new_with_tables([inventory_table()?]).await?)
+}
+
+async fn seed(h: &IcebergTestHarness, id: &str, rows: Vec<InventoryRow>) -> anyhow::Result<()> {
+    h.get_table_writer_in::<InventoryRow>(NAMESPACE, TABLE_NAME)
+        .await?
+        .write_idempotent(id, rows)
+        .await?;
+    Ok(())
+}
+
+/// A fully-qualified `catalog.schema.table` name for this test's catalog, so the
+/// resolver's query is independent of the client's default catalog.
+fn inventory_table_name(h: &IcebergTestHarness) -> String {
+    format!("{}.{}.{}", h.catalog_name(), NAMESPACE, TABLE_NAME)
+}
+
+async fn resolver(h: &IcebergTestHarness) -> anyhow::Result<TrinoGatewayResolver> {
+    let client = trino_client::Client::from_client(h.owned_trino().await?);
+    Ok(TrinoGatewayResolver::new_with_inventory_table(
+        client,
+        inventory_table_name(h),
+        Duration::from_mins(60),
+    )
+    .await)
+}
+
+#[tokio::test]
+async fn snapshot_resolves_each_device_type_and_location() -> anyhow::Result<()> {
+    let h = harness().await?;
+
+    let asserted = PublicKeyBinary::from(vec![1]);
+    let data_only = PublicKeyBinary::from(vec![2]);
+    let unasserted = PublicKeyBinary::from(vec![3]);
+    let unknown = PublicKeyBinary::from(vec![4]);
+
+    seed(
+        &h,
+        "initial",
+        vec![
+            row(&asserted, "wifi_indoor", "8c2681a3064d9ff"),
+            row(&data_only, "wifi_data_only", ""),
+            row(&unasserted, "wifi_outdoor", ""),
+        ],
+    )
+    .await?;
+
+    let resolver = resolver(&h).await?;
+    let now = Utc::now();
+
+    // Latest row wins: asserted wifi_indoor with the parsed hex location.
+    assert!(matches!(
+        resolver.resolve_gateway(&asserted, &now).await?,
+        GatewayResolution::AssertedLocation(loc, DeviceType::WifiIndoor) if loc == LOCATION
+    ));
+    assert!(matches!(
+        resolver.resolve_gateway(&data_only, &now).await?,
+        GatewayResolution::DataOnly
+    ));
+    assert!(matches!(
+        resolver.resolve_gateway(&unasserted, &now).await?,
+        GatewayResolution::GatewayNotAsserted
+    ));
+    assert!(matches!(
+        resolver.resolve_gateway(&unknown, &now).await?,
+        GatewayResolution::GatewayNotFound
+    ));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn fallback_resolves_gateway_missing_from_snapshot() -> anyhow::Result<()> {
+    let h = harness().await?;
+
+    // Snapshot is loaded with just this gateway.
+    let in_snapshot = PublicKeyBinary::from(vec![1]);
+    seed(&h, "initial", vec![row(&in_snapshot, "wifi_outdoor", "")]).await?;
+
+    let resolver = resolver(&h).await?;
+
+    // Onboarded after the snapshot load: only the per-pubkey Trino fallback can
+    // find it (the resolver's refresh interval is an hour and never fires here).
+    let onboarded_later = PublicKeyBinary::from(vec![9]);
+    seed(
+        &h,
+        "later",
+        vec![row(&onboarded_later, "wifi_indoor", "8c2681a3064d9ff")],
+    )
+    .await?;
+
+    let now = Utc::now();
+    assert!(matches!(
+        resolver.resolve_gateway(&onboarded_later, &now).await?,
+        GatewayResolution::AssertedLocation(loc, DeviceType::WifiIndoor) if loc == LOCATION
+    ));
+
+    // A pubkey in neither the snapshot nor the table resolves to not-found via
+    // the same fallback path.
+    let never_seen = PublicKeyBinary::from(vec![42]);
+    assert!(matches!(
+        resolver.resolve_gateway(&never_seen, &now).await?,
+        GatewayResolution::GatewayNotFound
+    ));
+
+    Ok(())
+}

--- a/mobile_verifier/tests/integrations/gateway_trino.rs
+++ b/mobile_verifier/tests/integrations/gateway_trino.rs
@@ -102,10 +102,10 @@ async fn snapshot_resolves_each_device_type_and_location() -> anyhow::Result<()>
         &h,
         "initial",
         vec![
-            row(&asserted, "wifi_indoor", Some("8c2681a3064d9ff")),
+            row(&asserted, "WIFI_INDOOR", Some("8c2681a3064d9ff")),
             // Unasserted / data-only gateways carry a NULL asserted_hex on-chain.
-            row(&data_only, "wifi_data_only", None),
-            row(&unasserted, "wifi_outdoor", None),
+            row(&data_only, "WIFI_DATA_ONLY", None),
+            row(&unasserted, "WIFI_OUTDOOR", None),
         ],
     )
     .await?;
@@ -140,7 +140,7 @@ async fn fallback_resolves_gateway_missing_from_snapshot() -> anyhow::Result<()>
 
     // Snapshot is loaded with just this gateway.
     let in_snapshot = PublicKeyBinary::from(vec![1]);
-    seed(&h, "initial", vec![row(&in_snapshot, "wifi_outdoor", None)]).await?;
+    seed(&h, "initial", vec![row(&in_snapshot, "WIFI_OUTDOOR", None)]).await?;
 
     let resolver = resolver(&h).await?;
 
@@ -150,7 +150,11 @@ async fn fallback_resolves_gateway_missing_from_snapshot() -> anyhow::Result<()>
     seed(
         &h,
         "later",
-        vec![row(&onboarded_later, "wifi_indoor", Some("8c2681a3064d9ff"))],
+        vec![row(
+            &onboarded_later,
+            "WIFI_INDOOR",
+            Some("8c2681a3064d9ff"),
+        )],
     )
     .await?;
 

--- a/mobile_verifier/tests/integrations/gateway_trino.rs
+++ b/mobile_verifier/tests/integrations/gateway_trino.rs
@@ -26,23 +26,24 @@ const TABLE_NAME: &str = "mobile_hotspot_inventory";
 const LOCATION: u64 = 0x8c2681a3064d9ff;
 
 /// Only the columns [`TrinoGatewayResolver`] queries: `pub_key`, `device_type`,
-/// `asserted_hex` and `inserted_at` (the as-of filter).
+/// `asserted_hex` and `inserted_at` (the as-of filter). `asserted_hex` is
+/// nullable — unasserted gateways carry a NULL (there are ~2k of these on-chain).
 #[derive(Serialize)]
 struct InventoryRow {
     pub_key: String,
     device_type: String,
-    asserted_hex: String,
+    asserted_hex: Option<String>,
     inserted_at: DateTime<FixedOffset>,
 }
 
-fn row(pub_key: &PublicKeyBinary, device_type: &str, asserted_hex: &str) -> InventoryRow {
+fn row(pub_key: &PublicKeyBinary, device_type: &str, asserted_hex: Option<&str>) -> InventoryRow {
     // A fixed past instant; the resolver's `inserted_at <= now` fallback filter
     // is satisfied by any past time.
     let inserted_at: DateTime<FixedOffset> = "2024-01-01T00:00:00Z".parse().unwrap();
     InventoryRow {
         pub_key: pub_key.to_string(),
         device_type: device_type.to_string(),
-        asserted_hex: asserted_hex.to_string(),
+        asserted_hex: asserted_hex.map(str::to_string),
         inserted_at,
     }
 }
@@ -52,7 +53,8 @@ fn inventory_table() -> anyhow::Result<TableDefinition> {
         .with_fields([
             FieldDefinition::required_string("pub_key"),
             FieldDefinition::required_string("device_type"),
-            FieldDefinition::required_string("asserted_hex"),
+            // Nullable, matching production (unasserted gateways have NULL here).
+            FieldDefinition::optional_string("asserted_hex"),
             FieldDefinition::required_timestamptz("inserted_at"),
         ])
         .with_partition(PartitionDefinition::day("inserted_at", "inserted_at_day"))
@@ -100,9 +102,10 @@ async fn snapshot_resolves_each_device_type_and_location() -> anyhow::Result<()>
         &h,
         "initial",
         vec![
-            row(&asserted, "wifi_indoor", "8c2681a3064d9ff"),
-            row(&data_only, "wifi_data_only", ""),
-            row(&unasserted, "wifi_outdoor", ""),
+            row(&asserted, "wifi_indoor", Some("8c2681a3064d9ff")),
+            // Unasserted / data-only gateways carry a NULL asserted_hex on-chain.
+            row(&data_only, "wifi_data_only", None),
+            row(&unasserted, "wifi_outdoor", None),
         ],
     )
     .await?;
@@ -137,7 +140,7 @@ async fn fallback_resolves_gateway_missing_from_snapshot() -> anyhow::Result<()>
 
     // Snapshot is loaded with just this gateway.
     let in_snapshot = PublicKeyBinary::from(vec![1]);
-    seed(&h, "initial", vec![row(&in_snapshot, "wifi_outdoor", "")]).await?;
+    seed(&h, "initial", vec![row(&in_snapshot, "wifi_outdoor", None)]).await?;
 
     let resolver = resolver(&h).await?;
 
@@ -147,7 +150,7 @@ async fn fallback_resolves_gateway_missing_from_snapshot() -> anyhow::Result<()>
     seed(
         &h,
         "later",
-        vec![row(&onboarded_later, "wifi_indoor", "8c2681a3064d9ff")],
+        vec![row(&onboarded_later, "wifi_indoor", Some("8c2681a3064d9ff"))],
     )
     .await?;
 

--- a/mobile_verifier/tests/integrations/heartbeats_iceberg.rs
+++ b/mobile_verifier/tests/integrations/heartbeats_iceberg.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, SubsecRound, Utc};
 use helium_crypto::PublicKeyBinary;
 use helium_proto::services::poc_mobile::{HeartbeatValidity, LocationSource};
-use mobile_config::gateway::service::info::DeviceType;
+use mobile_verifier::DeviceType;
 use mobile_verifier::{
     cell_type::CellType,
     heartbeats::{Heartbeat, ValidatedHeartbeat},

--- a/mobile_verifier/tests/integrations/main.rs
+++ b/mobile_verifier/tests/integrations/main.rs
@@ -2,6 +2,7 @@ mod common;
 
 mod banning;
 mod banning_iceberg;
+mod gateway_trino;
 mod heartbeats;
 mod heartbeats_iceberg;
 mod last_location;

--- a/mobile_verifier/tests/integrations/reward_dc.rs
+++ b/mobile_verifier/tests/integrations/reward_dc.rs
@@ -11,7 +11,7 @@ use helium_iceberg::IcebergTestHarness;
 use helium_iceberg_oracles::data_transfer::burned_session::{
     self, IcebergBurnedDataTransferSession,
 };
-use mobile_config::sub_dao_epoch_reward_info::EpochRewardInfo;
+use mobile_verifier::rewarder::EpochRewardInfo;
 use mobile_verifier::{
     data_session::{self, DataSessionSource},
     reward_shares, rewarder,

--- a/mobile_verifier/tests/integrations/speedtests.rs
+++ b/mobile_verifier/tests/integrations/speedtests.rs
@@ -3,44 +3,26 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use file_store::{file_info_poller::FileInfoStream, FileInfo};
 use file_store_oracles::speedtest::{CellSpeedtest, CellSpeedtestIngestReport};
 use helium_crypto::PublicKeyBinary;
-use helium_proto::services::{
-    mobile_config::DeviceType as MobileDeviceType,
-    poc_mobile::{SpeedtestAvgValidity, SpeedtestVerificationResult as SpeedtestResult},
-};
-use mobile_config::{
-    client::ClientError,
-    gateway::{
-        client::GatewayInfoResolver,
-        service::info::{DeviceType, GatewayInfo, GatewayInfoStream},
-    },
+use helium_proto::services::poc_mobile::{
+    SpeedtestAvgValidity, SpeedtestVerificationResult as SpeedtestResult,
 };
 use mobile_verifier::speedtests::{SpeedtestDaemon, BYTES_PER_MEGABIT};
+use mobile_verifier::{GatewayResolution, GatewayResolver};
 use sqlx::{Pool, Postgres};
 
 #[derive(Clone)]
 struct MockGatewayInfoResolver {}
 
 #[async_trait::async_trait]
-impl GatewayInfoResolver for MockGatewayInfoResolver {
-    async fn resolve_gateway_info(
+impl GatewayResolver for MockGatewayInfoResolver {
+    async fn resolve_gateway(
         &self,
-        address: &PublicKeyBinary,
+        _address: &PublicKeyBinary,
         _gateway_query_timestamp: &DateTime<Utc>,
-    ) -> Result<Option<GatewayInfo>, ClientError> {
-        Ok(Some(GatewayInfo {
-            address: address.clone(),
-            metadata: None,
-            device_type: DeviceType::Cbrs,
-            created_at: None,
-            updated_at: None,
-        }))
-    }
-
-    async fn stream_gateways_info(
-        &mut self,
-        _device_types: &[MobileDeviceType],
-    ) -> Result<GatewayInfoStream, ClientError> {
-        todo!()
+    ) -> anyhow::Result<GatewayResolution> {
+        // On-chain, non-data-only: speedtest verification treats this as a valid
+        // device type (the previous mock returned a CBRS gateway).
+        Ok(GatewayResolution::GatewayNotAsserted)
     }
 }
 


### PR DESCRIPTION
- Gateway resolution now done through trino, similar to mobile-packet-verifier.
- Authorization now done with hardcoded list of valid keys in settings, similar to mobile-packet-verifier.
- EpochRewardInfo + EpochInfo + DeviceType pulled from mobile-config, values come from trino.
- SETTINGS:
  - remove `config_client`
  - add `gateway_refresh_interval`
  - add `banning_authorized_keys`
  - add `mobile_carrier_authorized_keys`