### PR TITLE
HIP-150 Decision 3: contribute service provider rewards to deployers

### DIFF
--- a/mobile_verifier/src/reward_shares.rs
+++ b/mobile_verifier/src/reward_shares.rs
@@ -13,8 +13,19 @@ const DC_USD_PRICE: Decimal = dec!(0.00001);
 /// Default precision used for rounding
 pub const DEFAULT_PREC: u32 = 15;
 
-// Percent of total emissions allocated for service provider rewards
-const SERVICE_PROVIDER_PERCENT: Decimal = dec!(0.24);
+// Percent of total emissions allocated for service provider rewards.
+//
+// HIP-150 Decision 3: Nova Labs contributes its Service Provider Rewards to the
+// Deployer Data Reward Pool, moving the Mobile data bucket from 70% to 94% and
+// this allocation to zero. The contribution runs to 2027-07-31 and may be
+// extended once by a year; ending it earlier takes a later HIP. It is a
+// suspension, not a retirement — the Service Provider role stays defined
+// throughout, and unrewarded only while the contribution lasts.
+//
+// Restoring the allocation is this constant and nothing else: the split in
+// `emissions_split` and the guard in `rewarder::reward_service_providers` both
+// key off the resulting amount.
+const SERVICE_PROVIDER_PERCENT: Decimal = dec!(0);
 
 /// Returns the equivalent amount of Hnt bones for a specified amount of Data Credits
 pub fn dc_to_hnt_bones(dc_amount: Decimal, hnt_bone_price: Decimal) -> Decimal {

--- a/mobile_verifier/src/reward_shares/emissions_split.rs
+++ b/mobile_verifier/src/reward_shares/emissions_split.rs
@@ -1,4 +1,4 @@
-//! HIP-149 sub-DAO reward split.
+//! Sub-DAO reward split.
 //!
 //! Each epoch the chain hands the rewarder two figures via [`EpochRewardInfo`]:
 //! `epoch_emissions` (the 100% total) and `hnt_rewards_issued` (the slice this
@@ -7,26 +7,31 @@
 //!
 //! The rewarder splits `hnt_rewards_issued` into two pools:
 //!
-//! * **Service providers** — a flat 24% of *total* emissions. HIP-149 keeps this
-//!   fixed regardless of the cap/backstop.
+//! * **Service providers** — a flat [`SERVICE_PROVIDER_PERCENT`] of *total*
+//!   emissions, fixed regardless of the cap/backstop.
 //! * **Data transfer** — the *residual*: `hnt_rewards_issued − service_provider`.
 //!
-//! Making data transfer the residual (rather than a fixed 70%) is what keeps the
-//! split exact under HIP-149. The 3× cap moves HNT out of the data bucket and
+//! **Under HIP-150 the service-provider percent is zero**, so data transfer is
+//! the whole issued amount. The split is kept rather than collapsed because the
+//! contribution is a suspension with an end date (2027-07-31, extendable once),
+//! not a retirement — see [`SERVICE_PROVIDER_PERCENT`]. Everything below
+//! describes the mechanism that governs both states.
+//!
+//! Making data transfer the residual (rather than a fixed percentage of its own)
+//! is what keeps the split exact. The 3× cap moves HNT out of the data bucket and
 //! into delegation, shrinking `hnt_rewards_issued`; the backstop re-emits HNT
-//! into it, growing `hnt_rewards_issued`. A fixed `0.70 × emissions` would
+//! into it, growing `hnt_rewards_issued`. A fixed percentage of emissions would
 //! over-allocate when earnings run over the cap (minting HNT that was moved to
 //! delegators) and under-allocate when they fall under the backstop (stranding
-//! the re-emitted HNT). The residual
-//! instead absorbs the shift — and the sub-bone dropped when flooring the
-//! service-provider 24% — so
+//! the re-emitted HNT). The residual instead absorbs the shift — and the sub-bone
+//! dropped when flooring the service-provider share — so
 //!
 //! ```text
 //! service_provider + data_transfer == floor(hnt_rewards_issued)
 //! ```
 //!
-//! holds exactly, every epoch. The proptests below pin that invariant across the
-//! full input range.
+//! holds exactly, every epoch, at any percent. The proptests below pin that
+//! invariant across the full input range.
 
 use crate::rewarder::EpochRewardInfo;
 use rust_decimal::Decimal;
@@ -43,6 +48,10 @@ pub struct RewardPools {
 
 /// Split an epoch's `hnt_rewards_issued` into the service-provider and
 /// data-transfer pools (see module docs).
+///
+/// The split mechanism is HIP-149's and is unchanged; HIP-150 sets
+/// [`SERVICE_PROVIDER_PERCENT`] to zero, which makes data transfer the whole
+/// issued amount.
 pub fn hip_149_reward_pools(reward_info: &EpochRewardInfo) -> RewardPools {
     split(reward_info.epoch_emissions, reward_info.hnt_rewards_issued)
 }
@@ -53,13 +62,14 @@ pub fn hip_149_reward_pools(reward_info: &EpochRewardInfo) -> RewardPools {
 fn split(total_emissions: Decimal, hnt_rewards_issued: Decimal) -> RewardPools {
     let hnt = floor_to_u64(hnt_rewards_issued);
 
-    // Service providers take a flat 24% of *total* emissions, floored. We never
-    // round *up* — that is what guarantees the service-provider pool can't push
-    // the distributed total past `hnt_rewards_issued`. The `.min(hnt)` clamp
-    // keeps the residual non-negative even if the chain ever reported delegation
-    // above 76% of total (beyond what the 3× cap can produce, since it can move
-    // at most the 70% data bucket): in that case service providers simply take
-    // whatever HNT was issued.
+    // Service providers take a flat `SERVICE_PROVIDER_PERCENT` of *total*
+    // emissions, floored. We never round *up* — that is what guarantees the
+    // service-provider pool can't push the distributed total past
+    // `hnt_rewards_issued`. The `.min(hnt)` clamp keeps the residual non-negative
+    // if the chain ever reported delegation so high that the percent exceeds what
+    // was issued: in that case service providers simply take whatever HNT there
+    // was. Dormant while the percent is zero (HIP-150), and kept for when the
+    // contribution ends.
     let service_provider = floor_to_u64(total_emissions * SERVICE_PROVIDER_PERCENT).min(hnt);
 
     // Data transfer is the residual. `service_provider <= hnt`, so this never
@@ -90,13 +100,14 @@ mod tests {
     }
 
     #[test]
-    fn baseline_6pct_delegation_is_70_24() {
-        // total = 100, delegation = 6 → hnt = 94. SP = 24, data = 70.
+    fn baseline_6pct_delegation_gives_data_the_whole_94() {
+        // total = 100, delegation = 6 → hnt = 94. HIP-150: SP = 0, so data takes
+        // all 94 — the 70 it had under HIP-149 plus the 24 SP contributed.
         assert_eq!(
             run(100, 94),
             RewardPools {
-                service_provider: 24,
-                data_transfer: 70
+                service_provider: 0,
+                data_transfer: 94
             }
         );
     }
@@ -104,12 +115,12 @@ mod tests {
     #[test]
     fn cap_shrinks_data_only() {
         // 3× cap moved 14 from data → delegation: delegation 6+14=20, hnt = 80.
-        // SP stays at 24% of total; data absorbs the whole 14 (70 → 56).
+        // Data absorbs the whole cut.
         assert_eq!(
             run(100, 80),
             RewardPools {
-                service_provider: 24,
-                data_transfer: 56
+                service_provider: 0,
+                data_transfer: 80
             }
         );
     }
@@ -117,36 +128,37 @@ mod tests {
     #[test]
     fn backstop_grows_data_only() {
         // Backstop re-emitted HNT into the data bucket: hnt = 98 (> 94).
-        // SP unchanged; data absorbs the boost (70 → 74).
+        // Data absorbs the boost.
         assert_eq!(
             run(100, 98),
             RewardPools {
-                service_provider: 24,
-                data_transfer: 74
+                service_provider: 0,
+                data_transfer: 98
             }
         );
     }
 
     #[test]
-    fn no_delegation_gives_sp_24_data_76() {
+    fn no_delegation_gives_data_everything() {
         assert_eq!(
             run(100, 100),
             RewardPools {
-                service_provider: 24,
-                data_transfer: 76
+                service_provider: 0,
+                data_transfer: 100
             }
         );
     }
 
     #[test]
-    fn extreme_cap_clamps_sp_to_issued_hnt() {
-        // Out-of-spec: only 20 HNT issued though 24% of total would be 24. SP
-        // takes all 20, data is 0 — still accounts for exactly `hnt`.
+    fn far_below_baseline_issuance_still_accounts_exactly() {
+        // Out-of-spec: only 20 HNT issued against 100 emitted. At percent 0 the
+        // `.min(hnt)` clamp is dormant and data simply takes what was issued.
+        // (Under a non-zero percent this is the case where SP would be clamped.)
         assert_eq!(
             run(100, 20),
             RewardPools {
-                service_provider: 20,
-                data_transfer: 0
+                service_provider: 0,
+                data_transfer: 20
             }
         );
     }
@@ -198,12 +210,14 @@ mod tests {
             prop_assert!(pools.data_transfer <= hnt);
         }
 
-        /// Service providers get a flat 24% of *total* emissions, independent of
-        /// how the cap/backstop split that total between hnt and delegation —
-        /// except in the out-of-spec regime where less than 24% was issued, where
-        /// SP is clamped to what's available.
+        /// Service providers get a flat `SERVICE_PROVIDER_PERCENT` of *total*
+        /// emissions, independent of how the cap/backstop split that total between
+        /// hnt and delegation — except in the out-of-spec regime where less than
+        /// that percent was issued, where SP is clamped to what's available.
+        /// Percent-agnostic: `expected_sp` reads the same constant, so this keeps
+        /// holding when the HIP-150 contribution ends and the percent returns.
         #[test]
-        fn service_provider_is_24pct_of_total(
+        fn service_provider_matches_configured_percent(
             hnt in 0u64..=MAX_BONES,
             delegation in 0u64..=MAX_BONES,
         ) {
@@ -215,7 +229,8 @@ mod tests {
         /// Holding total emissions fixed, data transfer tracks issued HNT
         /// one-for-one — the cap (less hnt) shrinks it, the backstop (more hnt)
         /// grows it — while the service-provider pool is unchanged, as long as a
-        /// full 24% of total was issued (clamp not engaged).
+        /// full `SERVICE_PROVIDER_PERCENT` of total was issued (clamp not
+        /// engaged).
         #[test]
         fn data_tracks_hnt_one_for_one_with_sp_fixed(
             (total, hnt_a, hnt_b) in (1u64..=MAX_BONES).prop_flat_map(|total| {
@@ -230,6 +245,24 @@ mod tests {
                 a.data_transfer as i128 - b.data_transfer as i128,
                 hnt_a as i128 - hnt_b as i128
             );
+        }
+
+        /// HIP-150 Decision 3: with the service-provider contribution active, the
+        /// data-transfer pool is the *entire* issued amount and nothing is held
+        /// back. Distinct from `never_over_or_under_allocates_hnt`, which only
+        /// pins that the two pools sum to it — this pins which pool gets it.
+        ///
+        /// This test is specific to the suspension: when the contribution ends and
+        /// `SERVICE_PROVIDER_PERCENT` returns to a non-zero value, delete it. The
+        /// invariant tests above are the ones that hold in both states.
+        #[test]
+        fn hip_150_data_transfer_takes_the_whole_issued_amount(
+            hnt in 0u64..=MAX_BONES,
+            delegation in 0u64..=MAX_BONES,
+        ) {
+            let pools = run(hnt + delegation, hnt);
+            prop_assert_eq!(pools.service_provider, 0);
+            prop_assert_eq!(pools.data_transfer, hnt);
         }
     }
 }

--- a/mobile_verifier/src/rewarder.rs
+++ b/mobile_verifier/src/rewarder.rs
@@ -335,9 +335,10 @@ pub async fn reward_dc(
     )
     .await?;
 
-    // HIP-149: data transfer is the residual of `hnt_rewards_issued` after the
-    // flat 24% service-provider cut, so the cap/backstop shift is absorbed here
-    // rather than over-/under-allocating. See `reward_shares::emissions_split`.
+    // Data transfer is the residual of `hnt_rewards_issued` after the flat
+    // service-provider cut, so the cap/backstop shift is absorbed here rather
+    // than over-/under-allocating. Under HIP-150 that cut is zero and the pool is
+    // the whole issued amount. See `reward_shares::emissions_split`.
     let pool = Decimal::from(hip_149_reward_pools(reward_info).data_transfer);
     // Demand is the HNT-bone value of the burned DC at the epoch price — a
     // telemetry input only (the payout rate is `pool / total_dc`, price-free).
@@ -403,8 +404,21 @@ pub async fn reward_service_providers(
     reward_info: &EpochRewardInfo,
     reward_ctx: Option<(&iceberg::RewardWriters, &str)>,
 ) -> anyhow::Result<()> {
-    // HIP-149: a flat 24% of total emissions (see `reward_shares::emissions_split`).
+    // A flat percent of total emissions (see `reward_shares::emissions_split`).
     let sp_reward_amount = hip_149_reward_pools(reward_info).service_provider;
+
+    // HIP-150 Decision 3: Nova Labs contributes its Service Provider Rewards to
+    // the Deployer Data Reward Pool, so the pool is zero and *no reward is
+    // written at all* — not a reward of zero. Consumers see no service-provider
+    // rows for a suspended epoch rather than rows that claim an award of nothing.
+    //
+    // Guarded on the amount rather than deleted: the contribution runs to
+    // 2027-07-31 and may be extended once, so this path comes back. Restoring it
+    // is `SERVICE_PROVIDER_PERCENT` alone.
+    if sp_reward_amount == 0 {
+        tracing::info!("service provider pool is zero, skipping service provider rewards");
+        return Ok(());
+    }
 
     // The entire service-provider pool goes to the HeliumMobile Network Wallet.
     let network_share = proto::ServiceProviderReward {

--- a/mobile_verifier/tests/integrations/reward_dc.rs
+++ b/mobile_verifier/tests/integrations/reward_dc.rs
@@ -268,9 +268,10 @@ async fn test_single_hotspot_takes_whole_pool() -> anyhow::Result<()> {
     Ok(())
 }
 
-// HIP-149 sizes data transfer as the residual of `hnt_rewards_issued` after a flat
-// 24% service-provider cut, so the 3× cap (which moves HNT into delegation) and the
-// backstop (which re-emits it) land entirely on the data-transfer pool. The two
+// Data transfer is the residual of `hnt_rewards_issued` after the flat
+// service-provider cut — zero under HIP-150 — so the 3× cap (which moves HNT into
+// delegation) and the backstop (which re-emits it) land entirely on the
+// data-transfer pool. The two
 // tests below drive a capped and a backstopped epoch end-to-end and assert the
 // distributed pool shrinks / grows accordingly — the only place that wiring is
 // exercised at the integration level (the split math itself is unit-tested in
@@ -278,18 +279,17 @@ async fn test_single_hotspot_takes_whole_pool() -> anyhow::Result<()> {
 // independently of `hip_149_reward_pools` so they can't pass by mirroring a bug in
 // the code under test.
 
-/// A round 1e12-bone pool. The 24% SP cut (240e9) clears the 45e9 subscriber floor,
-/// and the residual data-transfer pools land on clean numbers.
+/// A round 1e12-bone pool, so the data-transfer pools land on clean numbers.
 const SPLIT_TEST_EMISSIONS: u64 = 1_000_000_000_000;
 /// Baseline (6% delegation) data-transfer pool at [`SPLIT_TEST_EMISSIONS`]:
-/// 94% issued (940e9) − 24% SP (240e9). The cap shrinks below this; the backstop
-/// grows above it.
-const BASELINE_DATA_POOL: u64 = 700_000_000_000;
+/// 94% issued (940e9), all of it (HIP-150: the SP allocation is contributed to
+/// this pool). The cap shrinks below this; the backstop grows above it.
+/// Pre-HIP-150 this was 700e9 — 940e9 less a 24% SP cut of 240e9.
+const BASELINE_DATA_POOL: u64 = 940_000_000_000;
 
 /// [`reward_info_24_hours`] with the on-chain split overridden. `hnt_issued` is what
 /// the chain handed this rewarder; `delegation` is paid to veHNT holders on-chain.
-/// Emissions are their sum, so the service-provider pool (a flat 24% of emissions)
-/// stays fixed while only the issued/delegation split moves.
+/// Emissions are their sum, so only the issued/delegation split moves.
 fn reward_info_with_split(hnt_issued: u64, delegation: u64) -> EpochRewardInfo {
     let mut reward_info = reward_info_24_hours();
     reward_info.epoch_emissions = Decimal::from(hnt_issued + delegation);
@@ -299,13 +299,14 @@ fn reward_info_with_split(hnt_issued: u64, delegation: u64) -> EpochRewardInfo {
 }
 
 /// Data-transfer pool computed *independently* of `hip_149_reward_pools` (the code
-/// the production path uses), via plain integer math: SP takes a flat floored 24%
-/// of total emissions, data transfer is the rest of the issued HNT.
+/// the production path uses).
+///
+/// HIP-150 Decision 3: the service-provider allocation is contributed to the
+/// deployer pool, so data transfer is the entire issued HNT. Before HIP-150 this
+/// subtracted a floored 24% of total emissions; when the contribution ends that
+/// subtraction comes back.
 fn expected_data_transfer_pool(reward_info: &EpochRewardInfo) -> u64 {
-    let emissions = reward_info.epoch_emissions.to_u64().unwrap();
-    let hnt_issued = reward_info.hnt_rewards_issued.to_u64().unwrap();
-    let service_provider = (emissions as u128 * 24 / 100) as u64;
-    hnt_issued - service_provider
+    reward_info.hnt_rewards_issued.to_u64().unwrap()
 }
 
 #[tokio::test]
@@ -313,8 +314,8 @@ async fn test_cap_shrinks_data_transfer_pool() -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
 
     // 3× cap moved 14% of emissions out of the data bucket into delegation:
-    // delegation 6%+14%=20%, issued HNT 80%. SP holds at 24%, so data transfer
-    // absorbs the whole cut (70% → 56%).
+    // delegation 6%+14%=20%, issued HNT 80%. Data transfer takes the whole issued
+    // amount (HIP-150), so it absorbs the entire cut (94% → 80%).
     let reward_info = reward_info_with_split(
         SPLIT_TEST_EMISSIONS * 80 / 100,
         SPLIT_TEST_EMISSIONS * 20 / 100,
@@ -339,7 +340,7 @@ async fn test_cap_shrinks_data_transfer_pool() -> anyhow::Result<()> {
     // The whole pool is distributed, and it is the cap-shrunk residual.
     let realized = rewards.dc_transfer_sum() + rewards.unallocated_sum();
     assert_eq!(realized, expected_data_transfer_pool(&reward_info));
-    assert_eq!(realized, 560_000_000_000, "80% issued − 24% SP");
+    assert_eq!(realized, 800_000_000_000, "80% issued, no SP cut");
     assert!(
         realized < BASELINE_DATA_POOL,
         "cap must shrink the data-transfer pool below baseline"
@@ -353,8 +354,8 @@ async fn test_backstop_grows_data_transfer_pool() -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
 
     // Backstop re-emitted HNT into the data bucket: issued HNT rises to 98%
-    // (delegation 2%). SP still holds at 24%, so data transfer absorbs the boost
-    // (70% → 74%).
+    // (delegation 2%). Data transfer takes the whole issued amount (HIP-150), so
+    // it absorbs the entire boost (94% → 98%).
     let reward_info = reward_info_with_split(
         SPLIT_TEST_EMISSIONS * 98 / 100,
         SPLIT_TEST_EMISSIONS * 2 / 100,
@@ -379,7 +380,7 @@ async fn test_backstop_grows_data_transfer_pool() -> anyhow::Result<()> {
     // The whole pool is distributed, and it is the backstop-grown residual.
     let realized = rewards.dc_transfer_sum() + rewards.unallocated_sum();
     assert_eq!(realized, expected_data_transfer_pool(&reward_info));
-    assert_eq!(realized, 740_000_000_000, "98% issued − 24% SP");
+    assert_eq!(realized, 980_000_000_000, "98% issued, no SP cut");
     assert!(
         realized > BASELINE_DATA_POOL,
         "backstop must grow the data-transfer pool above baseline"

--- a/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
+++ b/mobile_verifier/tests/integrations/rewarder_sp_rewards.rs
@@ -1,66 +1,66 @@
-use crate::common::{self, reward_info_24_hours};
-use helium_proto::{services::poc_mobile::UnallocatedRewardType, ServiceProvider};
-use mobile_verifier::reward_shares::RewardableEntityKey;
-use mobile_verifier::{reward_shares, rewarder};
-use rust_decimal::prelude::*;
-use rust_decimal_macros::dec;
-use sqlx::PgPool;
+//! HIP-150 Decision 3: Nova Labs contributes its Service Provider Rewards to the
+//! Deployer Data Reward Pool, so the service-provider pool is zero and the
+//! rewarder emits nothing for it.
+//!
+//! These tests pin the *suspension*. The contribution runs to 2027-07-31 and may
+//! be extended once by a year — when it ends and `SERVICE_PROVIDER_PERCENT`
+//! returns to a non-zero value, these become wrong and the pre-HIP-150 versions
+//! (asserting one reward at the configured percent) should come back.
 
-#[sqlx::test]
-async fn test_service_provider_rewards(_pool: PgPool) -> anyhow::Result<()> {
+use crate::common::{self, reward_info_24_hours};
+use mobile_verifier::{reward_shares, rewarder};
+use rust_decimal::Decimal;
+
+// No database involved: these exercise the pool split and the file sink only.
+// (The pre-HIP-150 versions took an unused `PgPool` via `#[sqlx::test]`, which
+// made them require a live Postgres to run.)
+#[tokio::test]
+async fn test_no_service_provider_rewards_while_contribution_active() -> anyhow::Result<()> {
     let (mobile_rewards_client, mobile_rewards) = common::create_file_sink();
 
     let reward_info = reward_info_24_hours();
+
+    // The pool itself is zero...
+    assert_eq!(
+        reward_shares::hip_149_reward_pools(&reward_info).service_provider,
+        0
+    );
 
     rewarder::reward_service_providers(mobile_rewards_client, &reward_info, None).await?;
 
     let rewards = mobile_rewards.finish().await?;
 
-    // The entire service-provider pool goes to the HeliumMobile Network wallet.
-    assert_eq!(rewards.sp_rewards.len(), 1);
-
-    let network_reward = rewards.sp_rewards.first().expect("sp reward");
-    assert_eq!(
-        network_reward.service_provider_id,
-        ServiceProvider::HeliumMobile as i32
-    );
-    assert_eq!(
-        network_reward.rewardable_entity_key,
-        RewardableEntityKey::Network.to_string()
+    // ...and no reward is written at all — not a reward of zero. A consumer sees
+    // no service-provider rows for the epoch rather than a row claiming an award
+    // of nothing.
+    assert!(
+        rewards.sp_rewards.is_empty(),
+        "expected no service provider rewards, got {:?}",
+        rewards.sp_rewards
     );
 
-    // confirm the total rewards allocated matches the full 24% pool
-    let expected_sum = reward_shares::hip_149_reward_pools(&reward_info).service_provider;
-    assert_eq!(expected_sum, network_reward.amount);
-
-    // confirm the rewarded percentage amount matches expectations
-    let percent = (Decimal::from(network_reward.amount) / reward_info.epoch_emissions)
-        .round_dp_with_strategy(2, RoundingStrategy::MidpointNearestEven);
-    assert_eq!(percent, dec!(0.24));
-
-    // Verify no unallocated service provider rewards
-    assert_eq!(
-        rewards
-            .unallocated
-            .iter()
-            .filter(|r| r.reward_type == UnallocatedRewardType::ServiceProvider as i32)
-            .count(),
-        0
+    // Nor is the suspended pool reported as unallocated: there is no pool to
+    // leave unallocated, because it was never carved out of the issued HNT.
+    // `emissions_split` gives the whole issued amount to data transfer.
+    assert!(
+        rewards.unallocated.is_empty(),
+        "expected no unallocated rewards, got {:?}",
+        rewards.unallocated
     );
 
     Ok(())
 }
 
-/// HIP-149: the service-provider pool is a flat 24% of *total* emissions, so the
-/// 3× cap / backstop — which shifts HNT between issued and delegation — must leave
-/// it untouched. Run a capped and a backstopped epoch at the same emissions and
-/// confirm the emitted SP reward is identical. Complements the data-transfer
-/// cap/backstop tests, which show the data pool absorbing the whole shift.
-#[sqlx::test]
-async fn test_service_provider_flat_across_cap_and_backstop(_pool: PgPool) -> anyhow::Result<()> {
+/// The 3× cap and the backstop shift HNT between issued and delegation. Under
+/// HIP-149 that had to leave the flat service-provider pool untouched; under
+/// HIP-150 there is no pool to move, so the rewarder stays silent in both
+/// regimes. Complements the data-transfer cap/backstop tests, which show the data
+/// pool absorbing the whole shift.
+#[tokio::test]
+async fn test_no_service_provider_rewards_across_cap_and_backstop() -> anyhow::Result<()> {
     const EMISSIONS: u64 = 1_000_000_000_000;
 
-    async fn sp_total(hnt_issued: u64, delegation: u64) -> anyhow::Result<u64> {
+    async fn sp_reward_count(hnt_issued: u64, delegation: u64) -> anyhow::Result<usize> {
         let (client, sink) = common::create_file_sink();
         let mut reward_info = reward_info_24_hours();
         reward_info.epoch_emissions = Decimal::from(hnt_issued + delegation);
@@ -69,19 +69,18 @@ async fn test_service_provider_flat_across_cap_and_backstop(_pool: PgPool) -> an
 
         rewarder::reward_service_providers(client, &reward_info, None).await?;
         let rewards = sink.finish().await?;
-        Ok(rewards.sp_rewards.iter().map(|r| r.amount).sum())
+        Ok(rewards.sp_rewards.len())
     }
 
     // Cap: issued 80%, delegation 20%. Backstop: issued 98%, delegation 2%.
-    let capped = sp_total(EMISSIONS * 80 / 100, EMISSIONS * 20 / 100).await?;
-    let backstopped = sp_total(EMISSIONS * 98 / 100, EMISSIONS * 2 / 100).await?;
+    let capped = sp_reward_count(EMISSIONS * 80 / 100, EMISSIONS * 20 / 100).await?;
+    let backstopped = sp_reward_count(EMISSIONS * 98 / 100, EMISSIONS * 2 / 100).await?;
 
+    assert_eq!(capped, 0, "cap must not produce a service provider reward");
     assert_eq!(
-        capped, backstopped,
-        "SP pool must not move with the cap/backstop"
+        backstopped, 0,
+        "backstop must not produce a service provider reward"
     );
-    // Independent of `hip_149_reward_pools`: a flat 24% of total emissions.
-    assert_eq!(capped, 240_000_000_000);
 
     Ok(())
 }


### PR DESCRIPTION
Nova Labs contributes its Service Provider Rewards to the Deployer Data Reward Pool, moving the Mobile data bucket from 70% to 94% of the Mobile sub-DAO slice and the Service Provider allocation to zero.

Set SERVICE_PROVIDER_PERCENT to 0. `emissions_split::split` already makes data transfer the residual of `hnt_rewards_issued`, so the whole issued amount now flows to the data pool with no change to the split mechanism — the `service_provider + data_transfer == floor(hnt_rewards_issued)` invariant and its proptests hold untouched.

`reward_service_providers` writes no reward at all rather than one with `amount: 0`, so consumers see no service-provider rows for a suspended epoch rather than rows claiming an award of nothing. Guarded on the amount rather than deleted: the contribution runs to 2027-07-31 and may be extended once by a year, so this is a suspension and not a retirement. Restoring the allocation is SERVICE_PROVIDER_PERCENT alone.

The two service-provider integration tests took a PgPool they never used, which made them require a live Postgres; they exercise the pool split and the file sink only, so they move to #[tokio::test].

Decision 2 (direct minting, 80% target, and the on-chain bucket move) is handled upstream and must deploy in the same window as this change.