### PR TITLE
Fix timestamp-aware gateway resolution in snapshots and caches

### DIFF
--- a/mobile_packet_verifier/src/gateway.rs
+++ b/mobile_packet_verifier/src/gateway.rs
@@ -6,12 +6,12 @@
 //! per-pubkey Trino fallback.
 
 use std::{
-    collections::HashSet,
+    collections::HashMap,
     sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, FixedOffset, Utc};
 use helium_crypto::PublicKeyBinary;
 use retainer::Cache;
 use task_manager::Periodic;
@@ -39,8 +39,8 @@ const GATEWAY_REFRESH_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 pub struct GatewayResolver {
     trino_client: trino_client::Client,
     inventory_table: String,
-    known_gateways: Arc<RwLock<HashSet<PublicKeyBinary>>>,
-    fallback_cache: Arc<Cache<PublicKeyBinary, bool>>,
+    known_gateways: Arc<RwLock<HashMap<PublicKeyBinary, GatewayEntry>>>,
+    fallback_cache: Arc<Cache<PublicKeyBinary, Option<GatewayEntry>>>,
     refresh_interval: Duration,
     /// When the startup snapshot was loaded (`None` if the load failed). Seeds
     /// the refresher's first-refresh timing via [`GatewayResolver::refresher`].
@@ -85,7 +85,7 @@ impl GatewayResolver {
                         ?err,
                         "failed to load gateway inventory at startup; starting empty, will retry"
                     );
-                    (HashSet::new(), None)
+                    (HashMap::new(), None)
                 }
             };
         let known_gateways = Arc::new(RwLock::new(initial));
@@ -124,22 +124,20 @@ impl GatewayResolver {
         gateway_query_time: &DateTime<Utc>,
     ) -> bool {
         // Fast path: the startup/refresh snapshot of every known gateway.
-        let in_snapshot = self.known_gateways.read().unwrap().contains(public_key);
-        if in_snapshot {
-            return true;
+        if let Some(entry) = self.known_gateways.read().unwrap().get(public_key).copied() {
+            return entry.is_known_at(gateway_query_time);
         }
 
         // Miss: an unknown gateway, or one onboarded since the last refresh.
         // Fall back to a per-pubkey query, cached to avoid re-querying.
         if let Some(cached) = self.fallback_cache.get(public_key).await {
-            return *cached.value();
+            return cached
+                .value()
+                .is_some_and(|entry| entry.is_known_at(gateway_query_time));
         }
 
-        let is_known = match self
-            .query_gateway_known(public_key, gateway_query_time)
-            .await
-        {
-            Ok(is_known) => is_known,
+        let entry = match self.query_gateway(public_key).await {
+            Ok(entry) => entry,
             Err(err) => {
                 // Don't cache transient failures — fail closed for this call only.
                 tracing::warn!(?err, %public_key, "gateway fallback query failed");
@@ -147,39 +145,47 @@ impl GatewayResolver {
             }
         };
         self.fallback_cache
-            .insert(public_key.clone(), is_known, self.refresh_interval)
+            .insert(public_key.clone(), entry, self.refresh_interval)
             .await;
-        is_known
+        entry.is_some_and(|entry| entry.is_known_at(gateway_query_time))
     }
 
-    async fn query_gateway_known(
+    async fn query_gateway(
         &self,
         public_key: &PublicKeyBinary,
-        gateway_query_time: &DateTime<Utc>,
-    ) -> trino_client::Result<bool> {
+    ) -> trino_client::Result<Option<GatewayEntry>> {
         use trino_rust_client::Trino;
         #[derive(Trino, serde::Serialize, serde::Deserialize)]
-        struct Exists {
-            is_known: bool,
+        struct Row {
+            inserted_at: DateTime<FixedOffset>,
         }
 
         let stmt = trino_client::Statement::new(format!(
             r#"
-            SELECT EXISTS (
-                SELECT 1
-                FROM {}
-                WHERE pub_key = :address
-                  AND inserted_at <= :timestamp
-            ) AS is_known
+            SELECT inserted_at
+            FROM {}
+            WHERE pub_key = :address
             "#,
             self.inventory_table
         ))
         .bind("address", public_key.to_string())
-        .bind("timestamp", *gateway_query_time)
-        .typed::<Exists>();
+        .typed::<Row>();
 
         let rows = self.trino_client.get_all(stmt).await?;
-        Ok(rows.first().is_some_and(|row| row.is_known))
+        Ok(rows.into_iter().next().map(|row| GatewayEntry {
+            inserted_at: row.inserted_at.with_timezone(&Utc),
+        }))
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct GatewayEntry {
+    inserted_at: DateTime<Utc>,
+}
+
+impl GatewayEntry {
+    fn is_known_at(&self, gateway_query_time: &DateTime<Utc>) -> bool {
+        self.inserted_at <= *gateway_query_time
     }
 }
 
@@ -193,7 +199,7 @@ impl GatewayResolver {
 pub struct GatewaySnapshotRefresher {
     trino_client: trino_client::Client,
     inventory_table: String,
-    known_gateways: Arc<RwLock<HashSet<PublicKeyBinary>>>,
+    known_gateways: Arc<RwLock<HashMap<PublicKeyBinary, GatewayEntry>>>,
     refresh_interval: Duration,
     last_refresh: Option<Instant>,
 }
@@ -238,26 +244,34 @@ impl Periodic for GatewaySnapshotRefresher {
     }
 }
 
-/// Load every gateway pubkey from the inventory table into a set.
+/// Load every gateway pubkey and its stable onboarding timestamp.
 async fn load_known_gateways(
     trino_client: &trino_client::Client,
     inventory_table: &str,
-) -> anyhow::Result<HashSet<PublicKeyBinary>> {
+) -> anyhow::Result<HashMap<PublicKeyBinary, GatewayEntry>> {
     use trino_rust_client::Trino;
     #[derive(Trino, serde::Serialize, serde::Deserialize)]
     struct Row {
         pub_key: String,
+        inserted_at: DateTime<FixedOffset>,
     }
 
-    let stmt = trino_client::Statement::new(format!("SELECT pub_key FROM {inventory_table}"))
-        .typed::<Row>();
+    let stmt = trino_client::Statement::new(format!(
+        "SELECT pub_key, inserted_at FROM {inventory_table}"
+    ))
+    .typed::<Row>();
     let rows = trino_client.get_all(stmt).await?;
 
-    let mut known = HashSet::with_capacity(rows.len());
+    let mut known = HashMap::with_capacity(rows.len());
     for row in rows {
         match row.pub_key.parse::<PublicKeyBinary>() {
             Ok(pubkey) => {
-                known.insert(pubkey);
+                known.insert(
+                    pubkey,
+                    GatewayEntry {
+                        inserted_at: row.inserted_at.with_timezone(&Utc),
+                    },
+                );
             }
             Err(err) => {
                 tracing::warn!(?err, pub_key = %row.pub_key, "skipping unparseable gateway pubkey")
@@ -265,4 +279,18 @@ async fn load_known_gateways(
         }
     }
     Ok(known)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gateway_entry_respects_inserted_at() {
+        let inserted_at = Utc::now();
+        let entry = GatewayEntry { inserted_at };
+
+        assert!(!entry.is_known_at(&(inserted_at - chrono::Duration::seconds(1))));
+        assert!(entry.is_known_at(&inserted_at));
+    }
 }

--- a/mobile_packet_verifier/tests/integrations/accumulate_sessions.rs
+++ b/mobile_packet_verifier/tests/integrations/accumulate_sessions.rs
@@ -804,7 +804,7 @@ async fn run_accumulate_sessions(
     iceberg_writer: Option<iceberg::DataTransferWriter>,
 ) -> anyhow::Result<MessageReceiver<VerifiedDataTransferIngestReportV1>> {
     // Mark each known gateway as present on-chain, comfortably before the
-    // reports' received timestamps so the `received_timestamp <=` check passes.
+    // reports' received timestamps so the `inserted_at <= query timestamp` check passes.
     let seed_ts = Utc::now() - Duration::hours(1);
     let rows = known_gateways
         .iter()

--- a/mobile_packet_verifier/tests/integrations/gateway_trino.rs
+++ b/mobile_packet_verifier/tests/integrations/gateway_trino.rs
@@ -1,0 +1,54 @@
+use chrono::{Duration, Utc};
+use helium_crypto::PublicKeyBinary;
+
+use crate::common::{self, hotspot_inventory::MobileHotspotInventory};
+
+#[tokio::test]
+async fn snapshot_respects_gateway_inserted_at() -> anyhow::Result<()> {
+    let harness = common::setup_iceberg().await?;
+    let gateway = PublicKeyBinary::from(vec![1]);
+    let inserted_at = Utc::now() - Duration::hours(1);
+
+    common::hotspot_inventory::seed(
+        &harness,
+        vec![MobileHotspotInventory::known(&gateway, inserted_at)],
+    )
+    .await?;
+    let resolver = common::gateway_resolver(&harness).await?;
+
+    assert!(
+        !resolver
+            .is_gateway_known(&gateway, &(inserted_at - Duration::seconds(1)))
+            .await
+    );
+    assert!(resolver.is_gateway_known(&gateway, &inserted_at).await);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn fallback_cache_respects_each_query_timestamp() -> anyhow::Result<()> {
+    let harness = common::setup_iceberg().await?;
+    let old_then_new = PublicKeyBinary::from(vec![1]);
+    let new_then_old = PublicKeyBinary::from(vec![2]);
+    let inserted_at = Utc::now() - Duration::hours(1);
+    let before = inserted_at - Duration::seconds(1);
+
+    let resolver = common::gateway_resolver(&harness).await?;
+    common::hotspot_inventory::seed(
+        &harness,
+        vec![
+            MobileHotspotInventory::known(&old_then_new, inserted_at),
+            MobileHotspotInventory::known(&new_then_old, inserted_at),
+        ],
+    )
+    .await?;
+
+    assert!(!resolver.is_gateway_known(&old_then_new, &before).await);
+    assert!(resolver.is_gateway_known(&old_then_new, &inserted_at).await);
+
+    assert!(resolver.is_gateway_known(&new_then_old, &inserted_at).await);
+    assert!(!resolver.is_gateway_known(&new_then_old, &before).await);
+
+    Ok(())
+}

--- a/mobile_packet_verifier/tests/integrations/main.rs
+++ b/mobile_packet_verifier/tests/integrations/main.rs
@@ -5,3 +5,4 @@ pub mod banning;
 pub mod burn_metric;
 pub mod burner;
 pub mod daemon;
+pub mod gateway_trino;

--- a/mobile_verifier/src/gateway.rs
+++ b/mobile_verifier/src/gateway.rs
@@ -15,7 +15,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, FixedOffset, Utc};
 use helium_crypto::PublicKeyBinary;
 use retainer::Cache;
 use task_manager::Periodic;
@@ -102,6 +102,18 @@ struct GatewayMeta {
     location: Option<u64>,
 }
 
+#[derive(Copy, Clone, Debug)]
+struct GatewayEntry {
+    inserted_at: DateTime<Utc>,
+    meta: GatewayMeta,
+}
+
+impl GatewayEntry {
+    fn resolve_at(&self, gateway_query_time: &DateTime<Utc>) -> Option<GatewayMeta> {
+        (self.inserted_at <= *gateway_query_time).then_some(self.meta)
+    }
+}
+
 impl GatewayMeta {
     fn resolution(&self) -> GatewayResolution {
         // Precedence matches the old mobile-config resolver: data-only first,
@@ -128,8 +140,8 @@ impl GatewayMeta {
 pub struct TrinoGatewayResolver {
     trino_client: trino_client::Client,
     inventory_table: String,
-    known_gateways: Arc<RwLock<HashMap<PublicKeyBinary, GatewayMeta>>>,
-    fallback_cache: Arc<Cache<PublicKeyBinary, Option<GatewayMeta>>>,
+    known_gateways: Arc<RwLock<HashMap<PublicKeyBinary, GatewayEntry>>>,
+    fallback_cache: Arc<Cache<PublicKeyBinary, Option<GatewayEntry>>>,
     refresh_interval: Duration,
     /// When the startup snapshot was loaded (`None` if the load failed). Seeds
     /// the refresher's first-refresh timing via [`TrinoGatewayResolver::refresher`].
@@ -211,31 +223,33 @@ impl TrinoGatewayResolver {
         gateway_query_time: &DateTime<Utc>,
     ) -> anyhow::Result<Option<GatewayMeta>> {
         // Fast path: the startup/refresh snapshot of every known gateway.
-        if let Some(meta) = self.known_gateways.read().unwrap().get(public_key).copied() {
-            return Ok(Some(meta));
+        if let Some(entry) = self.known_gateways.read().unwrap().get(public_key).copied() {
+            return Ok(entry.resolve_at(gateway_query_time));
         }
 
         // Miss: an unknown gateway, or one onboarded since the last refresh.
         // Fall back to a per-pubkey query, cached to avoid re-querying.
         if let Some(cached) = self.fallback_cache.get(public_key).await {
-            return Ok(*cached.value());
+            return Ok(cached
+                .value()
+                .and_then(|entry| entry.resolve_at(gateway_query_time)));
         }
 
-        let meta = self.query_gateway(public_key, gateway_query_time).await?;
+        let entry = self.query_gateway(public_key).await?;
         self.fallback_cache
-            .insert(public_key.clone(), meta, self.refresh_interval)
+            .insert(public_key.clone(), entry, self.refresh_interval)
             .await;
-        Ok(meta)
+        Ok(entry.and_then(|entry| entry.resolve_at(gateway_query_time)))
     }
 
     async fn query_gateway(
         &self,
         public_key: &PublicKeyBinary,
-        gateway_query_time: &DateTime<Utc>,
-    ) -> anyhow::Result<Option<GatewayMeta>> {
+    ) -> anyhow::Result<Option<GatewayEntry>> {
         use trino_rust_client::Trino;
         #[derive(Trino, serde::Serialize, serde::Deserialize)]
         struct Row {
+            inserted_at: DateTime<FixedOffset>,
             device_type: String,
             // Nullable: an unasserted gateway has a NULL `asserted_hex`.
             asserted_hex: Option<String>,
@@ -244,22 +258,22 @@ impl TrinoGatewayResolver {
         // The inventory table has one row per pubkey (unique index on `pub_key`).
         let stmt = trino_client::Statement::new(format!(
             r#"
-            SELECT device_type, asserted_hex
+            SELECT inserted_at, device_type, asserted_hex
             FROM {}
             WHERE pub_key = :address
-              AND inserted_at <= :timestamp
             "#,
             self.inventory_table
         ))
         .bind("address", public_key.to_string())
-        .bind("timestamp", *gateway_query_time)
         .typed::<Row>();
 
         let rows = self.trino_client.get_all(stmt).await?;
-        Ok(rows
-            .into_iter()
-            .next()
-            .and_then(|row| row_to_meta(&row.device_type, row.asserted_hex.as_deref())))
+        Ok(rows.into_iter().next().and_then(|row| {
+            row_to_meta(&row.device_type, row.asserted_hex.as_deref()).map(|meta| GatewayEntry {
+                inserted_at: row.inserted_at.with_timezone(&Utc),
+                meta,
+            })
+        }))
     }
 }
 
@@ -289,7 +303,7 @@ impl GatewayResolver for TrinoGatewayResolver {
 pub struct GatewaySnapshotRefresher {
     trino_client: trino_client::Client,
     inventory_table: String,
-    known_gateways: Arc<RwLock<HashMap<PublicKeyBinary, GatewayMeta>>>,
+    known_gateways: Arc<RwLock<HashMap<PublicKeyBinary, GatewayEntry>>>,
     refresh_interval: Duration,
     last_refresh: Option<Instant>,
 }
@@ -375,18 +389,19 @@ fn parse_asserted_location(asserted_hex: &str) -> Option<u64> {
 async fn load_known_gateways(
     trino_client: &trino_client::Client,
     inventory_table: &str,
-) -> anyhow::Result<HashMap<PublicKeyBinary, GatewayMeta>> {
+) -> anyhow::Result<HashMap<PublicKeyBinary, GatewayEntry>> {
     use trino_rust_client::Trino;
     #[derive(Trino, serde::Serialize, serde::Deserialize)]
     struct Row {
         pub_key: String,
+        inserted_at: DateTime<FixedOffset>,
         device_type: String,
         // Nullable: an unasserted gateway has a NULL `asserted_hex`.
         asserted_hex: Option<String>,
     }
 
     let stmt = trino_client::Statement::new(format!(
-        "SELECT pub_key, device_type, asserted_hex FROM {inventory_table}"
+        "SELECT pub_key, inserted_at, device_type, asserted_hex FROM {inventory_table}"
     ))
     .typed::<Row>();
     let rows = trino_client.get_all(stmt).await?;
@@ -401,7 +416,13 @@ async fn load_known_gateways(
             }
         };
         if let Some(meta) = row_to_meta(&row.device_type, row.asserted_hex.as_deref()) {
-            known.insert(pubkey, meta);
+            known.insert(
+                pubkey,
+                GatewayEntry {
+                    inserted_at: row.inserted_at.with_timezone(&Utc),
+                    meta,
+                },
+            );
         }
     }
     Ok(known)
@@ -410,6 +431,29 @@ async fn load_known_gateways(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gateway_entry_respects_inserted_at() {
+        let inserted_at = Utc::now();
+        let entry = GatewayEntry {
+            inserted_at,
+            meta: GatewayMeta {
+                device_type: DeviceType::WifiOutdoor,
+                location: None,
+            },
+        };
+
+        assert!(entry
+            .resolve_at(&(inserted_at - chrono::Duration::seconds(1)))
+            .is_none());
+        assert!(matches!(
+            entry.resolve_at(&inserted_at),
+            Some(GatewayMeta {
+                device_type: DeviceType::WifiOutdoor,
+                location: None,
+            })
+        ));
+    }
 
     #[tokio::test]
     #[ignore = "manual query validation"]

--- a/mobile_verifier/tests/integrations/gateway_trino.rs
+++ b/mobile_verifier/tests/integrations/gateway_trino.rs
@@ -37,14 +37,27 @@ struct InventoryRow {
 }
 
 fn row(pub_key: &PublicKeyBinary, device_type: &str, asserted_hex: Option<&str>) -> InventoryRow {
-    // A fixed past instant; the resolver's `inserted_at <= now` fallback filter
-    // is satisfied by any past time.
+    // A fixed past instant, so normal lookups resolve this row as already onboarded.
     let inserted_at: DateTime<FixedOffset> = "2024-01-01T00:00:00Z".parse().unwrap();
     InventoryRow {
         pub_key: pub_key.to_string(),
         device_type: device_type.to_string(),
         asserted_hex: asserted_hex.map(str::to_string),
         inserted_at,
+    }
+}
+
+fn row_at(
+    pub_key: &PublicKeyBinary,
+    device_type: &str,
+    asserted_hex: Option<&str>,
+    inserted_at: DateTime<Utc>,
+) -> InventoryRow {
+    InventoryRow {
+        pub_key: pub_key.to_string(),
+        device_type: device_type.to_string(),
+        asserted_hex: asserted_hex.map(str::to_string),
+        inserted_at: inserted_at.into(),
     }
 }
 
@@ -169,6 +182,78 @@ async fn fallback_resolves_gateway_missing_from_snapshot() -> anyhow::Result<()>
     let never_seen = PublicKeyBinary::from(vec![42]);
     assert!(matches!(
         resolver.resolve_gateway(&never_seen, &now).await?,
+        GatewayResolution::GatewayNotFound
+    ));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn snapshot_respects_gateway_inserted_at() -> anyhow::Result<()> {
+    let h = harness().await?;
+    let gateway = PublicKeyBinary::from(vec![1]);
+    let inserted_at = Utc::now() - chrono::Duration::hours(1);
+
+    seed(
+        &h,
+        "initial",
+        vec![row_at(&gateway, "WIFI_OUTDOOR", None, inserted_at)],
+    )
+    .await?;
+    let resolver = resolver(&h).await?;
+
+    assert!(matches!(
+        resolver
+            .resolve_gateway(&gateway, &(inserted_at - chrono::Duration::seconds(1)))
+            .await?,
+        GatewayResolution::GatewayNotFound
+    ));
+    assert!(matches!(
+        resolver.resolve_gateway(&gateway, &inserted_at).await?,
+        GatewayResolution::GatewayNotAsserted
+    ));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn fallback_cache_respects_each_query_timestamp() -> anyhow::Result<()> {
+    let h = harness().await?;
+    let old_then_new = PublicKeyBinary::from(vec![1]);
+    let new_then_old = PublicKeyBinary::from(vec![2]);
+    let inserted_at = Utc::now() - chrono::Duration::hours(1);
+    let before = inserted_at - chrono::Duration::seconds(1);
+
+    let resolver = resolver(&h).await?;
+    seed(
+        &h,
+        "later",
+        vec![
+            row_at(&old_then_new, "WIFI_OUTDOOR", None, inserted_at),
+            row_at(&new_then_old, "WIFI_OUTDOOR", None, inserted_at),
+        ],
+    )
+    .await?;
+
+    assert!(matches!(
+        resolver.resolve_gateway(&old_then_new, &before).await?,
+        GatewayResolution::GatewayNotFound
+    ));
+    assert!(matches!(
+        resolver
+            .resolve_gateway(&old_then_new, &inserted_at)
+            .await?,
+        GatewayResolution::GatewayNotAsserted
+    ));
+
+    assert!(matches!(
+        resolver
+            .resolve_gateway(&new_then_old, &inserted_at)
+            .await?,
+        GatewayResolution::GatewayNotAsserted
+    ));
+    assert!(matches!(
+        resolver.resolve_gateway(&new_then_old, &before).await?,
         GatewayResolution::GatewayNotFound
     ));
 


### PR DESCRIPTION
## Summary

Fix gateway resolution so the `inserted_at` onboarding boundary is consistently enforced by both the snapshot and fallback-cache paths.

Closes https://github.com/helium/oracles/issues/1229


## Problem

The per-gateway Trino queries evaluate gateway existence using:

```sql
inserted_at <= :timestamp
```

but the in-memory snapshots do not retain inserted_at, so snapshot hits ignore the supplied query timestamp.

Fallback results are also cached only by public key even though the result depends on both public key and timestamp. This can cause a lookup for one report timestamp to incorrectly determine the result for another timestamp.

## Changes

- Include inserted_at in gateway snapshot entries.
- Check inserted_at against the supplied query timestamp on every snapshot lookup.
- Cache timestamp-independent gateway entries instead of final boolean/resolution results.
- Apply the timestamp cutoff after reading from the fallback cache.
- Preserve the existing fail-closed behavior for Trino query failures.

## Tests

Added regression coverage for:
- snapshot lookup before onboarding;
- snapshot lookup at or after onboarding;
- fallback lookup before onboarding followed by one after onboarding;
- fallback lookup after onboarding followed by one before onboarding.

These cases are covered for both mobile_packet_verifier and mobile_verifier.




