### PR TITLE
Remove mobile-config from ingest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4765,7 +4765,6 @@ dependencies = [
  "humantime-serde",
  "metrics",
  "metrics-exporter-prometheus",
- "mobile-config",
  "poc-metrics",
  "prost",
  "rand 0.8.5",

--- a/ingest/Cargo.toml
+++ b/ingest/Cargo.toml
@@ -36,7 +36,6 @@ humantime-serde = { workspace = true }
 file-store = { path = "../file_store" }
 file-store-oracles = { path = "../file_store_oracles" }
 poc-metrics = { path = "../metrics" }
-mobile-config = { path = "../mobile_config" }
 task-manager = { path = "../task_manager" }
 custom-tracing = { path = "../custom_tracing", features = ["grpc"] }
 tls-init = { path = "../tls_init" }

--- a/ingest/pkg/settings-template.toml
+++ b/ingest/pkg/settings-template.toml
@@ -24,6 +24,13 @@ mode = "mobile"
 #
 network = "mainnet"
 
+# Comma-separated b58 public keys authorized to submit carrier-signed reports
+# (NetworkKeyRole::MobileCarrier): hex usage stats, radio usage stats (v1/v2),
+# and enabled carriers info. Replaces the mobile-config authorization lookup.
+# Required in "mobile" mode: at least one key, or the service errors on startup.
+# Ignored in "chain" mode.
+carrier_authorized_keys = "key1,key2"
+
 [output]
 # Output bucket for ingested data
 

--- a/ingest/src/authorization.rs
+++ b/ingest/src/authorization.rs
@@ -1,0 +1,63 @@
+//! Static, settings-backed authorization allow-lists.
+//!
+//! Replaces the mobile-config gRPC authorization service. mobile-config served
+//! authorized keys from an admin-registered `registered_keys` table —
+//! effectively static config — so ingest now reads the same allow-list straight
+//! from its settings. Mirrors `mobile_verifier::authorization` and the
+//! routing-key allow-list mobile-packet-verifier uses
+//! (`mobile_packet_verifier::routing`).
+
+use std::collections::HashSet;
+
+use helium_crypto::PublicKeyBinary;
+use helium_proto::services::mobile_config::NetworkKeyRole;
+
+/// The set of keys authorized for each role ingest checks. Built from settings —
+/// see [`Settings::authorized_keys`](crate::Settings::authorized_keys).
+#[derive(Debug, Clone, Default)]
+pub struct AuthorizedKeys {
+    carrier: HashSet<PublicKeyBinary>,
+}
+
+impl AuthorizedKeys {
+    pub fn new(carrier: HashSet<PublicKeyBinary>) -> Self {
+        Self { carrier }
+    }
+}
+
+/// A role-scoped authorization check. Kept as a trait (rather than using
+/// [`AuthorizedKeys`] directly at call sites) so tests can substitute a mock.
+pub trait AuthorizationVerifier: Send + Sync + 'static {
+    fn is_authorized(&self, address: &PublicKeyBinary, role: NetworkKeyRole) -> bool;
+}
+
+impl AuthorizationVerifier for AuthorizedKeys {
+    fn is_authorized(&self, address: &PublicKeyBinary, role: NetworkKeyRole) -> bool {
+        match role {
+            NetworkKeyRole::MobileCarrier => self.carrier.contains(address),
+            // Ingest only authorizes the role above.
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(byte: u8) -> PublicKeyBinary {
+        PublicKeyBinary::from(vec![byte])
+    }
+
+    #[test]
+    fn authorizes_only_configured_keys_per_role() {
+        let keys = AuthorizedKeys::new(HashSet::from([key(1)]));
+
+        assert!(keys.is_authorized(&key(1), NetworkKeyRole::MobileCarrier));
+        assert!(!keys.is_authorized(&key(2), NetworkKeyRole::MobileCarrier));
+
+        // Roles ingest doesn't manage are never authorized.
+        assert!(!keys.is_authorized(&key(1), NetworkKeyRole::Banning));
+        assert!(!keys.is_authorized(&key(1), NetworkKeyRole::MobileRouter));
+    }
+}

--- a/ingest/src/lib.rs
+++ b/ingest/src/lib.rs
@@ -1,9 +1,11 @@
 extern crate tls_init;
 
+pub mod authorization;
 pub mod server_chain;
 pub mod server_mobile;
 pub mod settings;
 
+pub use authorization::{AuthorizationVerifier, AuthorizedKeys};
 pub use settings::{Mode, Settings};
 
 #[cfg(test)]

--- a/ingest/src/server_mobile.rs
+++ b/ingest/src/server_mobile.rs
@@ -1,4 +1,4 @@
-use crate::Settings;
+use crate::{authorization::AuthorizationVerifier, Settings};
 use anyhow::{bail, Error, Result};
 use chrono::Utc;
 use file_store::{file_sink::FileSinkClient, file_upload};
@@ -29,7 +29,6 @@ use helium_proto::services::{
     poc_mobile::{UniqueConnectionsReqV1, UniqueConnectionsRespV1},
 };
 use helium_proto_crypto::MsgVerify;
-use mobile_config::client::{authorization_client::AuthorizationVerifier, AuthorizationClient};
 use std::net::SocketAddr;
 use task_manager::{ManagedTask, TaskManager};
 use tonic::{
@@ -178,15 +177,15 @@ where
         Ok((public_key, event))
     }
 
-    async fn verify_known_carrier_key(&self, public_key: PublicKey) -> VerifyResult<()> {
-        let public_key_bin = PublicKeyBinary::from(public_key.clone());
-        self.authorization_verifier
-            .verify_authorized_key(&public_key_bin, NetworkKeyRole::MobileCarrier)
-            .await
-            .map_err(|_| {
-                tracing::error!(%public_key_bin, "unknown carrier key");
-                Status::invalid_argument("unknown carrier key")
-            })?;
+    fn verify_known_carrier_key(&self, public_key: PublicKey) -> VerifyResult<()> {
+        let public_key_bin = PublicKeyBinary::from(public_key);
+        if !self
+            .authorization_verifier
+            .is_authorized(&public_key_bin, NetworkKeyRole::MobileCarrier)
+        {
+            tracing::error!(%public_key_bin, "unknown carrier key");
+            return Err(Status::invalid_argument("unknown carrier key"));
+        }
         Ok(())
     }
 }
@@ -527,7 +526,7 @@ where
             .verify_public_key(event.carrier_mapping_key.as_ref())
             .and_then(|public_key| self.verify_network(public_key))
             .and_then(|public_key| self.verify_signature(public_key, event))?;
-        self.verify_known_carrier_key(verified_pubkey).await?;
+        self.verify_known_carrier_key(verified_pubkey)?;
 
         let report = HexUsageStatsIngestReportV1 {
             received_timestamp: timestamp,
@@ -553,7 +552,7 @@ where
             .verify_public_key(event.carrier_mapping_key.as_ref())
             .and_then(|public_key| self.verify_network(public_key))
             .and_then(|public_key| self.verify_signature(public_key, event))?;
-        self.verify_known_carrier_key(verified_pubkey).await?;
+        self.verify_known_carrier_key(verified_pubkey)?;
 
         let report = RadioUsageStatsIngestReportV1 {
             received_timestamp: timestamp,
@@ -579,7 +578,7 @@ where
             .verify_public_key(event.carrier_pubkey.as_ref())
             .and_then(|public_key| self.verify_network(public_key))
             .and_then(|public_key| self.verify_signature(public_key, event))?;
-        self.verify_known_carrier_key(verified_pubkey).await?;
+        self.verify_known_carrier_key(verified_pubkey)?;
 
         let report = RadioUsageStatsIngestReportV2 {
             received_timestamp_ms: timestamp,
@@ -664,7 +663,7 @@ where
             .verify_public_key(&event.signer_pubkey)
             .and_then(|public_key| self.verify_network(public_key))
             .and_then(|public_key| self.verify_signature(public_key, event))?;
-        self.verify_known_carrier_key(verified_pubkey).await?;
+        self.verify_known_carrier_key(verified_pubkey)?;
 
         let report = EnabledCarriersInfoReportV1 {
             received_timestamp_ms,
@@ -857,10 +856,6 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
         bail!("expected valid api token in settings");
     };
 
-    let Some(config_client) = settings.config_client.as_ref() else {
-        bail!("expected mobile config client settings");
-    };
-
     let grpc_server = GrpcServer::new(
         wifi_heartbeat_report_sink,
         speedtest_report_sink,
@@ -881,7 +876,7 @@ pub async fn grpc_server(settings: &Settings) -> Result<()> {
         settings.network,
         settings.listen_addr,
         api_token,
-        AuthorizationClient::from_settings(config_client)?,
+        settings.authorized_keys()?,
     );
 
     tracing::info!(

--- a/ingest/src/settings.rs
+++ b/ingest/src/settings.rs
@@ -1,8 +1,12 @@
+use crate::authorization::AuthorizedKeys;
+use anyhow::Context;
 use config::{Config, Environment, File};
-use helium_crypto::Network;
+use helium_crypto::{Network, PublicKeyBinary};
 use humantime_serde::re::humantime;
 use serde::{Deserialize, Serialize};
-use std::{net::SocketAddr, path::Path, path::PathBuf, time::Duration};
+use std::{
+    collections::HashSet, net::SocketAddr, path::Path, path::PathBuf, str::FromStr, time::Duration,
+};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Settings {
@@ -45,9 +49,12 @@ pub struct Settings {
     /// Target output bucket details Metrics settings
     #[serde(default)]
     pub metrics: poc_metrics::Settings,
-    // mobile config client settings
-    // optional to avoid having to define a client for IOT mode
-    pub config_client: Option<mobile_config::ClientSettings>,
+    /// Public keys authorized to submit carrier-signed reports
+    /// (`NetworkKeyRole::MobileCarrier`). Comma-separated b58 keys. Required in
+    /// "mobile" mode — at least one key; see [`Settings::authorized_keys`].
+    /// Ignored in "chain" mode. Replaces the mobile-config authorization lookup.
+    #[serde(default)]
+    pub carrier_authorized_keys: String,
     /// Key that can sign Chain Rewardable Entities messages
     pub chain_rewardable_entities_auth_key: Option<String>,
 }
@@ -114,5 +121,63 @@ impl Settings {
             )
             .build()
             .and_then(|config| config.try_deserialize())
+    }
+
+    /// The static authorization allow-list, parsed from settings. The list is
+    /// required: an empty list is an error (mirrors mobile-verifier's
+    /// `banning_authorized_keys` and mobile-packet-verifier's `routing_keys`),
+    /// so a misconfiguration fails at startup rather than silently rejecting
+    /// every carrier report.
+    pub fn authorized_keys(&self) -> anyhow::Result<AuthorizedKeys> {
+        Ok(AuthorizedKeys::new(parse_authorized_keys(
+            "carrier_authorized_keys",
+            &self.carrier_authorized_keys,
+        )?))
+    }
+}
+
+/// Parse a comma-separated list of b58 public keys into a non-empty set. Blank
+/// entries are ignored; a list that yields no keys is an error, since each
+/// authorized-key role must be configured.
+fn parse_authorized_keys(setting: &str, keys: &str) -> anyhow::Result<HashSet<PublicKeyBinary>> {
+    let parsed: HashSet<PublicKeyBinary> = keys
+        .split(',')
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(|key| {
+            PublicKeyBinary::from_str(key)
+                .with_context(|| format!("settings parsing {setting}: {key}"))
+        })
+        .collect::<anyhow::Result<_>>()?;
+
+    if parsed.is_empty() {
+        anyhow::bail!("no keys provided in settings for {setting}");
+    }
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_authorized_keys;
+
+    const KEY: &str = "112NqN2WWMwtK29PMzRby62fDydBJfsCLkCAf392stdok48ovNT6";
+
+    #[test]
+    fn empty_authorized_keys_is_an_error() {
+        assert!(parse_authorized_keys("carrier_authorized_keys", "").is_err());
+        // Whitespace / stray commas still yield no keys — also an error.
+        assert!(parse_authorized_keys("carrier_authorized_keys", "  , ,").is_err());
+    }
+
+    #[test]
+    fn invalid_key_is_an_error() {
+        assert!(parse_authorized_keys("carrier_authorized_keys", "not-a-b58-key").is_err());
+    }
+
+    #[test]
+    fn parses_and_dedupes_keys() {
+        let keys = parse_authorized_keys("carrier_authorized_keys", &format!("{KEY}, {KEY}"))
+            .expect("valid keys");
+        assert_eq!(keys.len(), 1);
     }
 }

--- a/ingest/tests/common/mod.rs
+++ b/ingest/tests/common/mod.rs
@@ -21,9 +21,8 @@ use helium_proto::services::{
         SubscriberVerifiedMappingEventReqV1, SubscriberVerifiedMappingEventResV1,
     },
 };
+use ingest::authorization::AuthorizationVerifier;
 use ingest::server_mobile::GrpcServer;
-use mobile_config::client::authorization_client::AuthorizationVerifier;
-use mobile_config::client::ClientError;
 use prost::Message;
 use rand::rngs::OsRng;
 use std::str::FromStr;
@@ -31,7 +30,6 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::{net::TcpListener, sync::mpsc::Receiver, time::timeout};
 use tonic::{
-    async_trait,
     metadata::{Ascii, MetadataValue},
     transport::Channel,
     Request,
@@ -40,17 +38,20 @@ use triggered::Trigger;
 
 struct MockAuthorizationClient;
 
-#[async_trait]
 impl AuthorizationVerifier for MockAuthorizationClient {
-    async fn verify_authorized_key(
-        &self,
-        _pubkey: &PublicKeyBinary,
-        _role: NetworkKeyRole,
-    ) -> Result<bool, ClientError> {
-        Ok(true)
+    fn is_authorized(&self, _pubkey: &PublicKeyBinary, _role: NetworkKeyRole) -> bool {
+        true
     }
 }
 pub async fn setup_mobile() -> anyhow::Result<(TestClient, Trigger)> {
+    setup_mobile_with_verifier(MockAuthorizationClient).await
+}
+
+/// Boot the mobile server with a specific authorization verifier, so tests can
+/// exercise the carrier allow-list instead of the permissive mock.
+pub async fn setup_mobile_with_verifier<AV: AuthorizationVerifier>(
+    authorization_verifier: AV,
+) -> anyhow::Result<(TestClient, Trigger)> {
     let key_pair = generate_keypair();
 
     let socket_addr = {
@@ -105,7 +106,7 @@ pub async fn setup_mobile() -> anyhow::Result<(TestClient, Trigger)> {
             Network::MainNet,
             socket_addr,
             api_token,
-            MockAuthorizationClient,
+            authorization_verifier,
         );
 
         grpc_server.run(listener).await

--- a/ingest/tests/mobile_ingest.rs
+++ b/ingest/tests/mobile_ingest.rs
@@ -5,6 +5,7 @@ use helium_proto::services::poc_mobile::{
     CarrierIdV2, DataTransferRadioAccessTechnology, RadioUsageCarrierDataTransferInfoV2,
     RadioUsageCarrierTransferInfo, RadioUsageSamplingCarrierDataTransferInfoV1,
 };
+use ingest::AuthorizedKeys;
 use std::str::FromStr;
 
 mod common;
@@ -199,6 +200,66 @@ async fn submit_hex_usage_report() -> anyhow::Result<()> {
         }
         Err(e) => panic!("got error {e}"),
     }
+
+    trigger.trigger();
+    Ok(())
+}
+
+/// The carrier-signed endpoints are gated on the static allow-list from
+/// settings. With an empty allow-list every carrier key is unknown, so each
+/// gated endpoint must reject rather than write a report.
+#[tokio::test]
+async fn carrier_endpoints_reject_unauthorized_keys() -> anyhow::Result<()> {
+    let keypair = generate_keypair();
+    let (mut client, trigger) =
+        common::setup_mobile_with_verifier(AuthorizedKeys::default()).await?;
+
+    let hex_usage = client.submit_hex_usage_req(360, 10, 11, 12, 13, 14).await;
+    assert!(hex_usage.is_err(), "hex usage stats should be rejected");
+
+    let radio_usage = client
+        .submit_radio_usage_req(
+            PublicKeyBinary::from_str(PUBKEY1)?,
+            10,
+            11,
+            12,
+            13,
+            14,
+            vec![],
+        )
+        .await;
+    assert!(radio_usage.is_err(), "radio usage stats should be rejected");
+
+    let radio_usage_v2 = client
+        .submit_radio_usage_req_v2(
+            PublicKeyBinary::from_str(PUBKEY1)?,
+            10,
+            11,
+            12,
+            13,
+            14,
+            vec![],
+            vec![],
+        )
+        .await;
+    assert!(
+        radio_usage_v2.is_err(),
+        "radio usage stats v2 should be rejected"
+    );
+
+    let enabled_carriers = client
+        .submit_enabled_carriers_info(
+            &keypair,
+            PUBKEY1,
+            vec![CarrierIdV2::Carrier0],
+            vec![CarrierIdV2::Carrier1],
+            Utc::now().timestamp_millis() as u64,
+        )
+        .await;
+    assert!(
+        enabled_carriers.is_err(),
+        "enabled carriers info should be rejected"
+    );
 
     trigger.trigger();
     Ok(())


### PR DESCRIPTION
Ingest was the last production service calling the mobile-config gRPC service, which we are close to shutting down.

The only call it made was a single `verify_authorized_key(pubkey, NetworkKeyRole::MobileCarrier)` gate. mobile-config served those keys from an admin-registered `registered_keys` table — effectively static config — so ingest now reads the same allow-list straight from its settings, mirroring what #1228 did for mobile-verifier and the `routing_keys` allow-list mobile-packet-verifier already uses.

The gate covers the four carrier-signed endpoints:

| Endpoint |
|---|
| `submit_hex_usage_stats_report` |
| `submit_radio_usage_stats_report` |
| `submit_radio_usage_stats_report_v2` |
| `submit_enabled_carriers_info` |

Since that was the only usage, the `mobile-config` crate dependency is dropped entirely. `helium-proto` still supplies the `NetworkKeyRole` enum. `verify_known_carrier_key` is now synchronous — no gRPC round trip and no TTL cache on the hot path.

New `ingest::authorization` module matches `mobile_verifier::authorization`: `AuthorizedKeys` holding the carrier key set, a trait so tests can mock, and a role `match` that authorizes only `MobileCarrier`.

## Settings

- remove `config_client`
- add `carrier_authorized_keys` — comma-separated b58 keys

Required in `mobile` mode and ignored in `chain` mode. An empty or missing list errors on boot rather than silently rejecting every carrier report, same rule as mobile-verifier's `banning_authorized_keys` and mobile-packet-verifier's `routing_keys`.

## Deploy note

The key list has to come out of mobile-config while it is still up:

```
mobile-config-cli authorization list-keys --key-role carrier
```

Copy the `registered_keys` from that output into `carrier_authorized_keys` and drop the `[config_client]` block.

Worth flagging: `registered_keys` was admin-mutable at runtime, so adding a carrier key was a CLI call. It is now a settings change plus a restart. Same tradeoff the verifiers already took, but ingest is the front door for carrier submissions, so a key rotation costs more here.

## Testing

`cargo nextest run -p ingest` — 17/17 pass. `cargo clippy --workspace --all-targets` and `cargo fmt --check` clean.

Added `carrier_endpoints_reject_unauthorized_keys`, which boots the server with a real empty `AuthorizedKeys` and asserts all four gated endpoints reject. That needed a `setup_mobile_with_verifier` variant in the test harness; `setup_mobile()` delegates to it with the existing permissive mock, so the other tests are untouched.

## Remaining mobile-config references

`mobile_config_cli` and the CI/ECR image build. The server also still exposes Gateway, Entity, SubDao, and Admin, which have no in-repo callers — any remaining consumers of those are external and would not show up in this repo.