### PR TITLE
Add `chunks` to trino-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11951,7 +11951,9 @@ name = "trino-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "chrono",
+ "futures",
  "humantime-serde",
  "notify",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ edition = "2021"
 
 [workspace.dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
+async-stream = "0.3"
 async-trait = "*"
 base64 = ">=0.21"
 bincode = "1"

--- a/trino_client/Cargo.toml
+++ b/trino_client/Cargo.toml
@@ -6,7 +6,9 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+async-stream = { workspace = true }
 chrono = { workspace = true }
+futures = { workspace = true }
 humantime-serde = { workspace = true }
 notify = { workspace = true }
 serde = { workspace = true }
@@ -20,6 +22,7 @@ notify = { workspace = true, features = ["macos_fsevent"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+futures = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/trino_client/src/lib.rs
+++ b/trino_client/src/lib.rs
@@ -14,6 +14,7 @@ pub use statement::{Param, Statement, TypedStatement};
 
 pub use jwt_watcher::JwtWatcherError;
 
+use futures::{Stream, StreamExt};
 use jwt_watcher::JwtWatcher;
 use notify::PollWatcher;
 use std::sync::Arc;
@@ -136,6 +137,66 @@ impl Client {
         match self.inner().get_all::<T>(sql.into()).await {
             Ok(ds) => Ok(ds.into_vec()),
             Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Stream a query's rows in batches of `size`, letting the upstream client page
+    /// the result set. Prefer this to [`get_all`](Self::get_all) for anything
+    /// unbounded — `get_all` buffers the whole result in memory.
+    ///
+    /// The final batch is short rather than padded, and a query matching no rows
+    /// yields no batches at all. An error surfaces as a single `Err` item, after
+    /// which the stream ends. Dropping the stream early cancels the query
+    /// server-side.
+    ///
+    /// Unlike the one-shot methods this pins the inner client — and so the JWT it
+    /// was built with — for the life of the stream, instead of picking up a refresh
+    /// per request. Queries expected to outlive a token refresh should be split
+    /// across several calls.
+    pub fn chunks<S: SqlQuery>(
+        &self,
+        sql_query: S,
+        size: usize,
+    ) -> impl Stream<Item = Result<Vec<S::Row>>> + Send
+    where
+        S::Row: trino_rust_client::Trino + Send + 'static,
+        for<'de> S::Row: serde::Deserialize<'de> + serde::Serialize,
+    {
+        self.chunks_raw(sql_query.to_statement().render(), size)
+    }
+
+    /// [`chunks`](Self::chunks) over an already-rendered statement.
+    ///
+    /// Takes the render `Result` rather than a `String` so a failed render surfaces
+    /// as the stream's first item, which keeps this neither `async` nor fallible to
+    /// call.
+    pub fn chunks_raw<T>(
+        &self,
+        sql: Result<String>,
+        size: usize,
+    ) -> impl Stream<Item = Result<Vec<T>>> + Send
+    where
+        T: trino_rust_client::Trino + Send + 'static,
+        for<'de> T: serde::Deserialize<'de> + serde::Serialize,
+    {
+        // Moved into the generator, which keeps it alive as long as the `RowStream`
+        // borrowing it. A stream returned any other way would have to borrow this
+        // local `Arc`, which is self-referential and will not compile.
+        let client = self.inner();
+        let size = size.max(1);
+
+        async_stream::try_stream! {
+            let mut rows = client.stream::<T>(sql?).await?;
+            let mut batch = Vec::with_capacity(size);
+            while let Some(row) = rows.next().await {
+                batch.push(row?);
+                if batch.len() == size {
+                    yield std::mem::replace(&mut batch, Vec::with_capacity(size));
+                }
+            }
+            if !batch.is_empty() {
+                yield batch;
+            }
         }
     }
 }

--- a/trino_client/tests/integration.rs
+++ b/trino_client/tests/integration.rs
@@ -1,4 +1,5 @@
 use chrono::{NaiveDate, TimeZone, Utc};
+use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use trino_client::{
     Client, ClientBuilder, SqlQuery, SqlStatement, Statement, TrinoFromRow, TypedStatement,
@@ -233,5 +234,88 @@ async fn typed_statement_via_get_all() -> anyhow::Result<()> {
             d: 1.5,
         }]
     );
+    Ok(())
+}
+
+// ── chunks ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, TrinoFromRow, Deserialize, Serialize, PartialEq)]
+struct Num {
+    n: i64,
+}
+
+/// `SELECT n FROM (VALUES (1), (2), ...) AS t(n) ORDER BY n` over `1..=count`.
+fn numbers(count: i64) -> TypedStatement<Num> {
+    let values = (1..=count)
+        .map(|n| format!("({n})"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Statement::new(format!(
+        "SELECT n FROM (VALUES {values}) AS t(n) ORDER BY n"
+    ))
+    .typed()
+}
+
+async fn collect_chunks(count: i64, size: usize) -> anyhow::Result<Vec<Vec<i64>>> {
+    let stream = client().chunks(numbers(count), size);
+    futures::pin_mut!(stream);
+    let mut out = Vec::new();
+    while let Some(batch) = stream.next().await {
+        out.push(batch?.into_iter().map(|r| r.n).collect());
+    }
+    Ok(out)
+}
+
+#[tokio::test]
+async fn chunks_splits_on_an_exact_multiple() -> anyhow::Result<()> {
+    assert_eq!(
+        collect_chunks(6, 2).await?,
+        vec![vec![1, 2], vec![3, 4], vec![5, 6]]
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn chunks_leaves_a_short_final_batch() -> anyhow::Result<()> {
+    // 7 rows in 3s: the tail is short, not padded, and not dropped.
+    assert_eq!(
+        collect_chunks(7, 3).await?,
+        vec![vec![1, 2, 3], vec![4, 5, 6], vec![7]]
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn chunks_yields_nothing_for_an_empty_result() -> anyhow::Result<()> {
+    // Not one empty batch — no batches at all.
+    let stream = client().chunks(
+        Statement::new("SELECT n FROM (VALUES (1)) AS t(n) WHERE n < 0").typed::<Num>(),
+        10,
+    );
+    futures::pin_mut!(stream);
+    assert!(stream.next().await.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn chunks_renders_bound_parameters() -> anyhow::Result<()> {
+    let stmt = Statement::new("SELECT :n AS n")
+        .bind("n", 7i64)
+        .typed::<Num>();
+    let stream = client().chunks(stmt, 10);
+    futures::pin_mut!(stream);
+    let batch = stream.next().await.expect("one batch")?;
+    assert_eq!(batch, vec![Num { n: 7 }]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn chunks_surfaces_a_query_error() -> anyhow::Result<()> {
+    let stream = client().chunks(
+        Statement::new("SELECT * FROM no_such_table").typed::<Num>(),
+        10,
+    );
+    futures::pin_mut!(stream);
+    assert!(stream.next().await.expect("an item").is_err());
     Ok(())
 }


### PR DESCRIPTION
trino-rust-client 0.11 can stream a result set, but the wrapper only exposed `get_all`, which buffers everything — so callers reading unbounded tables hand-rolled keyset pagination and re-scanned per page.

`chunks` batches off the upstream stream, scanning once. It owns the inner Arc via an async-stream generator, since a `RowStream` borrows the client and returning one over a local Arc is self-referential.