### PR TITLE
Update price to hit new endpoint with bearer auth

### DIFF
--- a/price/pkg/settings-template.toml
+++ b/price/pkg/settings-template.toml
@@ -5,7 +5,13 @@
 # Hermes price update URL including the HNT feed id query parameter. Default
 # below.
 #
-# source = "https://hermes.pyth.network/v2/updates/price/latest?ids[]=649fdd7ec08e8e2a20f425729854e90293dcbe2376abc47197a14da6ff339756"
+# source = "https://pyth.dourolabs.app/hermes/v2/updates/price/latest?ids[]=649fdd7ec08e8e2a20f425729854e90293dcbe2376abc47197a14da6ff339756"
+
+# Bearer token sent in the `Authorization` header when fetching `source`.
+# Required. Prefer setting this via the `PRICE__API_KEY` environment variable
+# rather than in the config file.
+#
+# api_key = "..."
 
 
 # Folder for the local on-disk price cache / file sink staging area.

--- a/price/src/cli/check.rs
+++ b/price/src/cli/check.rs
@@ -2,9 +2,9 @@ use crate::hermes;
 use anyhow::{anyhow, Result};
 use chrono::{TimeZone, Utc};
 
-pub async fn run(url: String) -> Result<()> {
+pub async fn run(url: String, api_key: String) -> Result<()> {
     let client = reqwest::Client::new();
-    let parsed = hermes::fetch(&client, &url).await?;
+    let parsed = hermes::fetch(&client, &url, &api_key).await?;
     let scaled = parsed.price.scaled_u64()?;
     let timestamp = Utc
         .timestamp_opt(parsed.price.publish_time, 0)

--- a/price/src/hermes.rs
+++ b/price/src/hermes.rs
@@ -39,9 +39,14 @@ impl HermesPrice {
     }
 }
 
-pub async fn fetch(client: &reqwest::Client, url: &str) -> Result<HermesParsedPrice> {
+pub async fn fetch(
+    client: &reqwest::Client,
+    url: &str,
+    api_key: &str,
+) -> Result<HermesParsedPrice> {
     let response: HermesResponse = client
         .get(url)
+        .bearer_auth(api_key)
         .send()
         .await?
         .error_for_status()?

--- a/price/src/main.rs
+++ b/price/src/main.rs
@@ -56,11 +56,9 @@ impl Cmd {
                 cmd.run(&settings).await
             }
             Self::Check(options) => {
-                let url = match options.url {
-                    Some(url) => url,
-                    None => Settings::new(config)?.source,
-                };
-                check::run(url).await
+                let settings = Settings::new(config)?;
+                let url = options.url.unwrap_or_else(|| settings.source.clone());
+                check::run(url, settings.api_key).await
             }
             Self::Backfill(cmd) => {
                 let settings = Settings::new(config)?;

--- a/price/src/price_generator.rs
+++ b/price/src/price_generator.rs
@@ -27,6 +27,7 @@ impl Price {
 pub struct PriceGenerator {
     http: reqwest::Client,
     source_url: String,
+    api_key: String,
     interval_duration: std::time::Duration,
     last_price_opt: Option<Price>,
     default_price: Option<u64>,
@@ -80,6 +81,7 @@ impl PriceGenerator {
             last_price_opt: None,
             http: reqwest::Client::new(),
             source_url: settings.source.clone(),
+            api_key: settings.api_key.clone(),
             default_price: settings.default_price,
             interval_duration: settings.interval,
             stale_price_duration: settings.stale_price_duration,
@@ -134,7 +136,7 @@ impl PriceGenerator {
     }
 
     async fn fetch_hermes_price(&self) -> Result<Price> {
-        let parsed = hermes::fetch(&self.http, &self.source_url).await?;
+        let parsed = hermes::fetch(&self.http, &self.source_url, &self.api_key).await?;
         let price = parsed.price.scaled_u64()?;
         let timestamp = Utc
             .timestamp_opt(parsed.price.publish_time, 0)

--- a/price/src/settings.rs
+++ b/price/src/settings.rs
@@ -20,6 +20,11 @@ pub struct Settings {
     /// parameter for the HNT feed. Required.
     #[serde(default = "default_source")]
     pub source: String,
+    /// Bearer token sent in the `Authorization` header when fetching from
+    /// `source`. Required by the dourolabs Hermes endpoint. Prefer setting
+    /// this via the `PRICE__API_KEY` environment variable.
+    #[serde(skip_serializing)]
+    pub api_key: String,
     /// S3 bucket for `PriceReportV1` protobuf files. Optional for
     /// `server`; required for `backfill` (which reads these files
     /// back). When unset on the server, the file_sink/FileUpload tasks
@@ -82,7 +87,7 @@ fn default_backfill_start_after() -> DateTime<Utc> {
 }
 
 fn default_source() -> String {
-    "https://hermes.pyth.network/v2/updates/price/latest?ids[]=649fdd7ec08e8e2a20f425729854e90293dcbe2376abc47197a14da6ff339756".to_string()
+    "https://pyth.dourolabs.app/hermes/v2/updates/price/latest?ids[]=649fdd7ec08e8e2a20f425729854e90293dcbe2376abc47197a14da6ff339756".to_string()
 }
 
 fn default_log() -> String {
@@ -149,6 +154,7 @@ mod tests {
             [
                 ("PRICE__OUTPUT__BUCKET", Some("test-bucket".to_string())),
                 ("PRICE__DEFAULT_PRICE", Some("100000000".to_string())),
+                ("PRICE__API_KEY", Some("test-key".to_string())),
             ],
             || Settings::new::<PathBuf>(None),
         )?;
@@ -166,11 +172,14 @@ mod tests {
         let template = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("pkg/settings-template.toml");
         // The template ships with `[output]` commented out — `output`
         // is optional for the server and required only for backfill.
-        let settings = temp_env::with_vars(Vec::<(&str, Option<String>)>::new(), || {
-            Settings::new(Some(&template))
-        })?;
+        // `api_key` is required and ships commented out (set via env in
+        // production), so it must be supplied here for the parse to succeed.
+        let settings =
+            temp_env::with_vars([("PRICE__API_KEY", Some("test-key".to_string()))], || {
+                Settings::new(Some(&template))
+            })?;
 
-        assert!(settings.source.contains("hermes.pyth.network"));
+        assert!(settings.source.contains("pyth.dourolabs.app/hermes"));
         assert!(settings.output.is_none());
         assert_eq!(settings.interval, Duration::from_secs(60));
         Ok(())
@@ -183,6 +192,7 @@ mod tests {
             [
                 ("PRICE__OUTPUT__BUCKET", Some("test-bucket".to_string())),
                 ("PRICE__SOURCE", Some(url.to_string())),
+                ("PRICE__API_KEY", Some("test-key".to_string())),
             ],
             || Settings::new::<PathBuf>(None),
         )?;


### PR DESCRIPTION
Tested with 

NEW SETTINGS: `PRICE__API_KEY`

```sh
PRICE__API_KEY=... cargo run check
```

```
URL: https://pyth.dourolabs.app/hermes/v2/updates/price/latest?ids[]=649fdd7ec08e8e2a20f425729854e90293dcbe2376abc47197a14da6ff339756
Feed ID: 649fdd7ec08e8e2a20f425729854e90293dcbe2376abc47197a14da6ff339756
Raw price: 16935872
Confidence: 14139
Exponent: -8
Publish time: 2026-08-14 17:01:33 UTC (1786726893)

Scaled integer price (as emitted to S3): 16935872
```