### PR TITLE
Add multiplier-ticket-cli workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5696,6 +5696,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "multiplier-ticket-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "file-store-oracles",
+ "helium-crypto",
+ "helium-proto",
+ "helium-proto-crypto",
+ "prost",
+ "rand 0.8.5",
+ "rust_decimal",
+ "serde_json",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
 name = "murmur3"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "mobile_config_cli",
   "mobile_packet_verifier",
   "mobile_verifier",
+  "multiplier_ticket_cli",
   "price",
   "price_tracker",
   "reward_index",

--- a/multiplier_ticket_cli/Cargo.toml
+++ b/multiplier_ticket_cli/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "multiplier-ticket-cli"
+version = "0.1.0"
+description = "Submit HIP-150 data transfer multiplier tickets to ingest"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true, features = ["derive", "env"] }
+file-store-oracles = { path = "../file_store_oracles" }
+helium-crypto = { workspace = true }
+helium-proto = { workspace = true }
+prost = { workspace = true }
+rust_decimal = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tonic = { workspace = true }
+
+[dev-dependencies]
+helium-proto-crypto = { workspace = true }
+rand = { workspace = true }

--- a/multiplier_ticket_cli/README.md
+++ b/multiplier_ticket_cli/README.md
@@ -1,0 +1,82 @@
+# Multiplier Ticket CLI
+
+Submits HIP-150 data transfer multiplier tickets to the mobile ingestor.
+
+A ticket grants one hotspot a multiplier on the data credits its rewardable
+bytes convert to. Both sides move together: the payer burns that many times the
+data credits, and the hotspot's share of the mobile data pool grows in the same
+proportion.
+
+## Usage
+
+```
+multiplier-ticket-cli \
+    --keypair ./issuer.bin \
+    --ingest-url http://ingest:9080 \
+    submit --hotspot <b58 pubkey> --multiplier 1.5 --message "why"
+```
+
+Without `--commit` the ticket is printed and nothing is sent:
+
+```json
+{
+  "committed": false,
+  "hotspot_pubkey": "14ApnkU9WdbAxn7dh5NYAfgHubJKwxT5F4yF1kKMrTPMfdRB2VJ",
+  "message": "venue pilot",
+  "multiplier": "1.5",
+  "signed_timestamp": "2026-09-02T00:24:52.795Z",
+  "signer": "14ApnkU9WdbAxn7dh5NYAfgHubJKwxT5F4yF1kKMrTPMfdRB2VJ"
+}
+```
+
+Add `--commit` to send it. The output gains `"committed": true` and
+`received_timestamp_ms`, which is the timestamp ingest stamped on it.
+
+| Option | | |
+| :-- | :-- | :-- |
+| `--hotspot` | | Hotspot to grant the multiplier to, base58 |
+| `--multiplier` | | 1 to 5 inclusive, up to 6 decimal places |
+| `--message` | optional | Free text stored with the ticket |
+| `--keypair` | `MULTIPLIER_TICKET_KEYPAIR` | Signing key, defaults to `./keypair.bin` |
+| `--ingest-url` | `INGEST_URL` | Ingest gRPC endpoint |
+| `--commit` | | Actually send it |
+
+## Before you can submit
+
+The signing key must be in the ingestor's `data_transfer_multiplier`
+authorized keys. Anything else is refused at the gRPC boundary and leaves no
+record anywhere.
+
+## Things worth knowing
+
+**Submitting is not reversible.** Every ticket that reaches ingest is written to
+s3 and to `data_transfer.multiplier_ticket_history`, refusals included. There is
+no delete — the only way back is another ticket, which lands on the record as a
+second entry. Setting a multiplier of `1` is how a grant is revoked.
+
+**A ticket takes effect from its signed timestamp**, not from when it is
+processed, and it only applies to data that moved after that point. It starts
+affecting burns once the packet verifier has processed the ticket file.
+
+**The range is checked here as well as by the packet verifier.** The verifier is
+what actually decides, but a ticket it refuses is refused *on the record*. The
+local check keeps typos out of the audit log.
+
+## Checking that it landed
+
+The ticket is keyed on `(hotspot_pubkey, signed_timestamp)`, so both values from
+the output above identify the row:
+
+```sql
+SELECT multiplier, status, received_timestamp, verified_timestamp
+FROM data_transfer.multiplier_ticket_history
+WHERE hotspot_pubkey = '<hotspot_pubkey>'
+  AND signed_timestamp = TIMESTAMP '2026-09-02 00:24:52.795 UTC'
+```
+
+Note the timestamp changes shape between the two: the output prints
+`2026-09-02T00:24:52.795Z`, Trino wants `2026-09-02 00:24:52.795 UTC`. Same
+instant, and the milliseconds must be kept — the stored value has exactly that
+precision and nothing more.
+
+`status` says whether the packet verifier accepted it, and if not, why.

--- a/multiplier_ticket_cli/src/main.rs
+++ b/multiplier_ticket_cli/src/main.rs
@@ -1,0 +1,209 @@
+//! Submit HIP-150 data transfer multiplier tickets to ingest.
+//!
+//! A ticket grants one hotspot a multiplier on the data credits its rewardable
+//! bytes convert to. It must be signed by a key on ingest's
+//! `data_transfer_multiplier` allow-list.
+//!
+//! Submitting is not reversible. A ticket that verifies changes what a payer
+//! burns and what a deployer earns from the next burn on, and the only way back
+//! is another ticket. So nothing is sent without `--commit`.
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use chrono::Utc;
+use clap::{Parser, Subcommand};
+use file_store_oracles::mobile::data_transfer_multiplier::DataTransferMultiplier;
+use helium_crypto::{Keypair, PublicKeyBinary, Sign};
+use helium_proto::services::poc_mobile::{
+    Client as PocMobileClient, DataTransferMultiplierTicketReqV1,
+};
+use prost::Message;
+use rust_decimal::Decimal;
+use serde_json::json;
+
+#[derive(Debug, Parser)]
+#[command(name = "multiplier-ticket-cli", version, about, long_about = None)]
+struct Cli {
+    /// Ingest gRPC endpoint, e.g. http://localhost:9080
+    #[arg(global = true, long, env = "INGEST_URL")]
+    ingest_url: Option<String>,
+
+    /// Keypair to sign with. Must be on ingest's multiplier allow-list.
+    #[arg(
+        global = true,
+        long,
+        env = "MULTIPLIER_TICKET_KEYPAIR",
+        default_value = "./keypair.bin"
+    )]
+    keypair: PathBuf,
+
+    /// Actually send the ticket. Without it the ticket is printed and nothing
+    /// else — a ticket cannot be withdrawn, so the default is the harmless half.
+    #[arg(global = true, long)]
+    commit: bool,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Grant a hotspot a multiplier. Submitting 1 revokes an existing grant.
+    Submit {
+        /// Hotspot to grant it to, base58.
+        #[arg(long)]
+        hotspot: PublicKeyBinary,
+
+        /// HIP-150 accepts 1 to 5 inclusive, up to 6 decimal places.
+        #[arg(long)]
+        multiplier: Decimal,
+
+        /// Free text recorded with the ticket. Use it to say why.
+        #[arg(long, default_value = "")]
+        message: String,
+    },
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    let Commands::Submit {
+        hotspot,
+        multiplier,
+        message,
+    } = &cli.command;
+
+    // Checked here as well as in the packet verifier. The verifier is what
+    // decides, but a ticket refused there is refused *on the record* — it still
+    // gets a verified report and a history row. Catching a typo locally keeps
+    // the audit log a record of real decisions.
+    let multiplier = DataTransferMultiplier::new(*multiplier)
+        .with_context(|| format!("{multiplier} is not a multiplier the oracles will accept"))?;
+
+    let keypair = load_keypair(&cli.keypair)?;
+    let signer = PublicKeyBinary::from(keypair.public_key().to_owned());
+
+    // Truncated to milliseconds because that is what the ticket carries on the
+    // wire, so the timestamp printed here is the one that gets stored.
+    let timestamp = chrono::DateTime::from_timestamp_millis(Utc::now().timestamp_millis())
+        .context("clock is outside the representable range")?;
+
+    let mut out = json!({
+        "hotspot_pubkey": hotspot.to_string(),
+        "multiplier": multiplier.to_string(),
+        "signed_timestamp": timestamp.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        "signer": signer.to_string(),
+        "message": message,
+        "committed": false,
+    });
+
+    if cli.commit {
+        let url = cli
+            .ingest_url
+            .as_deref()
+            .context("--ingest-url (or INGEST_URL) is required to send")?;
+
+        let resp = send(&keypair, hotspot, multiplier, timestamp, message, url).await?;
+
+        out["committed"] = json!(true);
+        out["received_timestamp_ms"] = json!(resp);
+    }
+
+    println!("{}", serde_json::to_string_pretty(&out)?);
+    if !cli.commit {
+        eprintln!("not sent. re-run with --commit to issue this ticket");
+    }
+    Ok(())
+}
+
+/// Sign the ticket and hand it to ingest, returning ingest's received timestamp.
+///
+/// The signature covers the encoded request with the signature field still
+/// empty, which is the form ingest reconstructs to verify. Get that wrong and
+/// ingest rejects it with `invalid signature` and writes nothing at all — no
+/// report, no history row — so it looks like nothing happened.
+async fn send(
+    keypair: &Keypair,
+    hotspot: &PublicKeyBinary,
+    multiplier: DataTransferMultiplier,
+    timestamp: chrono::DateTime<Utc>,
+    message: &str,
+    url: &str,
+) -> anyhow::Result<u64> {
+    let req = signed_ticket(keypair, hotspot, multiplier, timestamp, message)?;
+
+    let mut client = PocMobileClient::connect(url.to_string())
+        .await
+        .with_context(|| format!("connecting to ingest at {url}"))?;
+
+    let resp = client
+        .submit_data_transfer_multiplier_ticket(req)
+        .await
+        .map_err(|status| anyhow::anyhow!("ingest refused the ticket: {status}"))?
+        .into_inner();
+
+    Ok(resp.timestamp_ms)
+}
+
+fn signed_ticket(
+    keypair: &Keypair,
+    hotspot: &PublicKeyBinary,
+    multiplier: DataTransferMultiplier,
+    timestamp: chrono::DateTime<Utc>,
+    message: &str,
+) -> anyhow::Result<DataTransferMultiplierTicketReqV1> {
+    let mut req = DataTransferMultiplierTicketReqV1 {
+        hotspot_pubkey: hotspot.clone().into(),
+        multiplier: Some(helium_proto::Decimal {
+            value: multiplier.to_string(),
+        }),
+        timestamp_ms: timestamp.timestamp_millis() as u64,
+        message: message.to_string(),
+        signer_pubkey: PublicKeyBinary::from(keypair.public_key().to_owned()).into(),
+        signature: vec![],
+    };
+    req.signature = keypair
+        .sign(&req.encode_to_vec())
+        .context("signing the ticket")?;
+    Ok(req)
+}
+
+fn load_keypair(path: &PathBuf) -> anyhow::Result<Keypair> {
+    let data =
+        std::fs::read(path).with_context(|| format!("reading keypair from {}", path.display()))?;
+    Keypair::try_from(&data[..]).context("parsing keypair")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use helium_proto_crypto::MsgVerify;
+    use rust_decimal::dec;
+
+    /// The signature has to verify the way ingest verifies it. A mismatch is
+    /// rejected at the gRPC boundary with no record of the attempt, so it would
+    /// look like nothing happened at all.
+    #[test]
+    fn a_signed_ticket_verifies_the_way_ingest_checks_it() {
+        let keypair = Keypair::generate(
+            helium_crypto::KeyTag {
+                network: helium_crypto::Network::MainNet,
+                key_type: helium_crypto::KeyType::Ed25519,
+            },
+            &mut rand::rngs::OsRng,
+        );
+
+        let req = signed_ticket(
+            &keypair,
+            &PublicKeyBinary::from(vec![1]),
+            DataTransferMultiplier::new(dec!(1.5)).unwrap(),
+            Utc::now(),
+            "why",
+        )
+        .unwrap();
+
+        req.verify(keypair.public_key())
+            .expect("ingest must accept this signature");
+    }
+}


### PR DESCRIPTION
With a single subcommand `submit`, sign and send a data transfer multiplier ticket to ingest for HIP-150 value multipliers.

https://github.com/helium/HIP/blob/main/0150-mobile-deployer-prioritization.md

Usage:
```sh
multiplier-ticket-cli \
    --keypair ./keypair.bin \
    --ingest-url INGEST_URL \
    submit \
    --hotspot <B58> \
    --multiplier 1.5 \
    --message "testing"
    [--commit]
```

Sample Output:
```json
{
  "committed": false,
  "hotspot_pubkey": "13fZvTpwLnGaKKiHhAuTnarbq2ohNCiexbyEdeSn13vTH2dfcDE",
  "message": "test message",
  "multiplier": "1.5",
  "signed_timestamp": "2026-09-02T22:36:28.190Z",
  "signer": "13fZvTpwLnGaKKiHhAuTnarbq2ohNCiexbyEdeSn13vTH2dfcDE"
}
```

Without `--commit` nothing is sent.

Tickets cannot be withdrawn, to reset a multiplier for a hotspot, submit a ticket with a `1` multiplier value.

To check the active status of a ticket, see README.md for a query to run in trino.

Mulitplier ranges between 1-5 are enforced in this CLI as well as in mobile-packet-verifier when tickets are ingested.

The signing key used for tickets must be present in the ingest settings under `Settings.data_transfer_multiplier_authorized_keys`, and in mobile-packet-verifier under `Settings.multiplier.authorized_keys`.