### PR TITLE
HIP-150: ingest data transfer multiplier tickets in the packet verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,15 +1717,15 @@ name = "beacon"
 version = "0.1.0"
 source = "git+https://www.github.com/helium/proto.git?branch=mj%2Fhip-150#0e1d14433cc7350cc4a13938fe23b6f12e4b3d7d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "byteorder",
  "helium-proto",
  "prost",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rust_decimal",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -1767,7 +1767,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3192,7 +3192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3344,7 +3344,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "beacon",
  "blake3",
  "bs58",
@@ -3974,7 +3974,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d292d4e2852445cbb610b515543a56b10d4a6fad90cfd6d281fe870f628573e"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bs58",
  "byteorder",
  "ed25519-compact",
@@ -4036,7 +4036,10 @@ dependencies = [
  "file-store-oracles",
  "helium-iceberg",
  "helium-proto",
+ "rust_decimal",
  "serde",
+ "serde_json",
+ "thiserror 1.0.69",
  "trino-rust-client",
 ]
 
@@ -4051,7 +4054,7 @@ dependencies = [
  "angry-purple-tiger",
  "async-trait",
  "backon",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bincode",
  "bytemuck",
  "chrono",
@@ -4426,7 +4429,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -4725,7 +4728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
  "serde",
  "serde_core",
 ]
@@ -4911,7 +4914,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5151,7 +5154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5467,7 +5470,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "blake3",
  "bs58",
  "chrono",
@@ -5524,7 +5527,7 @@ version = "0.1.0"
 dependencies = [
  "angry-purple-tiger",
  "anyhow",
- "base64 0.21.7",
+ "base64 0.22.1",
  "clap",
  "custom-tracing",
  "dialoguer",
@@ -5570,6 +5573,7 @@ dependencies = [
  "prost",
  "reqwest 0.12.28",
  "retainer",
+ "rust_decimal",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5594,7 +5598,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "config",
@@ -6587,7 +6591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -6609,7 +6613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -6733,7 +6737,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.32",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -6773,7 +6777,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7225,7 +7229,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "clap",
@@ -7476,7 +7480,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8092,7 +8096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11386,7 +11390,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/file_store_oracles/src/file_type.rs
+++ b/file_store_oracles/src/file_type.rs
@@ -154,5 +154,6 @@ make_string_mapped_enum! {
         EntityRewardDestinationChangeReport => "entity_reward_destination_change_report",
         EnabledCarriersInfoReport => "enabled_carriers_report",
         DataTransferMultiplierTicketIngestReport => "data_transfer_multiplier_ticket_ingest_report",
+        VerifiedDataTransferMultiplierTicketReport => "verified_data_transfer_multiplier_ticket_report",
     }
 }

--- a/file_store_oracles/src/mobile/data_transfer_multiplier.rs
+++ b/file_store_oracles/src/mobile/data_transfer_multiplier.rs
@@ -1,6 +1,60 @@
 //! HIP-150 data transfer multipliers, and the tickets that grant them.
+//!
+//! A multiplier applies to the data credits derived from a hotspot's rewardable
+//! bytes, not to the bytes themselves — a rewardable-byte count is a
+//! measurement and does not change. It raises what a payer burns for that
+//! hotspot's data and what its deployer earns, in the same proportion.
+//!
+//! A hotspot with no ticket is at [`DataTransferMultiplier::DEFAULT`] (1), and
+//! there is no ticket meaning "no multiplier": returning a hotspot to 1 means
+//! issuing a ticket that grants exactly 1.
+//!
+//! # Parsing and validating are separate steps
+//!
+//! The wire type is `helium.Decimal`, a string. [`parse_multiplier`] turns it
+//! into a plain `Decimal` without judging it, and that is what a decoded
+//! [`DataTransferMultiplierTicket`] carries — deliberately, because the file
+//! poller discards records that fail to decode, and a ticket has to survive
+//! decoding in order to be refused on the record.
+//!
+//! Validation is [`DataTransferMultiplier::new`], applied by the packet
+//! verifier when it rules on a ticket. Everything downstream of that point —
+//! the burn, the reward record — holds a [`DataTransferMultiplier`], so "is
+//! this multiplier in range" is answered by the type rather than re-checked at
+//! each call site.
 
-use std::time::Duration;
+use chrono::{DateTime, Utc};
+use file_store::traits::{MsgDecode, TimestampDecode, TimestampDecodeError, TimestampEncode};
+use helium_crypto::PublicKeyBinary;
+use rust_decimal::{prelude::ToPrimitive, Decimal, RoundingStrategy};
+
+use crate::prost_enum;
+
+pub mod proto {
+    pub use helium_proto::services::poc_mobile::{
+        DataTransferMultiplierTicketIngestReportV1, DataTransferMultiplierTicketReqV1,
+        VerifiedDataTransferMultiplierTicketReportV1, VerifiedDataTransferMultiplierTicketStatus,
+    };
+    pub use helium_proto::Decimal;
+}
+
+pub use proto::VerifiedDataTransferMultiplierTicketStatus;
+
+/// Smallest multiplier the oracles accept.
+///
+/// Operating policy, not wire format: HIP-150's 1-to-5 figures are starting
+/// values, and the proto deliberately does not encode a range. Widening the
+/// range later — a sub-1 multiplier, or a ceiling above 5 — is editing these
+/// constants, with no schema change and no migration.
+pub const MIN_MULTIPLIER: Decimal = Decimal::ONE;
+/// Largest multiplier the oracles accept. See [`MIN_MULTIPLIER`].
+pub const MAX_MULTIPLIER: Decimal = Decimal::from_parts(5, 0, 0, false, 0);
+/// Most fractional digits a multiplier may carry.
+///
+/// Bounds how much precision reaches the stored record, whose column is
+/// `decimal(9,6)`. Values are negotiated per venue, so this is generous rather
+/// than tight.
+pub const MAX_SCALE: u32 = 6;
 
 /// How far ahead of the receiving oracle's clock a ticket may be stamped.
 ///
@@ -18,4 +72,492 @@ use std::time::Duration;
 /// stamped on it. If ingest tolerated drift the verifier did not, every ticket
 /// ingest accepted from a fast client would then be refused downstream — so the
 /// two must use one value, not two settings that can be configured apart.
-pub const MAX_CLOCK_DRIFT: Duration = Duration::from_secs(60);
+pub const MAX_CLOCK_DRIFT: std::time::Duration = std::time::Duration::from_secs(60);
+
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum MultiplierError {
+    #[error("unparseable multiplier: {0}")]
+    Unparseable(String),
+    #[error("multiplier {0} out of range, must be between {MIN_MULTIPLIER} and {MAX_MULTIPLIER}")]
+    OutOfRange(Decimal),
+    #[error("multiplier {0} has more than {MAX_SCALE} fractional digits")]
+    TooPrecise(Decimal),
+    /// Applying the multiplier overflowed.
+    ///
+    /// Unreachable for any real burn — a multiplier is bounded by
+    /// [`MAX_MULTIPLIER`], so this needs a data credit count within a few
+    /// multiples of `u64::MAX`. It is an error rather than a saturating value
+    /// because the only saturating value available is `u64::MAX`, and the
+    /// number this produces is what a payer is charged.
+    #[error("multiplier {multiplier} applied to {data_credits} data credits overflows")]
+    Overflow {
+        data_credits: u64,
+        multiplier: Decimal,
+    },
+}
+
+/// A validated HIP-150 data transfer multiplier.
+///
+/// The inner value is private and every constructor validates, so holding one
+/// *is* the proof it is in range — callers never re-check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DataTransferMultiplier(Decimal);
+
+impl DataTransferMultiplier {
+    /// The multiplier every hotspot without a ticket is at.
+    ///
+    /// Where "no ticket means 1" is written down: a lookup that misses returns
+    /// this, and an absent multiplier on a *burned session* resolves to it.
+    ///
+    /// An absent multiplier on a *ticket* is a different thing — a grant that
+    /// grants nothing — and is refused rather than defaulted. See
+    /// `mobile_packet_verifier::multiplier::ingestor::ticket_status`.
+    pub const DEFAULT: Self = Self(Decimal::ONE);
+
+    /// Validate and normalize a multiplier.
+    ///
+    /// Normalizing means `1.5`, `1.50` and `1.5e0` all become the same value, so
+    /// a difference in spelling cannot become a difference in multiplier.
+    pub fn new(value: Decimal) -> Result<Self, MultiplierError> {
+        if value.scale() > MAX_SCALE {
+            return Err(MultiplierError::TooPrecise(value));
+        }
+        if value < MIN_MULTIPLIER || value > MAX_MULTIPLIER {
+            return Err(MultiplierError::OutOfRange(value));
+        }
+        Ok(Self(value.normalize()))
+    }
+
+    /// Data credits after the multiplier, rounded **down**.
+    ///
+    /// HIP-150: "Applied to a data credit count it is rounded down, so a payer
+    /// never burns more than the multiplier earns." This is the only place the
+    /// multiplication happens.
+    ///
+    /// # Why this returns an error
+    ///
+    /// Overflow is unreachable for any real burn: a multiplier is bounded by
+    /// [`MAX_MULTIPLIER`], so reaching it needs a data credit count within a few
+    /// multiples of `u64::MAX`. It is still an error rather than a fallback
+    /// value, because the number returned here is what a payer is charged, and
+    /// the only fallback `u64` offers is `u64::MAX` — burn everything. A default
+    /// that fails towards charging the most possible is the wrong default for
+    /// money, however unreachable. Stopping forces someone to look at why an
+    /// impossible thing happened before any DC moves.
+    pub fn apply(&self, data_credits: u64) -> Result<u64, MultiplierError> {
+        Decimal::from(data_credits)
+            .checked_mul(self.0)
+            .and_then(|scaled| {
+                scaled
+                    .round_dp_with_strategy(0, RoundingStrategy::ToZero)
+                    .to_u64()
+            })
+            .ok_or(MultiplierError::Overflow {
+                data_credits,
+                multiplier: self.0,
+            })
+    }
+
+    /// True when this is the default, i.e. the hotspot is effectively unmultiplied.
+    pub fn is_default(&self) -> bool {
+        *self == Self::DEFAULT
+    }
+
+    pub fn as_decimal(&self) -> Decimal {
+        self.0
+    }
+}
+
+impl std::fmt::Display for DataTransferMultiplier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl TryFrom<proto::Decimal> for DataTransferMultiplier {
+    type Error = MultiplierError;
+
+    fn try_from(value: proto::Decimal) -> Result<Self, Self::Error> {
+        // The Decimal proto permits an exponent ("2.5e8") as well as plain
+        // notation, and says services should normalize rather than reject.
+        // `rust_decimal`'s `FromStr` handles only the plain form, so fall back
+        // to the scientific parser rather than calling a legal value garbage.
+        let parsed = value
+            .value
+            .parse::<Decimal>()
+            .or_else(|_| Decimal::from_scientific(&value.value))
+            .map_err(|_| MultiplierError::Unparseable(value.value))?;
+        Self::new(parsed)
+    }
+}
+
+impl From<DataTransferMultiplier> for proto::Decimal {
+    fn from(value: DataTransferMultiplier) -> Self {
+        Self {
+            value: value.0.to_string(),
+        }
+    }
+}
+
+// ── Ticket reports ──────────────────────────────────────────────────────────
+
+#[derive(thiserror::Error, Debug)]
+pub enum TicketReportError {
+    #[error("invalid timestamp: {0}")]
+    Timestamp(#[from] TimestampDecodeError),
+    #[error("missing field: {0}")]
+    MissingField(&'static str),
+    #[error("invalid multiplier: {0}")]
+    Multiplier(#[from] MultiplierError),
+    #[error("unsupported status: {0}")]
+    Status(prost::UnknownEnumValue),
+}
+
+/// A ticket as submitted, after validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataTransferMultiplierTicket {
+    pub hotspot_pubkey: PublicKeyBinary,
+    /// The multiplier as submitted: parsed, but **not** range-checked.
+    ///
+    /// `None` means absent or unparseable. Deliberately not a
+    /// [`DataTransferMultiplier`]: validating at decode would drop a bad ticket
+    /// on the floor, because the file poller silently discards records that fail
+    /// to decode. HIP-150 wants refusals on the record, so the ticket has to
+    /// survive decoding in order to be refused — see
+    /// `mobile_packet_verifier::multiplier::ingestor::ticket_status`.
+    pub multiplier: Option<Decimal>,
+    /// When the issuer signed it. Authoritative for which ticket is current,
+    /// and the key that makes a replayed ticket a no-op.
+    pub timestamp: DateTime<Utc>,
+    pub message: String,
+    pub signer_pubkey: PublicKeyBinary,
+    pub signature: Vec<u8>,
+}
+
+/// A ticket as ingest recorded it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataTransferMultiplierTicketReport {
+    /// When ingest received it. Bounds which files the ticket may apply to; it
+    /// is deliberately *not* what decides which ticket is current.
+    pub received_timestamp: DateTime<Utc>,
+    pub report: DataTransferMultiplierTicket,
+}
+
+/// A ticket after the verifier ruled on it. Rejections are written too, so a
+/// refused grant is as auditable as an accepted one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedDataTransferMultiplierTicketReport {
+    pub verified_timestamp: DateTime<Utc>,
+    pub report: DataTransferMultiplierTicketReport,
+    pub status: VerifiedDataTransferMultiplierTicketStatus,
+}
+
+impl DataTransferMultiplierTicketReport {
+    pub fn hotspot_pubkey(&self) -> &PublicKeyBinary {
+        &self.report.hotspot_pubkey
+    }
+}
+
+impl VerifiedDataTransferMultiplierTicketReport {
+    pub fn is_valid(&self) -> bool {
+        matches!(
+            self.status,
+            VerifiedDataTransferMultiplierTicketStatus::Valid
+        )
+    }
+
+    pub fn hotspot_pubkey(&self) -> &PublicKeyBinary {
+        self.report.hotspot_pubkey()
+    }
+}
+
+impl MsgDecode for DataTransferMultiplierTicketReport {
+    type Msg = proto::DataTransferMultiplierTicketIngestReportV1;
+}
+
+impl MsgDecode for VerifiedDataTransferMultiplierTicketReport {
+    type Msg = proto::VerifiedDataTransferMultiplierTicketReportV1;
+}
+
+// === Conversion :: proto -> struct
+
+/// Parse without judging. `None` for absent or unparseable, so the caller can
+/// record a refusal rather than the record vanishing at decode.
+pub fn parse_multiplier(value: Option<proto::Decimal>) -> Option<Decimal> {
+    let value = value?;
+    // The Decimal proto permits an exponent ("2.5e8") as well as plain notation,
+    // and says services should normalize rather than reject.
+    value
+        .value
+        .parse::<Decimal>()
+        .or_else(|_| Decimal::from_scientific(&value.value))
+        .ok()
+}
+
+impl TryFrom<proto::DataTransferMultiplierTicketReqV1> for DataTransferMultiplierTicket {
+    type Error = TicketReportError;
+
+    fn try_from(value: proto::DataTransferMultiplierTicketReqV1) -> Result<Self, Self::Error> {
+        Ok(Self {
+            hotspot_pubkey: value.hotspot_pubkey.into(),
+            multiplier: parse_multiplier(value.multiplier),
+            timestamp: value.timestamp_ms.to_timestamp_millis()?,
+            message: value.message,
+            signer_pubkey: value.signer_pubkey.into(),
+            signature: value.signature,
+        })
+    }
+}
+
+impl TryFrom<proto::DataTransferMultiplierTicketIngestReportV1>
+    for DataTransferMultiplierTicketReport
+{
+    type Error = TicketReportError;
+
+    fn try_from(
+        value: proto::DataTransferMultiplierTicketIngestReportV1,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            received_timestamp: value.received_timestamp_ms.to_timestamp_millis()?,
+            report: value
+                .report
+                .ok_or(TicketReportError::MissingField("ticket_report.report"))?
+                .try_into()?,
+        })
+    }
+}
+
+impl TryFrom<proto::VerifiedDataTransferMultiplierTicketReportV1>
+    for VerifiedDataTransferMultiplierTicketReport
+{
+    type Error = TicketReportError;
+
+    fn try_from(
+        value: proto::VerifiedDataTransferMultiplierTicketReportV1,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            verified_timestamp: value.verified_timestamp_ms.to_timestamp_millis()?,
+            report: value
+                .report
+                .ok_or(TicketReportError::MissingField(
+                    "verified_ticket_report.report",
+                ))?
+                .try_into()?,
+            status: prost_enum(value.status, TicketReportError::Status)?,
+        })
+    }
+}
+
+// === Conversion :: struct -> proto
+
+impl From<DataTransferMultiplierTicket> for proto::DataTransferMultiplierTicketReqV1 {
+    fn from(value: DataTransferMultiplierTicket) -> Self {
+        Self {
+            hotspot_pubkey: value.hotspot_pubkey.into(),
+            multiplier: value.multiplier.map(|m| proto::Decimal {
+                value: m.to_string(),
+            }),
+            timestamp_ms: value.timestamp.encode_timestamp_millis(),
+            message: value.message,
+            signer_pubkey: value.signer_pubkey.into(),
+            signature: value.signature,
+        }
+    }
+}
+
+impl From<DataTransferMultiplierTicketReport>
+    for proto::DataTransferMultiplierTicketIngestReportV1
+{
+    fn from(value: DataTransferMultiplierTicketReport) -> Self {
+        Self {
+            received_timestamp_ms: value.received_timestamp.encode_timestamp_millis(),
+            report: Some(value.report.into()),
+        }
+    }
+}
+
+impl From<VerifiedDataTransferMultiplierTicketReport>
+    for proto::VerifiedDataTransferMultiplierTicketReportV1
+{
+    fn from(value: VerifiedDataTransferMultiplierTicketReport) -> Self {
+        Self {
+            verified_timestamp_ms: value.verified_timestamp.encode_timestamp_millis(),
+            report: Some(value.report.into()),
+            status: value.status.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal::dec;
+
+    fn dec_proto(s: &str) -> proto::Decimal {
+        proto::Decimal {
+            value: s.to_string(),
+        }
+    }
+
+    fn parse(s: &str) -> Result<DataTransferMultiplier, MultiplierError> {
+        DataTransferMultiplier::try_from(dec_proto(s))
+    }
+
+    #[test]
+    fn accepts_and_normalizes_valid_multipliers() {
+        // The Decimal spec permits a leading sign and an exponent, so these are
+        // legal input and are canonicalized rather than rejected.
+        for input in [
+            "1", "1.0", "1.00", "1.5", "1.50", "1.5e0", "+1.5", "5", "5.0",
+        ] {
+            assert!(parse(input).is_ok(), "{input} should parse");
+        }
+
+        // Every spelling of the same value must produce the same value, so a
+        // difference in formatting cannot become a difference in multiplier.
+        assert_eq!(parse("1.5").unwrap(), parse("1.50").unwrap());
+        assert_eq!(parse("1.5").unwrap(), parse("1.5e0").unwrap());
+        assert_eq!(parse("1.5").unwrap(), parse("+1.5").unwrap());
+        assert_eq!(parse("1").unwrap(), DataTransferMultiplier::DEFAULT);
+        assert_eq!(parse("1.000").unwrap(), DataTransferMultiplier::DEFAULT);
+    }
+
+    #[test]
+    fn rejects_invalid_multipliers() {
+        assert_eq!(
+            parse("").unwrap_err(),
+            MultiplierError::Unparseable("".into())
+        );
+        assert_eq!(
+            parse("abc").unwrap_err(),
+            MultiplierError::Unparseable("abc".into())
+        );
+        assert_eq!(
+            parse("NaN").unwrap_err(),
+            MultiplierError::Unparseable("NaN".into())
+        );
+
+        // Below the floor: negative, zero, and just under 1.
+        assert!(matches!(
+            parse("-1").unwrap_err(),
+            MultiplierError::OutOfRange(_)
+        ));
+        assert!(matches!(
+            parse("0").unwrap_err(),
+            MultiplierError::OutOfRange(_)
+        ));
+        assert!(matches!(
+            parse("0.999999").unwrap_err(),
+            MultiplierError::OutOfRange(_)
+        ));
+
+        // Above the ceiling, by the smallest representable step.
+        assert!(matches!(
+            parse("5.000001").unwrap_err(),
+            MultiplierError::OutOfRange(_)
+        ));
+
+        // More precision than we will carry.
+        assert!(matches!(
+            parse("1.5000001").unwrap_err(),
+            MultiplierError::TooPrecise(_)
+        ));
+
+        // A value far outside `Decimal`'s range fails at the parse step.
+        assert!(matches!(
+            parse("1e400").unwrap_err(),
+            MultiplierError::Unparseable(_)
+        ));
+    }
+
+    #[test]
+    fn bounds_are_inclusive() {
+        assert!(parse("1").is_ok());
+        assert!(parse("5").is_ok());
+    }
+
+    #[test]
+    fn default_is_the_identity() {
+        let default = DataTransferMultiplier::DEFAULT;
+        assert!(default.is_default());
+        for dc in [0, 1, 2, 7, 100_000, u32::MAX as u64] {
+            assert_eq!(
+                default.apply(dc).unwrap(),
+                dc,
+                "default must not change {dc}"
+            );
+        }
+    }
+
+    #[test]
+    fn apply_rounds_down() {
+        let one_and_a_half = DataTransferMultiplier::new(dec!(1.5)).unwrap();
+
+        // Exact.
+        assert_eq!(one_and_a_half.apply(2).unwrap(), 3);
+        assert_eq!(one_and_a_half.apply(10).unwrap(), 15);
+        // 3 * 1.5 = 4.5 -> 4, not 5. A payer never burns more than the
+        // multiplier earns.
+        assert_eq!(one_and_a_half.apply(3).unwrap(), 4);
+        assert_eq!(one_and_a_half.apply(1).unwrap(), 1);
+        assert_eq!(one_and_a_half.apply(0).unwrap(), 0);
+
+        let five = DataTransferMultiplier::new(dec!(5)).unwrap();
+        assert_eq!(five.apply(2).unwrap(), 10);
+    }
+
+    /// The reason `apply` returns a `Result`. Saturating would hand back
+    /// `u64::MAX` — charge the payer everything — for an arithmetic failure.
+    #[test]
+    fn overflow_is_an_error_not_a_maximum_charge() {
+        let five = DataTransferMultiplier::new(dec!(5)).unwrap();
+
+        let err = five.apply(u64::MAX).unwrap_err();
+        assert!(
+            matches!(err, MultiplierError::Overflow { .. }),
+            "expected Overflow, got {err:?}"
+        );
+
+        // Specifically: it must not come back as the largest possible burn.
+        assert_ne!(five.apply(u64::MAX).ok(), Some(u64::MAX));
+    }
+
+    /// The largest count that still fits, so the error above is a real boundary
+    /// rather than the multiplier refusing everything large.
+    #[test]
+    fn applies_right_up_to_the_boundary() {
+        let five = DataTransferMultiplier::new(dec!(5)).unwrap();
+        let fits = u64::MAX / 5;
+
+        assert_eq!(five.apply(fits).unwrap(), fits * 5);
+    }
+
+    #[test]
+    fn apply_never_exceeds_the_exact_value() {
+        let m = DataTransferMultiplier::new(dec!(1.333333)).unwrap();
+        for dc in 0..500u64 {
+            let exact = Decimal::from(dc) * m.as_decimal();
+            assert!(
+                Decimal::from(m.apply(dc).unwrap()) <= exact,
+                "apply({dc}) exceeded {exact}"
+            );
+        }
+    }
+
+    #[test]
+    fn ticket_round_trips_through_proto() {
+        let ticket = DataTransferMultiplierTicket {
+            hotspot_pubkey: PublicKeyBinary::from(vec![1, 2, 3]),
+            multiplier: Some(dec!(1.5)),
+            timestamp: DateTime::from_timestamp_millis(1_700_000_000_000).unwrap(),
+            message: "venue agreement 42".to_string(),
+            signer_pubkey: PublicKeyBinary::from(vec![4, 5, 6]),
+            signature: vec![7, 8, 9],
+        };
+
+        let proto: proto::DataTransferMultiplierTicketReqV1 = ticket.clone().into();
+        let back = DataTransferMultiplierTicket::try_from(proto).unwrap();
+
+        assert_eq!(ticket, back);
+    }
+}

--- a/file_store_oracles/src/traits/file_sink_write.rs
+++ b/file_store_oracles/src/traits/file_sink_write.rs
@@ -342,3 +342,8 @@ impl_file_sink!(
     FileType::DataTransferMultiplierTicketIngestReport.to_str(),
     "data_transfer_multiplier_ticket_ingest_report"
 );
+impl_file_sink!(
+    poc_mobile::VerifiedDataTransferMultiplierTicketReportV1,
+    FileType::VerifiedDataTransferMultiplierTicketReport.to_str(),
+    "verified_data_transfer_multiplier_ticket_report"
+);

--- a/helium_iceberg_oracles/Cargo.toml
+++ b/helium_iceberg_oracles/Cargo.toml
@@ -9,9 +9,14 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 chrono = { workspace = true }
+rust_decimal = { workspace = true }
 serde = { workspace = true }
+thiserror = { workspace = true }
 helium-proto = { workspace = true }
 trino-rust-client = { workspace = true }
 
 helium-iceberg = { path = "../helium_iceberg", default-features = false }
 file-store-oracles = { path = "../file_store_oracles" }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/helium_iceberg_oracles/src/data_transfer/mod.rs
+++ b/helium_iceberg_oracles/src/data_transfer/mod.rs
@@ -8,13 +8,23 @@
 //! - `invalid_sessions` — rejected sessions (same schema plus a `reason` column).
 //! - `burned_sessions` — sessions whose DC has been burned; the input to mobile
 //!   data-transfer rewards.
+//! - `multiplier_ticket_history` — every HIP-150 multiplier ticket seen,
+//!   accepted or refused. Append-only.
+//! - `multiplier_ticket_inventory` — the multiplier currently in force per
+//!   hotspot, merged from the history on a schedule. Follows the pattern
+//!   `network-dbt` uses for `enabled_carriers_inventory` over
+//!   `enabled_carriers_history`, with our own job issuing the SQL.
 
 pub mod burned_session;
 pub mod invalid_session;
+pub mod multiplier_ticket_history;
+pub mod multiplier_ticket_inventory;
 pub mod session;
 
 pub use burned_session::IcebergBurnedDataTransferSession;
 pub use invalid_session::IcebergInvalidDataTransferSession;
+pub use multiplier_ticket_history::IcebergMultiplierTicket;
+pub use multiplier_ticket_inventory::IcebergMultiplierInventory;
 pub use session::IcebergDataTransferSession;
 
 pub const NAMESPACE: &str = "data_transfer";

--- a/helium_iceberg_oracles/src/data_transfer/multiplier_ticket_history.rs
+++ b/helium_iceberg_oracles/src/data_transfer/multiplier_ticket_history.rs
@@ -1,0 +1,107 @@
+//! `data_transfer.multiplier_ticket_history` — every HIP-150 ticket ever seen.
+//!
+//! Append-only, one row per ticket received, accepted or not. HIP-150 requires
+//! every multiplier in force to be externally auditable; recording refusals too
+//! means the record answers "why is this hotspot not multiplied" as well as
+//! "why is it".
+//!
+//! This is the log. For "what is current", see
+//! [`super::multiplier_ticket_inventory`].
+
+use chrono::{DateTime, FixedOffset};
+use helium_iceberg::{FieldDefinition, PartitionDefinition, TableDefinition};
+use serde::{Deserialize, Serialize};
+use trino_rust_client::Trino;
+
+use file_store_oracles::mobile::data_transfer_multiplier::VerifiedDataTransferMultiplierTicketReport;
+
+use crate::IcebergDecimal;
+
+pub use super::NAMESPACE;
+pub const TABLE_NAME: &str = "multiplier_ticket_history";
+
+/// Precision and scale of the stored multiplier.
+///
+/// `decimal`, not `double`. Multipliers are negotiated per venue, so they are
+/// not always binary-representable — 1.5 and 5 survive a float exactly, 1.3 does
+/// not. A public record that has to explain floating-point artifacts is a worse
+/// record, and the exact type costs nothing.
+pub const MULTIPLIER_PRECISION: u32 = 9;
+pub const MULTIPLIER_SCALE: u32 = 6;
+// The Iceberg field builder takes u32; the Trino type takes const usize
+// generics. Same numbers, spelled for each.
+pub const MULTIPLIER_PRECISION_USIZE: usize = MULTIPLIER_PRECISION as usize;
+pub const MULTIPLIER_SCALE_USIZE: usize = MULTIPLIER_SCALE as usize;
+
+/// The stored multiplier's type, spelled once.
+pub type MultiplierDecimal = IcebergDecimal<MULTIPLIER_PRECISION_USIZE, MULTIPLIER_SCALE_USIZE>;
+
+#[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
+pub struct IcebergMultiplierTicket {
+    pub hotspot_pubkey: String,
+    /// When the issuer signed the ticket — what decides which ticket is current.
+    pub signed_timestamp: DateTime<FixedOffset>,
+    /// When ingest received it.
+    pub received_timestamp: DateTime<FixedOffset>,
+    /// When this oracle ruled on it.
+    pub verified_timestamp: DateTime<FixedOffset>,
+    /// `None` when the ticket carried no usable multiplier — absent,
+    /// unparseable, or too large for the column. `status` records that it was
+    /// refused, but not which of the three it was; all three are
+    /// `invalid_multiplier`. A value that is merely out of range *is* stored,
+    /// so the record shows what was asked for.
+    pub multiplier: Option<MultiplierDecimal>,
+    pub signer: String,
+    pub message: String,
+    /// The verdict, as the proto enum's string name. Rejected tickets are kept.
+    pub status: String,
+}
+
+pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {
+    TableDefinition::builder(NAMESPACE, TABLE_NAME)
+        .with_fields([
+            FieldDefinition::required_string("hotspot_pubkey"),
+            FieldDefinition::required_timestamptz("signed_timestamp"),
+            FieldDefinition::required_timestamptz("received_timestamp"),
+            FieldDefinition::required_timestamptz("verified_timestamp"),
+            FieldDefinition::required_decimal("multiplier", MULTIPLIER_PRECISION, MULTIPLIER_SCALE),
+            FieldDefinition::required_string("signer"),
+            FieldDefinition::required_string("message"),
+            FieldDefinition::required_string("status"),
+        ])
+        .with_partition(PartitionDefinition::day(
+            "received_timestamp",
+            "received_timestamp_day",
+        ))
+        .build()
+}
+
+pub async fn get_all(
+    trino: &trino_rust_client::Client,
+) -> anyhow::Result<Vec<IcebergMultiplierTicket>> {
+    let all = trino
+        .get_all(format!("SELECT * from {NAMESPACE}.{TABLE_NAME}"))
+        .await?
+        .into_vec();
+    Ok(all)
+}
+
+impl From<&VerifiedDataTransferMultiplierTicketReport> for IcebergMultiplierTicket {
+    fn from(verified: &VerifiedDataTransferMultiplierTicketReport) -> Self {
+        let ticket = &verified.report.report;
+        Self {
+            hotspot_pubkey: ticket.hotspot_pubkey.to_string(),
+            signed_timestamp: ticket.timestamp.into(),
+            received_timestamp: verified.report.received_timestamp.into(),
+            verified_timestamp: verified.verified_timestamp.into(),
+            // A refused ticket may carry a value too large for the column, or
+            // none at all; the row still records the refusal.
+            multiplier: ticket
+                .multiplier
+                .and_then(|m| MultiplierDecimal::try_from(m).ok()),
+            signer: ticket.signer_pubkey.to_string(),
+            message: ticket.message.clone(),
+            status: verified.status.as_str_name().to_string(),
+        }
+    }
+}

--- a/helium_iceberg_oracles/src/data_transfer/multiplier_ticket_inventory.rs
+++ b/helium_iceberg_oracles/src/data_transfer/multiplier_ticket_inventory.rs
@@ -1,0 +1,140 @@
+//! `data_transfer.multiplier_ticket_inventory` — the multiplier currently in
+//! force per hotspot.
+//!
+//! One row per ticketed hotspot, refreshed from
+//! [`super::multiplier_ticket_history`] by a periodic `MERGE`. Follows the
+//! pattern `network-dbt` uses for `enabled_carriers_inventory` over
+//! `enabled_carriers_history` — latest-per-key picked with a `row_number()`
+//! window, merged on the key — but it is our own job issuing the SQL, not a dbt
+//! model.
+//!
+//! **Unlike the history table it holds only valid tickets.** History records
+//! every ticket including refusals, so it answers "what happened"; this answers
+//! "what is in force", and a refused ticket is not in force. Note that a refusal
+//! does not revoke an earlier grant: a hotspot whose newest ticket was rejected
+//! keeps the last valid one, which is what excluding refusals from the source
+//! achieves.
+//!
+//! **Not written by the Rust iceberg writer.** It is maintained in place by
+//! `MERGE`, which the append-only writer cannot express — hence the table being
+//! unpartitioned, and hence the DDL existing only so the merge has a target.
+//!
+//! Readers: the burn path, the ticket CLI, and anyone asking what a hotspot's
+//! multiplier is. The burn deliberately takes whatever is current here rather
+//! than reconstructing what was in force when the data moved — see
+//! `mobile_packet_verifier::multiplier::trino`.
+
+use chrono::{DateTime, FixedOffset};
+use helium_iceberg::{FieldDefinition, TableDefinition};
+use serde::{Deserialize, Serialize};
+use trino_rust_client::Trino;
+
+use super::multiplier_ticket_history::{MultiplierDecimal, MULTIPLIER_PRECISION, MULTIPLIER_SCALE};
+pub use super::NAMESPACE;
+pub const TABLE_NAME: &str = "multiplier_ticket_inventory";
+
+#[derive(Debug, Clone, Trino, Serialize, Deserialize, PartialEq)]
+pub struct IcebergMultiplierInventory {
+    pub hotspot_pubkey: String,
+    pub multiplier: MultiplierDecimal,
+    /// When the issuer signed the ticket that granted this multiplier — the
+    /// value that decided it wins.
+    pub signed_timestamp: DateTime<FixedOffset>,
+    /// When ingest received that ticket.
+    pub received_timestamp: DateTime<FixedOffset>,
+    /// When the packet verifier accepted it.
+    pub verified_timestamp: DateTime<FixedOffset>,
+    pub signer: String,
+    pub message: String,
+}
+
+/// Deliberately unpartitioned: rows are updated in place by `MERGE`, so there is
+/// no append dimension to partition on.
+pub fn table_definition() -> helium_iceberg::Result<TableDefinition> {
+    TableDefinition::builder(NAMESPACE, TABLE_NAME)
+        .with_fields([
+            FieldDefinition::required_string("hotspot_pubkey"),
+            FieldDefinition::required_decimal("multiplier", MULTIPLIER_PRECISION, MULTIPLIER_SCALE),
+            FieldDefinition::required_timestamptz("signed_timestamp"),
+            FieldDefinition::required_timestamptz("received_timestamp"),
+            FieldDefinition::required_timestamptz("verified_timestamp"),
+            FieldDefinition::required_string("signer"),
+            FieldDefinition::required_string("message"),
+        ])
+        .build()
+}
+
+/// The `MERGE` that brings the inventory up to date with the history.
+///
+/// `valid_status` is passed in rather than written here so it stays the proto
+/// enum's own `as_str_name()`, and cannot drift from what the writer stored.
+///
+/// Rebuilds the source from the whole history each run rather than tracking a
+/// watermark. Tickets are rare — HIP-150 expects a small number of granted
+/// hotspots — so the scan is cheap and a full recompute cannot drift from the
+/// history the way an incremental one can. Revisit if ticket volume ever makes
+/// that untrue.
+pub fn merge_statement(history_table: &str, inventory_table: &str, valid_status: &str) -> String {
+    format!(
+        r#"
+        MERGE INTO {inventory_table} AS t
+        USING (
+            SELECT
+                hotspot_pubkey,
+                multiplier,
+                signed_timestamp,
+                received_timestamp,
+                verified_timestamp,
+                signer,
+                message
+            FROM (
+                SELECT
+                    *,
+                    row_number() OVER (
+                        PARTITION BY hotspot_pubkey
+                        ORDER BY signed_timestamp DESC, received_timestamp DESC
+                    ) AS rn
+                FROM {history_table}
+                WHERE status = '{valid_status}'
+                  AND multiplier IS NOT NULL
+            )
+            WHERE rn = 1
+        ) AS s
+        ON t.hotspot_pubkey = s.hotspot_pubkey
+        WHEN MATCHED THEN UPDATE SET
+            multiplier = s.multiplier,
+            signed_timestamp = s.signed_timestamp,
+            received_timestamp = s.received_timestamp,
+            verified_timestamp = s.verified_timestamp,
+            signer = s.signer,
+            message = s.message
+        WHEN NOT MATCHED THEN INSERT (
+            hotspot_pubkey,
+            multiplier,
+            signed_timestamp,
+            received_timestamp,
+            verified_timestamp,
+            signer,
+            message
+        ) VALUES (
+            s.hotspot_pubkey,
+            s.multiplier,
+            s.signed_timestamp,
+            s.received_timestamp,
+            s.verified_timestamp,
+            s.signer,
+            s.message
+        )
+        "#
+    )
+}
+
+pub async fn get_all(
+    trino: &trino_rust_client::Client,
+) -> anyhow::Result<Vec<IcebergMultiplierInventory>> {
+    let all = trino
+        .get_all(format!("SELECT * from {NAMESPACE}.{TABLE_NAME}"))
+        .await?
+        .into_vec();
+    Ok(all)
+}

--- a/helium_iceberg_oracles/src/decimal.rs
+++ b/helium_iceberg_oracles/src/decimal.rs
@@ -1,0 +1,156 @@
+//! Exact decimals for Iceberg `decimal(P, S)` columns.
+//!
+//! Bridges two APIs that don't quite meet. The write path serializes a row with
+//! serde and hands the JSON to `arrow-json`, whose `DecimalArrayDecoder`
+//! accepts a decimal *string*. The read path uses `trino-rust-client`'s `Trino`
+//! trait, whose `Decimal<P, S>` implements `DeserializeSeed` but neither
+//! `Serialize` nor `Deserialize` — so a row struct containing one cannot derive
+//! the serde impls the writer needs.
+//!
+//! [`IcebergDecimal`] implements all three, so a row type can carry an exact
+//! decimal and still `#[derive(Trino, Serialize, Deserialize)]` like every other
+//! table in this crate.
+//!
+//! Why not `double`: values that are not binary-representable — 1.3, 2.7 — pick
+//! up artifacts a float cannot shed, and these columns are a public record.
+
+use std::str::FromStr;
+
+use serde::{de::DeserializeSeed, Deserialize, Deserializer, Serialize, Serializer};
+use trino_rust_client::{
+    types::{Context, Decimal as TrinoDecimal},
+    Trino,
+};
+
+/// An exact decimal stored in an Iceberg `decimal(P, S)` column.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct IcebergDecimal<const P: usize, const S: usize>(TrinoDecimal<P, S>);
+
+#[derive(thiserror::Error, Debug)]
+#[error("invalid decimal: {0}")]
+pub struct ParseDecimalError(String);
+
+impl<const P: usize, const S: usize> IcebergDecimal<P, S> {
+    pub fn as_string(&self) -> String {
+        self.0.clone().into_bigdecimal().to_string()
+    }
+}
+
+impl<const P: usize, const S: usize> FromStr for IcebergDecimal<P, S> {
+    type Err = ParseDecimalError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        TrinoDecimal::from_str(s)
+            .map(Self)
+            .map_err(|_| ParseDecimalError(s.to_string()))
+    }
+}
+
+impl<const P: usize, const S: usize> TryFrom<rust_decimal::Decimal> for IcebergDecimal<P, S> {
+    type Error = ParseDecimalError;
+
+    fn try_from(value: rust_decimal::Decimal) -> Result<Self, Self::Error> {
+        Self::from_str(&value.to_string())
+    }
+}
+
+impl<const P: usize, const S: usize> std::fmt::Display for IcebergDecimal<P, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.as_string())
+    }
+}
+
+/// Serialized as a string, which is what `arrow-json` decodes into a
+/// `Decimal128` column. A JSON number would work for small values and lose
+/// precision for large ones.
+impl<const P: usize, const S: usize> Serialize for IcebergDecimal<P, S> {
+    fn serialize<T: Serializer>(&self, serializer: T) -> Result<T::Ok, T::Error> {
+        serializer.serialize_str(&self.as_string())
+    }
+}
+
+impl<'de, const P: usize, const S: usize> Deserialize<'de> for IcebergDecimal<P, S> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Wraps the inner seed so deserialization yields an [`IcebergDecimal`] rather
+/// than the type it delegates to.
+pub struct IcebergDecimalSeed<'a, 'de, const P: usize, const S: usize>(
+    <TrinoDecimal<P, S> as Trino>::Seed<'a, 'de>,
+);
+
+impl<'de, 'a, const P: usize, const S: usize> DeserializeSeed<'de>
+    for IcebergDecimalSeed<'a, 'de, P, S>
+{
+    type Value = IcebergDecimal<P, S>;
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        self.0.deserialize(deserializer).map(IcebergDecimal)
+    }
+}
+
+/// Delegates to the wrapped type, so Trino still sees a `decimal(P, S)`.
+impl<const P: usize, const S: usize> Trino for IcebergDecimal<P, S> {
+    type ValueType<'a> = <TrinoDecimal<P, S> as Trino>::ValueType<'a>;
+    type Seed<'a, 'de> = IcebergDecimalSeed<'a, 'de, P, S>;
+
+    fn value(&self) -> Self::ValueType<'_> {
+        self.0.value()
+    }
+
+    fn ty() -> trino_rust_client::types::TrinoTy {
+        TrinoDecimal::<P, S>::ty()
+    }
+
+    fn seed<'a, 'de>(ctx: &'a Context) -> Self::Seed<'a, 'de> {
+        IcebergDecimalSeed(TrinoDecimal::<P, S>::seed(ctx))
+    }
+
+    fn empty() -> Self {
+        Self(TrinoDecimal::empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal::dec;
+
+    type Multiplier = IcebergDecimal<9, 6>;
+
+    #[test]
+    fn round_trips_through_serde_as_a_string() {
+        for value in [dec!(1), dec!(1.5), dec!(1.3), dec!(5), dec!(2.718281)] {
+            let decimal = Multiplier::try_from(value).expect("in range");
+
+            let json = serde_json::to_string(&decimal).expect("serialize");
+            assert!(
+                json.starts_with('"'),
+                "must serialize as a string for arrow-json, got {json}"
+            );
+
+            let back: Multiplier = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(decimal, back);
+        }
+    }
+
+    /// The case that a `double` column would get wrong: 1.3 has no exact binary
+    /// representation, so a float round trip yields 1.3000000000000000444.
+    #[test]
+    fn keeps_values_a_float_would_mangle() {
+        let decimal = Multiplier::try_from(dec!(1.3)).expect("in range");
+        assert_eq!(decimal.as_string(), "1.3");
+
+        let json = serde_json::to_string(&decimal).expect("serialize");
+        assert_eq!(json, "\"1.3\"");
+    }
+
+    #[test]
+    fn rejects_nonsense() {
+        assert!(Multiplier::from_str("").is_err());
+        assert!(Multiplier::from_str("abc").is_err());
+    }
+}

--- a/helium_iceberg_oracles/src/lib.rs
+++ b/helium_iceberg_oracles/src/lib.rs
@@ -9,3 +9,6 @@
 //! `mobile-verifier`. Single-owner tables stay in their owning crate.
 
 pub mod data_transfer;
+pub mod decimal;
+
+pub use decimal::IcebergDecimal;

--- a/mobile_packet_verifier/Cargo.toml
+++ b/mobile_packet_verifier/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 solana = { path = "../solana" }
 sqlx = { workspace = true }
+rust_decimal = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }

--- a/mobile_packet_verifier/pkg/settings-template.toml
+++ b/mobile_packet_verifier/pkg/settings-template.toml
@@ -151,3 +151,55 @@ bucket = "helium-mainnet-mobile-verified"
 # Region for bucket. Defaults to below
 #
 region = "us-west-2"
+
+# HIP-150 data transfer multiplier tickets
+#
+# Verified tickets are written to s3 and to the append-only
+# data_transfer.multiplier_ticket_history table. No ticket data is stored in
+# Postgres.
+# A periodic job merges that history into
+# data_transfer.multiplier_ticket_inventory, which is what is currently in
+# force.
+#
+[multiplier]
+
+# Comma-separated b58 public keys authorized to issue tickets.
+#
+# Checked here as well as at ingest: the two services are deployed and
+# configured separately, and it is this verdict that lands on the record.
+#
+# May be empty, and is by default — no ticket can be issued until a key is
+# provisioned. Empty rejects every ticket and warns at startup.
+#
+# authorized_keys = "key1,key2"
+
+# How old a ticket's signed timestamp may be, measured against when ingest
+# received it, before it is refused. A second check of what ingest already
+# checked, configured separately so a mistake in ingest's window does not
+# silently widen the replay window everywhere.
+# Default: 10 minutes
+#
+# ticket_max_age = "10 minutes"
+
+# How often to merge the history into the inventory table. Nothing in the burn
+# depends on the inventory, so a slow cadence is fine.
+# Default: 15 minutes
+#
+# inventory_refresh_interval = "15 minutes"
+
+# How far back do we read ticket files?
+# Default: UNIX_EPOCH
+#
+# start_after = "2024-12-15 01:00:00Z"
+
+# Ingest bucket details for data transfer multiplier tickets
+#
+[multiplier.input_bucket]
+
+# Name of bucket to access ingest data. Required
+#
+bucket = "helium-mainnet-mobile-ingest"
+
+# Region for bucket. Defaults to below
+#
+region = "us-west-2"

--- a/mobile_packet_verifier/src/daemon.rs
+++ b/mobile_packet_verifier/src/daemon.rs
@@ -5,7 +5,7 @@ use crate::{
     event_ids::EventIdPurger,
     gateway::GatewayResolver,
     iceberg::{self, DataTransferWriter, InvalidDataTransferWriter},
-    pending_burns,
+    multiplier, pending_burns,
     routing::RoutingKeys,
     settings::Settings,
 };
@@ -312,16 +312,27 @@ impl Cmd {
             )
             .await?;
 
-        let (session_writer, invalid_session_writer, burned_session_writer) =
-            if let Some(ref iceberg_settings) = settings.iceberg_settings {
-                tracing::info!("iceberg settings provided, connecting...");
-                let (session, invalid_session, burned) =
-                    iceberg::get_writers(iceberg_settings).await?;
-                (Some(session), Some(invalid_session), Some(burned))
-            } else {
-                tracing::info!("no iceberg settings provided");
-                (None, None, None)
-            };
+        let writers = if let Some(ref iceberg_settings) = settings.iceberg_settings {
+            tracing::info!("iceberg settings provided, connecting...");
+            Some(iceberg::get_writers(iceberg_settings).await?)
+        } else {
+            tracing::info!("no iceberg settings provided");
+            None
+        };
+        let (
+            session_writer,
+            invalid_session_writer,
+            burned_session_writer,
+            multiplier_ticket_writer,
+        ) = match writers {
+            Some(w) => (
+                Some(w.session),
+                Some(w.invalid_session),
+                Some(w.burned_session),
+                Some(w.multiplier_ticket),
+            ),
+            None => (None, None, None, None),
+        };
 
         let burner = Burner::new(
             valid_sessions,
@@ -345,6 +356,10 @@ impl Cmd {
         )
         .await;
         let gw_refresher = gw_resolver.refresher();
+        // Shared, not a second resolver: clones point at the same snapshot, so
+        // the refresher above keeps the ticket path current too. Building
+        // another would load its own copy of the inventory and never refresh it.
+        let ticket_resolver = gw_resolver.clone();
 
         let ingest_reports = IngestReports::new(
             pool.clone(),
@@ -366,7 +381,19 @@ impl Cmd {
         );
 
         let event_id_purger = EventIdPurger::from_settings(pool.clone(), settings);
-        let banning = banning::create_managed_task(pool, &settings.banning).await?;
+        let banning = banning::create_managed_task(pool.clone(), &settings.banning).await?;
+
+        let multipliers = multiplier::create_managed_task(
+            pool,
+            file_upload,
+            &settings.multiplier,
+            settings.ticket_signers()?,
+            ticket_resolver,
+            &settings.cache,
+            multiplier_ticket_writer,
+            trino_client::Client::from_settings(&settings.trino)?,
+        )
+        .await?;
 
         TaskManager::builder()
             .add_task(file_upload_server)
@@ -374,6 +401,7 @@ impl Cmd {
             .add_task(verified_sessions_server)
             .add_task(reports_server)
             .add_task(banning)
+            .add_task(multipliers)
             .add_task(task_manager::periodic(event_id_purger))
             .add_task(task_manager::periodic(gw_refresher))
             .add_task(daemon)

--- a/mobile_packet_verifier/src/gateway.rs
+++ b/mobile_packet_verifier/src/gateway.rs
@@ -36,6 +36,12 @@ const GATEWAY_REFRESH_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 /// that misses the snapshot — an unknown gateway, or one onboarded since the
 /// last refresh — falls back to a per-pubkey Trino query, cached to avoid
 /// re-querying.
+/// Cloning shares the snapshot rather than copying it: `known_gateways` and
+/// `fallback_cache` are behind `Arc`, so every clone sees the same set and the
+/// single [`GatewaySnapshotRefresher`] keeps all of them current. Build one per
+/// process and clone it for each consumer — a second `new()` would load its own
+/// copy of the whole inventory and then never refresh it.
+#[derive(Clone)]
 pub struct GatewayResolver {
     trino_client: trino_client::Client,
     inventory_table: String,

--- a/mobile_packet_verifier/src/iceberg.rs
+++ b/mobile_packet_verifier/src/iceberg.rs
@@ -5,8 +5,9 @@ use serde::Serialize;
 // `data_transfer` schemas live in `helium-iceberg-oracles`; re-exported here so
 // existing `iceberg::*` paths keep resolving.
 pub use helium_iceberg_oracles::data_transfer::{
-    burned_session, invalid_session, session, IcebergBurnedDataTransferSession,
-    IcebergDataTransferSession, IcebergInvalidDataTransferSession, NAMESPACE, REASON_COLUMN,
+    burned_session, invalid_session, multiplier_ticket_history, multiplier_ticket_inventory,
+    session, IcebergBurnedDataTransferSession, IcebergDataTransferSession,
+    IcebergInvalidDataTransferSession, IcebergMultiplierTicket, NAMESPACE, REASON_COLUMN,
 };
 
 // Valid sessions go to `data_transfer.sessions`; rejected sessions go to the
@@ -15,14 +16,18 @@ pub use helium_iceberg_oracles::data_transfer::{
 pub type DataTransferWriter = BoxedDataWriter<IcebergDataTransferSession>;
 pub type InvalidDataTransferWriter = BoxedDataWriter<IcebergInvalidDataTransferSession>;
 pub type BurnedDataTransferWriter = BoxedDataWriter<IcebergBurnedDataTransferSession>;
+/// HIP-150: every multiplier ticket seen, accepted or refused.
+pub type MultiplierTicketWriter = BoxedDataWriter<IcebergMultiplierTicket>;
 
-pub async fn get_writers(
-    settings: &helium_iceberg::Settings,
-) -> anyhow::Result<(
-    DataTransferWriter,
-    InvalidDataTransferWriter,
-    BurnedDataTransferWriter,
-)> {
+/// Every Iceberg writer this service uses.
+pub struct Writers {
+    pub session: DataTransferWriter,
+    pub invalid_session: InvalidDataTransferWriter,
+    pub burned_session: BurnedDataTransferWriter,
+    pub multiplier_ticket: MultiplierTicketWriter,
+}
+
+pub async fn get_writers(settings: &helium_iceberg::Settings) -> anyhow::Result<Writers> {
     let catalog = settings.connect().await.context("connecting to catalog")?;
 
     catalog.create_namespace_if_not_exists(NAMESPACE).await?;
@@ -36,12 +41,24 @@ pub async fn get_writers(
     let burned_session_writer = catalog
         .create_table_if_not_exists(burned_session::table_definition()?)
         .await?;
+    let multiplier_ticket_writer = catalog
+        .create_table_if_not_exists(multiplier_ticket_history::table_definition()?)
+        .await?;
 
-    Ok((
-        session_writer.boxed(),
-        invalid_session_writer.boxed(),
-        burned_session_writer.boxed(),
-    ))
+    // The inventory is maintained in place by a Trino MERGE, not by a writer —
+    // created here only so the merge has a target. The returned writer is
+    // deliberately dropped.
+    let _ = catalog
+        .create_table_if_not_exists::<multiplier_ticket_inventory::IcebergMultiplierInventory>(
+            multiplier_ticket_inventory::table_definition()?,
+        )
+        .await?;
+    Ok(Writers {
+        session: session_writer.boxed(),
+        invalid_session: invalid_session_writer.boxed(),
+        burned_session: burned_session_writer.boxed(),
+        multiplier_ticket: multiplier_ticket_writer.boxed(),
+    })
 }
 
 /// Optional idempotent append — no-op when `writer` is `None` (iceberg

--- a/mobile_packet_verifier/src/lib.rs
+++ b/mobile_packet_verifier/src/lib.rs
@@ -7,6 +7,7 @@ pub mod daemon;
 pub mod event_ids;
 pub mod gateway;
 pub mod iceberg;
+pub mod multiplier;
 pub mod pending_burns;
 pub mod pending_txns;
 pub mod routing;

--- a/mobile_packet_verifier/src/multiplier/ingestor.rs
+++ b/mobile_packet_verifier/src/multiplier/ingestor.rs
@@ -1,0 +1,218 @@
+//! Reads ticket files from s3, rules on each ticket, records the verdict.
+//!
+//! Every ticket produces a verified report — accepted or rejected — so the
+//! public record shows refusals as well as grants. Both also land in the
+//! append-only history table, tagged with the verdict.
+//!
+//! Nothing here holds mutable state: this module only appends. What is
+//! *currently* in force is derived from those rows separately, by
+//! [`super::inventory`].
+
+use std::{ops::ControlFlow, time::Duration};
+
+use chrono::Utc;
+use file_store::file_info_poller::FileInfoStream;
+use file_store_oracles::mobile::data_transfer_multiplier::{
+    proto::VerifiedDataTransferMultiplierTicketReportV1, DataTransferMultiplier,
+    DataTransferMultiplierTicketReport, VerifiedDataTransferMultiplierTicketReport,
+    VerifiedDataTransferMultiplierTicketStatus as Status, MAX_CLOCK_DRIFT,
+};
+use futures::StreamExt;
+use sqlx::PgPool;
+use task_manager::ChannelConsumer;
+use tokio::sync::mpsc::Receiver;
+
+use crate::{
+    gateway::GatewayResolver,
+    iceberg::{IcebergMultiplierTicket, MultiplierTicketWriter},
+};
+
+use super::{TicketSigners, VerifiedTicketSink};
+
+pub struct TicketIngestor {
+    /// Only for the file poller's own "which files have I processed" bookkeeping
+    /// — no ticket data is stored in Postgres.
+    pool: PgPool,
+    report_rx: Receiver<FileInfoStream<DataTransferMultiplierTicketReport>>,
+    verified_sink: VerifiedTicketSink,
+    signers: TicketSigners,
+    resolver: GatewayResolver,
+    ticket_max_age: Duration,
+    history_writer: Option<MultiplierTicketWriter>,
+}
+
+impl ChannelConsumer for TicketIngestor {
+    type Item = FileInfoStream<DataTransferMultiplierTicketReport>;
+    type Error = anyhow::Error;
+
+    async fn recv(&mut self) -> Option<Self::Item> {
+        self.report_rx.recv().await
+    }
+
+    async fn handle(&mut self, file_info_stream: Self::Item) -> anyhow::Result<()> {
+        self.process_file(file_info_stream).await
+    }
+
+    async fn on_receiver_closed(&mut self) -> anyhow::Result<ControlFlow<()>> {
+        Err(anyhow::anyhow!(
+            "data transfer multiplier ticket FileInfoPoller sender was dropped unexpectedly"
+        ))
+    }
+}
+
+impl TicketIngestor {
+    pub fn new(
+        pool: PgPool,
+        report_rx: Receiver<FileInfoStream<DataTransferMultiplierTicketReport>>,
+        verified_sink: VerifiedTicketSink,
+        signers: TicketSigners,
+        resolver: GatewayResolver,
+        ticket_max_age: Duration,
+        history_writer: Option<MultiplierTicketWriter>,
+    ) -> Self {
+        Self {
+            pool,
+            report_rx,
+            verified_sink,
+            signers,
+            resolver,
+            ticket_max_age,
+            history_writer,
+        }
+    }
+
+    async fn process_file(
+        &self,
+        file_info_stream: FileInfoStream<DataTransferMultiplierTicketReport>,
+    ) -> anyhow::Result<()> {
+        let file = file_info_stream.file_info.key.clone();
+        tracing::info!(%file, "processing data transfer multiplier tickets");
+
+        // The transaction records only that this file was processed; the
+        // tickets themselves go to s3 and Iceberg.
+        let mut txn = self.pool.begin().await?;
+        let mut stream = file_info_stream.into_stream(&mut txn).await?;
+
+        let mut history = Vec::new();
+
+        while let Some(report) = stream.next().await {
+            let verified = self.verify(report).await?;
+
+            // Every ticket gets a history row, refusals included — a value the
+            // column cannot hold lands as NULL, with the status saying why.
+            if self.history_writer.is_some() {
+                history.push(IcebergMultiplierTicket::from(&verified));
+            }
+
+            let status = verified.status.as_str_name();
+            let proto = VerifiedDataTransferMultiplierTicketReportV1::from(verified);
+            self.verified_sink
+                .write(proto, &[("status", status)])
+                .await?;
+        }
+
+        // Keyed on the file, so reprocessing one cannot duplicate its rows.
+        if let Some(writer) = self.history_writer.as_ref() {
+            writer.write_idempotent(&file, history).await?;
+        }
+
+        txn.commit().await?;
+        self.verified_sink.commit().await?;
+
+        Ok(())
+    }
+
+    /// Rule on one ticket.
+    async fn verify(
+        &self,
+        report: DataTransferMultiplierTicketReport,
+    ) -> anyhow::Result<VerifiedDataTransferMultiplierTicketReport> {
+        let status =
+            ticket_status(&report, &self.signers, self.ticket_max_age, &self.resolver).await;
+
+        let verified = VerifiedDataTransferMultiplierTicketReport {
+            verified_timestamp: Utc::now(),
+            report,
+            status,
+        };
+
+        if !verified.is_valid() {
+            tracing::warn!(
+                hotspot_pubkey = %verified.hotspot_pubkey(),
+                status = status.as_str_name(),
+                "rejecting data transfer multiplier ticket"
+            );
+        }
+
+        Ok(verified)
+    }
+}
+
+/// The verdict on one ticket.
+///
+/// A free function rather than a method: this is the rule that decides whether a
+/// hotspot's rewards get multiplied, and it should be testable without a
+/// channel, a file poller or a sink.
+///
+/// HIP-150 fixes the accepted range at 1 to 5 inclusive, "enforced by the
+/// oracles" — and this is that enforcement. It is deliberately here rather than
+/// at ingest: ingest keeps the range out of the wire format so policy can move
+/// without a schema change, and refusing at the gRPC boundary would leave no
+/// record. Refusing here writes a verified report and a history row, so a
+/// rejected grant is as auditable as an accepted one.
+pub async fn ticket_status(
+    report: &DataTransferMultiplierTicketReport,
+    signers: &TicketSigners,
+    ticket_max_age: Duration,
+    resolver: &GatewayResolver,
+) -> Status {
+    let ticket = &report.report;
+
+    if !signers.contains(&ticket.signer_pubkey) {
+        return Status::InvalidSigner;
+    }
+
+    // Absent, unparseable, out of range, or carrying more precision than we
+    // store. All four mean the same thing to a submitter: not a multiplier we
+    // will grant.
+    match ticket.multiplier {
+        Some(multiplier) if DataTransferMultiplier::new(multiplier).is_ok() => {}
+        _ => return Status::InvalidMultiplier,
+    }
+
+    // A signature never expires, so a ticket is only as trustworthy as it is
+    // fresh. Measured against when *ingest* received it, not against now: this
+    // service may be replaying a backlog of files hours old, and every ticket in
+    // them would otherwise look stale.
+    //
+    // A ticket can be stamped slightly ahead of the timestamp ingest gave it,
+    // because the client's clock is not ingest's. Ingest accepts that drift, so
+    // this must too — otherwise every ticket ingest let through from a fast
+    // client would be refused here, and the two would disagree about the same
+    // ticket. Hence the shared constant rather than two settings.
+    let age = report.received_timestamp - ticket.timestamp;
+    let age = if age < chrono::TimeDelta::zero() {
+        match (-age).to_std() {
+            Ok(drift) if drift <= MAX_CLOCK_DRIFT => std::time::Duration::ZERO,
+            _ => return Status::InvalidTimestamp,
+        }
+    } else {
+        match age.to_std() {
+            Ok(age) => age,
+            Err(_) => return Status::InvalidTimestamp,
+        }
+    };
+
+    if age > ticket_max_age {
+        return Status::InvalidTimestamp;
+    }
+
+    if !resolver
+        .is_gateway_known(&ticket.hotspot_pubkey, &report.received_timestamp)
+        .await
+    {
+        return Status::InvalidHotspotKey;
+    }
+
+    Status::Valid
+}

--- a/mobile_packet_verifier/src/multiplier/inventory.rs
+++ b/mobile_packet_verifier/src/multiplier/inventory.rs
@@ -1,0 +1,91 @@
+//! Keeps `data_transfer.multiplier_ticket_inventory` up to date.
+//!
+//! The history table is the log; the inventory is what is currently in force.
+//! This periodically merges the second out of the first, following the pattern
+//! `network-dbt` uses for its `*_inventory` marts — latest-per-key by a
+//! `row_number()` window, merged on the key — with the SQL issued by us rather
+//! than by dbt.
+//!
+//! It runs as a `MERGE` through Trino rather than through the Rust iceberg
+//! writer, because the writer is append-only and cannot update a row in place.
+//!
+//! **The burn reads this table**, so a refresh that stops running freezes the
+//! multipliers burns apply — at the last merged value, not at 1. Tickets keep
+//! landing in the history either way, so a resumed refresh catches up without
+//! loss; the exposure is stale multipliers in the meantime, not lost grants.
+
+use std::time::Duration;
+
+use file_store_oracles::mobile::data_transfer_multiplier::VerifiedDataTransferMultiplierTicketStatus;
+use helium_iceberg_oracles::data_transfer::{
+    multiplier_ticket_history, multiplier_ticket_inventory,
+};
+use task_manager::Periodic;
+
+pub struct InventoryRefresher {
+    trino: trino_client::Client,
+    interval: Duration,
+    history_table: String,
+    inventory_table: String,
+}
+
+impl InventoryRefresher {
+    pub fn new(trino: trino_client::Client, interval: Duration) -> Self {
+        Self::new_with_tables(
+            trino,
+            interval,
+            format!(
+                "{}.{}",
+                multiplier_ticket_history::NAMESPACE,
+                multiplier_ticket_history::TABLE_NAME
+            ),
+            format!(
+                "{}.{}",
+                multiplier_ticket_inventory::NAMESPACE,
+                multiplier_ticket_inventory::TABLE_NAME
+            ),
+        )
+    }
+
+    /// Like [`new`](Self::new), with explicit table names so tests can point at
+    /// a per-test catalog.
+    pub fn new_with_tables(
+        trino: trino_client::Client,
+        interval: Duration,
+        history_table: String,
+        inventory_table: String,
+    ) -> Self {
+        Self {
+            trino,
+            interval,
+            history_table,
+            inventory_table,
+        }
+    }
+
+    /// Run one refresh. Public so a test can drive it without a scheduler.
+    pub async fn refresh(&self) -> anyhow::Result<()> {
+        let sql = multiplier_ticket_inventory::merge_statement(
+            &self.history_table,
+            &self.inventory_table,
+            VerifiedDataTransferMultiplierTicketStatus::Valid.as_str_name(),
+        );
+
+        self.trino.execute_raw(sql).await?;
+        Ok(())
+    }
+}
+
+impl Periodic for InventoryRefresher {
+    type Error = anyhow::Error;
+
+    fn interval(&self) -> Duration {
+        self.interval
+    }
+
+    async fn tick(&mut self) -> anyhow::Result<()> {
+        self.refresh().await?;
+        tracing::info!("refreshed data transfer multiplier inventory");
+        Ok(())
+    }
+}

--- a/mobile_packet_verifier/src/multiplier/mod.rs
+++ b/mobile_packet_verifier/src/multiplier/mod.rs
@@ -1,0 +1,243 @@
+//! HIP-150 data transfer multiplier tickets.
+//!
+//! A ticket grants one on-chain hotspot a multiplier on the data credits derived
+//! from its rewardable bytes. Ingest verifies who sent a ticket and when, then
+//! writes it to s3 verbatim; this module reads those files, rules on each
+//! ticket, and keeps the result.
+//!
+//! Deciding validity *here* rather than at ingest is deliberate. HIP-150 wants
+//! every multiplier in force to be externally auditable, and a ticket rejected
+//! at the gRPC boundary leaves no record — rejected here, it is written to a
+//! verified report alongside the accepted ones.
+//!
+//! Tickets are not stored in Postgres. A verified ticket is written to an s3
+//! report and appended to `data_transfer.multiplier_ticket_history`.
+//!
+//! Current state lives in `data_transfer.multiplier_ticket_inventory`, which
+//! [`inventory`] keeps merged out of that history on a schedule. It follows the
+//! shape `network-dbt` uses for `enabled_carriers_inventory` over
+//! `enabled_carriers_history`, but the SQL is ours and the job runs here.
+//!
+//! The burn will read the inventory — whatever is current when a session
+//! arrives, not what was in force when the data moved; see [`trino`]. Nothing
+//! reads either table yet; no multiplier is applied until the burn is wired up.
+
+use std::{collections::HashMap, time::Duration};
+
+use chrono::{DateTime, Utc};
+use file_store::{file_sink::FileSinkClient, file_upload::FileUpload};
+use file_store_oracles::{
+    mobile::data_transfer_multiplier::{
+        proto::VerifiedDataTransferMultiplierTicketReportV1, DataTransferMultiplier,
+    },
+    traits::{FileSinkCommitStrategy, FileSinkRollTime, FileSinkWriteExt},
+    FileType,
+};
+use helium_crypto::PublicKeyBinary;
+use humantime_serde::re::humantime;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use task_manager::{ManagedTask, TaskManager};
+
+use crate::gateway::GatewayResolver;
+
+pub mod ingestor;
+pub mod inventory;
+pub mod trino;
+
+pub use trino::get_multipliers;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct MultiplierSettings {
+    /// Where to look in s3 for data transfer multiplier ticket files.
+    pub input_bucket: file_store::BucketSettings,
+    /// How far back to read ticket files on a cold start.
+    #[serde(default = "default_ingest_start_after")]
+    pub start_after: DateTime<Utc>,
+    /// Public keys authorized to issue tickets, comma-separated b58.
+    ///
+    /// Checked again here even though ingest already checked it: ingest and this
+    /// verifier are separately deployed and separately configured, and it is
+    /// this verdict that lands on the record.
+    ///
+    /// May be empty, and is by default — no ticket can be issued until a key is
+    /// provisioned. Empty rejects every ticket.
+    #[serde(default)]
+    pub authorized_keys: String,
+    /// How often the inventory table is merged out of the history.
+    ///
+    /// This is burn-visible: a ticket takes effect once the next merge has run,
+    /// so this interval is the lag between verifying a grant and it being worth
+    /// anything. It also bounds how stale a burn's multipliers can be if the
+    /// merge starts failing.
+    #[serde(
+        with = "humantime_serde",
+        default = "default_inventory_refresh_interval"
+    )]
+    pub inventory_refresh_interval: Duration,
+    /// How old a ticket's signed timestamp may be, measured against the time
+    /// ingest stamped on it, before it is refused.
+    ///
+    /// A second check of what ingest already checked, configured separately, so
+    /// a mistake in ingest's window does not silently widen the replay window
+    /// everywhere. It is *not* an independent defence: both timestamps in the
+    /// comparison come from the same file, so it cannot help against anyone able
+    /// to write that file.
+    #[serde(with = "humantime_serde", default = "default_ticket_max_age")]
+    pub ticket_max_age: Duration,
+}
+
+fn default_ingest_start_after() -> DateTime<Utc> {
+    DateTime::UNIX_EPOCH
+}
+
+fn default_inventory_refresh_interval() -> Duration {
+    humantime::parse_duration("15 minutes").unwrap()
+}
+
+fn default_ticket_max_age() -> Duration {
+    humantime::parse_duration("10 minutes").unwrap()
+}
+
+/// The set of keys allowed to issue tickets.
+#[derive(Debug, Clone, Default)]
+pub struct TicketSigners(std::collections::HashSet<PublicKeyBinary>);
+
+impl TicketSigners {
+    pub fn contains(&self, signer: &PublicKeyBinary) -> bool {
+        self.0.contains(signer)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl FromIterator<PublicKeyBinary> for TicketSigners {
+    fn from_iter<I: IntoIterator<Item = PublicKeyBinary>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+/// The multiplier in force per hotspot at a point in time.
+///
+/// Only ticketed hotspots appear. [`Multipliers::get`] is the single place the
+/// "no ticket means 1" rule is written down — every other caller just asks.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Multipliers(HashMap<PublicKeyBinary, DataTransferMultiplier>);
+
+impl Multipliers {
+    pub fn get(&self, hotspot_pubkey: &PublicKeyBinary) -> DataTransferMultiplier {
+        self.0
+            .get(hotspot_pubkey)
+            .copied()
+            .unwrap_or(DataTransferMultiplier::DEFAULT)
+    }
+
+    pub fn insert(&mut self, hotspot_pubkey: PublicKeyBinary, multiplier: DataTransferMultiplier) {
+        self.0.insert(hotspot_pubkey, multiplier);
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl FromIterator<(PublicKeyBinary, DataTransferMultiplier)> for Multipliers {
+    fn from_iter<I: IntoIterator<Item = (PublicKeyBinary, DataTransferMultiplier)>>(
+        iter: I,
+    ) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn create_managed_task(
+    pool: PgPool,
+    file_upload: FileUpload,
+    settings: &MultiplierSettings,
+    signers: TicketSigners,
+    resolver: GatewayResolver,
+    store_base_path: &std::path::Path,
+    history_writer: Option<crate::iceberg::MultiplierTicketWriter>,
+    trino: trino_client::Client,
+) -> anyhow::Result<impl ManagedTask> {
+    if signers.is_empty() {
+        tracing::warn!(
+            "no data transfer multiplier ticket signers configured; all tickets will be rejected"
+        );
+    }
+
+    let (verified_sink, verified_sink_server) =
+        VerifiedDataTransferMultiplierTicketReportV1::file_sink(
+            store_base_path,
+            file_upload,
+            FileSinkCommitStrategy::Manual,
+            FileSinkRollTime::Default,
+            env!("CARGO_PKG_NAME"),
+        )
+        .await?;
+
+    let (report_rx, report_server) = file_store::file_source::continuous_source()
+        .state(pool.clone())
+        .bucket_client(settings.input_bucket.connect().await)
+        .lookback_start_after(settings.start_after)
+        .prefix(FileType::DataTransferMultiplierTicketIngestReport.to_string())
+        .create()
+        .await?;
+
+    let ingestor = ingestor::TicketIngestor::new(
+        pool,
+        report_rx,
+        verified_sink,
+        signers,
+        resolver,
+        settings.ticket_max_age,
+        history_writer,
+    );
+
+    let inventory = inventory::InventoryRefresher::new(trino, settings.inventory_refresh_interval);
+
+    Ok(TaskManager::builder()
+        .add_task(report_server)
+        .add_task(verified_sink_server)
+        .add_task(task_manager::channel_consumer(ingestor))
+        .add_task(task_manager::periodic(inventory))
+        .build())
+}
+
+/// Type alias so the sink type is spelled once.
+pub type VerifiedTicketSink = FileSinkClient<VerifiedDataTransferMultiplierTicketReportV1>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(byte: u8) -> PublicKeyBinary {
+        PublicKeyBinary::from(vec![byte])
+    }
+
+    #[test]
+    fn unknown_hotspot_gets_the_default_multiplier() {
+        let multipliers = Multipliers::default();
+        assert_eq!(
+            multipliers.get(&key(1)),
+            DataTransferMultiplier::DEFAULT,
+            "a hotspot with no ticket must be unmultiplied"
+        );
+    }
+
+    #[test]
+    fn ticketed_hotspot_gets_its_multiplier() {
+        let one_and_a_half = DataTransferMultiplier::new(rust_decimal::dec!(1.5)).expect("valid");
+        let multipliers = Multipliers::from_iter([(key(1), one_and_a_half)]);
+
+        assert_eq!(multipliers.get(&key(1)), one_and_a_half);
+        // ...and its neighbour is unaffected.
+        assert_eq!(multipliers.get(&key(2)), DataTransferMultiplier::DEFAULT);
+    }
+}

--- a/mobile_packet_verifier/src/multiplier/trino.rs
+++ b/mobile_packet_verifier/src/multiplier/trino.rs
@@ -1,0 +1,108 @@
+//! Reading the multiplier currently in force per hotspot.
+//!
+//! **Nothing calls this yet.** It is the read side the burn path will use once
+//! multipliers are applied to data credits; until then a ticket is recorded and
+//! affects nothing.
+//!
+//! # Whatever is current when the session arrives
+//!
+//! A session is multiplied by whatever is in force when it is accumulated — not
+//! by what was in force at the instant the data moved. Reconstructing the
+//! latter would mean a point-in-time query against the ticket history, bounded
+//! by the file's timestamp.
+//!
+//! That precision would be false. Sessions reach us batched behind an ingest
+//! roll, tickets arrive on their own schedule, and the burn only runs hourly, so
+//! the boundary between "before the ticket" and "after" is already fuzzy by
+//! minutes. Paying for an exact answer to a question whose inputs are
+//! approximate buys nothing, and it costs a scan of the whole history per file.
+//!
+//! So this reads the inventory table [`super::inventory`] keeps merged from the
+//! history — one row per hotspot, already latest-per-key. No window function,
+//! no timestamp bound.
+//!
+//! # What that trades away
+//!
+//! * **The inventory's refresh interval becomes visible in burns.** A ticket
+//!   takes effect once the next merge has run, not the moment it is verified.
+//!   Tune `inventory_refresh_interval` against how promptly a grant should land.
+//! * **Replaying a backlog applies today's multipliers to old data.** Files
+//!   reprocessed long after the fact are multiplied by what is in force now, not
+//!   by what was in force then. Normal operation processes files promptly, so
+//!   this shows up only after an outage or a deliberate replay.
+//!
+//! Both follow from the same decision, taken knowingly: the timing was never
+//! exact, and pretending otherwise would cost more than it is worth.
+
+use file_store_oracles::mobile::data_transfer_multiplier::DataTransferMultiplier;
+use helium_crypto::PublicKeyBinary;
+use helium_iceberg_oracles::data_transfer::multiplier_ticket_inventory::{NAMESPACE, TABLE_NAME};
+use serde::{Deserialize, Serialize};
+use trino_rust_client::Trino;
+
+use super::Multipliers;
+
+/// The multiplier in force per hotspot, as of the last inventory refresh.
+///
+/// Hotspots with no ticket are absent from the result; [`Multipliers::get`]
+/// resolves those to [`DataTransferMultiplier::DEFAULT`].
+pub async fn get_multipliers(trino: &trino_client::Client) -> anyhow::Result<Multipliers> {
+    get_multipliers_from(trino, &format!("{NAMESPACE}.{TABLE_NAME}")).await
+}
+
+/// Like [`get_multipliers`], with an explicit table name.
+///
+/// Tests point this at a per-test catalog, the same way
+/// [`crate::gateway::GatewayResolver::new_with_inventory_table`] does.
+pub async fn get_multipliers_from(
+    trino: &trino_client::Client,
+    table: &str,
+) -> anyhow::Result<Multipliers> {
+    #[derive(Trino, Serialize, Deserialize)]
+    struct Row {
+        hotspot_pubkey: String,
+        multiplier: String,
+    }
+
+    // The inventory is already one row per hotspot, so this is a plain read.
+    //
+    // `cast(... as varchar)` rather than reading a decimal: the value is
+    // re-parsed into a validated `DataTransferMultiplier` below, and a decimal
+    // string is the exact representation both sides already agree on.
+    let stmt = trino_client::Statement::new(format!(
+        "SELECT hotspot_pubkey, cast(multiplier AS varchar) AS multiplier FROM {table}"
+    ))
+    .typed::<Row>();
+
+    let rows = trino.get_all(stmt).await?;
+
+    let mut multipliers = Multipliers::default();
+    for row in rows {
+        let hotspot_pubkey: PublicKeyBinary = match row.hotspot_pubkey.parse() {
+            Ok(pubkey) => pubkey,
+            Err(err) => {
+                tracing::warn!(pub_key = %row.hotspot_pubkey, ?err, "skipping unparseable hotspot");
+                continue;
+            }
+        };
+
+        // Values were validated before being written, so a value that no longer
+        // parses means the accepted range was narrowed since. Skip it rather
+        // than fail the file: the hotspot falls back to the default, which is
+        // the conservative direction.
+        match row
+            .multiplier
+            .parse()
+            .map_err(anyhow::Error::from)
+            .and_then(|value| -> anyhow::Result<_> { Ok(DataTransferMultiplier::new(value)?) })
+        {
+            Ok(multiplier) => multipliers.insert(hotspot_pubkey, multiplier),
+            Err(err) => tracing::warn!(
+                %hotspot_pubkey, multiplier = %row.multiplier, ?err,
+                "stored multiplier is no longer valid, treating hotspot as unmultiplied"
+            ),
+        }
+    }
+
+    Ok(multipliers)
+}

--- a/mobile_packet_verifier/src/settings.rs
+++ b/mobile_packet_verifier/src/settings.rs
@@ -11,7 +11,7 @@ use std::{
     time::Duration,
 };
 
-use crate::{banning, routing::RoutingKeys};
+use crate::{banning, multiplier, routing::RoutingKeys};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Settings {
@@ -69,6 +69,8 @@ pub struct Settings {
 
     /// Settings for Banning
     pub banning: banning::BanSettings,
+    /// HIP-150 data transfer multiplier tickets.
+    pub multiplier: multiplier::MultiplierSettings,
 
     pub iceberg_settings: Option<helium_iceberg::Settings>,
 }
@@ -138,6 +140,26 @@ impl Settings {
             )
             .build()
             .and_then(|config| config.try_deserialize())
+    }
+
+    /// Keys authorized to issue HIP-150 multiplier tickets.
+    ///
+    /// May be empty, unlike [`Self::routing_keys`]: the release ships before any
+    /// ticket can be issued. An empty set rejects every ticket, and
+    /// `multiplier::create_managed_task` warns about it at startup.
+    pub fn ticket_signers(&self) -> anyhow::Result<multiplier::TicketSigners> {
+        let mut keys = HashSet::new();
+        for key in self.multiplier.authorized_keys.split(',') {
+            let key = key.trim();
+            if key.is_empty() {
+                continue;
+            }
+            let key = PublicKeyBinary::from_str(key)
+                .with_context(|| format!("settings parsing ticket signer: {key}"))?;
+            keys.insert(key);
+        }
+
+        Ok(multiplier::TicketSigners::from_iter(keys))
     }
 
     pub fn routing_keys(&self) -> anyhow::Result<RoutingKeys> {

--- a/mobile_packet_verifier/tests/integrations/common/mod.rs
+++ b/mobile_packet_verifier/tests/integrations/common/mod.rs
@@ -10,6 +10,8 @@ pub async fn setup_iceberg() -> anyhow::Result<IcebergTestHarness> {
         iceberg::session::table_definition()?,
         iceberg::invalid_session::table_definition()?,
         iceberg::burned_session::table_definition()?,
+        iceberg::multiplier_ticket_history::table_definition()?,
+        iceberg::multiplier_ticket_inventory::table_definition()?,
         hotspot_inventory::table_definition()?,
     ])
     .await?;

--- a/mobile_packet_verifier/tests/integrations/gateway_sharing.rs
+++ b/mobile_packet_verifier/tests/integrations/gateway_sharing.rs
@@ -1,0 +1,141 @@
+//! The gateway snapshot is shared, not copied.
+//!
+//! `GatewayResolver` is built once and cloned for each consumer — the data
+//! transfer session path and the HIP-150 ticket path. Building a second one with
+//! `new()` would load its own copy of the whole inventory and then never
+//! refresh, because only one refresher task is registered.
+
+use std::time::Duration;
+
+use chrono::Utc;
+use helium_crypto::PublicKeyBinary;
+use mobile_packet_verifier::gateway::GatewayResolver;
+use task_manager::Periodic;
+
+use crate::common::{self, hotspot_inventory};
+
+/// A resolver whose refresher fires on every tick.
+///
+/// `GatewaySnapshotRefresher` only reloads once `refresh_interval` has elapsed
+/// since the last load, so a resolver built with the usual hour-long interval
+/// would treat `tick()` as a no-op and these tests would pass for the wrong
+/// reason.
+async fn eager_resolver(
+    harness: &helium_iceberg::IcebergTestHarness,
+) -> anyhow::Result<GatewayResolver> {
+    Ok(GatewayResolver::new_with_inventory_table(
+        trino_client::Client::from_client(harness.owned_trino().await?),
+        hotspot_inventory::RESOLVER_TABLE,
+        Duration::from_secs(0),
+    )
+    .await)
+}
+
+/// A clone taken *before* a refresh must see gateways that arrive after it.
+/// That is the property the daemon depends on: one refresher keeps every
+/// consumer current.
+#[tokio::test]
+async fn a_clone_sees_gateways_added_after_it_was_taken() -> anyhow::Result<()> {
+    let harness = common::setup_iceberg().await?;
+    let known_at_startup = PublicKeyBinary::from(vec![1]);
+    let onboarded_later = PublicKeyBinary::from(vec![2]);
+    let seen_at = Utc::now() - chrono::Duration::days(1);
+
+    hotspot_inventory::seed(
+        &harness,
+        vec![hotspot_inventory::MobileHotspotInventory::known(
+            &known_at_startup,
+            seen_at,
+        )],
+    )
+    .await?;
+
+    let resolver = eager_resolver(&harness).await?;
+    let clone = resolver.clone();
+    let mut refresher = resolver.refresher();
+
+    // The later gateway lands on chain after both the resolver and its clone
+    // were built.
+    hotspot_inventory::seed(
+        &harness,
+        vec![hotspot_inventory::MobileHotspotInventory::known(
+            &onboarded_later,
+            seen_at,
+        )],
+    )
+    .await?;
+
+    refresher.tick().await?;
+
+    // Read through the clone. If clones held their own snapshot this would miss
+    // and fall through to a per-pubkey query — so ask at a timestamp before the
+    // gateway was ever seen, which the fallback would answer `false`.
+    let before_it_existed = seen_at - chrono::Duration::days(1);
+    assert!(
+        clone
+            .is_gateway_known(&onboarded_later, &before_it_existed)
+            .await,
+        "the clone must see the refreshed snapshot, not its own stale copy"
+    );
+
+    Ok(())
+}
+
+/// Two clones share one fallback cache, so a miss is queried once rather than
+/// once per consumer.
+#[tokio::test]
+async fn clones_share_the_fallback_cache() -> anyhow::Result<()> {
+    let harness = common::setup_iceberg().await?;
+    let resolver = common::gateway_resolver(&harness).await?;
+    let clone = resolver.clone();
+
+    let unknown = PublicKeyBinary::from(vec![9]);
+    let now = Utc::now();
+
+    assert!(!resolver.is_gateway_known(&unknown, &now).await);
+    // Answered from the shared cache the first call populated.
+    assert!(!clone.is_gateway_known(&unknown, &now).await);
+
+    Ok(())
+}
+
+/// Guards the reason clones exist: a resolver built independently starts from
+/// its own load and is not updated by anyone else's refresher.
+#[tokio::test]
+async fn an_independent_resolver_does_not_share_a_snapshot() -> anyhow::Result<()> {
+    let harness = common::setup_iceberg().await?;
+    let resolver = eager_resolver(&harness).await?;
+    let mut refresher = resolver.refresher();
+
+    // A second resolver, built the way the daemon used to build one for tickets.
+    let independent = eager_resolver(&harness).await?;
+
+    let onboarded_later = PublicKeyBinary::from(vec![3]);
+    let seen_at = Utc::now() - chrono::Duration::days(1);
+    hotspot_inventory::seed(
+        &harness,
+        vec![hotspot_inventory::MobileHotspotInventory::known(
+            &onboarded_later,
+            seen_at,
+        )],
+    )
+    .await?;
+
+    refresher.tick().await?;
+
+    let before_it_existed = seen_at - chrono::Duration::days(1);
+    assert!(
+        resolver
+            .is_gateway_known(&onboarded_later, &before_it_existed)
+            .await,
+        "the refreshed resolver should see it"
+    );
+    assert!(
+        !independent
+            .is_gateway_known(&onboarded_later, &before_it_existed)
+            .await,
+        "an independently built resolver is not refreshed by someone else's task"
+    );
+
+    Ok(())
+}

--- a/mobile_packet_verifier/tests/integrations/main.rs
+++ b/mobile_packet_verifier/tests/integrations/main.rs
@@ -5,3 +5,5 @@ pub mod banning;
 pub mod burn_metric;
 pub mod burner;
 pub mod daemon;
+pub mod gateway_sharing;
+pub mod multiplier_tickets;

--- a/mobile_packet_verifier/tests/integrations/multiplier_tickets.rs
+++ b/mobile_packet_verifier/tests/integrations/multiplier_tickets.rs
@@ -1,0 +1,758 @@
+//! HIP-150 data transfer multiplier tickets.
+//!
+//! Two things are tested here, and the first is the one that matters.
+//!
+//! **Which ticket is in force.** The history table is append-only and holds
+//! every ticket a hotspot has ever been issued, so "the multiplier" is whichever
+//! row wins an ordering — decided by the merge that builds the inventory. A
+//! ticket is a correctly signed message that never expires, so getting that
+//! ordering wrong is not cosmetic: it is a way to restore a revoked multiplier
+//! by replaying a captured message.
+//!
+//! These go through the whole path — seed the history, merge, read the
+//! inventory — because that is what the burn will do. There is deliberately no
+//! test that a ticket applies only to data that post-dates it: multipliers take
+//! effect from the next refresh, not from the instant the data moved.
+//!
+//! **Whether a ticket counts at all** — the `verdict` module at the bottom.
+
+use chrono::{DateTime, Duration, Utc};
+use file_store_oracles::mobile::data_transfer_multiplier::{
+    DataTransferMultiplier, DataTransferMultiplierTicket, DataTransferMultiplierTicketReport,
+    VerifiedDataTransferMultiplierTicketReport,
+    VerifiedDataTransferMultiplierTicketStatus as Status,
+};
+use helium_crypto::PublicKeyBinary;
+use helium_iceberg::IcebergTestHarness;
+use helium_iceberg_oracles::data_transfer::multiplier_ticket_history::{
+    IcebergMultiplierTicket, NAMESPACE, TABLE_NAME,
+};
+use mobile_packet_verifier::multiplier::{
+    inventory::InventoryRefresher, trino::get_multipliers_from, Multipliers,
+};
+use rust_decimal::dec;
+
+use crate::common;
+
+/// Two-part `schema.table` name, resolved against the per-test catalog the
+/// harness registers.
+const HISTORY_TABLE: &str = "data_transfer.multiplier_ticket_history";
+const INVENTORY_TABLE: &str = "data_transfer.multiplier_ticket_inventory";
+
+fn hotspot(byte: u8) -> PublicKeyBinary {
+    PublicKeyBinary::from(vec![byte])
+}
+
+fn multiplier(value: rust_decimal::Decimal) -> DataTransferMultiplier {
+    DataTransferMultiplier::new(value).expect("valid multiplier")
+}
+
+/// A ticket carrying whatever multiplier is given, valid or not — the range is
+/// judged by `ticket_status`, not by construction.
+fn ticket_with(
+    hotspot_pubkey: &PublicKeyBinary,
+    value: Option<rust_decimal::Decimal>,
+    signed: DateTime<Utc>,
+    received: DateTime<Utc>,
+) -> DataTransferMultiplierTicketReport {
+    let mut report = ticket(hotspot_pubkey, dec!(1), signed, received);
+    report.report.multiplier = value;
+    report
+}
+
+/// A ticket signed at `signed` and received at `received`.
+fn ticket(
+    hotspot_pubkey: &PublicKeyBinary,
+    value: rust_decimal::Decimal,
+    signed: DateTime<Utc>,
+    received: DateTime<Utc>,
+) -> DataTransferMultiplierTicketReport {
+    DataTransferMultiplierTicketReport {
+        received_timestamp: received,
+        report: DataTransferMultiplierTicket {
+            hotspot_pubkey: hotspot_pubkey.clone(),
+            multiplier: Some(value),
+            timestamp: signed,
+            message: "test ticket".to_string(),
+            signer_pubkey: hotspot(200),
+            signature: vec![],
+        },
+    }
+}
+
+/// A history row as the ingestor would have written it.
+fn history_row(
+    report: DataTransferMultiplierTicketReport,
+    status: Status,
+) -> IcebergMultiplierTicket {
+    let verified = VerifiedDataTransferMultiplierTicketReport {
+        verified_timestamp: report.received_timestamp,
+        report,
+        status,
+    };
+    IcebergMultiplierTicket::from(&verified)
+}
+
+fn valid_row(report: DataTransferMultiplierTicketReport) -> IcebergMultiplierTicket {
+    history_row(report, Status::Valid)
+}
+
+async fn seed(
+    harness: &IcebergTestHarness,
+    rows: Vec<IcebergMultiplierTicket>,
+) -> anyhow::Result<()> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    harness
+        .get_table_writer_in::<IcebergMultiplierTicket>(NAMESPACE, TABLE_NAME)
+        .await?
+        .write(rows)
+        .await?;
+    Ok(())
+}
+
+/// Seed the history, run the merge, and read what the burn would see.
+///
+/// The whole path: a ticket lands in the history, the inventory is merged out of
+/// it, and the burn reads the inventory. Ordering and refusal rules live in the
+/// merge, so exercising them through this helper tests them where they run.
+async fn multipliers_after_refresh(
+    rows: Vec<IcebergMultiplierTicket>,
+) -> anyhow::Result<Multipliers> {
+    let harness = common::setup_iceberg().await?;
+    seed(&harness, rows).await?;
+    let trino = trino_client::Client::from_client(harness.owned_trino().await?);
+
+    InventoryRefresher::new_with_tables(
+        trino.clone(),
+        std::time::Duration::from_secs(900),
+        HISTORY_TABLE.to_string(),
+        INVENTORY_TABLE.to_string(),
+    )
+    .refresh()
+    .await?;
+
+    get_multipliers_from(&trino, INVENTORY_TABLE).await
+}
+
+#[tokio::test]
+async fn no_tickets_means_every_hotspot_is_unmultiplied() -> anyhow::Result<()> {
+    let multipliers = multipliers_after_refresh(vec![]).await?;
+
+    assert!(multipliers.is_empty());
+    assert_eq!(
+        multipliers.get(&hotspot(1)),
+        DataTransferMultiplier::DEFAULT,
+        "a hotspot with no ticket must be unmultiplied"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn latest_ticket_by_issue_time_wins() -> anyhow::Result<()> {
+    let hotspot = hotspot(1);
+    let now = Utc::now();
+
+    let multipliers = multipliers_after_refresh(vec![
+        valid_row(ticket(
+            &hotspot,
+            dec!(5),
+            now - Duration::hours(2),
+            now - Duration::hours(2),
+        )),
+        valid_row(ticket(
+            &hotspot,
+            dec!(1.5),
+            now - Duration::hours(1),
+            now - Duration::hours(1),
+        )),
+    ])
+    .await?;
+
+    assert_eq!(multipliers.get(&hotspot), multiplier(dec!(1.5)));
+
+    Ok(())
+}
+
+/// **The replay test.** A ticket granting 5x is superseded by one granting 1x.
+/// An attacker resubmits the original 5x ticket — a genuine, correctly signed
+/// message — hours after it was revoked.
+///
+/// With no database there is no primary key to reject the duplicate, so the
+/// replay *does* become a row; the history honestly records that a resubmission
+/// happened. It changes nothing because the ordering is on the issuer's signed
+/// timestamp, which a replay cannot alter without the signing key. Ordering on
+/// arrival would hand the attacker the 5x back.
+#[tokio::test]
+async fn replaying_a_superseded_ticket_does_not_restore_it() -> anyhow::Result<()> {
+    let hotspot = hotspot(1);
+    let now = Utc::now();
+
+    let granted_at = now - Duration::hours(3);
+    let revoked_at = now - Duration::hours(2);
+
+    let granted = valid_row(ticket(&hotspot, dec!(5), granted_at, granted_at));
+    let revoked = valid_row(ticket(&hotspot, dec!(1), revoked_at, revoked_at));
+    // The captured 5x ticket, resubmitted now. Same signed timestamp — that is
+    // what makes it a replay rather than a new grant — but it arrives after the
+    // revocation.
+    let replayed = valid_row(ticket(&hotspot, dec!(5), granted_at, now));
+
+    // Control: before the revocation the grant really was in force. Without
+    // this the assertion below would pass just as well if the query returned
+    // nothing at all, since "no ticket" and "revoked to 1" are both the default.
+    assert_eq!(
+        multipliers_after_refresh(vec![granted.clone()])
+            .await?
+            .get(&hotspot),
+        multiplier(dec!(5)),
+        "the original grant should have been in force before revocation"
+    );
+
+    let multipliers = multipliers_after_refresh(vec![granted, revoked, replayed]).await?;
+
+    assert_eq!(
+        multipliers.get(&hotspot),
+        DataTransferMultiplier::DEFAULT,
+        "a replayed ticket must not restore a revoked multiplier"
+    );
+
+    Ok(())
+}
+
+/// A ticket held up in delivery must not leapfrog a newer one that overtook it.
+/// Ordering by arrival gets this wrong with no attacker involved at all.
+#[tokio::test]
+async fn a_delayed_ticket_does_not_supersede_a_newer_one() -> anyhow::Result<()> {
+    let hotspot = hotspot(1);
+    let now = Utc::now();
+
+    let multipliers = multipliers_after_refresh(vec![
+        // Signed second, arrived first.
+        valid_row(ticket(
+            &hotspot,
+            dec!(1.5),
+            now - Duration::hours(1),
+            now - Duration::minutes(30),
+        )),
+        // Signed first, arrived second.
+        valid_row(ticket(
+            &hotspot,
+            dec!(5),
+            now - Duration::hours(2),
+            now - Duration::minutes(10),
+        )),
+    ])
+    .await?;
+
+    assert_eq!(
+        multipliers.get(&hotspot),
+        multiplier(dec!(1.5)),
+        "the more recently *issued* ticket wins, not the more recently received"
+    );
+
+    Ok(())
+}
+
+/// The history table keeps refused tickets, so the read has to exclude them.
+/// Without the status filter a rejected grant would take effect.
+#[tokio::test]
+async fn rejected_tickets_do_not_take_effect() -> anyhow::Result<()> {
+    let hotspot = hotspot(1);
+    let now = Utc::now();
+
+    let multipliers = multipliers_after_refresh(vec![
+        valid_row(ticket(
+            &hotspot,
+            dec!(1.5),
+            now - Duration::hours(2),
+            now - Duration::hours(2),
+        )),
+        // Newer, larger, and refused — it must not win despite sorting first.
+        history_row(
+            ticket(
+                &hotspot,
+                dec!(5),
+                now - Duration::hours(1),
+                now - Duration::hours(1),
+            ),
+            Status::InvalidSigner,
+        ),
+    ])
+    .await?;
+
+    assert_eq!(
+        multipliers.get(&hotspot),
+        multiplier(dec!(1.5)),
+        "a refused ticket must not take effect"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn hotspots_do_not_affect_each_other() -> anyhow::Result<()> {
+    let now = Utc::now();
+    let (a, b, c) = (hotspot(1), hotspot(2), hotspot(3));
+
+    let multipliers = multipliers_after_refresh(vec![
+        valid_row(ticket(&a, dec!(1.5), now, now)),
+        valid_row(ticket(&b, dec!(5), now, now)),
+    ])
+    .await?;
+
+    assert_eq!(multipliers.len(), 2, "only ticketed hotspots appear");
+    assert_eq!(multipliers.get(&a), multiplier(dec!(1.5)));
+    assert_eq!(multipliers.get(&b), multiplier(dec!(5)));
+    assert_eq!(multipliers.get(&c), DataTransferMultiplier::DEFAULT);
+
+    Ok(())
+}
+
+/// The exact decimal must survive the round trip through `decimal(9,6)`. 1.3 is
+/// the value that would come back mangled from a float column.
+#[tokio::test]
+async fn multipliers_round_trip_exactly() -> anyhow::Result<()> {
+    let now = Utc::now();
+    let values = [dec!(1), dec!(1.5), dec!(1.3), dec!(2.718281), dec!(5)];
+
+    let rows = values
+        .iter()
+        .enumerate()
+        .map(|(i, value)| valid_row(ticket(&hotspot(i as u8 + 1), *value, now, now)))
+        .collect();
+
+    let multipliers = multipliers_after_refresh(rows).await?;
+
+    for (i, value) in values.iter().enumerate() {
+        assert_eq!(
+            multipliers.get(&hotspot(i as u8 + 1)),
+            multiplier(*value),
+            "{value} did not survive storage"
+        );
+    }
+
+    Ok(())
+}
+
+/// `1.5` and `1.50` are the same multiplier. Normalizing on parse is what keeps
+/// a difference in spelling from becoming a difference in value — including
+/// through the `decimal(9,6)` column, which returns everything scale-padded.
+#[tokio::test]
+async fn equivalent_spellings_are_one_multiplier() -> anyhow::Result<()> {
+    let hotspot = hotspot(1);
+    let now = Utc::now();
+
+    let multipliers =
+        multipliers_after_refresh(vec![valid_row(ticket(&hotspot, dec!(1.50), now, now))]).await?;
+
+    assert_eq!(multipliers.get(&hotspot), multiplier(dec!(1.5)));
+
+    Ok(())
+}
+
+// ── The inventory table ─────────────────────────────────────────────────────
+//
+// The history is the log; the inventory is what is currently in force. A
+// periodic MERGE builds the second from the first.
+
+mod inventory {
+    use super::*;
+    use helium_iceberg_oracles::data_transfer::multiplier_ticket_inventory::IcebergMultiplierInventory;
+    use mobile_packet_verifier::multiplier::inventory::InventoryRefresher;
+    use std::time::Duration as StdDuration;
+
+    /// Compare by value, not by formatting. Trino returns a `decimal(9,6)`
+    /// scale-padded — 1.5 comes back as "1.500000" — which says nothing about
+    /// whether the stored value is right.
+    fn stored(row: &IcebergMultiplierInventory) -> rust_decimal::Decimal {
+        row.multiplier
+            .as_string()
+            .parse()
+            .expect("stored multiplier parses")
+    }
+
+    /// Seed history, run the merge, and read the inventory back.
+    async fn refresh_and_read(
+        rows: Vec<IcebergMultiplierTicket>,
+    ) -> anyhow::Result<Vec<IcebergMultiplierInventory>> {
+        let harness = common::setup_iceberg().await?;
+        seed(&harness, rows).await?;
+        let trino = trino_client::Client::from_client(harness.owned_trino().await?);
+
+        InventoryRefresher::new_with_tables(
+            trino.clone(),
+            StdDuration::from_secs(900),
+            HISTORY_TABLE.to_string(),
+            INVENTORY_TABLE.to_string(),
+        )
+        .refresh()
+        .await?;
+
+        let mut rows: Vec<IcebergMultiplierInventory> = trino
+            .get_all_raw(format!("SELECT * FROM {INVENTORY_TABLE}"))
+            .await?;
+        rows.sort_by(|a, b| a.hotspot_pubkey.cmp(&b.hotspot_pubkey));
+        Ok(rows)
+    }
+
+    #[tokio::test]
+    async fn merges_the_latest_valid_ticket_per_hotspot() -> anyhow::Result<()> {
+        let now = Utc::now();
+        let (a, b) = (hotspot(1), hotspot(2));
+
+        let rows = refresh_and_read(vec![
+            valid_row(ticket(
+                &a,
+                dec!(5),
+                now - Duration::hours(2),
+                now - Duration::hours(2),
+            )),
+            valid_row(ticket(
+                &a,
+                dec!(1.5),
+                now - Duration::hours(1),
+                now - Duration::hours(1),
+            )),
+            valid_row(ticket(
+                &b,
+                dec!(2),
+                now - Duration::hours(1),
+                now - Duration::hours(1),
+            )),
+        ])
+        .await?;
+
+        assert_eq!(rows.len(), 2, "one row per hotspot, not one per ticket");
+        assert_eq!(stored(&rows[0]), dec!(1.5), "superseded 5 must not win");
+        assert_eq!(stored(&rows[1]), dec!(2));
+
+        Ok(())
+    }
+
+    /// The inventory holds what is in force, so refusals are excluded. A refusal
+    /// also must not revoke an earlier grant.
+    #[tokio::test]
+    async fn refused_tickets_are_excluded() -> anyhow::Result<()> {
+        let hotspot = hotspot(1);
+        let now = Utc::now();
+
+        let rows = refresh_and_read(vec![
+            valid_row(ticket(
+                &hotspot,
+                dec!(1.5),
+                now - Duration::hours(2),
+                now - Duration::hours(2),
+            )),
+            // Newer, larger, refused.
+            history_row(
+                ticket(
+                    &hotspot,
+                    dec!(5),
+                    now - Duration::hours(1),
+                    now - Duration::hours(1),
+                ),
+                Status::InvalidSigner,
+            ),
+        ])
+        .await?;
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            stored(&rows[0]),
+            dec!(1.5),
+            "a refusal must not take effect, nor revoke the last valid grant"
+        );
+
+        Ok(())
+    }
+
+    /// **The merge test.** Running twice must update in place, not append a
+    /// second row per hotspot — that is the whole difference between a merge and
+    /// the append-only writer.
+    #[tokio::test]
+    async fn refreshing_twice_updates_in_place() -> anyhow::Result<()> {
+        let hotspot = hotspot(1);
+        let now = Utc::now();
+
+        let harness = common::setup_iceberg().await?;
+        seed(
+            &harness,
+            vec![valid_row(ticket(
+                &hotspot,
+                dec!(1.5),
+                now - Duration::hours(2),
+                now - Duration::hours(2),
+            ))],
+        )
+        .await?;
+        let trino = trino_client::Client::from_client(harness.owned_trino().await?);
+        let refresher = InventoryRefresher::new_with_tables(
+            trino.clone(),
+            StdDuration::from_secs(900),
+            HISTORY_TABLE.to_string(),
+            INVENTORY_TABLE.to_string(),
+        );
+
+        refresher.refresh().await?;
+
+        // A newer grant arrives, then we refresh again.
+        seed(
+            &harness,
+            vec![valid_row(ticket(
+                &hotspot,
+                dec!(5),
+                now - Duration::hours(1),
+                now - Duration::hours(1),
+            ))],
+        )
+        .await?;
+        refresher.refresh().await?;
+
+        let rows: Vec<IcebergMultiplierInventory> = trino
+            .get_all_raw(format!("SELECT * FROM {INVENTORY_TABLE}"))
+            .await?;
+
+        assert_eq!(
+            rows.len(),
+            1,
+            "the hotspot must have one row, not one per refresh"
+        );
+        assert_eq!(stored(&rows[0]), dec!(5), "the row must have been updated");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn no_tickets_leaves_the_inventory_empty() -> anyhow::Result<()> {
+        assert!(refresh_and_read(vec![]).await?.is_empty());
+        Ok(())
+    }
+}
+
+// ── The verdict rule ────────────────────────────────────────────────────────
+//
+// Storage above decides which ticket wins. These decide whether a ticket counts
+// at all — the second line of defence behind ingest, exercised here because
+// ingest and this verifier are configured separately and either could be wrong.
+
+mod verdict {
+    use super::*;
+    use file_store_oracles::mobile::data_transfer_multiplier::MAX_CLOCK_DRIFT;
+    use mobile_packet_verifier::multiplier::{ingestor::ticket_status, TicketSigners};
+    use std::time::Duration as StdDuration;
+
+    const MAX_AGE: StdDuration = StdDuration::from_secs(600);
+
+    fn signer() -> PublicKeyBinary {
+        hotspot(200)
+    }
+
+    async fn status_of(
+        report: &DataTransferMultiplierTicketReport,
+        signers: TicketSigners,
+    ) -> anyhow::Result<Status> {
+        let harness = common::setup_iceberg().await?;
+        // Seed the ticket's hotspot as known on chain, well before the ticket.
+        common::hotspot_inventory::seed(
+            &harness,
+            vec![common::hotspot_inventory::MobileHotspotInventory::known(
+                &report.report.hotspot_pubkey,
+                report.received_timestamp - Duration::days(1),
+            )],
+        )
+        .await?;
+        let resolver = common::gateway_resolver(&harness).await?;
+
+        Ok(ticket_status(report, &signers, MAX_AGE, &resolver).await)
+    }
+
+    #[tokio::test]
+    async fn accepts_a_fresh_ticket_from_a_known_signer() -> anyhow::Result<()> {
+        let now = Utc::now();
+        let report = ticket(&hotspot(1), dec!(1.5), now, now);
+
+        let status = status_of(&report, TicketSigners::from_iter([signer()])).await?;
+        assert_eq!(status, Status::Valid);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_an_unauthorized_signer() -> anyhow::Result<()> {
+        let now = Utc::now();
+        let report = ticket(&hotspot(1), dec!(1.5), now, now);
+
+        // A different key is authorized — the ticket's signer is not.
+        let status = status_of(&report, TicketSigners::from_iter([hotspot(201)])).await?;
+        assert_eq!(status, Status::InvalidSigner);
+
+        Ok(())
+    }
+
+    /// The empty allow-list, which is how this ships. Fails closed.
+    #[tokio::test]
+    async fn rejects_every_ticket_when_no_signers_are_configured() -> anyhow::Result<()> {
+        let now = Utc::now();
+        let report = ticket(&hotspot(1), dec!(1.5), now, now);
+
+        let status = status_of(&report, TicketSigners::default()).await?;
+        assert_eq!(status, Status::InvalidSigner);
+
+        Ok(())
+    }
+
+    /// Signed well before ingest received it — the shape a replayed ticket has.
+    #[tokio::test]
+    async fn rejects_a_stale_ticket() -> anyhow::Result<()> {
+        let now = Utc::now();
+        let report = ticket(&hotspot(1), dec!(1.5), now - Duration::hours(2), now);
+
+        let status = status_of(&report, TicketSigners::from_iter([signer()])).await?;
+        assert_eq!(status, Status::InvalidTimestamp);
+
+        Ok(())
+    }
+
+    /// Post-dating must not buy an arbitrarily long window.
+    #[tokio::test]
+    async fn rejects_a_future_dated_ticket() -> anyhow::Result<()> {
+        let now = Utc::now();
+        let report = ticket(&hotspot(1), dec!(1.5), now + Duration::hours(1), now);
+
+        let status = status_of(&report, TicketSigners::from_iter([signer()])).await?;
+        assert_eq!(status, Status::InvalidTimestamp);
+
+        Ok(())
+    }
+
+    /// Ingest tolerates a client whose clock runs slightly fast, so this must
+    /// too. If it did not, a ticket ingest accepted would be refused here and
+    /// the two services would disagree about the same ticket.
+    #[tokio::test]
+    async fn tolerates_the_same_clock_drift_ingest_does() -> anyhow::Result<()> {
+        let now = Utc::now();
+        // Signed ahead of the timestamp ingest stamped on it.
+        let signed = now + Duration::from_std(MAX_CLOCK_DRIFT)? - Duration::seconds(5);
+        let report = ticket(&hotspot(1), dec!(1.5), signed, now);
+
+        let status = status_of(&report, TicketSigners::from_iter([signer()])).await?;
+        assert_eq!(status, Status::Valid);
+
+        Ok(())
+    }
+
+    /// The far side of the allowance, so the test above cannot pass by the
+    /// tolerance being unbounded.
+    #[tokio::test]
+    async fn rejects_drift_beyond_the_allowance() -> anyhow::Result<()> {
+        let now = Utc::now();
+        let signed = now + Duration::from_std(MAX_CLOCK_DRIFT)? + Duration::minutes(1);
+        let report = ticket(&hotspot(1), dec!(1.5), signed, now);
+
+        let status = status_of(&report, TicketSigners::from_iter([signer()])).await?;
+        assert_eq!(status, Status::InvalidTimestamp);
+
+        Ok(())
+    }
+
+    /// Inside the window is still accepted — without this the rejection tests
+    /// would pass just as well if the window were zero.
+    #[tokio::test]
+    async fn accepts_a_ticket_inside_the_window() -> anyhow::Result<()> {
+        let now = Utc::now();
+        let signed = now - Duration::from_std(MAX_AGE)? + Duration::minutes(1);
+        let report = ticket(&hotspot(1), dec!(1.5), signed, now);
+
+        let status = status_of(&report, TicketSigners::from_iter([signer()])).await?;
+        assert_eq!(status, Status::Valid);
+
+        Ok(())
+    }
+
+    /// HIP-150 fixes the range at 1 to 5 inclusive, enforced by the oracles.
+    /// Enforced *here* rather than at ingest so the refusal lands on the record
+    /// instead of vanishing at the gRPC boundary.
+    #[tokio::test]
+    async fn rejects_a_multiplier_outside_the_hip_range() -> anyhow::Result<()> {
+        let now = Utc::now();
+
+        for value in [dec!(0), dec!(0.999999), dec!(5.000001), dec!(7), dec!(-1)] {
+            let report = ticket_with(&hotspot(1), Some(value), now, now);
+            let status = status_of(&report, TicketSigners::from_iter([signer()])).await?;
+            assert_eq!(
+                status,
+                Status::InvalidMultiplier,
+                "{value} is outside 1..=5 and must be refused"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// The bounds themselves are accepted, so the test above cannot pass by the
+    /// range being empty.
+    #[tokio::test]
+    async fn accepts_the_bounds_of_the_hip_range() -> anyhow::Result<()> {
+        let now = Utc::now();
+
+        for value in [dec!(1), dec!(5), dec!(1.5), dec!(4.999999)] {
+            let report = ticket_with(&hotspot(1), Some(value), now, now);
+            let status = status_of(&report, TicketSigners::from_iter([signer()])).await?;
+            assert_eq!(status, Status::Valid, "{value} is within 1..=5");
+        }
+
+        Ok(())
+    }
+
+    /// More precision than the column stores is refused too — same outcome to a
+    /// submitter, and it keeps the stored value exact.
+    #[tokio::test]
+    async fn rejects_a_multiplier_with_too_much_precision() -> anyhow::Result<()> {
+        let now = Utc::now();
+        let report = ticket_with(&hotspot(1), Some(dec!(1.5000001)), now, now);
+
+        let status = status_of(&report, TicketSigners::from_iter([signer()])).await?;
+        assert_eq!(status, Status::InvalidMultiplier);
+
+        Ok(())
+    }
+
+    /// An absent or unparseable multiplier is a refusal on the record, not a
+    /// record that never existed. The file poller silently drops anything that
+    /// fails to decode, so the ticket has to survive decoding to be refused.
+    #[tokio::test]
+    async fn rejects_an_absent_multiplier() -> anyhow::Result<()> {
+        let now = Utc::now();
+        let report = ticket_with(&hotspot(1), None, now, now);
+
+        let status = status_of(&report, TicketSigners::from_iter([signer()])).await?;
+        assert_eq!(status, Status::InvalidMultiplier);
+
+        Ok(())
+    }
+
+    /// A multiplier can only attach to an on-chain hotspot.
+    #[tokio::test]
+    async fn rejects_an_unknown_hotspot() -> anyhow::Result<()> {
+        let now = Utc::now();
+        let report = ticket(&hotspot(1), dec!(1.5), now, now);
+
+        let harness = common::setup_iceberg().await?;
+        // Nothing seeded: the hotspot is not on chain.
+        let resolver = common::gateway_resolver(&harness).await?;
+
+        let status = ticket_status(
+            &report,
+            &TicketSigners::from_iter([signer()]),
+            MAX_AGE,
+            &resolver,
+        )
+        .await;
+        assert_eq!(status, Status::InvalidHotspotKey);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is only the ingestion of multipliers in mobile-packet-verifier, applying them to the burn process is coming in the next PR.

---- 

Reads ticket files from s3, rules on each ticket, and writes the verdict to
a verified report and to data_transfer.multiplier_ticket_history.

No behaviour change: nothing applies a multiplier yet. The burn path is
untouched, and get_multipliers has no caller outside tests. A ticket can be
issued, verified and recorded, and it affects nothing until the burn is
wired up in a following change.

Ruling here rather than at ingest means a refused ticket is recorded: every
ticket produces a verified report and a history row, so the record shows why
a hotspot is not multiplied as well as why it is.

Nothing is stored in Postgres. The history table is append-only, and current
state is a dbt model over it — the same shape as enabled_carriers_inventory
over enabled_carriers_history — so no service owns a mutable copy.

Notes:

- The burn will read the history table rather than the inventory mart. It
  needs the multiplier in force at the timestamp of the file being
  processed, which merged current state cannot answer, and reading the log
  this service wrote keeps burning off the dbt cadence.
- Latest-per-hotspot is ordered on the issuer's signed timestamp, not on
  arrival. A ticket is a correctly signed message that never expires, so a
  captured one can be resubmitted after the grant it carries was revoked;
  ordered by arrival it would win. Ordered by signed timestamp it sorts below
  the ticket that superseded it, which a replay cannot change without the
  signing key.
- received_timestamp bounds which files a ticket applies to, so a ticket
  never applies retroactively.
- Signer and freshness are checked again even though ingest checked them.
  The two services are configured separately, and this is the copy that
  decides whether a hotspot's rewards are multiplied. Freshness is measured
  against when ingest received the ticket, so replaying a backlog of files
  does not reject every ticket in it.
- The multiplier is stored as decimal(9,6), never a float: values are
  negotiated per venue and are not always binary-representable.
  IcebergDecimal bridges serde (the write path) and the Trino trait (the
  read path), which no existing type spans.
- Ticket signers may be empty and default to empty, matching ingest.